### PR TITLE
Added support for recursive build and publish output

### DIFF
--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/Program.cs
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/Program.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("Hello, World!");

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/csharp-recursive.csproj
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/csharp-recursive.csproj
@@ -1,0 +1,34 @@
+<!--
+  Do not include this project in the solution. It is intended to validate our MSBuild task.
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <!-- enable recursive build and publish outputs -->
+    <BicepOutputStyle>Recursive</BicepOutputStyle>
+  </PropertyGroup>
+
+  <!-- 
+    Pickup latest available packages (including prerelease) from local feed configured in NuGet.config.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Bicep.CommandLine.$(RuntimeSuffix)" Version="*-*" />
+    <PackageReference Include="Azure.Bicep.MSBuild" Version="*-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Bicep Include="**\*.bicep"/>
+  </ItemGroup>
+  <ItemGroup>
+    <BicepParam Include="root1.bicepparam"/>
+    <BicepParam Include="root2.bicepparam"/>
+    <BicepParam Include="one/one1.bicepparam"/>
+    <BicepParam Include="one/one2.bicepparam"/>
+    <BicepParam Include="one/two/two1.bicepparam"/>
+    <BicepParam Include="one/two/two2.bicepparam"/>
+  </ItemGroup>
+</Project>
+

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/one.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/one.bicep
@@ -1,0 +1,2 @@
+#disable-next-line no-unused-params
+param one string

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/one1.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/one1.bicepparam
@@ -1,0 +1,3 @@
+using 'one.bicep'
+
+param one = 'one1'

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/one2.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/one2.bicepparam
@@ -1,0 +1,3 @@
+using 'one.bicep'
+
+param one = 'one2'

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/two/two.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/two/two.bicep
@@ -1,0 +1,2 @@
+#disable-next-line no-unused-params
+param two string

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/two/two1.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/two/two1.bicepparam
@@ -1,0 +1,3 @@
+using 'two.bicep'
+
+param two = 'one1'

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/two/two2.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/one/two/two2.bicepparam
@@ -1,0 +1,3 @@
+using 'two.bicep'
+
+param two = 'two2'

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/root.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/root.bicep
@@ -1,0 +1,2 @@
+#disable-next-line no-unused-params
+param root string

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/root1.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/root1.bicepparam
@@ -1,0 +1,3 @@
+using 'root.bicep'
+
+param root = 'root1'

--- a/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/root2.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/csharp-recursive/root2.bicepparam
@@ -1,0 +1,3 @@
+using 'root.bicep'
+
+param root = 'root2'

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/multitarget-mitigation.targets
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/multitarget-mitigation.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <!-- Mitigation for https://github.com/microsoft/MSBuildSdks/issues/155 -->
+    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets" Condition="$(IsCrossTargetingBuild) == 'true'" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="$(IsCrossTargetingBuild) != 'true'" />
+</Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/recursive-badmode.proj
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/recursive-badmode.proj
@@ -1,0 +1,25 @@
+<!--
+  Do not include this project in the solution. It is intended to validate our MSBuild task.
+-->
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <!-- Ensure the package supports multi-targeting -->
+    <TargetFramework>net8.0</TargetFramework>
+    <LanguageTargets>$(MSBuildThisFileDirectory)\multitarget-mitigation.targets</LanguageTargets> <!-- https://github.com/microsoft/MSBuildSdks/issues/155 -->
+    <!-- intentionally set incorrect mode -->
+    <BicepOutputStyle>WRONG MODE</BicepOutputStyle>
+  </PropertyGroup>
+
+  <!-- 
+    Pickup latest available packages (including prerelease) from local feed configured in NuGet.config.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Bicep.CommandLine.$(RuntimeSuffix)" Version="*-*" />
+    <PackageReference Include="Azure.Bicep.MSBuild" Version="*-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Bicep Include="root.bicep"/>
+    <Bicep Include="root1.bicepparam"/>
+  </ItemGroup>
+</Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/root.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/root.bicep
@@ -1,0 +1,2 @@
+#disable-next-line no-unused-params
+param root string

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/root1.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive-badmode/root1.bicepparam
@@ -1,0 +1,3 @@
+using 'root.bicep'
+
+param root = 'root1'

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/multitarget-mitigation.targets
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/multitarget-mitigation.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <!-- Mitigation for https://github.com/microsoft/MSBuildSdks/issues/155 -->
+    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.CrossTargeting.targets" Condition="$(IsCrossTargetingBuild) == 'true'" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="$(IsCrossTargetingBuild) != 'true'" />
+</Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/one/one.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/one/one.bicep
@@ -1,0 +1,2 @@
+#disable-next-line no-unused-params
+param one string

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/one/one1.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/one/one1.bicepparam
@@ -1,0 +1,3 @@
+using 'one.bicep'
+
+param one = 'one1'

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/one/one2.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/one/one2.bicepparam
@@ -1,0 +1,3 @@
+using 'one.bicep'
+
+param one = 'one2'

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/one/two/two.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/one/two/two.bicep
@@ -1,0 +1,2 @@
+#disable-next-line no-unused-params
+param two string

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/one/two/two1.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/one/two/two1.bicepparam
@@ -1,0 +1,3 @@
+using 'two.bicep'
+
+param two = 'one1'

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/one/two/two2.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/one/two/two2.bicepparam
@@ -1,0 +1,3 @@
+using 'two.bicep'
+
+param two = 'two2'

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/recursive.proj
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/recursive.proj
@@ -1,0 +1,29 @@
+<!--
+  Do not include this project in the solution. It is intended to validate our MSBuild task.
+-->
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <!-- Ensure the package supports multi-targeting -->
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <LanguageTargets>$(MSBuildThisFileDirectory)\multitarget-mitigation.targets</LanguageTargets> <!-- https://github.com/microsoft/MSBuildSdks/issues/155 -->
+    <!-- enable recursive build and publish outputs -->
+    <BicepOutputStyle>Recursive</BicepOutputStyle>
+  </PropertyGroup>
+
+  <!-- 
+    Pickup latest available packages (including prerelease) from local feed configured in NuGet.config.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Bicep.CommandLine.$(RuntimeSuffix)" Version="*-*" />
+    <PackageReference Include="Azure.Bicep.MSBuild" Version="*-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Bicep Include="root.bicep"/>
+    <Bicep Include="one\one.bicep"/>
+    <Bicep Include="one\two\two.bicep"/>
+  </ItemGroup>
+  <ItemGroup>
+    <BicepParam Include="**\*.bicepparam"/>
+  </ItemGroup>
+</Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/root.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/root.bicep
@@ -1,0 +1,2 @@
+#disable-next-line no-unused-params
+param root string

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/root1.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/root1.bicepparam
@@ -1,0 +1,3 @@
+using 'root.bicep'
+
+param root = 'root1'

--- a/src/Bicep.MSBuild.E2eTests/examples/recursive/root2.bicepparam
+++ b/src/Bicep.MSBuild.E2eTests/examples/recursive/root2.bicepparam
@@ -1,0 +1,3 @@
+using 'root.bicep'
+
+param root = 'root2'

--- a/src/Bicep.MSBuild.E2eTests/src/csharpRecursive.test.ts
+++ b/src/Bicep.MSBuild.E2eTests/src/csharpRecursive.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Example } from "./example";
+
+function getOutputFiles(
+  configuration: "Debug" | "Release",
+  framework: string,
+  publish: boolean,
+): string[] {
+  const publishPart = publish ? "publish/" : "";
+  return [
+    // templates
+    `bin/${configuration}/${framework}/${publishPart}root.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/one.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/two/two.json`,
+
+    // compiles params
+    `bin/${configuration}/${framework}/${publishPart}root1.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}root2.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/one1.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/one2.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/two/two1.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/two/two2.parameters.json`,
+  ];
+}
+
+describe("msbuild", () => {
+  it("should build a c# project with recursive copy enabled", () => {
+    const example = new Example("csharp-recursive", "csharp-recursive.csproj");
+    example.cleanProjectDir();
+
+    const result = example.build();
+
+    expect(result.stderr).toBe("");
+
+    const framework = "net8.0";
+    getOutputFiles("Debug", framework, false).forEach((file) =>
+      example.expectTemplate(file),
+    );
+
+    const cleanResult = example.clean();
+    expect(cleanResult.stderr).toBe("");
+
+    getOutputFiles("Debug", framework, false).forEach((file) =>
+      example.expectNoFile(file),
+    );
+
+    const publishResult = example.publish(framework);
+    expect(publishResult.stderr).toBe("");
+
+    // after publish we should expect build output
+    // in the Release directory for the chosen framework
+    getOutputFiles("Release", framework, false).forEach((file) =>
+      example.expectTemplate(file),
+    );
+
+    // publish dir should be populated with the same content
+    getOutputFiles("Release", framework, true).forEach((file) =>
+      example.expectTemplate(file),
+    );
+  });
+});

--- a/src/Bicep.MSBuild.E2eTests/src/recursive.test.ts
+++ b/src/Bicep.MSBuild.E2eTests/src/recursive.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Example } from "./example";
+import * as asserts from "./asserts";
+
+function getOutputFiles(
+  configuration: "Debug" | "Release",
+  framework: string,
+  publish: boolean,
+): string[] {
+  const publishPart = publish ? "publish/" : "";
+  return [
+    // templates
+    `bin/${configuration}/${framework}/${publishPart}root.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/one.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/two/two.json`,
+
+    // compiles params
+    `bin/${configuration}/${framework}/${publishPart}root1.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}root2.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/one1.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/one2.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/two/two1.parameters.json`,
+    `bin/${configuration}/${framework}/${publishPart}one/two/two2.parameters.json`,
+  ];
+}
+
+describe("msbuild", () => {
+  it("should build a multi-targeting project with recursive copy enabled", () => {
+    const example = new Example("recursive");
+    example.cleanProjectDir();
+
+    const result = example.build();
+
+    expect(result.stderr).toBe("");
+
+    const targetFrameworks = ["net8.0", "net472"];
+
+    targetFrameworks.forEach((framework: string): void => {
+      getOutputFiles("Debug", framework, false).forEach((file) =>
+        example.expectTemplate(file),
+      );
+    });
+
+    const cleanResult = example.clean();
+    expect(cleanResult.stderr).toBe("");
+
+    targetFrameworks.forEach((framework: string): void => {
+      getOutputFiles("Debug", framework, false).forEach((file) =>
+        example.expectNoFile(file),
+      );
+    });
+
+    const publishFramework = targetFrameworks[0];
+    const publishResult = example.publish(publishFramework);
+    expect(publishResult.stderr).toBe("");
+
+    // after publish we should expect build output
+    // in the Release directory for the chosen framework
+    getOutputFiles("Release", publishFramework, false).forEach((file) =>
+      example.expectTemplate(file),
+    );
+
+    // publish dir should be populated with the same content
+    getOutputFiles("Release", publishFramework, true).forEach((file) =>
+      example.expectTemplate(file),
+    );
+  });
+
+  it("should fail if BicepOutputStyle is not set to a valid value", () => {
+    const example = new Example("recursive-badmode");
+    example.cleanProjectDir();
+
+    const result = example.build(false);
+    expect(result.status).not.toBe(0);
+
+    asserts.expectLinesInLog(result.stdout, [
+      ": error : The BicepOutputStyle property must be set to either 'Flat' or 'Recursive'.",
+      "0 Warning(s)",
+      "1 Error(s)",
+    ]);
+  });
+});

--- a/src/Bicep.MSBuild.E2eTests/src/simple.test.ts
+++ b/src/Bicep.MSBuild.E2eTests/src/simple.test.ts
@@ -21,8 +21,8 @@ describe("msbuild", () => {
 
     example.cleanProjectDir();
 
-    example.publish(null);
-    expect(buildResult.stderr).toBe("");
+    const publishResult = example.publish(null);
+    expect(publishResult.stderr).toBe("");
 
     // both build and publish outputs should be present
     example.expectTemplate(templateRelativePath);

--- a/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.targets
+++ b/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.targets
@@ -6,14 +6,22 @@
 
     <!-- default to project OutputPath -->
     <BicepOutputPath Condition=" $(BicepOutputPath) == '' ">$(OutputPath)</BicepOutputPath>
+    <!-- all files by default will get dumped into the configured output path -->
+    <BicepOutputStyle Condition=" $(BicepOutputStyle) == '' ">Flat</BicepOutputStyle>
   </PropertyGroup>
 
-  <Target Name="BeforeBicepCompile" Condition=" @(Bicep) != '' " BeforeTargets="BicepCompile">
+  <Target Name="BeforeBicepCompileCommon">
+    <Error Text="The BicepOutputStyle property must be set to either 'Flat' or 'Recursive'." Condition=" ($(BicepOutputStyle) != 'Flat') and ($(BicepOutputStyle) != 'Recursive') " />
+  </Target>
+
+  <Target Name="BeforeBicepCompile" Condition=" @(Bicep) != '' " BeforeTargets="BicepCompile" DependsOnTargets="BeforeBicepCompileCommon">
     <ItemGroup>
       <!-- consider only files without NoBuild metadata set -->
       <_BicepResolvedIntermediate Include="@(Bicep)" Condition=" %(Bicep.NoBuild) != 'true' ">
-        <!-- populate missing output file metadata using the default path -->
-        <OutputFile Condition=" %(Bicep.OutputFile) == '' ">$(BicepOutputPath)\%(FileName)$(BicepDefaultOutputFileExtension)</OutputFile>
+        <!-- in recursive mode, incorporate the file's relative path into the final output path -->
+        <OutputFile Condition=" ($(BicepOutputStyle) == 'Recursive') and (%(Bicep.OutputFile) == '') ">$(BicepOutputPath)\$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(RootDir)%(Directory)%(Filename)$(BicepDefaultOutputFileExtension)))</OutputFile>
+        <!-- in flat mode, append the file name to the output path -->
+        <OutputFile Condition=" ($(BicepOutputStyle) == 'Flat') and (%(Bicep.OutputFile) == '') ">$(BicepOutputPath)\%(FileName)$(BicepDefaultOutputFileExtension)</OutputFile>
       </_BicepResolvedIntermediate>
       <_BicepResolved Include="@(_BicepResolvedIntermediate)">
         <OutputFile>$([System.IO.Path]::GetFullPath('%(OutputFile)'))</OutputFile>
@@ -30,12 +38,14 @@
     <Error Text="The path to the Bicep compiler is not set. Reference the appropriate Azure.Bicep.CommandLine.* package for your runtime or set the BicepPath property." Condition=" $(BicepPath) == '' " />
   </Target>
 
-  <Target Name="BeforeBicepParamCompile" Condition=" @(BicepParam) != '' " BeforeTargets="BicepParamCompile">
+  <Target Name="BeforeBicepParamCompile" Condition=" @(BicepParam) != '' " BeforeTargets="BicepParamCompile" DependsOnTargets="BeforeBicepCompileCommon">
     <ItemGroup>
       <!-- consider only files without NoBuild metadata set -->
       <_BicepParamResolvedIntermediate Include="@(BicepParam)" Condition=" %(BicepParam.NoBuild) != 'true' ">
-        <!-- populate missing output file metadata using the default path -->
-        <OutputFile Condition=" %(BicepParam.OutputFile) == '' ">$(BicepOutputPath)\%(FileName)$(BicepParamDefaultOutputFileExtension)</OutputFile>
+        <!-- in recursive mode, incorporate the file's relative path into the final output path -->
+        <OutputFile Condition=" ($(BicepOutputStyle) == 'Recursive') and (%(BicepParam.OutputFile) == '') ">$(BicepOutputPath)\$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(RootDir)%(Directory)%(Filename)$(BicepParamDefaultOutputFileExtension)))</OutputFile>
+        <!-- in flat mode, append the file name to the output path -->
+        <OutputFile Condition=" ($(BicepOutputStyle) == 'Flat') and (%(BicepParam.OutputFile) == '') ">$(BicepOutputPath)\%(FileName)$(BicepParamDefaultOutputFileExtension)</OutputFile>
       </_BicepParamResolvedIntermediate>
       <_BicepParamResolved Include="@(_BicepParamResolvedIntermediate)">
         <OutputFile>$([System.IO.Path]::GetFullPath('%(OutputFile)'))</OutputFile>
@@ -76,14 +86,19 @@
       <_BicepOutputFiles Include="%(_BicepParamResolved.OutputFile)" />
     </ItemGroup>
 
+    <PropertyGroup>
+      <_BicepNormalizedOutputPath>$([MSBuild]::NormalizeDirectory($(OutputPath)))</_BicepNormalizedOutputPath>
+    </PropertyGroup>
+
     <!-- find all files compiled by Bicep under the project output dir -->
-    <FindUnderPath Path="$([MSBuild]::NormalizeDirectory($(OutputPath)))" Files="@(_BicepOutputFiles)" UpdateToAbsolutePaths="true">
+    <FindUnderPath Path="$(_BicepNormalizedOutputPath)" Files="@(_BicepOutputFiles)" UpdateToAbsolutePaths="true">
       <Output TaskParameter="InPath" ItemName="_PublishableBicepOutputFiles"/>
     </FindUnderPath>
 
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_PublishableBicepOutputFiles)">
-        <RelativePath>%(FileName)%(Extension)</RelativePath>
+        <RelativePath Condition=" $(BicepOutputStyle) == 'Flat' ">%(FileName)%(Extension)</RelativePath>
+        <RelativePath Condition=" $(BicepOutputStyle) == 'Recursive' ">$([MSBuild]::MakeRelative($(_BicepNormalizedOutputPath), %(FullPath)))</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
     </ItemGroup>


### PR DESCRIPTION
Added support for recursive build and publish output to the MSBuild package. To avoid breaking changes, users will have to opt into the new behavior by setting the `BicepOutputStyle` msbuild property to `Recursive`. The default value for the property is `Flat`, which preserves the previous behavior for users who took a dependency on it.

This fixes #10989.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13292)