### PR TITLE
Add "/lockfiles" command that can be run as a comment in PRs to fix lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
       day: "sunday"
     ignore:
       - dependency-name: "Moq"
+    labels:
+      - vs-bicep-dependencies
+      - dependencies
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/lockfiles-command.yml
+++ b/.github/workflows/lockfiles-command.yml
@@ -1,0 +1,33 @@
+# To run this, comment "/lockfiles" on the PR
+name: Update lockfiles
+on:
+  workflow_dispatch:
+
+jobs:
+  lockfiles:
+    # dotnet restore for src/vs-bicep/BicepInVisualStudio.sln doesn't seem to work well on Linux
+    runs-on: windows-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4.0.0
+
+      - name: Restore dependencies
+        run: |
+          echo "Restoring dependencies for Bicep.sln"
+          dotnet restore --force-evaluate
+          echo "Restoring dependencies for BicepInVisualStudio.sln"
+          dotnet restore src/vs-bicep/BicepInVisualStudio.sln --force-evaluate
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update lockfiles

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,43 @@
+# Implements "slash commands" on PR comments
+#   see https://github.com/peter-evans/slash-command-dispatch
+#   and https://david.gardiner.net.au/2021/05/dependabot-nuget-lockfiles.html
+# Listens for a comment on a pull request beginning with "/{command}" and dispatches that command
+# E.g. commenting "/lockfiles" will dispatch the "lockfiles-command.yml" workflow
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bot Details
+        id: bot-details
+        uses: raven-actions/bot-details@v1
+
+        # Obtain the name of the branch that is linked to the pull request for the triggering comment.
+      - uses: xt0rted/pull-request-comment-branch@v2
+        id: comment-branch
+
+      - name: Dump comment context
+        env:
+          COMMENT_CONTEXT: ${{ toJson(steps.comment-branch.outputs) }}
+        run: echo "$COMMENT_CONTEXT"
+
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v4
+        id: slash-command
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commands: |
+            lockfiles
+          permission: write
+          issue-type: pull-request
+          # We want the secondary workflow to run against the pull request branch (not the default branch)
+          dispatch-type: workflow
+          static-args: ref=${{ steps.comment-branch.outputs.head_ref }}
+
+      - name: Dump slash context
+        env:
+          SLASH_CONTEXT: ${{ toJson(steps.slash-command) }}
+        run: echo "$SLASH_CONTEXT"


### PR DESCRIPTION
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13353)

Fixes #4772 

Unfortunately a new build does not get kicked off after the lockfiles are modified.  Will consider looking into that later.

Not sure there's a way to test this without it being merged first.  I did test it in a forked repo, though.