### PR TITLE
Fix for issue #13558

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/GenerateParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/GenerateParamsCommandTests.cs
@@ -91,7 +91,46 @@ namespace Bicep.Cli.IntegrationTests
                 content.Should().Be(@"{
   ""$schema"": ""https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#"",
   ""contentVersion"": ""1.0.0.0"",
-  ""parameters"": {}
+  ""parameters"": {
+    ""name"": {
+      ""value"": """"
+    }
+  }
+}".ReplaceLineEndings());
+            }
+        }
+
+        [TestMethod]
+        public async Task GenerateParams_ImplicitOutputFormatJson_ExplicitIncludeParamsAll_OneParameterWithDefaultValueAndOneRequiredParameter_Should_Succeed()
+        {
+            var bicep = $@"param optional string = 'sampleparameter'
+param required string";
+
+            var tempDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
+            Directory.CreateDirectory(tempDirectory);
+
+            var bicepFilePath = Path.Combine(tempDirectory, "built.bicep");
+            File.WriteAllText(bicepFilePath, bicep);
+
+            var (output, error, result) = await Bicep("generate-params", "--include-params", "all", bicepFilePath);
+
+            var content = File.ReadAllText(Path.Combine(tempDirectory, "built.parameters.json")).ReplaceLineEndings();
+
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+
+                content.Should().Be(@"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0"",
+  ""parameters"": {
+    ""optional"": {
+      ""value"": """"
+    },
+    ""required"": {
+      ""value"": """"
+    }
+  }
 }".ReplaceLineEndings());
             }
         }

--- a/src/Bicep.Core/Emit/PlaceholderParametersJsonWriter.cs
+++ b/src/Bicep.Core/Emit/PlaceholderParametersJsonWriter.cs
@@ -95,8 +95,6 @@ namespace Bicep.Core.Emit
 
                 foreach (var parameterSymbol in filteredParameterDeclarations)
                 {
-                    if (parameterSymbol.DeclaringParameter.Modifier is not ParameterDefaultValueSyntax)
-                    {
                         jsonWriter.WritePropertyName(parameterSymbol.Name);
 
                         jsonWriter.WriteStartObject();
@@ -119,7 +117,6 @@ namespace Bicep.Core.Emit
                                 break;
                         }
                         jsonWriter.WriteEndObject();
-                    }
                 }
 
                 jsonWriter.WriteEndObject();


### PR DESCRIPTION
Closes https://github.com/Azure/bicep/issues/13558 Bicep generate-params don't emit optional parameters with --include-params All flag
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13559)