### PR TITLE
Support loading source dynamically for nested external modules

### DIFF
--- a/src/Bicep.Cli/Commands/PublishCommand.cs
+++ b/src/Bicep.Cli/Commands/PublishCommand.cs
@@ -93,7 +93,7 @@ namespace Bicep.Cli.Commands
 
                 await ioContext.Output.WriteLineAsync(string.Format(CliResources.ExperimentalFeaturesDisclaimerMessage, PublishSourceFeatureName));
 
-                sourcesStream = SourceArchive.PackSourcesIntoStream(compilation.SourceFileGrouping, features.CacheRootDirectory);
+                sourcesStream = SourceArchive.PackSourcesIntoStream(moduleDispatcher, compilation.SourceFileGrouping, features.CacheRootDirectory);
                 Trace.WriteLine("Publishing Bicep module with source");
             }
             else

--- a/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Bicep.Core.Extensions;
+using Bicep.Core.Registry;
+using Bicep.Core.SourceCode;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Features;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Workspaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+
+namespace Bicep.Core.IntegrationTests
+{
+    [TestClass]
+    public class SourceArchiveTests : TestBase
+    {
+        #region Helpers
+
+        [NotNull]
+        private string? CacheRoot { get; set; }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            CacheRoot = FileHelper.GetUniqueTestOutputPath(TestContext);
+        }
+
+        private ServiceBuilder GetServices(IContainerRegistryClientFactory clientFactory)
+        {
+            Directory.CreateDirectory(CacheRoot);
+
+            var services = new ServiceBuilder()
+                .WithFeatureOverrides(new(CacheRootDirectory: CacheRoot, OptionalModuleNamesEnabled: true))
+                .WithContainerRegistryClientFactory(clientFactory);
+
+            return services;
+        }
+
+        private IModuleDispatcher GetModuleDispatcher(IContainerRegistryClientFactory clientFactory)
+        {
+            var featureProviderFactory = BicepTestConstants.CreateFeatureProviderFactory(new FeatureProviderOverrides(PublishSourceEnabled: true, CacheRootDirectory: CacheRoot));
+            var dispatcher = ServiceBuilder.Create(s => s.WithDisabledAnalyzersConfiguration()
+                .AddSingleton(clientFactory)
+                .AddSingleton(BicepTestConstants.TemplateSpecRepositoryFactory)
+                .AddSingleton(featureProviderFactory)
+                ).Construct<IModuleDispatcher>();
+            return dispatcher;
+        }
+
+        private async Task PublishModule(IContainerRegistryClientFactory clientFactory, string target, string source, bool withSource)
+        {
+            await RegistryHelper.PublishModuleToRegistry(
+                  clientFactory,
+                  target.Substring(target.LastIndexOf('/')),
+                  target,
+                  source,
+                  publishSource: withSource);
+        }
+
+        private string[] Extract(string s, Regex regex, params string[] groupNamesToExtract)
+        {
+            var match = regex.Match(s);
+            match.Should().NotBeNull();
+
+            return groupNamesToExtract.SelectArray(group => match.Groups[group].Value);
+        }
+
+        private async Task<IContainerRegistryClientFactory> PublishModules(params (string target, string source, bool withSource)[] modules)
+        {
+            var repos = new List<(string registry, string repo)>();
+
+            foreach (var module in modules)
+            {
+                var (registry, repo) = Extract(
+                    module.target,
+                    new Regex("br:(?<registry>.+?)/(?<repo>.+?)[:@](?<tag>.+?)"),
+                    "registry",
+                    "repo");
+
+                if (!repos.Contains((registry, repo)))
+                {
+                    repos.Add((registry, repo));
+                }
+            }
+
+            var clientFactory = RegistryHelper.CreateMockRegistryClients(repos.ToArray()).factoryMock;
+
+            foreach (var module in modules)
+            {
+                await PublishModule(
+                      clientFactory,
+                      module.target,
+                      module.source,
+                      module.withSource);
+            }
+
+            return clientFactory;
+        }
+
+        private SourceArchive CreateSourceArchive(IModuleDispatcher moduleDispatcher, CompilationHelper.CompilationResult result)
+        {
+            return CreateSourceArchive(moduleDispatcher, result.Compilation.SourceFileGrouping);
+        }
+
+        private SourceArchive CreateSourceArchive(IModuleDispatcher moduleDispatcher, SourceFileGrouping sourceFileGrouping)
+        {
+            return SourceArchive.UnpackFromStream(
+                SourceArchive.PackSourcesIntoStream(
+                    moduleDispatcher,
+                    sourceFileGrouping,
+                    CacheRoot))
+                .UnwrapOrThrow();
+        }
+
+#endregion
+
+        [TestMethod]
+        public async Task SourceArtifactId_ForLocalModules_ShouldBeNull()
+        {
+            var clientFactory = await PublishModules(Array.Empty<(string, string, bool)>());
+            var moduleDispatcher = GetModuleDispatcher(clientFactory);
+            var result = await CompilationHelper.RestoreAndCompile(
+                GetServices(clientFactory),
+                ("main.bicep", """
+                    module local1 'local.bicep' = {
+                        params: {
+                            p1: 'hello'
+                      }
+                    }
+                    module local2 './modules/local.bicep' = {
+                        params: {
+                            p2: 'there'
+                      }
+                    }
+                    """),
+                ("local.bicep", """
+                    param p1 string
+                    """),
+                ("./modules/local.bicep", """
+                    param p2 string
+                    """));
+            result.Should().NotHaveAnyDiagnostics();
+
+            // act
+            var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
+
+            sourceArchive.FindExpectedSourceFile("local.bicep").SourceArtifactId.Should().BeNull();
+            sourceArchive.FindExpectedSourceFile("modules/local.bicep").SourceArtifactId.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task SourceArtifactId_ForExternalModulesWithoutSource_ShouldBeNull()
+        {
+            var clientFactory = await PublishModules(
+                new[] {
+                    ("br:mockregistry.io/test/module1:v1", "param p1 bool", withSource: false),
+                });
+            var moduleDispatcher = GetModuleDispatcher(clientFactory);
+            var result = await CompilationHelper.RestoreAndCompile(
+                GetServices(clientFactory),
+                ("main.bicep", """
+                    module m1 'br:mockregistry.io/test/module1:v1' = {
+                        params: {
+                            p1: true
+                      }
+                    }
+                    """));
+            result.Should().NotHaveAnyDiagnostics();
+
+            // act
+            var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
+
+            var file = sourceArchive.FindExpectedSourceFile("<cache>/br/mockregistry.io/test$module1/v1$/main.json");
+            file.SourceArtifactId.Should().BeNull();
+            file.Kind.Should().Be("armTemplate");
+        }
+
+        [TestMethod]
+        public async Task SourceArtifactId_ForExternalModulesWithSource_ShouldBeTheArtifactId()
+        {
+            var clientFactory = await PublishModules(
+                new[] {
+                    ("br:mockregistry.io/test/module1:v1", "param p1 bool", withSource: true),
+                });
+            var moduleDispatcher = GetModuleDispatcher(clientFactory);
+            var result = await CompilationHelper.RestoreAndCompile(
+                GetServices(clientFactory),
+                ("main.bicep", """
+                    module m1 'br:mockregistry.io/test/module1:v1' = {
+                        params: {
+                            p1: true
+                      }
+                    }
+                    """));
+            result.Should().NotHaveAnyDiagnostics();
+
+            // act
+            var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
+
+            var file = sourceArchive.FindExpectedSourceFile("<cache>/br/mockregistry.io/test$module1/v1$/main.json");
+            file.SourceArtifactId.Should().Be("br:mockregistry.io/test/module1:v1");
+            file.Kind.Should().Be("armTemplate");
+
+        }
+
+        [TestMethod]
+        public async Task SourceArtifactId_ShouldHandleMultipleRefsToSameModule()
+        {
+            var clientFactory = await PublishModules(
+                new[] {
+                    ("br:mockregistry.io/test/module1:v1", "param p1 bool", withSource: true),
+                    ("br:mockregistry.io/test/module2:v1", "param p2 string", withSource: true),
+                    ("br:mockregistry.io/test/module1:v2", "param p12 string", withSource: true),
+                });
+            var moduleDispatcher = GetModuleDispatcher(clientFactory);
+            var result = await CompilationHelper.RestoreAndCompile(
+                GetServices(clientFactory),
+                ("main.bicep", """
+                    module m1 'br:mockregistry.io/test/module1:v1' = {
+                        params: {
+                            p1: true
+                      }
+                    }
+
+                    module m1b 'br:mockregistry.io/test/module1:v1' = {
+                        params: {
+                            p1: false
+                      }
+                    }
+                    
+                    module local 'local.bicep' = {
+                        params: {
+                            p2: 'there'
+                      }
+                    }
+
+                    module local2 'local.bicep' = {
+                        params: {
+                            p2: 'there'
+                      }
+                    }
+
+                    module m12 'br:mockregistry.io/test/module1:v2' = {
+                        params: {
+                            p12: 'p12'
+                      }
+                    }
+                    """),
+                ("local.bicep", """
+                    param p2 string
+
+                    module m1 'br:mockregistry.io/test/module1:v1' = {
+                        params: {
+                            p1: true
+                      }
+                    }
+                    module m2 'br:mockregistry.io/test/module2:v1' = {
+                        params: {
+                            p2: 'p2'
+                      }
+                    }
+                    module m12 'br:mockregistry.io/test/module1:v2' = {
+                        params: {
+                            p12: 'p12'
+                      }
+                    }
+                    """));
+            result.Should().NotHaveAnyDiagnostics();
+
+            // act
+            var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
+
+            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifactId))
+                .Should().BeEquivalentTo(new[] {
+                    ("main.bicep", null),
+                    ("<cache>/br/mockregistry.io/test$module1/v1$/main.json", "br:mockregistry.io/test/module1:v1"),
+                    ("<cache>/br/mockregistry.io/test$module1/v2$/main.json", "br:mockregistry.io/test/module1:v2"),
+                    ("<cache>/br/mockregistry.io/test$module2/v1$/main.json", "br:mockregistry.io/test/module2:v1"),
+                    ("local.bicep", null)
+            });
+        }
+
+        [TestMethod]
+        public async Task SourceArtifactId_ShouldIgnoreModuleRefsWithErrors()
+        {
+            var clientFactory = await PublishModules(
+                new[] {
+                    ("br:mockregistry.io/test/module1:v1", "param p1 bool", withSource: true),
+                });
+            var moduleDispatcher = GetModuleDispatcher(clientFactory);
+            var result = await CompilationHelper.RestoreAndCompile(
+                GetServices(clientFactory),
+                ("main.bicep", """
+                    module m1 'br:mockregistry.io/test/module1:v1' = {
+                        params: {
+                            p1: true
+                      }
+                    }
+
+                    module m2 'br:mockregistry.io/test/module2:v1' = { // not found
+                        params: {
+                            p1: true
+                      }
+                    }
+                    """));
+            result.Should().OnlyContainDiagnostic("BCP192", Diagnostics.DiagnosticLevel.Error, "Unable to restore the artifact with reference \"br:mockregistry.io/test/module2:v1\"*");
+
+            // act
+            var sourceArchive = CreateSourceArchive(moduleDispatcher,result);
+
+            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifactId))
+                .Should().BeEquivalentTo(new[] {
+                    ("main.bicep", null),
+                    ("<cache>/br/mockregistry.io/test$module1/v1$/main.json", "br:mockregistry.io/test/module1:v1"),
+            });
+        }
+    }
+}
+

--- a/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
@@ -205,7 +205,7 @@ namespace Bicep.Core.IntegrationTests
             var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
 
             var file = sourceArchive.FindExpectedSourceFile("<cache>/br/mockregistry.io/test$module1/v1$/main.json");
-            file.SourceArtifact!.ArtifactId.Should().Be("br:mockregistry.io/test/module1:v1");
+            file.SourceArtifact!.FullyQualifiedReference.Should().Be("br:mockregistry.io/test/module1:v1");
             file.Kind.Should().Be("armTemplate");
 
         }
@@ -277,7 +277,7 @@ namespace Bicep.Core.IntegrationTests
             // act
             var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
 
-            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifact?.ArtifactId))
+            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifact?.FullyQualifiedReference))
                 .Should().BeEquivalentTo(new[] {
                     ("main.bicep", null),
                     ("<cache>/br/mockregistry.io/test$module1/v1$/main.json", "br:mockregistry.io/test/module1:v1"),
@@ -315,7 +315,7 @@ namespace Bicep.Core.IntegrationTests
             // act
             var sourceArchive = CreateSourceArchive(moduleDispatcher,result);
 
-            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifact?.ArtifactId))
+            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifact?.FullyQualifiedReference))
                 .Should().BeEquivalentTo(new[] {
                     ("main.bicep", null),
                     ("<cache>/br/mockregistry.io/test$module1/v1$/main.json", "br:mockregistry.io/test/module1:v1"),

--- a/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
@@ -151,8 +151,8 @@ namespace Bicep.Core.IntegrationTests
             // act
             var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
 
-            sourceArchive.FindExpectedSourceFile("local.bicep").SourceArtifactId.Should().BeNull();
-            sourceArchive.FindExpectedSourceFile("modules/local.bicep").SourceArtifactId.Should().BeNull();
+            sourceArchive.FindExpectedSourceFile("local.bicep").SourceArtifact.Should().BeNull();
+            sourceArchive.FindExpectedSourceFile("modules/local.bicep").SourceArtifact.Should().BeNull();
         }
 
         [TestMethod]
@@ -178,7 +178,7 @@ namespace Bicep.Core.IntegrationTests
             var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
 
             var file = sourceArchive.FindExpectedSourceFile("<cache>/br/mockregistry.io/test$module1/v1$/main.json");
-            file.SourceArtifactId.Should().BeNull();
+            file.SourceArtifact.Should().BeNull();
             file.Kind.Should().Be("armTemplate");
         }
 
@@ -205,7 +205,7 @@ namespace Bicep.Core.IntegrationTests
             var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
 
             var file = sourceArchive.FindExpectedSourceFile("<cache>/br/mockregistry.io/test$module1/v1$/main.json");
-            file.SourceArtifactId.Should().Be("br:mockregistry.io/test/module1:v1");
+            file.SourceArtifact!.ArtifactId.Should().Be("br:mockregistry.io/test/module1:v1");
             file.Kind.Should().Be("armTemplate");
 
         }
@@ -277,7 +277,7 @@ namespace Bicep.Core.IntegrationTests
             // act
             var sourceArchive = CreateSourceArchive(moduleDispatcher, result);
 
-            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifactId))
+            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifact?.ArtifactId))
                 .Should().BeEquivalentTo(new[] {
                     ("main.bicep", null),
                     ("<cache>/br/mockregistry.io/test$module1/v1$/main.json", "br:mockregistry.io/test/module1:v1"),
@@ -315,7 +315,7 @@ namespace Bicep.Core.IntegrationTests
             // act
             var sourceArchive = CreateSourceArchive(moduleDispatcher,result);
 
-            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifactId))
+            sourceArchive.SourceFiles.Select(sf => (sf.Path, sf.SourceArtifact?.ArtifactId))
                 .Should().BeEquivalentTo(new[] {
                     ("main.bicep", null),
                     ("<cache>/br/mockregistry.io/test$module1/v1$/main.json", "br:mockregistry.io/test/module1:v1"),

--- a/src/Bicep.Core.Samples/MockRegistry.cs
+++ b/src/Bicep.Core.Samples/MockRegistry.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Oci;
 using Bicep.Core.UnitTests.Baselines;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
@@ -31,7 +32,7 @@ public class MockRegistry
         var index = registryFiles.First(x => x.StreamPath == "Files/mockregistry/index.json").Contents.FromJson<MockRegistryIndex>();
 
         var modules = new Dictionary<string, DataSet.ExternalModuleInfo>();
-        foreach (var (registryPath, filePath) in index.modules.Where(x => x.Key.StartsWith("br:")))
+        foreach (var (registryPath, filePath) in index.modules.Where(x => x.Key.StartsWith(OciArtifactReferenceFacts.SchemeWithColon)))
         {
             var sourceFile = registryFiles.First(x => x.StreamPath == $"Files/mockregistry/{filePath}");
 

--- a/src/Bicep.Core.UnitTests/Assertions/DiagnosticAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/DiagnosticAssertions.cs
@@ -98,12 +98,15 @@ namespace Bicep.Core.UnitTests.Assertions
             return new AndConstraint<DiagnosticAssertions>(this);
         }
 
+        // "*abc" means the message should end with "abc"
+        // "abc*" means the message should start with "abc"
+        // "*abc*" means the message should contain "abc"
         public AndConstraint<DiagnosticAssertions> HaveMessage(string message, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .Given<string>(() => Subject.Message)
-                .ForCondition(x => x == message)
+                .ForCondition(x => DiagnosticMessageMatches(x, message))
                 .FailWith("Expected message to be {0}{reason} but it was {1}", _ => message, x => x);
 
             return new AndConstraint<DiagnosticAssertions>(this);
@@ -119,5 +122,26 @@ namespace Bicep.Core.UnitTests.Assertions
 
             return new AndConstraint<DiagnosticAssertions>(this);
         }
+
+        public static bool DiagnosticMessageMatches(string message, string expectedMessage)
+        {
+            if (expectedMessage.StartsWith('*') && expectedMessage.EndsWith('*'))
+            {
+                return message.Contains(message.Substring(1, message.Length - 2));
+            }
+            else if (expectedMessage.StartsWith('*'))
+            {
+                return message.EndsWith(expectedMessage.Substring(1));
+            }
+            else if (expectedMessage.EndsWith('*'))
+            {
+                return message.StartsWith(expectedMessage.Substring(0, expectedMessage.Length - 1));
+            }
+            else
+            {
+                return message == expectedMessage;
+            }
+        }
+
     }
 }

--- a/src/Bicep.Core.UnitTests/Assertions/IDiagnosticCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/IDiagnosticCollectionExtensions.cs
@@ -30,7 +30,7 @@ namespace Bicep.Core.UnitTests.Assertions
 
         public AndConstraint<IDiagnosticCollectionAssertions> ContainDiagnostic(string code, DiagnosticLevel level, string message, string because = "", params object[] becauseArgs)
         {
-            AssertionExtensions.Should(Subject).Contain(x => x.Code == code && x.Level == level && x.Message == message, because, becauseArgs);
+            AssertionExtensions.Should(Subject).Contain(x => x.Code == code && x.Level == level && DiagnosticAssertions.DiagnosticMessageMatches(x.Message, message), because, becauseArgs);
 
             return new AndConstraint<IDiagnosticCollectionAssertions>(this);
         }
@@ -44,14 +44,14 @@ namespace Bicep.Core.UnitTests.Assertions
 
         public AndConstraint<IDiagnosticCollectionAssertions> ContainSingleDiagnostic(string code, DiagnosticLevel level, string message, string because = "", params object[] becauseArgs)
         {
-            AssertionExtensions.Should(Subject).ContainSingle(x => x.Code == code && x.Level == level && x.Message == message, because, becauseArgs);
+            AssertionExtensions.Should(Subject).ContainSingle(x => x.Code == code && x.Level == level && DiagnosticAssertions.DiagnosticMessageMatches(x.Message, message), because, becauseArgs);
 
             return new AndConstraint<IDiagnosticCollectionAssertions>(this);
         }
 
         public AndConstraint<IDiagnosticCollectionAssertions> NotHaveAnyDiagnostics(string because = "", params object[] becauseArgs)
         {
-            AssertionExtensions.Should(Subject).BeEmpty();
+            AssertionExtensions.Should(Subject).BeEmpty(because, becauseArgs);
             return new AndConstraint<IDiagnosticCollectionAssertions>(this);
         }
 

--- a/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
@@ -152,7 +152,7 @@ namespace Bicep.Core.UnitTests.Modules
         [DataTestMethod]
         public void InvalidReferencesShouldProduceExpectedError(string value, string expectedCode, string expectedError)
         {
-            OciArtifactReference.TryParseModule(null, value, BicepTestConstants.BuiltInConfigurationWithAllAnalyzersDisabled, RandomFileUri()).IsSuccess(out var @ref, out var failureBuilder).Should().BeFalse();
+            OciArtifactReference.TryParseModuleAndAlias(null, value, BicepTestConstants.BuiltInConfigurationWithAllAnalyzersDisabled, RandomFileUri()).IsSuccess(out var @ref, out var failureBuilder).Should().BeFalse();
             @ref.Should().BeNull();
             failureBuilder!.Should().NotBeNull();
 

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -9,7 +9,6 @@ using Bicep.Core.SourceCode;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
-using Bicep.Core.Workspaces;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -662,8 +661,9 @@ namespace Bicep.Core.UnitTests.Registry
             if (publishSource)
             {
                 var uri = new Uri("file://path/to/bicep.bicep", UriKind.Absolute);
-                var stream = SourceArchive.PackSourcesIntoStream(uri, cacheRoot: null, new ISourceFile[] { SourceFileFactory.CreateBicepFile(uri, "// contents") });
-                sources = BinaryData.FromStream(stream);
+                sources = new SourceArchiveBuilder()
+                    .WithBicepFile(uri, "// contents")
+                    .BuildBinaryData();
             }
 
             await ociRegistry.PublishModule(moduleReference, template, sources, "http://documentation", "description");

--- a/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
@@ -13,6 +13,7 @@ using Bicep.Core.Workspaces;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+using static Bicep.Core.SourceCode.SourceArchive;
 
 namespace Bicep.Core.UnitTests.SourceCode;
 
@@ -121,24 +122,40 @@ public class SourceArchiveTests
         }
     }";
 
-    private ISourceFile CreateSourceFile(MockFileSystem fs, string path, string sourceKind, string content)
+    private const string ExternalModuleDotJsonSource = @"{
+        // external module json
+        ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+        ""contentVersion"": ""1.0.0.0"",
+        ""resources"": [],
+        ""parameters"": {
+            ""stringParam"": {
+                ""type"": ""string""
+            }
+        }
+    }";
+
+    private SourceFileWithArtifactReference CreateSourceFile(MockFileSystem fs, string path, string sourceKind, string content, string? artifactReference = null)
     {
-        return CreateSourceFile(fs, null, path, sourceKind, content);
+        return CreateSourceFile(fs, null, path, sourceKind, content, artifactReference);
     }
 
-    private ISourceFile CreateSourceFile(MockFileSystem fs, Uri? projectFolderUri, string relativePath, string sourceKind, string content)
+    private SourceFileWithArtifactReference CreateSourceFile(MockFileSystem fs, Uri? projectFolderUri, string relativePath, string sourceKind, string content, string? artifactReferenceId = null)
     {
+        var artifactReference = artifactReferenceId is null ? null : OciRegistryHelper.CreateModuleReference(artifactReferenceId);
         projectFolderUri?.AbsolutePath.Should().EndWith("/");
         Uri uri = projectFolderUri is null ? PathHelper.FilePathToFileUrl(relativePath) : PathHelper.FilePathToFileUrl(Path.Combine(projectFolderUri.LocalPath, relativePath));
         fs.AddFile(uri.LocalPath, content);
         string actualContents = fs.File.ReadAllText(uri.LocalPath);
-        return sourceKind switch
-        {
-            SourceArchive.SourceKind_ArmTemplate => SourceFileFactory.CreateArmTemplateFile(uri, actualContents),
-            SourceArchive.SourceKind_Bicep => SourceFileFactory.CreateSourceFile(uri, actualContents),
-            SourceArchive.SourceKind_TemplateSpec => SourceFileFactory.CreateTemplateSpecFile(uri, actualContents),
-            _ => throw new Exception($"Unrecognized source kind: {sourceKind}")
-        };
+
+        return new SourceFileWithArtifactReference(
+            sourceKind switch
+            {
+                SourceArchive.SourceKind_ArmTemplate => SourceFileFactory.CreateArmTemplateFile(uri, actualContents),
+                SourceArchive.SourceKind_Bicep => SourceFileFactory.CreateSourceFile(uri, actualContents),
+                SourceArchive.SourceKind_TemplateSpec => SourceFileFactory.CreateTemplateSpecFile(uri, actualContents),
+                _ => throw new Exception($"Unrecognized source kind: {sourceKind}")
+            },
+            artifactReference);
     }
 
     [TestMethod]
@@ -154,10 +171,13 @@ public class SourceArchiveTests
         var templateSpecMainJson = CreateSourceFile(fs, projectFolder, "Template spec 1.json", SourceArchive.SourceKind_TemplateSpec, TemplateSpecJsonSource);
         var localModuleJson = CreateSourceFile(fs, projectFolder, "localModule.json", SourceArchive.SourceKind_ArmTemplate, LocalModuleDotJsonSource);
         var templateSpecMainJson2 = CreateSourceFile(fs, projectFolder, "folder/template spec 2.json", SourceArchive.SourceKind_TemplateSpec, TemplateSpecJsonSource);
+        var externalModuleJson = CreateSourceFile(fs, $"{CacheRoot}/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
+                SourceArchive.SourceKind_ArmTemplate /* the actual source archived is the compiled JSON */, ExternalModuleDotJsonSource, "mcr.microsoft.com/bicep/storage/storage-account:1.0.1");
+
 
         using var stream = SourceArchive.PackSourcesIntoStream(
-            mainBicep.FileUri,
-            CacheRoot, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, templateSpecMainJson2);
+            mainBicep.SourceFile.FileUri,
+            CacheRoot, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, templateSpecMainJson2, externalModuleJson);
         stream.Length.Should().BeGreaterThan(0);
 
         SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
@@ -168,10 +188,12 @@ public class SourceArchiveTests
         archivedFiles.Should().BeEquivalentTo(
             new SourceArchive.SourceFileInfo[] {
                 // Note: the template spec files will be filtered out
-                new ("main.bicep", "files/main.bicep", SourceArchive.SourceKind_Bicep, MainDotBicepSource),
-                new ("main.json", "files/main.json", SourceArchive.SourceKind_ArmTemplate, MainDotJsonSource ),
-                new ("standalone.json", "files/standalone.json", SourceArchive.SourceKind_ArmTemplate, StandaloneJsonSource),
-                new ("localModule.json", "files/localModule.json", SourceArchive.SourceKind_ArmTemplate,  LocalModuleDotJsonSource),
+                new ("main.bicep", "files/main.bicep", SourceArchive.SourceKind_Bicep, MainDotBicepSource, null),
+                new ("main.json", "files/main.json", SourceArchive.SourceKind_ArmTemplate, MainDotJsonSource, null),
+                new ("standalone.json", "files/standalone.json", SourceArchive.SourceKind_ArmTemplate, StandaloneJsonSource, null),
+                new ("localModule.json", "files/localModule.json", SourceArchive.SourceKind_ArmTemplate,  LocalModuleDotJsonSource, null),
+                new ("<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json", "files/_cache_/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
+                    SourceArchive.SourceKind_ArmTemplate, ExternalModuleDotJsonSource, "br:mcr.microsoft.com/bicep/storage/storage-account:1.0.1"),
             });
     }
 
@@ -187,6 +209,8 @@ public class SourceArchiveTests
         var templateSpecMainJson = CreateSourceFile(fs, projectFolder, "cache/wherever/template spec 1.json", SourceArchive.SourceKind_TemplateSpec, TemplateSpecJsonSource);
         var localModuleJson = CreateSourceFile(fs, projectFolder, "modules/localJsonModule.json", SourceArchive.SourceKind_ArmTemplate, LocalModuleDotJsonSource);
         var localModuleBicep = CreateSourceFile(fs, projectFolder, "modules/localBicepModule.bicep", SourceArchive.SourceKind_ArmTemplate, LocalModuleDotJsonSource);
+        var externalModuleJson = CreateSourceFile(fs, $"{CacheRoot}/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
+            SourceArchive.SourceKind_ArmTemplate, ExternalModuleDotJsonSource, "mcr.microsoft.com/bicep/storage/storage-account:1.0.1");
 
         var linksInput = new Dictionary<Uri, SourceCodeDocumentUriLink[]>()
         {
@@ -196,6 +220,7 @@ public class SourceArchiveTests
                 {
                     new(new SourceCodeRange(1, 2, 1, 3), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/modules/localJsonModule.json")),
                     new(new SourceCodeRange(11, 2, 11, 3), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/modules/localBicepModule.bicep")),
+                    new(new SourceCodeRange(12, 45, 23, 56), PathHelper.FilePathToFileUrl($"{CacheRoot}/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json")),
                 }
             },
             {
@@ -208,10 +233,11 @@ public class SourceArchiveTests
                     new(new SourceCodeRange(1234, 4567, 2345, 5678), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/wherever/template spec 1.json")),
                     new(new SourceCodeRange(345, 2, 345, 3), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/modules/localJsonModule.json")),
                     new(new SourceCodeRange(12, 45, 23, 56), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/wherever/template spec 1.json")),
+                    new(new SourceCodeRange(12, 45, 23, 56), PathHelper.FilePathToFileUrl($"{CacheRoot}/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json")),
                 }
             },
             {
-                // Shouldn't be possible to hav a template spec file as the source, but still test that it's filtered out
+                // Shouldn't be possible to have a template spec file as the source, but still test that it's filtered out
                 PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/wherever/template spec 1.json"),
                 new SourceCodeDocumentUriLink[]
                 {
@@ -221,10 +247,11 @@ public class SourceArchiveTests
                     new(new SourceCodeRange(1234, 4567, 2345, 5678), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/cache/wherever/template spec 1.json")),
                     new(new SourceCodeRange(345, 2, 345, 3), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/modules/localJsonModule.json")),
                     new(new SourceCodeRange(12, 45, 23, 56), PathHelper.FilePathToFileUrl($"{ROOT}my project/my sources/cache/wherever/template spec 1.json")),
+                    new(new SourceCodeRange(12, 45, 23, 56), PathHelper.FilePathToFileUrl($"{CacheRoot}/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json")),
                 }
             },
         };
-        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.FileUri, CacheRoot, linksInput, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, localModuleBicep);
+        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.SourceFile.FileUri, CacheRoot, linksInput, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, localModuleBicep, externalModuleJson);
         stream.Length.Should().BeGreaterThan(0);
 
         SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).TryUnwrap();
@@ -241,6 +268,7 @@ public class SourceArchiveTests
                 {
                     new(new SourceCodeRange(1, 2, 1, 3), "modules/localJsonModule.json"),
                     new(new SourceCodeRange(11, 2, 11, 3), "modules/localBicepModule.bicep"),
+                    new(new SourceCodeRange(12, 45, 23, 56), "<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json"),
                 }
             },
             {
@@ -251,6 +279,7 @@ public class SourceArchiveTests
                     new(new SourceCodeRange(234, 235, 345, 346), "main.json"),
                     new(new SourceCodeRange(123, 456, 234, 567), "main&.bicep"),
                     new(new SourceCodeRange(345, 2, 345, 3), "modules/localJsonModule.json"),
+                    new(new SourceCodeRange(12, 45, 23, 56), "<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json"),
                 }
             },
         };
@@ -403,7 +432,7 @@ public class SourceArchiveTests
         }
         var files = inputPaths.Select(path => CreateSourceFile(fs, path, SourceArchive.SourceKind_Bicep, $"// {path}")).ToArray();
 
-        using var stream = SourceArchive.PackSourcesIntoStream(files[0].FileUri, CacheRoot, files);
+        using var stream = SourceArchive.PackSourcesIntoStream(files[0].SourceFile.FileUri, CacheRoot, files);
         SourceArchive sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
 
         sourceArchive.EntrypointRelativePath.Should().Be(expectedPaths[0], "entrypoint path should be correct");
@@ -417,7 +446,7 @@ public class SourceArchiveTests
 
         for (int i = 0; i < inputPaths.Length; ++i)
         {
-            var archivedTestFile = sourceArchive.SourceFiles.Single(f => f.Contents.Equals(files[i].GetOriginalSource()));
+            var archivedTestFile = sourceArchive.SourceFiles.Single(f => f.Contents.Equals(files[i].SourceFile.GetOriginalSource()));
             archivedTestFile.Path.Should().Be(expectedPaths[i]);
             archivedTestFile.ArchivePath.Should().Be(expectedArchivePaths[i]);
         }
@@ -465,8 +494,8 @@ public class SourceArchiveTests
         var sutFile3 = inputBicepPath3 is null ? null : CreateSourceFile(fs, rootBicepFolder, inputBicepPath3, SourceArchive.SourceKind_Bicep, SecondaryDotBicepSource);
 
         using var stream = sutFile3 is null ?
-            SourceArchive.PackSourcesIntoStream(entrypointFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2) :
-            SourceArchive.PackSourcesIntoStream(entrypointFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2, sutFile3);
+            SourceArchive.PackSourcesIntoStream(entrypointFile.SourceFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2) :
+            SourceArchive.PackSourcesIntoStream(entrypointFile.SourceFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2, sutFile3);
 
         SourceArchive sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
 

--- a/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/SourceArchiveTests.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions.TestingHelpers;
 using System.IO.Compression;
 using System.Text;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry.Oci;
 using Bicep.Core.SourceCode;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
@@ -141,7 +142,7 @@ public class SourceArchiveTests
 
     private SourceFileWithArtifactReference CreateSourceFile(MockFileSystem fs, Uri? projectFolderUri, string relativePath, string sourceKind, string content, string? artifactReferenceId = null)
     {
-        var artifactReference = artifactReferenceId is null ? null : OciRegistryHelper.CreateModuleReference(artifactReferenceId);
+        var artifactReference = artifactReferenceId is null ? null : OciRegistryHelper.ParseModuleReference(artifactReferenceId);
         projectFolderUri?.AbsolutePath.Should().EndWith("/");
         Uri uri = projectFolderUri is null ? PathHelper.FilePathToFileUrl(relativePath) : PathHelper.FilePathToFileUrl(Path.Combine(projectFolderUri.LocalPath, relativePath));
         fs.AddFile(uri.LocalPath, content);
@@ -193,7 +194,7 @@ public class SourceArchiveTests
                 new ("standalone.json", "files/standalone.json", SourceArchive.SourceKind_ArmTemplate, StandaloneJsonSource, null),
                 new ("localModule.json", "files/localModule.json", SourceArchive.SourceKind_ArmTemplate,  LocalModuleDotJsonSource, null),
                 new ("<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json", "files/_cache_/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
-                    SourceArchive.SourceKind_ArmTemplate, ExternalModuleDotJsonSource, "br:mcr.microsoft.com/bicep/storage/storage-account:1.0.1"),
+                    SourceArchive.SourceKind_ArmTemplate, ExternalModuleDotJsonSource, OciRegistryHelper.ParseModuleReference("br:mcr.microsoft.com/bicep/storage/storage-account:1.0.1")),
             });
     }
 

--- a/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
@@ -22,7 +22,7 @@ namespace Bicep.Core.UnitTests.Utils
             => new (ArtifactType.Module, registry, repository, tag, digest, parentModuleUri);
 
 
-        public static OciArtifactReference CreateModuleReference(string moduleId /* with or without br: */, Uri? parentModuleUri = null)
+        public static OciArtifactReference ParseModuleReference(string moduleId /* with or without br: */, Uri? parentModuleUri = null)
         {
             if (moduleId.StartsWith(OciArtifactReferenceFacts.SchemeWithColon))
             {
@@ -41,7 +41,7 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static OciArtifactReference CreateModuleReference(string registry, string repository, string? tag, string? digest, Uri? parentModuleUri = null)
         {
-            return CreateModuleReference($"{registry}/{repository}" + (tag is null ? $"@{digest}" : $":{tag}"), parentModuleUri);
+            return ParseModuleReference($"{registry}/{repository}" + (tag is null ? $"@{digest}" : $":{tag}"), parentModuleUri);
         }
 
         public static void SaveManifestFileToModuleRegistryCache(

--- a/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
@@ -19,20 +19,29 @@ namespace Bicep.Core.UnitTests.Utils
     public static class OciRegistryHelper
     {
         public static OciArtifactReference CreateModuleReferenceMock(string registry, string repository, Uri parentModuleUri, string? digest, string? tag)
-            => new(ArtifactType.Module, registry, repository, tag, digest, parentModuleUri);
+            => new (ArtifactType.Module, registry, repository, tag, digest, parentModuleUri);
 
 
-        public static OciArtifactReference CreateModuleReference(string registry, string repository, string? tag, string? digest)
+        public static OciArtifactReference CreateModuleReference(string moduleId /* with or without br: */, Uri? parentModuleUri = null)
         {
-            var rawValue = $"{registry}/{repository}" + (tag is null ? $"@{digest}" : $":{tag}");
+            if (moduleId.StartsWith(OciArtifactReferenceFacts.SchemeWithColon))
+            {
+                moduleId = moduleId.Substring(OciArtifactReferenceFacts.SchemeWithColon.Length);
+            }
+
             OciArtifactReference.TryParse(
                 ArtifactType.Module,
                 null,
-                rawValue,
+                moduleId,
                 BicepTestConstants.BuiltInConfiguration,
-                new Uri("file:///main.bicep"))
+                parentModuleUri ?? new Uri("file:///main.bicep"))
                     .IsSuccess(out var moduleReference).Should().BeTrue();
             return moduleReference!;
+        }
+
+        public static OciArtifactReference CreateModuleReference(string registry, string repository, string? tag, string? digest, Uri? parentModuleUri = null)
+        {
+            return CreateModuleReference($"{registry}/{repository}" + (tag is null ? $"@{digest}" : $":{tag}"), parentModuleUri);
         }
 
         public static void SaveManifestFileToModuleRegistryCache(

--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -54,7 +54,7 @@ public static class RegistryHelper
         }
 
         var features = featureProviderFactory.GetFeatureProvider(result.BicepFile.FileUri);
-        BinaryData? sourcesStream = publishSource ? BinaryData.FromStream(SourceArchive.PackSourcesIntoStream(result.Compilation.SourceFileGrouping, features.CacheRootDirectory)) : null;
+        BinaryData? sourcesStream = publishSource ? BinaryData.FromStream(SourceArchive.PackSourcesIntoStream(dispatcher, result.Compilation.SourceFileGrouping, features.CacheRootDirectory)) : null;
         await dispatcher.PublishModule(targetReference, BinaryData.FromString(result.Template.ToString()), sourcesStream, documentationUri);
     }
 

--- a/src/Bicep.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Bicep.Core/Extensions/EnumerableExtensions.cs
@@ -92,6 +92,33 @@ namespace Bicep.Core.Extensions
                 next = getNextElement(next);
             }
         }
+
+        // Enables this usage:
+        // var (first) = new[] { 1, 2, 3 };
+        public static void Deconstruct<T>(this IEnumerable<T> items, out T t1)
+        {
+            using var enumerator = items.GetEnumerator();
+            t1 = enumerator.MoveNext() ? enumerator.Current : throw new InvalidOperationException("Sequence contains no elements");
+        }
+
+        // Enables this usage:
+        // var (first, second) = new[] { 1, 2, 3 };
+        public static void Deconstruct<T>(this IEnumerable<T> items, out T t1, out T t2)
+        {
+            using var enumerator = items.GetEnumerator();
+            t1 = enumerator.MoveNext() ? enumerator.Current : throw new InvalidOperationException("Sequence contains no elements");
+            t2 = enumerator.MoveNext() ? enumerator.Current : throw new InvalidOperationException("Sequence contains no more elements");
+        }
+
+        // Enables this usage:
+        // var (first, second, third) = new[] { 1, 2, 3 };
+        public static void Deconstruct<T>(this IEnumerable<T> items, out T t1, out T t2, out T t3)
+        {
+            using var enumerator = items.GetEnumerator();
+            t1 = enumerator.MoveNext() ? enumerator.Current : throw new InvalidOperationException("Sequence contains no elements");
+            t2 = enumerator.MoveNext() ? enumerator.Current : throw new InvalidOperationException("Sequence contains no more elements");
+            t3 = enumerator.MoveNext() ? enumerator.Current : throw new InvalidOperationException("Sequence contains no more elements");
+        }
     }
 }
 

--- a/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
@@ -102,7 +102,7 @@ namespace Bicep.Core.Registry.Oci
 
             static string DecodeSegment(string segment) => HttpUtility.UrlDecode(segment);
 
-            if (configuration is { } && aliasName is not null)
+            if (configuration is { } && aliasName is { })
             {
                 switch (type)
                 {

--- a/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
@@ -70,14 +70,18 @@ namespace Bicep.Core.Registry.Oci
         public override bool IsExternal => true;
 
         // unqualifiedReference is the reference without a scheme or alias, e.g. "example.azurecr.invalid/foo/bar:v3"
-        public static ResultWithDiagnostic<OciArtifactReference> TryParseModule(string? aliasName, string unqualifiedReference, RootConfiguration configuration, Uri parentModuleUri)
+        // The configuration and parentModuleUri are needed to resolve aliases and experimental features
+        public static ResultWithDiagnostic<OciArtifactReference> TryParseModuleAndAlias(string? aliasName, string unqualifiedReference, RootConfiguration configuration, Uri parentModuleUri)
             => TryParse(ArtifactType.Module, aliasName, unqualifiedReference, configuration, parentModuleUri);
 
-        public static ResultWithDiagnostic<OciArtifactReference> TryParse(ArtifactType type, string? aliasName, string unqualifiedReference, RootConfiguration configuration, Uri parentModuleUri)
+        public static ResultWithDiagnostic<OciArtifactReference> TryParseModule(string unqualifiedReference)
+            => TryParse(ArtifactType.Module, null, unqualifiedReference, null, null);
+
+        public static ResultWithDiagnostic<OciArtifactReference> TryParse(ArtifactType type, string? aliasName, string unqualifiedReference, RootConfiguration? configuration, Uri? parentModuleUri)
         {
             if (TryParseParts(type, aliasName, unqualifiedReference, configuration).IsSuccess(out var parts, out var errorBuilder))
             {
-                return new(new OciArtifactReference(type, parts.Registry, parts.Repository, parts.Tag, parts.Digest, parentModuleUri));
+                return new(new OciArtifactReference(type, parts.Registry, parts.Repository, parts.Tag, parts.Digest, parentModuleUri ?? new Uri("file:///no-parent-file-is-available.bicep")));
             }
             else
             {

--- a/src/Bicep.Core/Registry/Oci/OciArtifactReferenceFacts.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactReferenceFacts.cs
@@ -8,6 +8,7 @@ namespace Bicep.Core.Registry.Oci
     public static partial class OciArtifactReferenceFacts
     {
         public const string Scheme = "br";
+        public const string SchemeWithColon = Scheme + ":";
 
         public const int MaxRegistryLength = 255;
 

--- a/src/Bicep.Core/SourceCode/SourceArchive.cs
+++ b/src/Bicep.Core/SourceCode/SourceArchive.cs
@@ -144,14 +144,21 @@ namespace Bicep.Core.SourceCode
 
         public static ResultWithException<SourceArchive> UnpackFromStream(Stream stream)
         {
-            var archive = new SourceArchive(stream);
-            if (archive.GetRequiredBicepVersionMessage() is string message)
+            try
             {
-                return new(new Exception(message));
+                var archive = new SourceArchive(stream);
+                if (archive.GetRequiredBicepVersionMessage() is string message)
+                {
+                    return new(new Exception(message));
+                }
+                else
+                {
+                    return new(archive);
+                }
             }
-            else
+            catch (Exception ex)
             {
-                return new(archive);
+                return new(ex);
             }
         }
 
@@ -172,8 +179,8 @@ namespace Bicep.Core.SourceCode
                 // Only those that were published with source
                 .Where(pair => moduleDispatcher.TryGetModuleSources(pair.artifactReference).IsSuccess())
                 .ToDictionary(x => x.uri, x => x.artifactReference);
-            var sourceFilesWithArtifactReference  =
-                sourceFileGrouping.SourceFiles.Select(x => new SourceFileWithArtifactReference(x, uriToArtifactReference.TryGetValue(x.FileUri, out var reference)? reference:null));
+            var sourceFilesWithArtifactReference =
+                sourceFileGrouping.SourceFiles.Select(x => new SourceFileWithArtifactReference(x, uriToArtifactReference.TryGetValue(x.FileUri, out var reference) ? reference : null));
 
             var documentLinks = SourceCodeDocumentLinkHelper.GetAllModuleDocumentLinks(sourceFileGrouping);
             return PackSourcesIntoStream(sourceFileGrouping.EntryFileUri, cacheRoot, documentLinks, sourceFilesWithArtifactReference.ToArray());

--- a/src/Bicep.Core/SourceCode/SourceArchive.cs
+++ b/src/Bicep.Core/SourceCode/SourceArchive.cs
@@ -9,7 +9,10 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Bicep.Core.Exceptions;
+using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Registry;
+using Bicep.Core.Registry.Oci;
 using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
@@ -79,7 +82,13 @@ namespace Bicep.Core.SourceCode
                     "sourcePath": "modules/main.bicep",
                     "archivePath": "files/modules/main.bicep",
                     "kind": "bicep"
-                }
+                },
+                {
+                  "path": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$app$app-configuration/1.0.1$/main.json",
+                  "archivePath": "files/_cache_/br/mcr.microsoft.com/bicep$app$app-configuration/1.0.1$/main.json",
+                  "kind": "armTemplate",
+                  "sourceArtifactId": "br:contoso.io/test/module1:v1"
+                },
             ],
             "DocumentLinks": { ... }
         }
@@ -91,16 +100,21 @@ namespace Bicep.Core.SourceCode
 
         #endregion
 
-        #region Serialization
-
-        public partial record SourceFileInfo(
+        // This is the info we expose via SourceFiles
+        public record SourceFileInfo(
             // Note: Path is also used as the key for source file retrieval
             string Path,        // The location, relative to the main.bicep file's folder or one of the other roots.
-
             string ArchivePath, // The location (relative to root) of where the file is stored in the archive (munged from Path, e.g. in case Path starts with "../")
-            string Kind,        // Kind of source
-            string Contents     // File contents
+            string Kind,        // Kind of source (SourceKind)
+            string Contents,    // File contents
+            string? SourceArtifactId // Points to an external artifact that contains the source for this module (e.g. "br:contoso.io/test/module1:v1"), appears in v0.26 and higher
         );
+
+        public record SourceFileWithArtifactReference(
+            ISourceFile SourceFile,
+            ArtifactReference? SourceArtifactId);
+
+        #region Serialization
 
         [JsonSerializable(typeof(ArchiveMetadata))]
         [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
@@ -115,13 +129,15 @@ namespace Bicep.Core.SourceCode
             IReadOnlyDictionary<string, SourceCodeDocumentPathLink[]>? DocumentLinks = null // Maps source file path -> array of document links inside that file
         );
 
+        // A single SourceFiles entry in the metadata.json file
         private partial record SourceFileInfoEntry(
             // IF ADDING TO THIS: Remember both forwards and backwards compatibility.
             // E.g., previous versions must be able to deal with unrecognized source kinds.
             // (but see CurrentMetadataVersion for breaking changes)
             string Path,        // the location, relative to the main.bicep file's folder, for the file that will be shown to the end user (required in all Bicep versions)
             string ArchivePath, // the location (relative to root) of where the file is stored in the archive
-            string Kind         // kind of source
+            string Kind,        // kind of source (SourceKind)
+            string? SourceArtifactId = null // Points to an external artifact that contains the source for this module (e.g. "br:contoso.io/test/module1:v1"), appears in v0.26 and higher
         );
 
         #endregion
@@ -143,25 +159,38 @@ namespace Bicep.Core.SourceCode
         /// Bundles all the sources from a compilation group (thus source for a bicep file and all its dependencies
         /// in JSON form) into an archive (as a stream)
         /// </summary>
-        /// <returns>A .tar.gz file as a binary stream</returns>
-        public static Stream PackSourcesIntoStream(SourceFileGrouping sourceFileGrouping, string? cacheRoot)
+        /// <returns>A .tgz file as a binary stream</returns>
+        public static Stream PackSourcesIntoStream(IModuleDispatcher moduleDispatcher, SourceFileGrouping sourceFileGrouping, string? cacheRoot)
         {
+            // Find the artifact reference for each source file of an external module that was published with sources
+            var artifactReferenceUriResultPairs = sourceFileGrouping.FileUriResultByBicepSourceFileByArtifactReference.Values.SelectMany(x => x);
+            var uriToArtifactReference = artifactReferenceUriResultPairs.Where(pair => pair.Value.IsSuccess())
+                .Select(pair => (artifactReference: pair.Key, uri: pair.Value.Unwrap()))
+                .Distinct()
+                // Only deal with OCI module references
+                .Where(pair => pair.artifactReference is OciArtifactReference ociReference && ociReference.Type == ArtifactType.Module)
+                // Only those that were published with source
+                .Where(pair => moduleDispatcher.TryGetModuleSources(pair.artifactReference).IsSuccess())
+                .ToDictionary(x => x.uri, x => x.artifactReference);
+            var sourceFilesWithArtifactReference  =
+                sourceFileGrouping.SourceFiles.Select(x => new SourceFileWithArtifactReference(x, uriToArtifactReference.TryGetValue(x.FileUri, out var reference)? reference:null));
+
             var documentLinks = SourceCodeDocumentLinkHelper.GetAllModuleDocumentLinks(sourceFileGrouping);
-            return PackSourcesIntoStream(sourceFileGrouping.EntryFileUri, cacheRoot, documentLinks, sourceFileGrouping.SourceFiles.ToArray());
+            return PackSourcesIntoStream(sourceFileGrouping.EntryFileUri, cacheRoot, documentLinks, sourceFilesWithArtifactReference.ToArray());
         }
 
-        public static Stream PackSourcesIntoStream(Uri entrypointFileUri, string? cacheRoot, params ISourceFile[] sourceFiles)
+        public static Stream PackSourcesIntoStream(Uri entrypointFileUri, string? cacheRoot, params SourceFileWithArtifactReference[] sourceFiles)
         {
             return PackSourcesIntoStream(entrypointFileUri, cacheRoot, documentLinks: null, sourceFiles);
         }
 
-        public static Stream PackSourcesIntoStream(Uri entrypointFileUri, string? cacheRoot, IReadOnlyDictionary<Uri, SourceCodeDocumentUriLink[]>? documentLinks, params ISourceFile[] sourceFiles)
+        public static Stream PackSourcesIntoStream(Uri entrypointFileUri, string? cacheRoot, IReadOnlyDictionary<Uri, SourceCodeDocumentUriLink[]>? documentLinks, params SourceFileWithArtifactReference[] sourceFiles)
         {
             // Don't package template spec files - they don't appear in the compiled JSON so we shouldn't expose them
-            sourceFiles = sourceFiles.Where(sf => sf is not TemplateSpecFile).ToArray();
+            sourceFiles = sourceFiles.Where(sf => sf.SourceFile is not TemplateSpecFile).ToArray();
 
             // Filter out any links where the source or target is not in our list of files to package
-            var sourceFileUris = sourceFiles.Select(sf => sf.FileUri).ToArray();
+            var sourceFileUris = sourceFiles.Select(sf => sf.SourceFile.FileUri).ToArray();
             documentLinks = documentLinks?
                 .Where(kvp => sourceFileUris.Contains(kvp.Key))
                 .Select(uriAndLink => (uriAndLink.Key, uriAndLink.Value.Where(link => sourceFileUris.Contains(link.Target)).ToArray()))
@@ -175,14 +204,14 @@ namespace Bicep.Core.SourceCode
                     var filesMetadata = new List<SourceFileInfoEntry>();
                     string? entryPointPath = null;
 
-                    var paths = sourceFiles.Select(f => GetPath(f.FileUri)).ToArray();
+                    var paths = sourceFiles.Select(f => GetPath(f.SourceFile.FileUri)).ToArray();
                     var mapPathToRootPath = SourceCodePathHelper.MapPathsToDistinctRoots(cacheRoot, paths);
                     var entrypointRootPath = mapPathToRootPath[GetPath(entrypointFileUri)];
                     var mapRootPathToRootNewName = NameRoots(mapPathToRootPath, entrypointRootPath, cacheRoot);
 
                     var sourceUriToRelativePathMap = new Dictionary<Uri, string>();
 
-                    foreach (var file in sourceFiles)
+                    foreach (var (file, artifactReference) in sourceFiles)
                     {
                         string source = file.GetOriginalSource();
                         string kind = file switch
@@ -190,8 +219,11 @@ namespace Bicep.Core.SourceCode
                             BicepFile bicepFile => SourceKind_Bicep,
                             ArmTemplateFile armTemplateFile => SourceKind_ArmTemplate,
                             TemplateSpecFile => SourceKind_TemplateSpec,
-                            _ => throw new ArgumentException($"Unexpected source file type {file.GetType().Name}"),
+                            _ => throw new ArgumentException($"Unexpected input source file type {file.GetType().Name}"),
                         };
+
+                        Debug.Assert(artifactReference is null || artifactReference is OciArtifactReference ociArtifactReference && ociArtifactReference.Type == ArtifactType.Module,
+                            "Artifact reference must be null or an OCI module reference");
 
                         var path = GetPath(file.FileUri);
                         var root = mapPathToRootPath[path];
@@ -209,7 +241,12 @@ namespace Bicep.Core.SourceCode
                         archivePath = UniquifyArchivePath(filesMetadata, archivePath);
 
                         WriteNewFileEntry(tarWriter, archivePath, source);
-                        filesMetadata.Add(new SourceFileInfoEntry(relativePath, archivePath, kind));
+                        filesMetadata.Add(
+                            new SourceFileInfoEntry(
+                                relativePath,
+                                archivePath,
+                                kind,
+                                artifactReference?.FullyQualifiedReference));
 
                         if (PathHelper.PathComparer.Equals(file.FileUri, entrypointFileUri))
                         {
@@ -371,7 +408,7 @@ namespace Bicep.Core.SourceCode
             {
                 var contents = dictionary[info.ArchivePath]
                     ?? throw new BicepException("Incorrectly formatted source file: File entry not found: \"{info.ArchivePath}\"");
-                infos.Add(new SourceFileInfo(info.Path, info.ArchivePath, info.Kind, contents));
+                infos.Add(new SourceFileInfo(info.Path, info.ArchivePath, info.Kind, contents, info.SourceArtifactId));
             }
 
             this.InstanceMetadata = metadata;

--- a/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
@@ -177,15 +177,6 @@ namespace Bicep.Core.Workspaces
                 }
                 uriResultByArtifactReferenceSyntaxLookup[restorable] = uriResult;
 
-                if (childArtifactReference is { }) {
-                    if (!uriResultByBicepSourceFileByArtifactReference.TryGetValue(file, out var uriResultByArtifactReferenceLookup))
-                    {
-                        uriResultByArtifactReferenceLookup = [];
-                        uriResultByBicepSourceFileByArtifactReference[file] = uriResultByArtifactReferenceLookup;
-                    }
-                    uriResultByArtifactReferenceLookup[childArtifactReference] = uriResult;
-                }
-
                 if (!uriResult.IsSuccess(out var artifactUri))
                 {
                     continue;

--- a/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
@@ -177,6 +177,15 @@ namespace Bicep.Core.Workspaces
                 }
                 uriResultByArtifactReferenceSyntaxLookup[restorable] = uriResult;
 
+                if (childArtifactReference is { }) {
+                    if (!uriResultByBicepSourceFileByArtifactReference.TryGetValue(file, out var uriResultByArtifactReferenceLookup))
+                    {
+                        uriResultByArtifactReferenceLookup = [];
+                        uriResultByBicepSourceFileByArtifactReference[file] = uriResultByArtifactReferenceLookup;
+                    }
+                    uriResultByArtifactReferenceLookup[childArtifactReference] = uriResult;
+                }
+
                 if (!uriResult.IsSuccess(out var artifactUri))
                 {
                     continue;

--- a/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
@@ -54,7 +54,7 @@ namespace Bicep.LangServer.IntegrationTests
             var moduleRegistry = StrictMock.Of<IArtifactRegistry>();
             if (bicepModuleEntrypoint is not null && entrypointSource is not null)
             {
-                sourceArchiveResult ??= new(new SourceArchiveBuilder().WithEntrypointFile(bicepModuleEntrypoint, entrypointSource).Build());
+                sourceArchiveResult ??= new(new SourceArchiveBuilder().WithBicepFile(bicepModuleEntrypoint, entrypointSource).Build());
             }
             sourceArchiveResult ??= new(new SourceNotAvailableException());
             moduleRegistry.Setup(m => m.TryGetSource(It.IsAny<ArtifactReference>())).Returns(sourceArchiveResult);

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -126,7 +126,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var configuration = IConfigurationManager.GetBuiltInConfiguration();
             var parentModuleLocalPath = "/foo/main.bicep";
             var parentModuleUri = new Uri($"file://{parentModuleLocalPath}");
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, parentModuleUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModuleAndAlias(null, UnqualifiedModuleRefStr, configuration, parentModuleUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
@@ -162,7 +162,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var configuration = IConfigurationManager.GetBuiltInConfiguration();
             var parentModuleLocalPath = "/main.bicep";
             var parentModuleUri = new Uri($"file://{parentModuleLocalPath}");
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, parentModuleUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModuleAndAlias(null, UnqualifiedModuleRefStr, configuration, parentModuleUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
@@ -201,7 +201,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             const string ModuleRefStr = "br:" + UnqualifiedModuleRefStr;
 
             var configuration = IConfigurationManager.GetBuiltInConfiguration();
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModuleAndAlias(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
@@ -242,7 +242,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var configuration = ConfigurationManager.GetConfiguration(compiledJsonUri);
 
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModuleAndAlias(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
@@ -291,7 +291,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var configuration = ConfigurationManager.GetConfiguration(compiledJsonUri);
 
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModuleAndAlias(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
@@ -301,9 +301,8 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var bicepSource = "metadata hi = 'This is the bicep source file'";
             var bicepUri = PathHelper.FilePathToFileUrl(Root("foo/bar/entrypoint.bicep"));
-            var sourceArchive = SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(bicepUri, cacheRoot: null, new Core.Workspaces.ISourceFile[] {
-                        SourceFileFactory.CreateBicepFile(bicepUri, bicepSource)}));
-            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
+            var sourceArchive = new SourceArchiveBuilder().WithBicepFile(bicepUri, bicepSource).Build();
+            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(sourceArchive ));
 
             var resolver = StrictMock.Of<IFileResolver>();
             resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create(compiledJsonContents, nullBuilder));
@@ -343,7 +342,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var configuration = ConfigurationManager.GetConfiguration(compiledJsonUri);
 
-            OciArtifactReference.TryParseModule(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParseModuleAndAlias(null, UnqualifiedModuleRefStr, configuration, compiledJsonUri).IsSuccess(out var moduleReference).Should().BeTrue();
             moduleReference.Should().NotBeNull();
 
             ArtifactReference? outRef = moduleReference;
@@ -353,9 +352,8 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
             var bicepSource = "metadata hi = 'This is the bicep source file'";
             var bicepUri = PathHelper.FilePathToFileUrl(Root("foo/bar/entrypoint.bicep"));
-            var sourceArchive = SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(bicepUri, cacheRoot: null, new Core.Workspaces.ISourceFile[] {
-                        SourceFileFactory.CreateBicepFile(bicepUri, bicepSource)}));
-            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(sourceArchive);
+            var sourceArchive = new SourceArchiveBuilder().WithBicepFile(bicepUri, bicepSource).Build();
+            dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(sourceArchive));
 
             var resolver = StrictMock.Of<IFileResolver>();
             resolver.Setup(m => m.TryRead(compiledJsonUri)).Returns(ResultHelper.Create(compiledJsonContents, nullBuilder));
@@ -498,12 +496,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 new Uri("file:///parent.bicep", UriKind.Absolute));
 
             SourceArchive? sourceArchive = entrypointUri is { } ?
-                SourceArchive.UnpackFromStream(SourceArchive.PackSourcesIntoStream(
-                    entrypointUri,
-                    cacheRoot: null,
-                    new ISourceFile[] {
-                                SourceFileFactory.CreateBicepFile(entrypointUri, "metadata description = 'bicep module'")
-                    })).TryUnwrap()
+                new SourceArchiveBuilder().WithBicepFile(entrypointUri, "metadata description = 'bicep module'").Build()
                 : null;
 
             return BicepExternalSourceRequestHandler.GetExternalSourceLinkUri(reference, sourceArchive, defaultToDisplayingBicep);

--- a/src/Bicep.LangServer/Completions/ModuleReferenceCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/ModuleReferenceCompletionProvider.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using Bicep.Core;
 using Bicep.Core.Configuration;
 using Bicep.Core.Parsing;
+using Bicep.Core.Registry.Oci;
 using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Settings;
@@ -114,7 +115,7 @@ namespace Bicep.LanguageServer.Completions
             }
 
             // Top-level Bicep registry completions
-            AddCompletionItem("br:", null, "Bicep registry", ModuleCompletionPriority.FullPath, "module registry completion");
+            AddCompletionItem(OciArtifactReferenceFacts.SchemeWithColon, null, "Bicep registry", ModuleCompletionPriority.FullPath, "module registry completion");
             if (bicepModuleAliases.Any())
             {
                 // br/<alias>

--- a/src/Bicep.LangServer/Completions/ModuleReferenceCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/ModuleReferenceCompletionProvider.cs
@@ -116,7 +116,7 @@ namespace Bicep.LanguageServer.Completions
 
             // Top-level Bicep registry completions
             AddCompletionItem(OciArtifactReferenceFacts.SchemeWithColon, null, "Bicep registry", ModuleCompletionPriority.FullPath, "module registry completion");
-            if (bicepModuleAliases.Any())
+            if (!bicepModuleAliases.IsEmpty)
             {
                 // br/<alias>
                 foreach (var kvp in bicepModuleAliases)

--- a/src/Bicep.LangServer/Handlers/BicepDocumentLinkHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentLinkHandler.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Oci;
 using Bicep.LanguageServer.Extensions;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
@@ -10,79 +12,149 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepDocumentLinkHandler : DocumentLinkHandlerBase
+#nullable disable // The generated code is not yet nullable-aware, this disables #nullable for the generated code to fix that
+
+    public partial record ExternalSourceDocumentLinkData : IHandlerIdentity
     {
-        private readonly IModuleDispatcher moduleDispatcher;
+        public string TargetArtifactId { get; init; }
 
-        public BicepDocumentLinkHandler(IModuleDispatcher moduleDispatcher)
+        public ExternalSourceDocumentLinkData(string targetArtifactId)
         {
-            this.moduleDispatcher = moduleDispatcher;
+            TargetArtifactId = targetArtifactId;
         }
+    }
 
-        public override Task<DocumentLinkContainer?> Handle(DocumentLinkParams request, CancellationToken cancellationToken)
+#nullable restore
+
+    /// <summary>
+    /// This handles the case where the document is a source file from an external module, and we've been asked to return nested links within it (to files local to that module or to other external modules)
+    /// </summary>
+    public class BicepExternalSourceDocumentLinkHandler(IModuleDispatcher ModuleDispatcher)
+        : DocumentLinkHandlerBase<ExternalSourceDocumentLinkData>
+    {
+        protected override Task<DocumentLinkContainer<ExternalSourceDocumentLinkData>> HandleParams(DocumentLinkParams request, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var links = GetDocumentLinks(moduleDispatcher, request, cancellationToken);
-            return Task.FromResult<DocumentLinkContainer?>(new DocumentLinkContainer(links));
+            var links = GetDocumentLinks(ModuleDispatcher, request, cancellationToken);
+            return Task.FromResult(new DocumentLinkContainer<ExternalSourceDocumentLinkData>(links));
         }
 
-        public override Task<DocumentLink> Handle(DocumentLink request, CancellationToken cancellationToken)
+        protected override async Task<DocumentLink<ExternalSourceDocumentLinkData>> HandleResolve(DocumentLink<ExternalSourceDocumentLinkData> request, CancellationToken cancellationToken)
         {
-            throw new System.NotImplementedException();
+            return await ResolveDocumentLink(request, cancellationToken);
         }
 
         protected override DocumentLinkRegistrationOptions CreateRegistrationOptions(DocumentLinkCapability capability, ClientCapabilities clientCapabilities) => new()
         {
-            DocumentSelector = TextDocumentSelector.ForScheme(LangServerConstants.ExternalSourceFileScheme)
+            DocumentSelector = TextDocumentSelector.ForScheme(LangServerConstants.ExternalSourceFileScheme),
+            ResolveProvider = true,
         };
 
-        public static IEnumerable<DocumentLink> GetDocumentLinks(IModuleDispatcher moduleDispatcher, DocumentLinkParams request, CancellationToken cancellationToken)
+        public static IEnumerable<DocumentLink<ExternalSourceDocumentLinkData>> GetDocumentLinks(IModuleDispatcher moduleDispatcher, DocumentLinkParams request, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            var currentDocument = request.TextDocument;
 
-            if (request.TextDocument.Uri.Scheme == LangServerConstants.ExternalSourceFileScheme)
+            if (currentDocument.Uri.Scheme == LangServerConstants.ExternalSourceFileScheme)
             {
-                ExternalSourceReference? externalReference;
+                ExternalSourceReference? currentDocumentReference;
                 try
                 {
-                    externalReference = new ExternalSourceReference(request.TextDocument.Uri);
+                    currentDocumentReference = new ExternalSourceReference(currentDocument.Uri);
                 }
                 catch (Exception ex)
                 {
-                    Trace.WriteLine($"(Experimental) There was an error retrieving source code for this module: {ex.Message}");
+                    Trace.WriteLine($"There was an error retrieving source code for this module: {ex.Message}");
                     yield break;
                 }
 
-                if (externalReference.RequestedFile is not null)
+
+                var currentDocumentRelativeFile = currentDocumentReference.RequestedFile;
+                if (currentDocumentRelativeFile is { })
                 {
-                    if (!externalReference.ToArtifactReference().IsSuccess(out var artifactReference, out var message))
+                    if (!currentDocumentReference.ToArtifactReference().IsSuccess(out var currentDocumentArtifact, out var message))
                     {
                         Trace.WriteLine(message);
                         yield break;
                     }
 
-                    if (!moduleDispatcher.TryGetModuleSources(artifactReference).IsSuccess(out var sourceArchive, out var ex))
+                    if (!moduleDispatcher.TryGetModuleSources(currentDocumentArtifact).IsSuccess(out var currentDocumentSourceArchive, out var ex))
                     {
                         Trace.WriteLine(ex.Message);
                         yield break;
                     }
 
-                    sourceArchive.FindExpectedSourceFile(externalReference.RequestedFile);
-                    if (sourceArchive.DocumentLinks.TryGetValue(externalReference.RequestedFile, out var links))
+                    if (currentDocumentSourceArchive.DocumentLinks.TryGetValue(currentDocumentRelativeFile, out var nestedLinks))
                     {
-                        foreach (var link in links)
+                        foreach (var nestedLink in nestedLinks)
                         {
-                            yield return new DocumentLink()
+                            // Does this nested link have a pointer to its artifact so we can try restoring it and get the source?
+                            var targetFileInfo = currentDocumentSourceArchive.FindExpectedSourceFile(nestedLink.Target);
+                            if (targetFileInfo.SourceArtifactId is { } && targetFileInfo.SourceArtifactId.StartsWith(OciArtifactReferenceFacts.SchemeWithColon))
                             {
-                                Range = link.Range.ToRange(),
-                                Target = new ExternalSourceReference(request.TextDocument.Uri)
-                                    .WithRequestForSourceFile(link.Target).ToUri().ToString()
-                            };
+                                // Yes, it's an external module with source.  We won't set the target now - we'll wait until the user clicks on it to resolve it, to give us a chance to restore the module.
+                                var sourceId = targetFileInfo.SourceArtifactId.Substring(OciArtifactReferenceFacts.SchemeWithColon.Length);
+                                yield return new DocumentLink<ExternalSourceDocumentLinkData>()
+                                {
+                                    Range = nestedLink.Range.ToRange(),
+                                    Data = new ExternalSourceDocumentLinkData(sourceId),
+                                };
+                            }
+                            else
+                            {
+                                yield return new DocumentLink()
+                                {
+                                    // This is a link to a file that we don't have source for, so we'll just display the main.json file
+                                    Range = nestedLink.Range.ToRange(),
+                                    Target = new ExternalSourceReference(request.TextDocument.Uri)
+                                        .WithRequestForSourceFile(targetFileInfo.Path).ToUri().ToString(),
+                                };
+                            }
                         }
                     }
                 }
             }
+        }
+
+        public async Task<DocumentLink<ExternalSourceDocumentLinkData>> ResolveDocumentLink(DocumentLink<ExternalSourceDocumentLinkData> request, CancellationToken cancellationToken)
+        {
+            Trace.WriteLine($"{nameof(BicepExternalSourceDocumentLinkHandler)}: Resolving document link: {request.Data.TargetArtifactId}");
+
+            var data = request.Data;
+
+            if (!OciArtifactReference.TryParseModule(data.TargetArtifactId).IsSuccess(out var targetArtifactReference, out var error))
+            {
+                Trace.WriteLine($"{nameof(BicepExternalSourceDocumentLinkHandler)}: {error(DiagnosticBuilder.ForDocumentStart()).Message}");
+                return request;
+            }
+
+            var restoreStatus = ModuleDispatcher.GetArtifactRestoreStatus(targetArtifactReference, out var errorBuilder);
+            if (restoreStatus != ArtifactRestoreStatus.Succeeded)
+            {
+                var errorMessage = errorBuilder is { } ? errorBuilder(DiagnosticBuilder.ForDocumentStart()).Message : "The module has not yet been successfully restored.";
+
+                Trace.WriteLine($"{nameof(BicepExternalSourceDocumentLinkHandler)}: {errorMessage}");
+
+                // Attempt to restore the module
+                if (!await ModuleDispatcher.RestoreArtifacts(new[] { targetArtifactReference }, forceRestore: true))
+                {
+                    ModuleDispatcher.GetArtifactRestoreStatus(targetArtifactReference, out errorBuilder);
+                    errorMessage = errorBuilder is { } ? errorBuilder(DiagnosticBuilder.ForDocumentStart()).Message : "Unknown error.";
+                    Trace.WriteLine($"{nameof(BicepExternalSourceDocumentLinkHandler)}: {errorMessage})");
+                    throw new InvalidOperationException($"Unable to restore module {targetArtifactReference.FullyQualifiedReference}: {errorMessage}");
+                }
+            }
+
+            if (!ModuleDispatcher.TryGetModuleSources(targetArtifactReference).IsSuccess(out var sourceArchive, out var ex))
+            {
+                Trace.WriteLine($"{nameof(BicepExternalSourceDocumentLinkHandler)}: {ex.Message})");
+                throw ex;
+            }
+
+            return request with
+            {
+                Target = new ExternalSourceReference(targetArtifactReference, sourceArchive).ToUri().ToString()
+            };
         }
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDocumentLinkHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentLinkHandler.cs
@@ -103,10 +103,10 @@ namespace Bicep.LanguageServer.Handlers
                                 .WithRequestForSourceFile(targetFileInfo.Path).ToUri().ToString();
 
                             // Does this nested link have a pointer to its artifact so we can try restoring it and get the source?
-                            if (targetFileInfo.SourceArtifactId is { } && targetFileInfo.SourceArtifactId.StartsWith(OciArtifactReferenceFacts.SchemeWithColon))
+                            if (targetFileInfo.SourceArtifact is { })
                             {
                                 // Yes, it's an external module with source.  We won't set the target now - we'll wait until the user clicks on it to resolve it, to give us a chance to restore the module.
-                                var sourceId = targetFileInfo.SourceArtifactId.Substring(OciArtifactReferenceFacts.SchemeWithColon.Length);
+                                var sourceId = targetFileInfo.SourceArtifact?.ArtifactId;
                                 yield return new DocumentLink<ExternalSourceDocumentLinkData>()
                                 {
                                     Range = nestedLink.Range.ToRange(),

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -33,7 +33,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepDeploymentGraphHandler>()
                     .WithHandler<GetDeploymentDataHandler>()
                     .WithHandler<BicepReferencesHandler>()
-                    .WithHandler<BicepDocumentLinkHandler>()
+                    .WithHandler<BicepExternalSourceDocumentLinkHandler>()
                     .WithHandler<BicepDocumentHighlightHandler>()
                     .WithHandler<BicepDocumentFormattingHandler>()
                     .WithHandler<BicepRenameHandler>()


### PR DESCRIPTION
Two main pieces to this (most of the rest of the changes are minor, tests, or refactoring/renaming):

1) Add sourceArtifactId to source.gzp for module JSON files that were published with source, so that when the client module is published and displayed on another user's machine, that user view the source as well (if they have permissions to restore it)
NOTE: I need to do some work to handle errors better here, such as don't have permissions to restore
2) Changed the document link handler (that displays links for nested external modules when viewing the sources for a module) so that it is resolved when clicked, giving us a chance to try to restore the module first

An example __metadata.json file with sourceArtifactId:
```json
{
    "metadataVersion": 1,
    "bicepVersion": "0.25.0.0",
    "entryPoint": "my complicated module.bicep",
    "sourceFiles": [
        {
            "path": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
            "archivePath": "files/_cache_/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json",
            "kind": "armTemplate",
            "sourceArtifactId": null
        },
        {
            "path": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$app$app-configuration/1.0.1$/main.json",
            "archivePath": "files/_cache_/br/mcr.microsoft.com/bicep$app$app-configuration/1.0.1$/main.json",
            "kind": "armTemplate",
            "sourceArtifactId": null
        },
        {
            "path": "\u003Ccache\u003E/br/contoso.azurecr.io/demo$complicated/v101$/main.json",
            "archivePath": "files/_cache_/br/contoso.azurecr.io/demo$complicated/v101$/main.json",
            "kind": "armTemplate",
            "sourceArtifactId": "br:contoso.azurecr.io/demo/complicated:v101"
        },
        {
            "path": "\u003Croot2\u003E/storageAccount.bicep",
            "archivePath": "files/_root2_/storageAccount.bicep",
            "kind": "bicep",
            "sourceArtifactId": null
        },
        {
            "path": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$avm$res$network$public-ip-prefix/0.2.1$/main.json",
            "archivePath": "files/_cache_/br/mcr.microsoft.com/bicep$avm$res$network$public-ip-prefix/0.2.1$/main.json",
            "kind": "armTemplate",
            "sourceArtifactId": "br:mcr.microsoft.com/bicep/avm/res/network/public-ip-prefix:0.2.1"
        },
        {
            "path": "my complicated module.bicep",
            "archivePath": "files/my complicated module.bicep",
            "kind": "bicep",
            "sourceArtifactId": null
        },
        {
            "path": "\u003Ccache\u003E/br/contosopublic.azurecr.io/sourcetest$avm$automation$automation-account/v1.0.1$/main.json",
            "archivePath": "files/_cache_/br/contosopublic.azurecr.io/sourcetest$avm$automation$automation-account/v1.0.1$/main.json",
            "kind": "armTemplate",
            "sourceArtifactId": "br:contosopublic.azurecr.io/sourcetest/avm/automation/automation-account:v1.0.1"
        },
        {
            "path": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$samples$hello-world/1.0.2$/main.json",
            "archivePath": "files/_cache_/br/mcr.microsoft.com/bicep$samples$hello-world/1.0.2$/main.json",
            "kind": "armTemplate",
            "sourceArtifactId": null
        },
        {
            "path": "modules/module1.bicep",
            "archivePath": "files/modules/module1.bicep",
            "kind": "bicep",
            "sourceArtifactId": null
        }
    ],
    "documentLinks": {
        "modules/module1.bicep": [
            {
                "range": "[8:10]-[8:47]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$samples$hello-world/1.0.2$/main.json"
            }
        ],
        "my complicated module.bicep": [
            {
                "range": "[183:20]-[183:58]",
                "target": "\u003Croot2\u003E/storageAccount.bicep"
            },
            {
                "range": "[55:10]-[55:47]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$samples$hello-world/1.0.2$/main.json"
            },
            {
                "range": "[121:17]-[121:73]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$app$app-configuration/1.0.1$/main.json"
            },
            {
                "range": "[44:27]-[44:66]",
                "target": "\u003Ccache\u003E/br/contosopublic.azurecr.io/sourcetest$avm$automation$automation-account/v1.0.1$/main.json"
            },
            {
                "range": "[151:27]-[151:74]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json"
            },
            {
                "range": "[138:26]-[138:67]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json"
            },
            {
                "range": "[125:17]-[125:75]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json"
            },
            {
                "range": "[147:27]-[147:72]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$app$app-configuration/1.0.1$/main.json"
            },
            {
                "range": "[134:26]-[134:65]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$app$app-configuration/1.0.1$/main.json"
            },
            {
                "range": "[62:22]-[62:72]",
                "target": "\u003Ccache\u003E/br/mcr.microsoft.com/bicep$avm$res$network$public-ip-prefix/0.2.1$/main.json"
            },
            {
                "range": "[179:11]-[179:34]",
                "target": "modules/module1.bicep"
            },
            {
                "range": "[176:10]-[176:33]",
                "target": "modules/module1.bicep"
            },
            {
                "range": "[32:26]-[32:51]",
                "target": "\u003Ccache\u003E/br/contoso.azurecr.io/demo$complicated/v101$/main.json"
            }
        ]
    }
}
```
