### PR TITLE
Add documentation for `dynamicTypeLoading` experimental feature

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -41,6 +41,10 @@ Enables publishing source code with modules using the `bicep publish` `--with-so
 ### `resourceDerivedTypes`
 If enabled, templates can reuse resource types wherever a type is expected. For example, to declare a parameter `foo` that should be usable as the name of an Azure Storage account, the following syntax would be used: `param foo resouce<'Microsoft.Storage/storageAccounts@2022-09-01'>.name`. **NB:** Because resource types may be inaccurate in some cases, no constraints other than the ARM type primitive will be enforced on resource derived types within the ARM deployment engine. Resource-derived types will be checked by Bicep at compile time, but violations will be emitted as warnings rather than errors.
 
+### `dynamicTypeLoading`
+Requires `extensibility` to be enabled. If enabled, users are able to fetch the azure resource type definitions from an OCI Registry as a runtime dependency. To fetch the type definitions the following syntax can be used. For example `provider 'br:mcr.microsoft.com/bicep/providers/az@1.0.0' as az`.
+The provider definitions also support aliasing via `bicepconfig.json` similar to [`moduleAliases`](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config-modules#aliases-for-modules). For example `provider 'br/public:az@1.0.0' as az`.
+
 ## Other experimental functionality
 
 ### `publish-provider` CLI Command

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -43,7 +43,7 @@ If enabled, templates can reuse resource types wherever a type is expected. For 
 
 ### `dynamicTypeLoading`
 Requires `extensibility` to be enabled. If enabled, users are able to fetch the azure resource type definitions from an OCI Registry as a runtime dependency. To fetch the type definitions the following syntax can be used. For example `provider 'br:mcr.microsoft.com/bicep/providers/az@1.0.0' as az`.
-The provider definitions also support aliasing via `bicepconfig.json` similar to [`moduleAliases`](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config-modules#aliases-for-modules). For example `provider 'br/public:az@1.0.0' as az`.
+The provider definitions also support aliasing via `bicepconfig.json` similar to [`moduleAliases`](https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-config-modules#aliases-for-modules). For example `provider 'br/public:az@1.0.0' as az`.
 
 ## Other experimental functionality
 

--- a/src/Bicep.Core.UnitTests/Configuration/BicepConfigSchemaTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/BicepConfigSchemaTests.cs
@@ -29,7 +29,6 @@ namespace Bicep.Core.UnitTests.Configuration
 
         // TODO: Remove these when they're fixed
         private readonly string[] GrandfatheredFeaturesNeedingHelpOrDescription = {
-                "dynamicTypeLoading",
                 "microsoftGraphPreview",
                 "providerRegistry",
             };
@@ -233,7 +232,7 @@ namespace Bicep.Core.UnitTests.Configuration
             foreach (var (featureName, featureValue) in experimentalFeatures)
             {
                 /* Example:
-                 
+
                     "publishSource": {
                         "type": "boolean",
                         "description": "Enables publishing source code with modules using the bicep publish `--with-source` option. See https://aka.ms/bicep/experimental-features#publishsource"
@@ -289,7 +288,7 @@ namespace Bicep.Core.UnitTests.Configuration
             foreach (var (featureName, featureValue) in experimentalFeatures)
             {
                 /* Example:
-                 
+
                     "publishSource": {
                         "type": "boolean",
                         "description": "Enables publishing source code with modules using the bicep publish `--with-source` option. See https://aka.ms/bicep/experimental-features#publishsource"

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -736,6 +736,7 @@
           "description": "Allows you to author boolean assertions using the assert keyword. Should be enabled in tandem with 'testFramework'. See https://aka.ms/bicep/experimental-features#assertions"
         },
         "dynamicTypeLoading": {
+          "description": "Enables dynamic type loading for resource type providers. See https://aka.ms/bicep/experimental-features#dynamictypeloading",
           "type": "boolean"
         },
         "providerRegistry": {


### PR DESCRIPTION
Partially addresses #13109 

Added documentation for the "dynamic type loading" experimental feature that was added in #10868 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13273)