### PR TITLE
Fix formatting for comma-separated arguments list

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.syntax.bicep
@@ -1750,15 +1750,13 @@ var multiLineTrailingCommas = map([0], (
 //@[039:0059) |   | └─LambdaSyntax
 //@[039:0050) |   |   ├─VariableBlockSyntax
 //@[039:0040) |   |   | ├─Token(LeftParen) |(|
-//@[040:0041) |   |   | ├─SkippedTriviaSyntax
-//@[040:0041) |   |   | | └─Token(NewLine) |\n|
+//@[040:0041) |   |   | ├─Token(NewLine) |\n|
   a,
 //@[002:0003) |   |   | ├─LocalVariableSyntax
 //@[002:0003) |   |   | | └─IdentifierSyntax
 //@[002:0003) |   |   | |   └─Token(Identifier) |a|
 //@[003:0004) |   |   | ├─Token(Comma) |,|
-//@[004:0005) |   |   | ├─SkippedTriviaSyntax
-//@[004:0005) |   |   | | └─Token(NewLine) |\n|
+//@[004:0005) |   |   | ├─Token(NewLine) |\n|
   ,) => 'foo')
 //@[002:0002) |   |   | ├─SkippedTriviaSyntax
 //@[002:0003) |   |   | ├─Token(Comma) |,|

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.bicep
@@ -93,3 +93,9 @@ var multiLine = reduce(['abc', 'def', 'ghi'], '', (
   cur,
   next
 ) => concat(cur, next))
+
+var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
+  // comment
+  cur,
+  next
+) => concat(cur, next))

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.diagnostics.bicep
@@ -126,3 +126,11 @@ var multiLine = reduce(['abc', 'def', 'ghi'], '', (
 ) => concat(cur, next))
 //@[05:22) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (CodeDescription: bicep core(https://aka.ms/bicep/linter/prefer-interpolation)) |concat(cur, next)|
 
+var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
+//@[04:24) [no-unused-vars (Warning)] Variable "multiLineWithComment" is declared but never used. (CodeDescription: bicep core(https://aka.ms/bicep/linter/no-unused-vars)) |multiLineWithComment|
+  // comment
+  cur,
+  next
+) => concat(cur, next))
+//@[05:22) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (CodeDescription: bicep core(https://aka.ms/bicep/linter/prefer-interpolation)) |concat(cur, next)|
+

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.formatted.bicep
@@ -112,4 +112,14 @@ var objectMap6 = toObject(
     }
 )
 
-var multiLine = reduce(['abc', 'def', 'ghi'], '', (, cur, , next, ) => concat(cur, next))
+var multiLine = reduce(['abc', 'def', 'ghi'], '', (cur, next) => concat(cur, next))
+
+var multiLineWithComment = reduce(
+  ['abc', 'def', 'ghi'],
+  '',
+  (
+    // comment
+    cur,
+    next
+  ) => concat(cur, next)
+)

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 var doggos = [
-//@[000:2938) ProgramExpression
+//@[000:3053) ProgramExpression
 //@[000:0054) ├─DeclaredVariableExpression { Name = doggos }
 //@[013:0054) | └─ArrayExpression
   'Evie'
@@ -496,6 +496,23 @@ var multiLine = reduce(['abc', 'def', 'ghi'], '', (
 //@[038:0043) |   | └─StringLiteralExpression { Value = ghi }
 //@[046:0048) |   ├─StringLiteralExpression { Value =  }
 //@[050:0088) |   └─LambdaExpression
+  cur,
+  next
+) => concat(cur, next))
+//@[005:0022) |     └─FunctionCallExpression { Name = concat }
+//@[012:0015) |       ├─LambdaVariableReferenceExpression { Variable = cur }
+//@[017:0021) |       └─LambdaVariableReferenceExpression { Variable = next }
+
+var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
+//@[000:0113) ├─DeclaredVariableExpression { Name = multiLineWithComment }
+//@[027:0113) | └─FunctionCallExpression { Name = reduce }
+//@[034:0055) |   ├─ArrayExpression
+//@[035:0040) |   | ├─StringLiteralExpression { Value = abc }
+//@[042:0047) |   | ├─StringLiteralExpression { Value = def }
+//@[049:0054) |   | └─StringLiteralExpression { Value = ghi }
+//@[057:0059) |   ├─StringLiteralExpression { Value =  }
+//@[061:0112) |   └─LambdaExpression
+  // comment
   cur,
   next
 ) => concat(cur, next))

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6660155820585164580"
+      "templateHash": "2297205748781454198"
     }
   },
   "variables": {
@@ -52,7 +52,8 @@
     "objectMap4": "[toObject(variables('sortByObjectKey'), lambda('x', lambdaVariables('x').name))]",
     "objectMap5": "[toObject(variables('sortByObjectKey'), lambda('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', lambdaVariables('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx').name))]",
     "objectMap6": "[toObject(range(0, 10), lambda('i', format('{0}', lambdaVariables('i'))), lambda('i', createObject('isEven', equals(mod(lambdaVariables('i'), 2), 0), 'isGreaterThan4', greater(lambdaVariables('i'), 4))))]",
-    "multiLine": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]"
+    "multiLine": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]",
+    "multiLineWithComment": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]"
   },
   "resources": [
     {

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.sourcemap.bicep
@@ -177,7 +177,14 @@ var objectMap6 = toObject(range(0, 10), i => '${i}', i => // comment
 })
 
 var multiLine = reduce(['abc', 'def', 'ghi'], '', (
-//@    "multiLine": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]"
+//@    "multiLine": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]",
+  cur,
+  next
+) => concat(cur, next))
+
+var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
+//@    "multiLineWithComment": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]"
+  // comment
   cur,
   next
 ) => concat(cur, next))

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16061951843437581449"
+      "templateHash": "5220387717821090616"
     }
   },
   "variables": {
@@ -53,7 +53,8 @@
     "objectMap4": "[toObject(variables('sortByObjectKey'), lambda('x', lambdaVariables('x').name))]",
     "objectMap5": "[toObject(variables('sortByObjectKey'), lambda('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', lambdaVariables('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx').name))]",
     "objectMap6": "[toObject(range(0, 10), lambda('i', format('{0}', lambdaVariables('i'))), lambda('i', createObject('isEven', equals(mod(lambdaVariables('i'), 2), 0), 'isGreaterThan4', greater(lambdaVariables('i'), 4))))]",
-    "multiLine": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]"
+    "multiLine": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]",
+    "multiLineWithComment": "[reduce(createArray('abc', 'def', 'ghi'), '', lambda('cur', 'next', concat(lambdaVariables('cur'), lambdaVariables('next'))))]"
   },
   "resources": {
     "storageAcc": {

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbols.bicep
@@ -179,3 +179,12 @@ var multiLine = reduce(['abc', 'def', 'ghi'], '', (
 //@[002:006) Local next. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 2, length: 4
 ) => concat(cur, next))
 
+var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
+//@[004:024) Variable multiLineWithComment. Type: string. Declaration start char: 0, length: 113
+  // comment
+  cur,
+//@[002:005) Local cur. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 2, length: 3
+  next
+//@[002:006) Local next. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 2, length: 4
+) => concat(cur, next))
+

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 var doggos = [
-//@[000:2938) ProgramSyntax
+//@[000:3053) ProgramSyntax
 //@[000:0054) ├─VariableDeclarationSyntax
 //@[000:0003) | ├─Token(Identifier) |var|
 //@[004:0010) | ├─IdentifierSyntax
@@ -1871,21 +1871,86 @@ var multiLine = reduce(['abc', 'def', 'ghi'], '', (
 //@[050:0088) |   | └─LambdaSyntax
 //@[050:0067) |   |   ├─VariableBlockSyntax
 //@[050:0051) |   |   | ├─Token(LeftParen) |(|
-//@[051:0052) |   |   | ├─SkippedTriviaSyntax
-//@[051:0052) |   |   | | └─Token(NewLine) |\n|
+//@[051:0052) |   |   | ├─Token(NewLine) |\n|
   cur,
 //@[002:0005) |   |   | ├─LocalVariableSyntax
 //@[002:0005) |   |   | | └─IdentifierSyntax
 //@[002:0005) |   |   | |   └─Token(Identifier) |cur|
 //@[005:0006) |   |   | ├─Token(Comma) |,|
-//@[006:0007) |   |   | ├─SkippedTriviaSyntax
-//@[006:0007) |   |   | | └─Token(NewLine) |\n|
+//@[006:0007) |   |   | ├─Token(NewLine) |\n|
   next
 //@[002:0006) |   |   | ├─LocalVariableSyntax
 //@[002:0006) |   |   | | └─IdentifierSyntax
 //@[002:0006) |   |   | |   └─Token(Identifier) |next|
-//@[006:0007) |   |   | ├─SkippedTriviaSyntax
-//@[006:0007) |   |   | | └─Token(NewLine) |\n|
+//@[006:0007) |   |   | ├─Token(NewLine) |\n|
+) => concat(cur, next))
+//@[000:0001) |   |   | └─Token(RightParen) |)|
+//@[002:0004) |   |   ├─Token(Arrow) |=>|
+//@[005:0022) |   |   └─FunctionCallSyntax
+//@[005:0011) |   |     ├─IdentifierSyntax
+//@[005:0011) |   |     | └─Token(Identifier) |concat|
+//@[011:0012) |   |     ├─Token(LeftParen) |(|
+//@[012:0015) |   |     ├─FunctionArgumentSyntax
+//@[012:0015) |   |     | └─VariableAccessSyntax
+//@[012:0015) |   |     |   └─IdentifierSyntax
+//@[012:0015) |   |     |     └─Token(Identifier) |cur|
+//@[015:0016) |   |     ├─Token(Comma) |,|
+//@[017:0021) |   |     ├─FunctionArgumentSyntax
+//@[017:0021) |   |     | └─VariableAccessSyntax
+//@[017:0021) |   |     |   └─IdentifierSyntax
+//@[017:0021) |   |     |     └─Token(Identifier) |next|
+//@[021:0022) |   |     └─Token(RightParen) |)|
+//@[022:0023) |   └─Token(RightParen) |)|
+//@[023:0025) ├─Token(NewLine) |\n\n|
+
+var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
+//@[000:0113) ├─VariableDeclarationSyntax
+//@[000:0003) | ├─Token(Identifier) |var|
+//@[004:0024) | ├─IdentifierSyntax
+//@[004:0024) | | └─Token(Identifier) |multiLineWithComment|
+//@[025:0026) | ├─Token(Assignment) |=|
+//@[027:0113) | └─FunctionCallSyntax
+//@[027:0033) |   ├─IdentifierSyntax
+//@[027:0033) |   | └─Token(Identifier) |reduce|
+//@[033:0034) |   ├─Token(LeftParen) |(|
+//@[034:0055) |   ├─FunctionArgumentSyntax
+//@[034:0055) |   | └─ArraySyntax
+//@[034:0035) |   |   ├─Token(LeftSquare) |[|
+//@[035:0040) |   |   ├─ArrayItemSyntax
+//@[035:0040) |   |   | └─StringSyntax
+//@[035:0040) |   |   |   └─Token(StringComplete) |'abc'|
+//@[040:0041) |   |   ├─Token(Comma) |,|
+//@[042:0047) |   |   ├─ArrayItemSyntax
+//@[042:0047) |   |   | └─StringSyntax
+//@[042:0047) |   |   |   └─Token(StringComplete) |'def'|
+//@[047:0048) |   |   ├─Token(Comma) |,|
+//@[049:0054) |   |   ├─ArrayItemSyntax
+//@[049:0054) |   |   | └─StringSyntax
+//@[049:0054) |   |   |   └─Token(StringComplete) |'ghi'|
+//@[054:0055) |   |   └─Token(RightSquare) |]|
+//@[055:0056) |   ├─Token(Comma) |,|
+//@[057:0059) |   ├─FunctionArgumentSyntax
+//@[057:0059) |   | └─StringSyntax
+//@[057:0059) |   |   └─Token(StringComplete) |''|
+//@[059:0060) |   ├─Token(Comma) |,|
+//@[061:0112) |   ├─FunctionArgumentSyntax
+//@[061:0112) |   | └─LambdaSyntax
+//@[061:0091) |   |   ├─VariableBlockSyntax
+//@[061:0062) |   |   | ├─Token(LeftParen) |(|
+//@[062:0063) |   |   | ├─Token(NewLine) |\n|
+  // comment
+//@[012:0013) |   |   | ├─Token(NewLine) |\n|
+  cur,
+//@[002:0005) |   |   | ├─LocalVariableSyntax
+//@[002:0005) |   |   | | └─IdentifierSyntax
+//@[002:0005) |   |   | |   └─Token(Identifier) |cur|
+//@[005:0006) |   |   | ├─Token(Comma) |,|
+//@[006:0007) |   |   | ├─Token(NewLine) |\n|
+  next
+//@[002:0006) |   |   | ├─LocalVariableSyntax
+//@[002:0006) |   |   | | └─IdentifierSyntax
+//@[002:0006) |   |   | |   └─Token(Identifier) |next|
+//@[006:0007) |   |   | ├─Token(NewLine) |\n|
 ) => concat(cur, next))
 //@[000:0001) |   |   | └─Token(RightParen) |)|
 //@[002:0004) |   |   ├─Token(Arrow) |=>|

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.tokens.bicep
@@ -1027,6 +1027,45 @@ var multiLine = reduce(['abc', 'def', 'ghi'], '', (
 //@[017:021) Identifier |next|
 //@[021:022) RightParen |)|
 //@[022:023) RightParen |)|
+//@[023:025) NewLine |\n\n|
+
+var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
+//@[000:003) Identifier |var|
+//@[004:024) Identifier |multiLineWithComment|
+//@[025:026) Assignment |=|
+//@[027:033) Identifier |reduce|
+//@[033:034) LeftParen |(|
+//@[034:035) LeftSquare |[|
+//@[035:040) StringComplete |'abc'|
+//@[040:041) Comma |,|
+//@[042:047) StringComplete |'def'|
+//@[047:048) Comma |,|
+//@[049:054) StringComplete |'ghi'|
+//@[054:055) RightSquare |]|
+//@[055:056) Comma |,|
+//@[057:059) StringComplete |''|
+//@[059:060) Comma |,|
+//@[061:062) LeftParen |(|
+//@[062:063) NewLine |\n|
+  // comment
+//@[012:013) NewLine |\n|
+  cur,
+//@[002:005) Identifier |cur|
+//@[005:006) Comma |,|
+//@[006:007) NewLine |\n|
+  next
+//@[002:006) Identifier |next|
+//@[006:007) NewLine |\n|
+) => concat(cur, next))
+//@[000:001) RightParen |)|
+//@[002:004) Arrow |=>|
+//@[005:011) Identifier |concat|
+//@[011:012) LeftParen |(|
+//@[012:015) Identifier |cur|
+//@[015:016) Comma |,|
+//@[017:021) Identifier |next|
+//@[021:022) RightParen |)|
+//@[022:023) RightParen |)|
 //@[023:024) NewLine |\n|
 
 //@[000:000) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.bicep
@@ -138,7 +138,9 @@ param defaultExpression bool = 18 != (true || false)
 ])
 param stringLiteral string
 
-@allowed([
+@allowed(
+    // some comment
+    [
   'abc'
   'def'
   'ghi'

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.diagnostics.bicep
@@ -162,7 +162,9 @@ param defaultExpression bool = 18 != (true || false)
 ])
 param stringLiteral string
 
-@allowed([
+@allowed(
+    // some comment
+    [
   'abc'
   'def'
   'ghi'

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.formatted.bicep
@@ -136,11 +136,14 @@ param defaultExpression bool = 18 != (true || false)
 ])
 param stringLiteral string
 
-@allowed([
-  'abc'
-  'def'
-  'ghi'
-])
+@allowed(
+  // some comment
+  [
+    'abc'
+    'def'
+    'ghi'
+  ]
+)
 param stringLiteralWithAllowedValuesSuperset string = stringLiteral
 
 @secure()

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 /*
-//@[000:3137) ProgramExpression
+//@[000:3162) ProgramExpression
   This is a block comment.
 */
 
@@ -283,8 +283,10 @@ param defaultExpression bool = 18 != (true || false)
 param stringLiteral string
 //@[020:0026) | └─AmbientTypeReferenceExpression { Name = string }
 
-@allowed([
-//@[000:0105) ├─DeclaredParameterExpression { Name = stringLiteralWithAllowedValuesSuperset }
+@allowed(
+//@[000:0130) ├─DeclaredParameterExpression { Name = stringLiteralWithAllowedValuesSuperset }
+    // some comment
+    [
   'abc'
   'def'
   'ghi'

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.sourcemap.bicep
@@ -292,7 +292,9 @@ param stringLiteral string
 //@      "type": "string",
 //@    },
 
-@allowed([
+@allowed(
+    // some comment
+    [
 //@      "allowedValues": [
 //@      ]
   'abc'

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.symbols.bicep
@@ -161,13 +161,15 @@ param defaultExpression bool = 18 != (true || false)
 param stringLiteral string
 //@[6:19) Parameter stringLiteral. Type: 'abc' | 'def'. Declaration start char: 0, length: 56
 
-@allowed([
+@allowed(
+    // some comment
+    [
   'abc'
   'def'
   'ghi'
 ])
 param stringLiteralWithAllowedValuesSuperset string = stringLiteral
-//@[6:44) Parameter stringLiteralWithAllowedValuesSuperset. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 0, length: 105
+//@[6:44) Parameter stringLiteralWithAllowedValuesSuperset. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 0, length: 130
 
 @secure()
 @minLength(2)

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 /*
-//@[000:3137) ProgramSyntax
+//@[000:3162) ProgramSyntax
   This is a block comment.
 */
 //@[002:0004) ├─Token(NewLine) |\n\n|
@@ -890,18 +890,22 @@ param stringLiteral string
 //@[020:0026) |     └─Token(Identifier) |string|
 //@[026:0028) ├─Token(NewLine) |\n\n|
 
-@allowed([
-//@[000:0105) ├─ParameterDeclarationSyntax
-//@[000:0037) | ├─DecoratorSyntax
+@allowed(
+//@[000:0130) ├─ParameterDeclarationSyntax
+//@[000:0062) | ├─DecoratorSyntax
 //@[000:0001) | | ├─Token(At) |@|
-//@[001:0037) | | └─FunctionCallSyntax
+//@[001:0062) | | └─FunctionCallSyntax
 //@[001:0008) | |   ├─IdentifierSyntax
 //@[001:0008) | |   | └─Token(Identifier) |allowed|
 //@[008:0009) | |   ├─Token(LeftParen) |(|
-//@[009:0036) | |   ├─FunctionArgumentSyntax
-//@[009:0036) | |   | └─ArraySyntax
-//@[009:0010) | |   |   ├─Token(LeftSquare) |[|
-//@[010:0011) | |   |   ├─Token(NewLine) |\n|
+//@[009:0010) | |   ├─Token(NewLine) |\n|
+    // some comment
+//@[019:0020) | |   ├─Token(NewLine) |\n|
+    [
+//@[004:0031) | |   ├─FunctionArgumentSyntax
+//@[004:0031) | |   | └─ArraySyntax
+//@[004:0005) | |   |   ├─Token(LeftSquare) |[|
+//@[005:0006) | |   |   ├─Token(NewLine) |\n|
   'abc'
 //@[002:0007) | |   |   ├─ArrayItemSyntax
 //@[002:0007) | |   |   | └─StringSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.tokens.bicep
@@ -562,12 +562,16 @@ param stringLiteral string
 //@[020:026) Identifier |string|
 //@[026:028) NewLine |\n\n|
 
-@allowed([
+@allowed(
 //@[000:001) At |@|
 //@[001:008) Identifier |allowed|
 //@[008:009) LeftParen |(|
-//@[009:010) LeftSquare |[|
-//@[010:011) NewLine |\n|
+//@[009:010) NewLine |\n|
+    // some comment
+//@[019:020) NewLine |\n|
+    [
+//@[004:005) LeftSquare |[|
+//@[005:006) NewLine |\n|
   'abc'
 //@[002:007) StringComplete |'abc'|
 //@[007:008) NewLine |\n|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.bicep
@@ -87,7 +87,9 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
 }
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
+var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
+// comment
+cosmosDb.account)
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
@@ -93,7 +93,9 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
 }
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
+var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
+// comment
+cosmosDb.account)
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.formatted.bicep
@@ -86,7 +86,11 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
 }
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
+var cosmosDbResourceId = resourceId(
+  'Microsoft.DocumentDB/databaseAccounts',
+  // comment
+  cosmosDb.account
+)
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.ir.bicep
@@ -1,5 +1,5 @@
 
-//@[000:13313) ProgramExpression
+//@[000:13326) ProgramExpression
 //@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
 //@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
 //@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
@@ -290,12 +290,14 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
 }
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
-//@[000:00094) ├─DeclaredVariableExpression { Name = cosmosDbResourceId }
-//@[025:00094) | └─FunctionCallExpression { Name = resourceId }
+var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
+//@[000:00107) ├─DeclaredVariableExpression { Name = cosmosDbResourceId }
+//@[025:00107) | └─FunctionCallExpression { Name = resourceId }
 //@[036:00075) |   ├─StringLiteralExpression { Value = Microsoft.DocumentDB/databaseAccounts }
-//@[077:00093) |   └─PropertyAccessExpression { PropertyName = account }
-//@[077:00085) |     └─ParametersReferenceExpression { Parameter = cosmosDb }
+// comment
+cosmosDb.account)
+//@[000:00016) |   └─PropertyAccessExpression { PropertyName = account }
+//@[000:00008) |     └─ParametersReferenceExpression { Parameter = cosmosDb }
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.sourcemap.bicep
@@ -187,8 +187,10 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
 }
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
+var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
 //@    "cosmosDbResourceId": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDb').account)]",
+// comment
+cosmosDb.account)
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 
 // this variable is not accessed anywhere in this template and depends on a run-time reference

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
@@ -97,8 +97,10 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
   }
 }
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
-//@[04:022) Variable cosmosDbResourceId. Type: string. Declaration start char: 0, length: 94
+var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
+//@[04:022) Variable cosmosDbResourceId. Type: string. Declaration start char: 0, length: 107
+// comment
+cosmosDb.account)
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 //@[04:015) Variable cosmosDbRef. Type: any. Declaration start char: 0, length: 64
 

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
@@ -1,5 +1,5 @@
 
-//@[000:13313) ProgramSyntax
+//@[000:13326) ProgramSyntax
 //@[000:00002) ├─Token(NewLine) |\r\n|
 @sys.description('this is basicStorage')
 //@[000:00225) ├─ResourceDeclarationSyntax
@@ -618,13 +618,13 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
 //@[000:00001) |   └─Token(RightBrace) |}|
 //@[001:00005) ├─Token(NewLine) |\r\n\r\n|
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
-//@[000:00094) ├─VariableDeclarationSyntax
+var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
+//@[000:00107) ├─VariableDeclarationSyntax
 //@[000:00003) | ├─Token(Identifier) |var|
 //@[004:00022) | ├─IdentifierSyntax
 //@[004:00022) | | └─Token(Identifier) |cosmosDbResourceId|
 //@[023:00024) | ├─Token(Assignment) |=|
-//@[025:00094) | └─FunctionCallSyntax
+//@[025:00107) | └─FunctionCallSyntax
 //@[025:00035) |   ├─IdentifierSyntax
 //@[025:00035) |   | └─Token(Identifier) |resourceId|
 //@[035:00036) |   ├─Token(LeftParen) |(|
@@ -632,16 +632,20 @@ var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cos
 //@[036:00075) |   | └─StringSyntax
 //@[036:00075) |   |   └─Token(StringComplete) |'Microsoft.DocumentDB/databaseAccounts'|
 //@[075:00076) |   ├─Token(Comma) |,|
-//@[077:00093) |   ├─FunctionArgumentSyntax
-//@[077:00093) |   | └─PropertyAccessSyntax
-//@[077:00085) |   |   ├─VariableAccessSyntax
-//@[077:00085) |   |   | └─IdentifierSyntax
-//@[077:00085) |   |   |   └─Token(Identifier) |cosmosDb|
-//@[085:00086) |   |   ├─Token(Dot) |.|
-//@[086:00093) |   |   └─IdentifierSyntax
-//@[086:00093) |   |     └─Token(Identifier) |account|
-//@[093:00094) |   └─Token(RightParen) |)|
-//@[094:00096) ├─Token(NewLine) |\r\n|
+//@[076:00078) |   ├─Token(NewLine) |\r\n|
+// comment
+//@[010:00012) |   ├─Token(NewLine) |\r\n|
+cosmosDb.account)
+//@[000:00016) |   ├─FunctionArgumentSyntax
+//@[000:00016) |   | └─PropertyAccessSyntax
+//@[000:00008) |   |   ├─VariableAccessSyntax
+//@[000:00008) |   |   | └─IdentifierSyntax
+//@[000:00008) |   |   |   └─Token(Identifier) |cosmosDb|
+//@[008:00009) |   |   ├─Token(Dot) |.|
+//@[009:00016) |   |   └─IdentifierSyntax
+//@[009:00016) |   |     └─Token(Identifier) |account|
+//@[016:00017) |   └─Token(RightParen) |)|
+//@[017:00019) ├─Token(NewLine) |\r\n|
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 //@[000:00064) ├─VariableDeclarationSyntax
 //@[000:00003) | ├─Token(Identifier) |var|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.tokens.bicep
@@ -403,7 +403,7 @@ resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
 //@[000:001) RightBrace |}|
 //@[001:005) NewLine |\r\n\r\n|
 
-var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosDb.account)
+var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts',
 //@[000:003) Identifier |var|
 //@[004:022) Identifier |cosmosDbResourceId|
 //@[023:024) Assignment |=|
@@ -411,11 +411,15 @@ var cosmosDbResourceId = resourceId('Microsoft.DocumentDB/databaseAccounts', cos
 //@[035:036) LeftParen |(|
 //@[036:075) StringComplete |'Microsoft.DocumentDB/databaseAccounts'|
 //@[075:076) Comma |,|
-//@[077:085) Identifier |cosmosDb|
-//@[085:086) Dot |.|
-//@[086:093) Identifier |account|
-//@[093:094) RightParen |)|
-//@[094:096) NewLine |\r\n|
+//@[076:078) NewLine |\r\n|
+// comment
+//@[010:012) NewLine |\r\n|
+cosmosDb.account)
+//@[000:008) Identifier |cosmosDb|
+//@[008:009) Dot |.|
+//@[009:016) Identifier |account|
+//@[016:017) RightParen |)|
+//@[017:019) NewLine |\r\n|
 var cosmosDbRef = reference(cosmosDbResourceId).documentEndpoint
 //@[000:003) Identifier |var|
 //@[004:015) Identifier |cosmosDbRef|

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -489,7 +489,7 @@ namespace Bicep.Core.Parsing
             var rewritten = expressionsOrCommas.Select(item => item switch
             {
                 VariableAccessSyntax varAccess => new LocalVariableSyntax(varAccess.Name),
-                Token { Type: TokenType.Comma } => item,
+                Token { Type: TokenType.Comma or TokenType.NewLine } => item,
                 SkippedTriviaSyntax => item,
                 _ => new SkippedTriviaSyntax(item.Span, item.AsEnumerable()),
             });

--- a/src/Bicep.Core/PrettyPrintV2/Documents/DocumentOperators.cs
+++ b/src/Bicep.Core/PrettyPrintV2/Documents/DocumentOperators.cs
@@ -37,11 +37,6 @@ namespace Bicep.Core.PrettyPrintV2.Documents
         /// </summary>
         public static readonly LineDocument LineOrCommaSpace = new(", ");
 
-        /// <summary>
-        /// Prints a comma and newline and indent the next line. If the enclosing group fits on one line, the newline will be replaced with a whitespace.
-        /// </summary>
-        public static readonly Document CommaLineOrCommaSpace = Glue(",", LineOrSpace);
-
         public static Document Glue(params Document[] documents) => new GlueDocument(documents);
 
         public static Document Glue(this IEnumerable<Document> documents) => documents is Document single ? single : new GlueDocument(documents);

--- a/src/Bicep.Core/Syntax/FunctionCallSyntaxBase.cs
+++ b/src/Bicep.Core/Syntax/FunctionCallSyntaxBase.cs
@@ -16,7 +16,7 @@ namespace Bicep.Core.Syntax
             this.OpenParen = openParen;
             this.Children = children.ToImmutableArray();
             this.CloseParen = closeParen;
-            this.Arguments = children.OfType<FunctionArgumentSyntax>().ToImmutableArray();
+            this.Arguments = this.Children.OfType<FunctionArgumentSyntax>().ToImmutableArray();
         }
 
         public IdentifierSyntax Name { get; }

--- a/src/Bicep.Core/Syntax/ParameterizedTypeInstantiationSyntaxBase.cs
+++ b/src/Bicep.Core/Syntax/ParameterizedTypeInstantiationSyntaxBase.cs
@@ -17,7 +17,7 @@ public abstract class ParameterizedTypeInstantiationSyntaxBase : TypeSyntax, ISy
         this.OpenChevron = openChevron;
         this.Children = children.ToImmutableArray();
         this.CloseChevron = closeChevron;
-        this.Arguments = children.OfType<ParameterizedTypeArgumentSyntax>().ToImmutableArray();
+        this.Arguments = this.Children.OfType<ParameterizedTypeArgumentSyntax>().ToImmutableArray();
     }
 
     public IdentifierSyntax Name { get; }

--- a/src/Bicep.Core/Syntax/TypedVariableBlockSyntax.cs
+++ b/src/Bicep.Core/Syntax/TypedVariableBlockSyntax.cs
@@ -15,7 +15,7 @@ public class TypedVariableBlockSyntax : SyntaxBase
         this.OpenParen = openParen;
         this.Children = children.ToImmutableArray();
         this.CloseParen = closeParen;
-        this.Arguments = Children.OfType<TypedLocalVariableSyntax>().ToImmutableArray();
+        this.Arguments = this.Children.OfType<TypedLocalVariableSyntax>().ToImmutableArray();
     }
 
     public Token OpenParen { get; }

--- a/src/Bicep.Core/Syntax/VariableBlockSyntax.cs
+++ b/src/Bicep.Core/Syntax/VariableBlockSyntax.cs
@@ -15,7 +15,7 @@ namespace Bicep.Core.Syntax
             this.OpenParen = openParen;
             this.Children = children.ToImmutableArray();
             this.CloseParen = closeParen;
-            this.Arguments = Children.OfType<LocalVariableSyntax>().ToImmutableArray();
+            this.Arguments = this.Children.OfType<LocalVariableSyntax>().ToImmutableArray();
         }
 
         public Token OpenParen { get; }


### PR DESCRIPTION
Discovered a bug while experimenting with comment formatting. If a line comment is present within the argument list of a function call or within other variable block syntax structures, formatting the code will unintentionally add a comma after the comment. This PR fixes it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13504)