### PR TITLE
Avoid running no-hardcoded-env-urls linter rule in .bicepparam files

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -5724,6 +5724,23 @@ param foo2 string[]
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
 
+    // https://github.com/Azure/bicep/issues/13607
+    [TestMethod]
+    public void Test_Issue13607()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+using 'main.bicep'
+
+param endpoint = 'management.core.windows.net'
+"""),
+            ("main.bicep", """
+param endpoint string
+"""));
+
+        result.Should().NotHaveAnyDiagnostics();
+    }
+
     // https://github.com/Azure/bicep/issues/13250
     [TestMethod]
     public void Test_Issue13250()

--- a/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedEnvironmentUrlsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/NoHardcodedEnvironmentUrlsRule.cs
@@ -6,6 +6,7 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
+using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.Analyzers.Linter.Rules
 {
@@ -28,6 +29,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
         public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
         {
+            if (model.SourceFile is BicepParamFile)
+            {
+                // The environment() function isn't available for .bicepparam files
+                return Enumerable.Empty<IDiagnostic>();
+            }
+
             var disallowedHosts = GetConfigurationValue(model.Configuration.Analyzers, DisallowedHostsKey.ToLowerInvariant(), Array.Empty<string>()).ToImmutableArray();
             var excludedHosts = GetConfigurationValue(model.Configuration.Analyzers, ExcludedHostsKey.ToLowerInvariant(), Array.Empty<string>()).ToImmutableArray();
 


### PR DESCRIPTION
Raised under #13607. This doesn't address the ask for the `environment()` function, but does ensure we avoid surfacing a warning that can't be actioned.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13608)