### PR TITLE
Show tooltips on hover for type property definitions and type additional properties accesses

### DIFF
--- a/src/Bicep.Core.IntegrationTests/TypeSystem/Providers/ResourceTypeProviderFactoryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/Providers/ResourceTypeProviderFactoryTests.cs
@@ -31,7 +31,7 @@ public class ResourceTypeProviderFactoryTests
         var (clientFactory, _) = RegistryHelper.CreateMockRegistryClients(repositoryNames.Select(name => (registry, $"{repositoryPath}/{name}")).ToArray());
 
         var services = new ServiceBuilder()
-            .WithFeatureOverrides(new(ExtensibilityEnabled: true, ProviderRegistry: true, DynamicTypeLoadingEnabled: true))
+            .WithFeatureOverrides(new(TestContext, ExtensibilityEnabled: true, ProviderRegistry: true, DynamicTypeLoadingEnabled: true))
             .WithContainerRegistryClientFactory(clientFactory);
 
         foreach (var repoName in repositoryNames)
@@ -46,7 +46,7 @@ public class ResourceTypeProviderFactoryTests
                 "main.bicep",
                 @$"
                 provider 'br:example.azurecr.io/test/provider/foo@1.2.3' as foo
-                
+
                 module mod './mod.bicep' = {{
                     name: 'mod'
                     params: {{ }}


### PR DESCRIPTION
Resolves #13461 
Resolves #13398

There were a couple of scenarios where the LS was not showing hover tooltips for properties:
* When hovering over a type property definition
* When hovering over a property name that would match against a value's additional properties type

There's no way to capture a description for an object's additional properties type, but the hover can at least show the expected type.