### PR TITLE
Preserve distinction between `{}` and `object` in compiled JSON

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -451,6 +451,18 @@ param anotherObject object = {prop: 'someVal'}
     }
 
     [TestMethod]
+    public void Empty_object_should_be_distinguishable_from_untyped_object_in_compiled_JSON()
+    {
+        var result = CompilationHelper.Compile("""
+            type emptyObject = {}
+            type untypedObect = object
+            """);
+
+        result.Template.Should().HaveValueAtPath("definitions.emptyObject.properties", new JObject());
+        result.Template.Should().NotHaveValueAtPath("definitions.untypedObject.properties");
+    }
+
+    [TestMethod]
     public void Error_should_be_shown_when_setting_unknown_properties_that_do_not_match_additional_properties_type()
     {
         var result = CompilationHelper.Compile(@"

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7210691896706139249"
+      "templateHash": "8162009081861809153"
     }
   },
   "definitions": {
@@ -194,6 +194,7 @@
     },
     "stringStringDictionary": {
       "type": "object",
+      "properties": {},
       "additionalProperties": {
         "type": "string"
       }
@@ -665,6 +666,7 @@
     },
     "discriminatedUnionInlineAdditionalProps1": {
       "type": "object",
+      "properties": {},
       "additionalProperties": {
         "type": "object",
         "discriminator": {
@@ -682,6 +684,7 @@
     },
     "discriminatedUnionInlineAdditionalProps2": {
       "type": "object",
+      "properties": {},
       "additionalProperties": {
         "type": "object",
         "discriminator": {

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
@@ -305,6 +305,7 @@ type tupleSecondItem = tuple[1]
 type stringStringDictionary = {
 //@    "stringStringDictionary": {
 //@      "type": "object",
+//@      "properties": {},
 //@    },
     *: string
 //@      "additionalProperties": {
@@ -903,6 +904,7 @@ type discriminatorUnionAsPropertyType = {
 type discriminatedUnionInlineAdditionalProps1 = {
 //@    "discriminatedUnionInlineAdditionalProps1": {
 //@      "type": "object",
+//@      "properties": {},
 //@    },
   @discriminator('type')
   *: typeA | typeB
@@ -925,6 +927,7 @@ type discriminatedUnionInlineAdditionalProps1 = {
 type discriminatedUnionInlineAdditionalProps2 = {
 //@    "discriminatedUnionInlineAdditionalProps2": {
 //@      "type": "object",
+//@      "properties": {},
 //@    },
   @discriminator('type')
   *: (typeA | typeB)?

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7210691896706139249"
+      "templateHash": "8162009081861809153"
     }
   },
   "definitions": {
@@ -194,6 +194,7 @@
     },
     "stringStringDictionary": {
       "type": "object",
+      "properties": {},
       "additionalProperties": {
         "type": "string"
       }
@@ -665,6 +666,7 @@
     },
     "discriminatedUnionInlineAdditionalProps1": {
       "type": "object",
+      "properties": {},
       "additionalProperties": {
         "type": "object",
         "discriminator": {
@@ -682,6 +684,7 @@
     },
     "discriminatedUnionInlineAdditionalProps2": {
       "type": "object",
+      "properties": {},
       "additionalProperties": {
         "type": "object",
         "discriminator": {

--- a/src/Bicep.Core.UnitTests/Semantics/ArmTemplateSemanticModelTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/ArmTemplateSemanticModelTests.cs
@@ -514,6 +514,30 @@ public class ArmTemplateSemanticModelTests
         fallbackType.Properties["name"].TypeReference.Type.Should().Be(TypeFactory.CreateStringLiteralType("default"));
     }
 
+    [TestMethod]
+    public void Empty_properties_constraint_causes_loaded_object_to_use_FallbackProperty_flag_on_additional_properties()
+    {
+        var parameterType = GetLoadedParameterType("""
+            {
+              "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "languageVersion": "2.0",
+              "resources": {},
+              "parameters": {
+                "emptyObject": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+            """,
+            "emptyObject");
+
+        var objectParameterType = parameterType.Should().BeAssignableTo<ObjectType>().Subject;
+        objectParameterType.AdditionalPropertiesType.Should().Be(LanguageConstants.Any);
+        objectParameterType.AdditionalPropertiesFlags.Should().HaveFlag(TypePropertyFlags.FallbackProperty);
+    }
+
     private static TypeSymbol GetLoadedParameterType(string jsonTemplate, string parameterName)
     {
         var model = LoadModel(jsonTemplate);

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -745,10 +745,7 @@ namespace Bicep.Core.Emit
                 propertySchemata.Add(ExpressionFactory.CreateObjectProperty(property.PropertyName, propertySchema, property.SourceSyntax));
             }
 
-            if (propertySchemata.Any())
-            {
-                properties.Add(ExpressionFactory.CreateObjectProperty("properties", ExpressionFactory.CreateObject(propertySchemata, expression.SourceSyntax)));
-            }
+            properties.Add(ExpressionFactory.CreateObjectProperty("properties", ExpressionFactory.CreateObject(propertySchemata, expression.SourceSyntax)));
 
             if (expression.AdditionalPropertiesExpression is { } addlPropsType)
             {


### PR DESCRIPTION
Resolves #13556 

Given an object type declaration with no catchall schema, the type checker will issue warnings if a property whose name does not match any property declarations is supplied.

```bicep
param example { foo: string } = { bar: 'string' }         // <-- Issues a BCP037 warning because there is no known `bar` property

@sealed()
param sealedExample { foo: string } = { bar: 'string' }   // <-- Issues a BCP037 error because there is no known `bar` property and the object is sealed
```

This means that given an object type declaration of `{}`, all supplied properties will trigger a BCP037 warning because an empty object was expected. This behaves differently from the untyped object `object`, which matches without warning against any object. The distinction between `{}` and `object` was getting dropped when templates were compiled to JSON, however, because the compiler wasn't including any information in the type definition that would allow the two to be distinguished; instead, they would both be compiled to `{"type": "object"}`.

This PR updates the compiler to include an empty `properties` constraint on object type declarations that include no properties so that it can tell the difference between `{}` and `object` when loading or importing from JSON modules.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13597)