### PR TITLE
Handle single-member unions imported from JSON templates

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -5760,4 +5760,41 @@ var startAndEndBracketInString = 'x[]y'
 
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
+
+    [TestMethod]
+    public void Test_Issue13462()
+    {
+        var result = CompilationHelper.Compile(
+            ("main.bicep", """
+                import { bar } from 'main-depend.json'
+
+                param parameter bar
+                """),
+            ("main-depend.json", """
+                {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "definitions": {
+                    "bar": {
+                      "type": "object",
+                      "properties": {
+                        "foo": {
+                          "type": "string",
+                          "allowedValues": [
+                            "foo"
+                          ]
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    }
+                  },
+                  "resources": {}
+                }
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
 }


### PR DESCRIPTION
Potentially a resolution to #13462 

When importing a type from an ARM template, we convert the ARM schema into a Bicep IR representation so that it can be injected into the importing template. This conversion process didn't account for scenarios where the ARM `allowedValues` constraint was present but only allows a single value, which the Bicep type system converts to a singular literal type rather than a union.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13464)