### PR TITLE
Support resource functions for extensible resources

### DIFF
--- a/src/Bicep.Core.IntegrationTests/RegistryProviderTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryProviderTests.cs
@@ -3,11 +3,17 @@
 
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using System.Text.Json;
+using Azure.Bicep.Types;
+using Azure.Bicep.Types.Concrete;
+using Azure.Bicep.Types.Index;
+using Azure.Bicep.Types.Serialization;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 using Newtonsoft.Json.Linq;
 
 namespace Bicep.Core.IntegrationTests;
@@ -41,16 +47,16 @@ public class RegistryProviderTests : TestBase
         await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), "/types/index.json", $"br:{registry}/{repository}:1.2.3");
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-        provider 'br:example.azurecr.io/test/provider/http@1.2.3'
+provider 'br:example.azurecr.io/test/provider/http@1.2.3'
 
-        resource dadJoke 'request@v1' = {
-        uri: 'https://icanhazdadjoke.com'
-        method: 'GET'
-        format: 'json'
-        }
+resource dadJoke 'request@v1' = {
+  uri: 'https://icanhazdadjoke.com'
+  method: 'GET'
+  format: 'json'
+}
 
-        output joke string = dadJoke.body.joke
-        """);
+output joke string = dadJoke.body.joke
+""");
 
         result.Should().NotHaveAnyDiagnostics();
         result.Template.Should().NotBeNull();
@@ -106,21 +112,46 @@ resource fooRes 'fooType@v1' existing = {
         await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), "/types/index.json", $"br:{registry}/{repository}:1.2.3");
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-        provider 'br:example.azurecr.io/test/provider/http@1.2.3' with {}
+provider 'br:example.azurecr.io/test/provider/http@1.2.3' with {}
 
-        resource dadJoke 'request@v1' = {
-        uri: 'https://icanhazdadjoke.com'
-        method: 'GET'
-        format: 'json'
-        }
+resource dadJoke 'request@v1' = {
+  uri: 'https://icanhazdadjoke.com'
+  method: 'GET'
+  format: 'json'
+}
 
-        output joke string = dadJoke.body.joke
-        """);
+output joke string = dadJoke.body.joke
+""");
 
         result.Should().NotGenerateATemplate();
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
             ("BCP205", DiagnosticLevel.Error, "Provider namespace \"http\" does not support configuration.")
         });
+    }
+
+    [TestMethod]
+    public async Task Resource_function_types_are_permitted_through_3p_type_registry()
+    {
+        var registry = "example.azurecr.io";
+        var repository = $"providers/foo";
+
+        var services = GetServiceBuilder(new MockFileSystem(), registry, repository, true, true);
+
+        var tgzData  = ThirdPartyTypeHelper.GetTestTypesTgz();
+        await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), $"br:{registry}/{repository}:1.2.3", tgzData);
+
+        var result = await CompilationHelper.RestoreAndCompile(services, """
+provider 'br:example.azurecr.io/providers/foo@1.2.3'
+
+resource fooRes 'fooType@v1' existing = {
+  identifier: 'foo'
+}
+
+output baz string = fooRes.convertBarToBaz('bar')
+""");
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveValueAtPath("$.outputs['baz'].value", "[invokeResourceMethod('fooRes', 'convertBarToBaz', createArray('bar'))]");
     }
 
     [TestMethod]
@@ -138,35 +169,35 @@ resource fooRes 'fooType@v1' existing = {
         await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), "/types/index.json", $"br:{registry}/{repository}:1.2.3");
 
         var result = await CompilationHelper.RestoreAndCompile(services, @$"
-        provider 'br:example.azurecr.io/test/provider/http@1.2.3'
-        ");
+provider 'br:example.azurecr.io/test/provider/http@1.2.3'
+");
         result.Should().NotHaveAnyDiagnostics();
         result.Template.Should().NotBeNull();
         result.Template.Should().DeepEqual(JToken.Parse("""
-        {
-        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-        "languageVersion": "2.1-experimental",
-        "contentVersion": "1.0.0.0",
-        "metadata": {
-            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
-            "_EXPERIMENTAL_FEATURES_ENABLED": [
-            "Extensibility"
-            ],
-            "_generator": {
-            "name": "bicep",
-            "version": "dev",
-            "templateHash": "14577456470128607958"
-            }
-        },
-        "imports": {
-            "http": {
-            "provider": "http",
-            "version": "1.2.3"
-            }
-        },
-        "resources": {}
-        }
-        """));
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Extensibility"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "14577456470128607958"
+    }
+  },
+  "imports": {
+    "http": {
+    "provider": "http",
+    "version": "1.2.3"
+    }
+  },
+  "resources": {}
+}
+"""));
     }
 
     [TestMethod]

--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -70,7 +70,6 @@ public static class RegistryHelper
     public static async Task PublishProviderToRegistryAsync(IDependencyHelper services, string target, BinaryData tgzData)
     {
         var dispatcher = services.Construct<IModuleDispatcher>();
-        var fileSystem = services.Construct<IFileSystem>();
 
         var targetReference = dispatcher.TryGetArtifactReference(ArtifactType.Provider, target, new Uri("file:///main.bicep")).Unwrap();
 

--- a/src/Bicep.Core.UnitTests/Utils/ThirdPartyTypeHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ThirdPartyTypeHelper.cs
@@ -13,7 +13,7 @@ using Azure.Bicep.Types.Serialization;
 namespace Bicep.Core.UnitTests.Utils;
 
 public static class ThirdPartyTypeHelper
-{
+{    
     /// <summary>
     /// Returns a .tgz file containing a set of pre-defined types for testing purposes.
     /// </summary>
@@ -37,13 +37,19 @@ public static class ThirdPartyTypeHelper
             ["properties"] = new(factory.GetReference(fooBodyPropertiesType), ObjectTypePropertyFlags.Required, "Resource properties"),
         }, null));
 
+        var barFunctionType = factory.Create(() => new FunctionType([ 
+            new FunctionParameter("bar", factory.GetReference(stringType), "The bar parameter"),
+        ], factory.GetReference(stringType)));
+
         var fooType = factory.Create(() => new ResourceType(
             "fooType@v1",
             ScopeType.Unknown,
             ScopeType.Unknown,
             factory.GetReference(fooBodyType),
             ResourceFlags.None,
-            null));
+            new Dictionary<string, ResourceTypeFunction>{
+                ["convertBarToBaz"] = new(factory.GetReference(barFunctionType), "Converts a bar into a baz!")
+            }));
 
         var index = new TypeIndex(new Dictionary<string, CrossFileTypeReference>
             {

--- a/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeLoader.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using Azure.Bicep.Types;
 using Azure.Bicep.Types.K8s;
 using Bicep.Core.Resources;
+using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem.Providers.ThirdParty;
 using Bicep.Core.TypeSystem.Types;
 

--- a/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ExtensibilityResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ExtensibilityResourceTypeFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System.Collections.Concurrent;
 using Bicep.Core.Resources;
+using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem.Types;
 
 namespace Bicep.Core.TypeSystem.Providers.ThirdParty
@@ -21,7 +22,49 @@ namespace Bicep.Core.TypeSystem.Providers.ThirdParty
             var resourceTypeReference = ResourceTypeReference.Parse(resourceType.Name);
             var bodyType = GetTypeSymbol(resourceType.Body.Type, true);
 
+            if (bodyType is ObjectType objectType && 
+                GetResourceFunctionOverloads(resourceType) is {} resourceFunctions &&
+                resourceFunctions.Any())
+            {
+                bodyType = new ObjectType(bodyType.Name, bodyType.ValidationFlags, objectType.Properties.Values, objectType.AdditionalPropertiesType, objectType.AdditionalPropertiesFlags, resourceFunctions);
+            }
+
             return new ResourceTypeComponents(resourceTypeReference, ToResourceScope(resourceType.ScopeType), ToResourceScope(resourceType.ReadOnlyScopes), ToResourceFlags(resourceType.Flags), bodyType);
+        }
+
+        private IEnumerable<FunctionOverload> GetResourceFunctionOverloads(Azure.Bicep.Types.Concrete.ResourceType resourceType)
+        {
+            if (resourceType.Functions is null)
+            {
+                yield break;
+            }
+
+            foreach (var (key, value) in resourceType.Functions)
+            {
+                if (value.Type.Type is not Azure.Bicep.Types.Concrete.FunctionType functionType)
+                {
+                    throw new ArgumentException();
+                }
+
+                var builder = new FunctionOverloadBuilder(key);
+                if (value.Description is {})
+                {
+                    builder = builder.WithDescription(value.Description);
+                }
+
+                var returnType = GetTypeSymbol(functionType.Output.Type, false);
+                builder = builder.WithReturnType(returnType);
+
+                foreach (var parameter in functionType.Parameters)
+                {
+                    var paramType = GetTypeSymbol(parameter.Type.Type, false);
+                    builder = builder.WithRequiredParameter(parameter.Name, paramType, parameter.Description ?? "");
+                }
+                
+                builder = builder.WithFlags(FunctionFlags.RequiresInlining);
+
+                yield return builder.Build();
+            }
         }
 
         private TypeSymbol GetTypeSymbol(Azure.Bicep.Types.Concrete.TypeBase serializedType, bool isResourceBodyType)

--- a/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ThirdPartyResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ThirdPartyResourceTypeProvider.cs
@@ -57,7 +57,7 @@ namespace Bicep.Core.TypeSystem.Providers.ThirdParty
                 isExistingResource ? ConvertToReadOnly(properties.Values) : properties.Values,
                 objectType.AdditionalPropertiesType,
                 isExistingResource ? ConvertToReadOnly(objectType.AdditionalPropertiesFlags) : objectType.AdditionalPropertiesFlags,
-                functions: null);
+                functions: objectType.MethodResolver.functionOverloads);
         }
 
         private static IEnumerable<TypeProperty> ConvertToReadOnly(IEnumerable<TypeProperty> properties)


### PR DESCRIPTION
This was an ask from the Radius team.

If a 3rd party provider exposes "functions" on resources, we will allow the user to consume them, as follows:
```bicep
provider 'br:example.azurecr.io/providers/foo@1.2.3'

resource fooRes 'fooType@v1' existing = {
  identifier: 'foo'
}

output baz string = fooRes.convertBarToBaz('bar')
```

This will result in the following code gen for the `baz` output value:
```
[invokeResourceMethod('fooRes', 'convertBarToBaz', createArray('bar'))]
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13433)