### PR TITLE
MAINT: Delegate span calculation to StringSyntax method

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
@@ -186,7 +186,7 @@ namespace Bicep.Core.UnitTests.Diagnostics
                 return new ProviderDeclarationSyntax(
                     Enumerable.Empty<SyntaxBase>(),
                     SyntaxFactory.ImportKeywordToken,
-                    SyntaxFactory.CreateStringLiteral("kubernetes@1.0.0"),
+                    SyntaxFactory.CreateStringLiteralForStringComplete("kubernetes@1.0.0"),
                     withClause: SyntaxFactory.EmptySkippedTrivia,
                     asClause: SyntaxFactory.EmptySkippedTrivia);
             }
@@ -209,7 +209,7 @@ namespace Bicep.Core.UnitTests.Diagnostics
             throw new AssertFailedException($"Unable to generate mock parameter value of type '{parameter.ParameterType}' for the diagnostic builder method.");
         }
 
-        private void ExpectDiagnosticWithFixedText(string text, string expectedText)
+        private static void ExpectDiagnosticWithFixedText(string text, string expectedText)
         {
             var result = CompilationHelper.Compile(text);
             result.Diagnostics.Should().HaveCount(1);

--- a/src/Bicep.Core.UnitTests/Syntax/ImportSpecificationTest.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/ImportSpecificationTest.cs
@@ -28,7 +28,7 @@ public class ImportSpecificationTests
     public void TestCreateFromStringSyntax(string input, bool isValidDeclaration, string expectedName = LanguageConstants.ErrorName)
     {
         // Arrange
-        var syntax = SyntaxFactory.CreateStringLiteral(input);
+        var syntax = SyntaxFactory.CreateStringLiteralForStringComplete(input);
         // Act
         var got = ImportSpecification.From(syntax);
         // Assert

--- a/src/Bicep.Core/Syntax/ImportSpecification.cs
+++ b/src/Bicep.Core/Syntax/ImportSpecification.cs
@@ -70,7 +70,7 @@ namespace Bicep.Core.Syntax
             if (BuiltInSpecificationPattern().Match(value) is { } builtInMatch && builtInMatch.Success)
             {
                 var name = builtInMatch.Groups["name"].Value;
-                var span = new TextSpan(stringSyntax.Span.Position + 1, name.Length);
+                var span = stringSyntax.GetInnerSpan();
                 var version = builtInMatch.Groups["version"].Value;
                 // built-in providers (e.g. kubernetes@1.0.0 or sys@1.0.0) are allowed as long as the name is not 'az'
                 return new(name, version, null, span, isValid: name != AzNamespaceType.BuiltInName);
@@ -82,7 +82,7 @@ namespace Bicep.Core.Syntax
                 var address = registryMatch.Groups["address"].Value;
                 var version = registryMatch.Groups["version"].Value;
 
-                var span = new TextSpan(stringSyntax.Span.Position + 1, address.Length);
+                var span = stringSyntax.GetInnerSpan();
                 // NOTE(asilverman): I normalize the artifact address to the way we represent module addresses, see https://github.com/Azure/bicep/issues/12202
                 var unexpandedArtifactAddress = $"{address}:{version}";
                 var name = RepositoryNamePattern().Match(address).Groups["name"].Value;

--- a/src/Bicep.Core/Syntax/StringSyntax.cs
+++ b/src/Bicep.Core/Syntax/StringSyntax.cs
@@ -25,5 +25,13 @@ namespace Bicep.Core.Syntax
 
         public override TextSpan Span
             => TextSpan.Between(StringTokens.First(), StringTokens.Last());
+
+        public TextSpan GetInnerSpan()
+        {
+            var skipChars = StringTokens.First().Type == TokenType.MultilineString ? 3 : 1;
+            var outerSpan = Span;
+
+            return new(outerSpan.Position + skipChars, outerSpan.Length - (skipChars * 2));
+        }
     }
 }

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -214,7 +214,10 @@ namespace Bicep.Core.Syntax
             }
         }
 
-        public static StringSyntax CreateStringLiteral(string value) => CreateString(value.AsEnumerable(), Enumerable.Empty<SyntaxBase>());
+        public static StringSyntax CreateStringLiteral(string value) => CreateString(value.AsEnumerable(), []);
+
+        public static StringSyntax CreateStringLiteralForStringComplete(string value)
+            => new(new FreeformToken(TokenType.StringComplete, new TextSpan(0, value.Length), value, [], []).AsEnumerable(), [], [value]);
 
         public static BooleanLiteralSyntax CreateBooleanLiteral(bool value) => new(value ? TrueKeywordToken : FalseKeywordToken, value);
 


### PR DESCRIPTION
## Description

Delegates the calculation of the InnerSpan of a string to a StringSyntax method to account for multiline strings.