### PR TITLE
Distinguish between type syntax vs expression syntax in the parser

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/AKS_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/AKS_LF/main.syntax.bicep
@@ -6,7 +6,7 @@ param dnsPrefix string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |dnsPrefix|
-//@[016:0022) | └─VariableAccessSyntax
+//@[016:0022) | └─TypeVariableAccessSyntax
 //@[016:0022) |   └─IdentifierSyntax
 //@[016:0022) |     └─Token(Identifier) |string|
 //@[022:0023) ├─Token(NewLine) |\n|
@@ -15,7 +15,7 @@ param linuxAdminUsername string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0024) | ├─IdentifierSyntax
 //@[006:0024) | | └─Token(Identifier) |linuxAdminUsername|
-//@[025:0031) | └─VariableAccessSyntax
+//@[025:0031) | └─TypeVariableAccessSyntax
 //@[025:0031) |   └─IdentifierSyntax
 //@[025:0031) |     └─Token(Identifier) |string|
 //@[031:0032) ├─Token(NewLine) |\n|
@@ -24,7 +24,7 @@ param sshRSAPublicKey string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0021) | ├─IdentifierSyntax
 //@[006:0021) | | └─Token(Identifier) |sshRSAPublicKey|
-//@[022:0028) | └─VariableAccessSyntax
+//@[022:0028) | └─TypeVariableAccessSyntax
 //@[022:0028) |   └─IdentifierSyntax
 //@[022:0028) |     └─Token(Identifier) |string|
 //@[028:0030) ├─Token(NewLine) |\n\n|
@@ -43,7 +43,7 @@ param servcePrincipalClientId string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0029) | ├─IdentifierSyntax
 //@[006:0029) | | └─Token(Identifier) |servcePrincipalClientId|
-//@[030:0036) | └─VariableAccessSyntax
+//@[030:0036) | └─TypeVariableAccessSyntax
 //@[030:0036) |   └─IdentifierSyntax
 //@[030:0036) |     └─Token(Identifier) |string|
 //@[036:0038) ├─Token(NewLine) |\n\n|
@@ -62,7 +62,7 @@ param servicePrincipalClientSecret string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0034) | ├─IdentifierSyntax
 //@[006:0034) | | └─Token(Identifier) |servicePrincipalClientSecret|
-//@[035:0041) | └─VariableAccessSyntax
+//@[035:0041) | └─TypeVariableAccessSyntax
 //@[035:0041) |   └─IdentifierSyntax
 //@[035:0041) |     └─Token(Identifier) |string|
 //@[041:0043) ├─Token(NewLine) |\n\n|
@@ -74,7 +74,7 @@ param clusterName string = 'aks101cluster'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |clusterName|
-//@[018:0024) | ├─VariableAccessSyntax
+//@[018:0024) | ├─TypeVariableAccessSyntax
 //@[018:0024) | | └─IdentifierSyntax
 //@[018:0024) | |   └─Token(Identifier) |string|
 //@[025:0042) | └─ParameterDefaultValueSyntax
@@ -87,7 +87,7 @@ param location string = resourceGroup().location
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0014) | ├─IdentifierSyntax
 //@[006:0014) | | └─Token(Identifier) |location|
-//@[015:0021) | ├─VariableAccessSyntax
+//@[015:0021) | ├─TypeVariableAccessSyntax
 //@[015:0021) | | └─IdentifierSyntax
 //@[015:0021) | |   └─Token(Identifier) |string|
 //@[022:0048) | └─ParameterDefaultValueSyntax
@@ -132,7 +132,7 @@ param osDiskSizeGB int = 0
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0018) | ├─IdentifierSyntax
 //@[006:0018) | | └─Token(Identifier) |osDiskSizeGB|
-//@[019:0022) | ├─VariableAccessSyntax
+//@[019:0022) | ├─TypeVariableAccessSyntax
 //@[019:0022) | | └─IdentifierSyntax
 //@[019:0022) | |   └─Token(Identifier) |int|
 //@[023:0026) | └─ParameterDefaultValueSyntax
@@ -170,7 +170,7 @@ param agentCount int = 3
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0016) | ├─IdentifierSyntax
 //@[006:0016) | | └─Token(Identifier) |agentCount|
-//@[017:0020) | ├─VariableAccessSyntax
+//@[017:0020) | ├─TypeVariableAccessSyntax
 //@[017:0020) | | └─IdentifierSyntax
 //@[017:0020) | |   └─Token(Identifier) |int|
 //@[021:0024) | └─ParameterDefaultValueSyntax
@@ -184,7 +184,7 @@ param agentVMSize string = 'Standard_DS2_v2'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |agentVMSize|
-//@[018:0024) | ├─VariableAccessSyntax
+//@[018:0024) | ├─TypeVariableAccessSyntax
 //@[018:0024) | | └─IdentifierSyntax
 //@[018:0024) | |   └─Token(Identifier) |string|
 //@[025:0044) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/Dependencies_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Dependencies_LF/main.syntax.bicep
@@ -4,7 +4,7 @@ param deployTimeParam string = 'steve'
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0021) | ├─IdentifierSyntax
 //@[06:0021) | | └─Token(Identifier) |deployTimeParam|
-//@[22:0028) | ├─VariableAccessSyntax
+//@[22:0028) | ├─TypeVariableAccessSyntax
 //@[22:0028) | | └─IdentifierSyntax
 //@[22:0028) | |   └─Token(Identifier) |string|
 //@[29:0038) | └─ParameterDefaultValueSyntax
@@ -144,7 +144,7 @@ output resourceAType string = resA.type
 //@[00:0006) | ├─Token(Identifier) |output|
 //@[07:0020) | ├─IdentifierSyntax
 //@[07:0020) | | └─Token(Identifier) |resourceAType|
-//@[21:0027) | ├─VariableAccessSyntax
+//@[21:0027) | ├─TypeVariableAccessSyntax
 //@[21:0027) | | └─IdentifierSyntax
 //@[21:0027) | |   └─Token(Identifier) |string|
 //@[28:0029) | ├─Token(Assignment) |=|
@@ -212,7 +212,7 @@ output resourceBId string = resB.id
 //@[00:0006) | ├─Token(Identifier) |output|
 //@[07:0018) | ├─IdentifierSyntax
 //@[07:0018) | | └─Token(Identifier) |resourceBId|
-//@[19:0025) | ├─VariableAccessSyntax
+//@[19:0025) | ├─TypeVariableAccessSyntax
 //@[19:0025) | | └─IdentifierSyntax
 //@[19:0025) | |   └─Token(Identifier) |string|
 //@[26:0027) | ├─Token(Assignment) |=|
@@ -443,7 +443,7 @@ output resourceCProperties object = resC.properties
 //@[00:0006) | ├─Token(Identifier) |output|
 //@[07:0026) | ├─IdentifierSyntax
 //@[07:0026) | | └─Token(Identifier) |resourceCProperties|
-//@[27:0033) | ├─VariableAccessSyntax
+//@[27:0033) | ├─TypeVariableAccessSyntax
 //@[27:0033) | | └─IdentifierSyntax
 //@[27:0033) | |   └─Token(Identifier) |object|
 //@[34:0035) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/DisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/DisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
@@ -113,7 +113,7 @@ param storageAccount1 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount1|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -128,7 +128,7 @@ param storageAccount2 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount2|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -143,7 +143,7 @@ param storageAccount3 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount3|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -158,7 +158,7 @@ param storageAccount5 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount5|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.syntax.bicep
@@ -10,25 +10,25 @@ func buildUrl(https bool, hostname string, path string) string => '${https ? 'ht
 //@[014:0024) |   | ├─TypedLocalVariableSyntax
 //@[014:0019) |   | | ├─IdentifierSyntax
 //@[014:0019) |   | | | └─Token(Identifier) |https|
-//@[020:0024) |   | | └─VariableAccessSyntax
+//@[020:0024) |   | | └─TypeVariableAccessSyntax
 //@[020:0024) |   | |   └─IdentifierSyntax
 //@[020:0024) |   | |     └─Token(Identifier) |bool|
 //@[024:0025) |   | ├─Token(Comma) |,|
 //@[026:0041) |   | ├─TypedLocalVariableSyntax
 //@[026:0034) |   | | ├─IdentifierSyntax
 //@[026:0034) |   | | | └─Token(Identifier) |hostname|
-//@[035:0041) |   | | └─VariableAccessSyntax
+//@[035:0041) |   | | └─TypeVariableAccessSyntax
 //@[035:0041) |   | |   └─IdentifierSyntax
 //@[035:0041) |   | |     └─Token(Identifier) |string|
 //@[041:0042) |   | ├─Token(Comma) |,|
 //@[043:0054) |   | ├─TypedLocalVariableSyntax
 //@[043:0047) |   | | ├─IdentifierSyntax
 //@[043:0047) |   | | | └─Token(Identifier) |path|
-//@[048:0054) |   | | └─VariableAccessSyntax
+//@[048:0054) |   | | └─TypeVariableAccessSyntax
 //@[048:0054) |   | |   └─IdentifierSyntax
 //@[048:0054) |   | |     └─Token(Identifier) |string|
 //@[054:0055) |   | └─Token(RightParen) |)|
-//@[056:0062) |   ├─VariableAccessSyntax
+//@[056:0062) |   ├─TypeVariableAccessSyntax
 //@[056:0062) |   | └─IdentifierSyntax
 //@[056:0062) |   |   └─Token(Identifier) |string|
 //@[063:0065) |   ├─Token(Arrow) |=>|
@@ -77,7 +77,7 @@ output foo string = buildUrl(true, 'google.com', 'search')
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |foo|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -110,11 +110,11 @@ func sayHello(name string) string => 'Hi ${name}!'
 //@[014:0025) |   | ├─TypedLocalVariableSyntax
 //@[014:0018) |   | | ├─IdentifierSyntax
 //@[014:0018) |   | | | └─Token(Identifier) |name|
-//@[019:0025) |   | | └─VariableAccessSyntax
+//@[019:0025) |   | | └─TypeVariableAccessSyntax
 //@[019:0025) |   | |   └─IdentifierSyntax
 //@[019:0025) |   | |     └─Token(Identifier) |string|
 //@[025:0026) |   | └─Token(RightParen) |)|
-//@[027:0033) |   ├─VariableAccessSyntax
+//@[027:0033) |   ├─TypeVariableAccessSyntax
 //@[027:0033) |   | └─IdentifierSyntax
 //@[027:0033) |   |   └─Token(Identifier) |string|
 //@[034:0036) |   ├─Token(Arrow) |=>|
@@ -131,7 +131,7 @@ output hellos array = map(['Evie', 'Casper'], name => sayHello(name))
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0013) | ├─IdentifierSyntax
 //@[007:0013) | | └─Token(Identifier) |hellos|
-//@[014:0019) | ├─VariableAccessSyntax
+//@[014:0019) | ├─TypeVariableAccessSyntax
 //@[014:0019) | | └─IdentifierSyntax
 //@[014:0019) | |   └─Token(Identifier) |array|
 //@[020:0021) | ├─Token(Assignment) |=|
@@ -180,11 +180,11 @@ func objReturnType(name string) object => {
 //@[019:0030) |   | ├─TypedLocalVariableSyntax
 //@[019:0023) |   | | ├─IdentifierSyntax
 //@[019:0023) |   | | | └─Token(Identifier) |name|
-//@[024:0030) |   | | └─VariableAccessSyntax
+//@[024:0030) |   | | └─TypeVariableAccessSyntax
 //@[024:0030) |   | |   └─IdentifierSyntax
 //@[024:0030) |   | |     └─Token(Identifier) |string|
 //@[030:0031) |   | └─Token(RightParen) |)|
-//@[032:0038) |   ├─VariableAccessSyntax
+//@[032:0038) |   ├─TypeVariableAccessSyntax
 //@[032:0038) |   | └─IdentifierSyntax
 //@[032:0038) |   |   └─Token(Identifier) |object|
 //@[039:0041) |   ├─Token(Arrow) |=>|
@@ -218,11 +218,11 @@ func arrayReturnType(name string) array => [
 //@[021:0032) |   | ├─TypedLocalVariableSyntax
 //@[021:0025) |   | | ├─IdentifierSyntax
 //@[021:0025) |   | | | └─Token(Identifier) |name|
-//@[026:0032) |   | | └─VariableAccessSyntax
+//@[026:0032) |   | | └─TypeVariableAccessSyntax
 //@[026:0032) |   | |   └─IdentifierSyntax
 //@[026:0032) |   | |     └─Token(Identifier) |string|
 //@[032:0033) |   | └─Token(RightParen) |)|
-//@[034:0039) |   ├─VariableAccessSyntax
+//@[034:0039) |   ├─TypeVariableAccessSyntax
 //@[034:0039) |   | └─IdentifierSyntax
 //@[034:0039) |   |   └─Token(Identifier) |array|
 //@[040:0042) |   ├─Token(Arrow) |=>|
@@ -250,11 +250,11 @@ func asdf(name string) array => [
 //@[010:0021) |   | ├─TypedLocalVariableSyntax
 //@[010:0014) |   | | ├─IdentifierSyntax
 //@[010:0014) |   | | | └─Token(Identifier) |name|
-//@[015:0021) |   | | └─VariableAccessSyntax
+//@[015:0021) |   | | └─TypeVariableAccessSyntax
 //@[015:0021) |   | |   └─IdentifierSyntax
 //@[015:0021) |   | |     └─Token(Identifier) |string|
 //@[021:0022) |   | └─Token(RightParen) |)|
-//@[023:0028) |   ├─VariableAccessSyntax
+//@[023:0028) |   ├─TypeVariableAccessSyntax
 //@[023:0028) |   | └─IdentifierSyntax
 //@[023:0028) |   |   └─Token(Identifier) |array|
 //@[029:0031) |   ├─Token(Arrow) |=>|
@@ -294,7 +294,7 @@ type positiveInt = int
 //@[005:0016) | ├─IdentifierSyntax
 //@[005:0016) | | └─Token(Identifier) |positiveInt|
 //@[017:0018) | ├─Token(Assignment) |=|
-//@[019:0022) | └─VariableAccessSyntax
+//@[019:0022) | └─TypeVariableAccessSyntax
 //@[019:0022) |   └─IdentifierSyntax
 //@[019:0022) |     └─Token(Identifier) |int|
 //@[022:0024) ├─Token(NewLine) |\n\n|
@@ -312,13 +312,13 @@ func typedArg(input string[]) positiveInt => length(input)
 //@[014:0019) |   | | | └─Token(Identifier) |input|
 //@[020:0028) |   | | └─ArrayTypeSyntax
 //@[020:0026) |   | |   ├─ArrayTypeMemberSyntax
-//@[020:0026) |   | |   | └─VariableAccessSyntax
+//@[020:0026) |   | |   | └─TypeVariableAccessSyntax
 //@[020:0026) |   | |   |   └─IdentifierSyntax
 //@[020:0026) |   | |   |     └─Token(Identifier) |string|
 //@[026:0027) |   | |   ├─Token(LeftSquare) |[|
 //@[027:0028) |   | |   └─Token(RightSquare) |]|
 //@[028:0029) |   | └─Token(RightParen) |)|
-//@[030:0041) |   ├─VariableAccessSyntax
+//@[030:0041) |   ├─TypeVariableAccessSyntax
 //@[030:0041) |   | └─IdentifierSyntax
 //@[030:0041) |   |   └─Token(Identifier) |positiveInt|
 //@[042:0044) |   ├─Token(Arrow) |=>|
@@ -342,7 +342,7 @@ func barTest() array => ['abc', 'def']
 //@[012:0014) |   ├─TypedVariableBlockSyntax
 //@[012:0013) |   | ├─Token(LeftParen) |(|
 //@[013:0014) |   | └─Token(RightParen) |)|
-//@[015:0020) |   ├─VariableAccessSyntax
+//@[015:0020) |   ├─TypeVariableAccessSyntax
 //@[015:0020) |   | └─IdentifierSyntax
 //@[015:0020) |   |   └─Token(Identifier) |array|
 //@[021:0023) |   ├─Token(Arrow) |=>|
@@ -366,7 +366,7 @@ func fooTest() array => map(barTest(), a => 'Hello ${a}!')
 //@[012:0014) |   ├─TypedVariableBlockSyntax
 //@[012:0013) |   | ├─Token(LeftParen) |(|
 //@[013:0014) |   | └─Token(RightParen) |)|
-//@[015:0020) |   ├─VariableAccessSyntax
+//@[015:0020) |   ├─TypeVariableAccessSyntax
 //@[015:0020) |   | └─IdentifierSyntax
 //@[015:0020) |   |   └─Token(Identifier) |array|
 //@[021:0023) |   ├─Token(Arrow) |=>|
@@ -401,7 +401,7 @@ output fooValue array = fooTest()
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0015) | ├─IdentifierSyntax
 //@[007:0015) | | └─Token(Identifier) |fooValue|
-//@[016:0021) | ├─VariableAccessSyntax
+//@[016:0021) | ├─TypeVariableAccessSyntax
 //@[016:0021) | | └─IdentifierSyntax
 //@[016:0021) | |   └─Token(Identifier) |array|
 //@[022:0023) | ├─Token(Assignment) |=|
@@ -421,7 +421,7 @@ func test() object => loadJsonContent('./repro-data.json')
 //@[009:0011) |   ├─TypedVariableBlockSyntax
 //@[009:0010) |   | ├─Token(LeftParen) |(|
 //@[010:0011) |   | └─Token(RightParen) |)|
-//@[012:0018) |   ├─VariableAccessSyntax
+//@[012:0018) |   ├─TypeVariableAccessSyntax
 //@[012:0018) |   | └─IdentifierSyntax
 //@[012:0018) |   |   └─Token(Identifier) |object|
 //@[019:0021) |   ├─Token(Arrow) |=>|
@@ -443,7 +443,7 @@ func test2() string => loadTextContent('./repro-data.json')
 //@[010:0012) |   ├─TypedVariableBlockSyntax
 //@[010:0011) |   | ├─Token(LeftParen) |(|
 //@[011:0012) |   | └─Token(RightParen) |)|
-//@[013:0019) |   ├─VariableAccessSyntax
+//@[013:0019) |   ├─TypeVariableAccessSyntax
 //@[013:0019) |   | └─IdentifierSyntax
 //@[013:0019) |   |   └─Token(Identifier) |string|
 //@[020:0022) |   ├─Token(Arrow) |=>|
@@ -465,7 +465,7 @@ func test3() object => loadYamlContent('./repro-data.json')
 //@[010:0012) |   ├─TypedVariableBlockSyntax
 //@[010:0011) |   | ├─Token(LeftParen) |(|
 //@[011:0012) |   | └─Token(RightParen) |)|
-//@[013:0019) |   ├─VariableAccessSyntax
+//@[013:0019) |   ├─TypeVariableAccessSyntax
 //@[013:0019) |   | └─IdentifierSyntax
 //@[013:0019) |   |   └─Token(Identifier) |object|
 //@[020:0022) |   ├─Token(Arrow) |=>|
@@ -487,7 +487,7 @@ func test4() string => loadFileAsBase64('./repro-data.json')
 //@[010:0012) |   ├─TypedVariableBlockSyntax
 //@[010:0011) |   | ├─Token(LeftParen) |(|
 //@[011:0012) |   | └─Token(RightParen) |)|
-//@[013:0019) |   ├─VariableAccessSyntax
+//@[013:0019) |   ├─TypeVariableAccessSyntax
 //@[013:0019) |   | └─IdentifierSyntax
 //@[013:0019) |   |   └─Token(Identifier) |string|
 //@[020:0022) |   ├─Token(Arrow) |=>|
@@ -514,11 +514,11 @@ func a(_________________________________________________________________________
 //@[007:0106) |   | ├─TypedLocalVariableSyntax
 //@[007:0099) |   | | ├─IdentifierSyntax
 //@[007:0099) |   | | | └─Token(Identifier) |____________________________________________________________________________________________|
-//@[100:0106) |   | | └─VariableAccessSyntax
+//@[100:0106) |   | | └─TypeVariableAccessSyntax
 //@[100:0106) |   | |   └─IdentifierSyntax
 //@[100:0106) |   | |     └─Token(Identifier) |string|
 //@[106:0107) |   | └─Token(RightParen) |)|
-//@[108:0114) |   ├─VariableAccessSyntax
+//@[108:0114) |   ├─TypeVariableAccessSyntax
 //@[108:0114) |   | └─IdentifierSyntax
 //@[108:0114) |   |   └─Token(Identifier) |string|
 //@[115:0117) |   ├─Token(Arrow) |=>|
@@ -536,32 +536,32 @@ func b(longParameterName1 string, longParameterName2 string, longParameterName3 
 //@[007:0032) |   | ├─TypedLocalVariableSyntax
 //@[007:0025) |   | | ├─IdentifierSyntax
 //@[007:0025) |   | | | └─Token(Identifier) |longParameterName1|
-//@[026:0032) |   | | └─VariableAccessSyntax
+//@[026:0032) |   | | └─TypeVariableAccessSyntax
 //@[026:0032) |   | |   └─IdentifierSyntax
 //@[026:0032) |   | |     └─Token(Identifier) |string|
 //@[032:0033) |   | ├─Token(Comma) |,|
 //@[034:0059) |   | ├─TypedLocalVariableSyntax
 //@[034:0052) |   | | ├─IdentifierSyntax
 //@[034:0052) |   | | | └─Token(Identifier) |longParameterName2|
-//@[053:0059) |   | | └─VariableAccessSyntax
+//@[053:0059) |   | | └─TypeVariableAccessSyntax
 //@[053:0059) |   | |   └─IdentifierSyntax
 //@[053:0059) |   | |     └─Token(Identifier) |string|
 //@[059:0060) |   | ├─Token(Comma) |,|
 //@[061:0086) |   | ├─TypedLocalVariableSyntax
 //@[061:0079) |   | | ├─IdentifierSyntax
 //@[061:0079) |   | | | └─Token(Identifier) |longParameterName3|
-//@[080:0086) |   | | └─VariableAccessSyntax
+//@[080:0086) |   | | └─TypeVariableAccessSyntax
 //@[080:0086) |   | |   └─IdentifierSyntax
 //@[080:0086) |   | |     └─Token(Identifier) |string|
 //@[086:0087) |   | ├─Token(Comma) |,|
 //@[088:0113) |   | ├─TypedLocalVariableSyntax
 //@[088:0106) |   | | ├─IdentifierSyntax
 //@[088:0106) |   | | | └─Token(Identifier) |longParameterName4|
-//@[107:0113) |   | | └─VariableAccessSyntax
+//@[107:0113) |   | | └─TypeVariableAccessSyntax
 //@[107:0113) |   | |   └─IdentifierSyntax
 //@[107:0113) |   | |     └─Token(Identifier) |string|
 //@[113:0114) |   | └─Token(RightParen) |)|
-//@[115:0121) |   ├─VariableAccessSyntax
+//@[115:0121) |   ├─TypeVariableAccessSyntax
 //@[115:0121) |   | └─IdentifierSyntax
 //@[115:0121) |   |   └─Token(Identifier) |string|
 //@[122:0124) |   ├─Token(Arrow) |=>|
@@ -582,7 +582,7 @@ func buildUrlMultiLine(
 //@[002:0012) |   | ├─TypedLocalVariableSyntax
 //@[002:0007) |   | | ├─IdentifierSyntax
 //@[002:0007) |   | | | └─Token(Identifier) |https|
-//@[008:0012) |   | | └─VariableAccessSyntax
+//@[008:0012) |   | | └─TypeVariableAccessSyntax
 //@[008:0012) |   | |   └─IdentifierSyntax
 //@[008:0012) |   | |     └─Token(Identifier) |bool|
 //@[012:0013) |   | ├─Token(Comma) |,|
@@ -591,7 +591,7 @@ func buildUrlMultiLine(
 //@[002:0017) |   | ├─TypedLocalVariableSyntax
 //@[002:0010) |   | | ├─IdentifierSyntax
 //@[002:0010) |   | | | └─Token(Identifier) |hostname|
-//@[011:0017) |   | | └─VariableAccessSyntax
+//@[011:0017) |   | | └─TypeVariableAccessSyntax
 //@[011:0017) |   | |   └─IdentifierSyntax
 //@[011:0017) |   | |     └─Token(Identifier) |string|
 //@[017:0018) |   | ├─Token(Comma) |,|
@@ -600,13 +600,13 @@ func buildUrlMultiLine(
 //@[002:0013) |   | ├─TypedLocalVariableSyntax
 //@[002:0006) |   | | ├─IdentifierSyntax
 //@[002:0006) |   | | | └─Token(Identifier) |path|
-//@[007:0013) |   | | └─VariableAccessSyntax
+//@[007:0013) |   | | └─TypeVariableAccessSyntax
 //@[007:0013) |   | |   └─IdentifierSyntax
 //@[007:0013) |   | |     └─Token(Identifier) |string|
 //@[013:0014) |   | ├─Token(NewLine) |\n|
 ) string => '${https ? 'https' : 'http'}://${hostname}${empty(path) ? '' : '/${path}'}'
 //@[000:0001) |   | └─Token(RightParen) |)|
-//@[002:0008) |   ├─VariableAccessSyntax
+//@[002:0008) |   ├─TypeVariableAccessSyntax
 //@[002:0008) |   | └─IdentifierSyntax
 //@[002:0008) |   |   └─Token(Identifier) |string|
 //@[009:0011) |   ├─Token(Arrow) |=>|

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.syntax.bicep
@@ -100,7 +100,7 @@ type fizzes = fizz[]
 //@[12:013) | ├─Token(Assignment) |=|
 //@[14:020) | └─ArrayTypeSyntax
 //@[14:018) |   ├─ArrayTypeMemberSyntax
-//@[14:018) |   | └─VariableAccessSyntax
+//@[14:018) |   | └─TypeVariableAccessSyntax
 //@[14:018) |   |   └─IdentifierSyntax
 //@[14:018) |   |     └─Token(Identifier) |fizz|
 //@[18:019) |   ├─Token(LeftSquare) |[|
@@ -113,7 +113,7 @@ param fizzParam mod2.fizz
 //@[06:015) | ├─IdentifierSyntax
 //@[06:015) | | └─Token(Identifier) |fizzParam|
 //@[16:025) | └─TypePropertyAccessSyntax
-//@[16:020) |   ├─VariableAccessSyntax
+//@[16:020) |   ├─TypeVariableAccessSyntax
 //@[16:020) |   | └─IdentifierSyntax
 //@[16:020) |   |   └─Token(Identifier) |mod2|
 //@[20:021) |   ├─Token(Dot) |.|
@@ -125,7 +125,7 @@ output magicWord pop = refersToCopyVariable[3].value
 //@[00:006) | ├─Token(Identifier) |output|
 //@[07:016) | ├─IdentifierSyntax
 //@[07:016) | | └─Token(Identifier) |magicWord|
-//@[17:020) | ├─VariableAccessSyntax
+//@[17:020) | ├─TypeVariableAccessSyntax
 //@[17:020) | | └─IdentifierSyntax
 //@[17:020) | |   └─Token(Identifier) |pop|
 //@[21:022) | ├─Token(Assignment) |=|
@@ -148,7 +148,7 @@ output greeting string = greet('friend')
 //@[00:006) | ├─Token(Identifier) |output|
 //@[07:015) | ├─IdentifierSyntax
 //@[07:015) | | └─Token(Identifier) |greeting|
-//@[16:022) | ├─VariableAccessSyntax
+//@[16:022) | ├─TypeVariableAccessSyntax
 //@[16:022) | | └─IdentifierSyntax
 //@[16:022) | |   └─Token(Identifier) |string|
 //@[23:024) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidDisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidDisableNextLineDiagnosticsDirective_CRLF/main.syntax.bicep
@@ -6,7 +6,7 @@ param storageAccount1 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount1|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -34,7 +34,7 @@ param storageAccount2 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount2|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -62,7 +62,7 @@ param storageAccount3 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount3|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -84,7 +84,7 @@ param storageAccount4 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount4|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -100,7 +100,7 @@ param storageAccount5 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount5|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -124,7 +124,7 @@ param storageAccount6 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount6|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -145,7 +145,7 @@ param storageAccount7 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount7|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax
@@ -180,7 +180,7 @@ param storageAccount8 string = 'testStorageAccount'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:021) | ├─IdentifierSyntax
 //@[06:021) | | └─Token(Identifier) |storageAccount8|
-//@[22:028) | ├─VariableAccessSyntax
+//@[22:028) | ├─TypeVariableAccessSyntax
 //@[22:028) | | └─IdentifierSyntax
 //@[22:028) | |   └─Token(Identifier) |string|
 //@[29:051) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.syntax.bicep
@@ -1144,7 +1144,7 @@ param funcvarparam bool = concat
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0018) | ├─IdentifierSyntax
 //@[06:0018) | | └─Token(Identifier) |funcvarparam|
-//@[19:0023) | ├─VariableAccessSyntax
+//@[19:0023) | ├─TypeVariableAccessSyntax
 //@[19:0023) | | └─IdentifierSyntax
 //@[19:0023) | |   └─Token(Identifier) |bool|
 //@[24:0032) | └─ParameterDefaultValueSyntax
@@ -1158,7 +1158,7 @@ output funcvarout array = padLeft
 //@[00:0006) | ├─Token(Identifier) |output|
 //@[07:0017) | ├─IdentifierSyntax
 //@[07:0017) | | └─Token(Identifier) |funcvarout|
-//@[18:0023) | ├─VariableAccessSyntax
+//@[18:0023) | ├─TypeVariableAccessSyntax
 //@[18:0023) | | └─IdentifierSyntax
 //@[18:0023) | |   └─Token(Identifier) |array|
 //@[24:0025) | ├─Token(Assignment) |=|
@@ -1200,7 +1200,7 @@ param fakeFuncP string = blue()
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0015) | ├─IdentifierSyntax
 //@[06:0015) | | └─Token(Identifier) |fakeFuncP|
-//@[16:0022) | ├─VariableAccessSyntax
+//@[16:0022) | ├─TypeVariableAccessSyntax
 //@[16:0022) | | └─IdentifierSyntax
 //@[16:0022) | |   └─Token(Identifier) |string|
 //@[23:0031) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidFunctions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidFunctions_LF/main.syntax.bicep
@@ -8,7 +8,7 @@ func useRuntimeFunction() string => reference('foo').bar
 //@[023:0025) |   ├─TypedVariableBlockSyntax
 //@[023:0024) |   | ├─Token(LeftParen) |(|
 //@[024:0025) |   | └─Token(RightParen) |)|
-//@[026:0032) |   ├─VariableAccessSyntax
+//@[026:0032) |   ├─TypeVariableAccessSyntax
 //@[026:0032) |   | └─IdentifierSyntax
 //@[026:0032) |   |   └─Token(Identifier) |string|
 //@[033:0035) |   ├─Token(Arrow) |=>|
@@ -39,7 +39,7 @@ func missingArgType(input) string => input
 //@[020:0025) |   | | | └─Token(Identifier) |input|
 //@[025:0025) |   | | └─SkippedTriviaSyntax
 //@[025:0026) |   | └─Token(RightParen) |)|
-//@[027:0033) |   ├─VariableAccessSyntax
+//@[027:0033) |   ├─TypeVariableAccessSyntax
 //@[027:0033) |   | └─IdentifierSyntax
 //@[027:0033) |   |   └─Token(Identifier) |string|
 //@[034:0036) |   ├─Token(Arrow) |=>|
@@ -59,7 +59,7 @@ func missingOutputType(input string) => input
 //@[023:0035) |   | ├─TypedLocalVariableSyntax
 //@[023:0028) |   | | ├─IdentifierSyntax
 //@[023:0028) |   | | | └─Token(Identifier) |input|
-//@[029:0035) |   | | └─VariableAccessSyntax
+//@[029:0035) |   | | └─TypeVariableAccessSyntax
 //@[029:0035) |   | |   └─IdentifierSyntax
 //@[029:0035) |   | |     └─Token(Identifier) |string|
 //@[035:0036) |   | └─Token(RightParen) |)|
@@ -81,11 +81,11 @@ func invalidType(input string) string => input
 //@[017:0029) |   | ├─TypedLocalVariableSyntax
 //@[017:0022) |   | | ├─IdentifierSyntax
 //@[017:0022) |   | | | └─Token(Identifier) |input|
-//@[023:0029) |   | | └─VariableAccessSyntax
+//@[023:0029) |   | | └─TypeVariableAccessSyntax
 //@[023:0029) |   | |   └─IdentifierSyntax
 //@[023:0029) |   | |     └─Token(Identifier) |string|
 //@[029:0030) |   | └─Token(RightParen) |)|
-//@[031:0037) |   ├─VariableAccessSyntax
+//@[031:0037) |   ├─TypeVariableAccessSyntax
 //@[031:0037) |   | └─IdentifierSyntax
 //@[031:0037) |   |   └─Token(Identifier) |string|
 //@[038:0040) |   ├─Token(Arrow) |=>|
@@ -99,7 +99,7 @@ output invalidType string = invalidType(true)
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0018) | ├─IdentifierSyntax
 //@[007:0018) | | └─Token(Identifier) |invalidType|
-//@[019:0025) | ├─VariableAccessSyntax
+//@[019:0025) | ├─TypeVariableAccessSyntax
 //@[019:0025) | | └─IdentifierSyntax
 //@[019:0025) | |   └─Token(Identifier) |string|
 //@[026:0027) | ├─Token(Assignment) |=|
@@ -124,18 +124,18 @@ func madeUpTypeArgs(a notAType, b alsoNotAType) string => '${a}-${b}'
 //@[020:0030) |   | ├─TypedLocalVariableSyntax
 //@[020:0021) |   | | ├─IdentifierSyntax
 //@[020:0021) |   | | | └─Token(Identifier) |a|
-//@[022:0030) |   | | └─VariableAccessSyntax
+//@[022:0030) |   | | └─TypeVariableAccessSyntax
 //@[022:0030) |   | |   └─IdentifierSyntax
 //@[022:0030) |   | |     └─Token(Identifier) |notAType|
 //@[030:0031) |   | ├─Token(Comma) |,|
 //@[032:0046) |   | ├─TypedLocalVariableSyntax
 //@[032:0033) |   | | ├─IdentifierSyntax
 //@[032:0033) |   | | | └─Token(Identifier) |b|
-//@[034:0046) |   | | └─VariableAccessSyntax
+//@[034:0046) |   | | └─TypeVariableAccessSyntax
 //@[034:0046) |   | |   └─IdentifierSyntax
 //@[034:0046) |   | |     └─Token(Identifier) |alsoNotAType|
 //@[046:0047) |   | └─Token(RightParen) |)|
-//@[048:0054) |   ├─VariableAccessSyntax
+//@[048:0054) |   ├─TypeVariableAccessSyntax
 //@[048:0054) |   | └─IdentifierSyntax
 //@[048:0054) |   |   └─Token(Identifier) |string|
 //@[055:0057) |   ├─Token(Arrow) |=>|
@@ -162,10 +162,10 @@ func noLambda('foo') string => ''
 //@[014:0019) |   | ├─TypedLocalVariableSyntax
 //@[014:0014) |   | | ├─IdentifierSyntax
 //@[014:0014) |   | | | └─SkippedTriviaSyntax
-//@[014:0019) |   | | └─StringSyntax
+//@[014:0019) |   | | └─StringTypeLiteralSyntax
 //@[014:0019) |   | |   └─Token(StringComplete) |'foo'|
 //@[019:0020) |   | └─Token(RightParen) |)|
-//@[021:0027) |   ├─VariableAccessSyntax
+//@[021:0027) |   ├─TypeVariableAccessSyntax
 //@[021:0027) |   | └─IdentifierSyntax
 //@[021:0027) |   |   └─Token(Identifier) |string|
 //@[028:0030) |   ├─Token(Arrow) |=>|
@@ -211,25 +211,25 @@ func argLengthMismatch(a string, b string, c string) array => ([a, b, c])
 //@[023:0031) |   | ├─TypedLocalVariableSyntax
 //@[023:0024) |   | | ├─IdentifierSyntax
 //@[023:0024) |   | | | └─Token(Identifier) |a|
-//@[025:0031) |   | | └─VariableAccessSyntax
+//@[025:0031) |   | | └─TypeVariableAccessSyntax
 //@[025:0031) |   | |   └─IdentifierSyntax
 //@[025:0031) |   | |     └─Token(Identifier) |string|
 //@[031:0032) |   | ├─Token(Comma) |,|
 //@[033:0041) |   | ├─TypedLocalVariableSyntax
 //@[033:0034) |   | | ├─IdentifierSyntax
 //@[033:0034) |   | | | └─Token(Identifier) |b|
-//@[035:0041) |   | | └─VariableAccessSyntax
+//@[035:0041) |   | | └─TypeVariableAccessSyntax
 //@[035:0041) |   | |   └─IdentifierSyntax
 //@[035:0041) |   | |     └─Token(Identifier) |string|
 //@[041:0042) |   | ├─Token(Comma) |,|
 //@[043:0051) |   | ├─TypedLocalVariableSyntax
 //@[043:0044) |   | | ├─IdentifierSyntax
 //@[043:0044) |   | | | └─Token(Identifier) |c|
-//@[045:0051) |   | | └─VariableAccessSyntax
+//@[045:0051) |   | | └─TypeVariableAccessSyntax
 //@[045:0051) |   | |   └─IdentifierSyntax
 //@[045:0051) |   | |     └─Token(Identifier) |string|
 //@[051:0052) |   | └─Token(RightParen) |)|
-//@[053:0058) |   ├─VariableAccessSyntax
+//@[053:0058) |   ├─TypeVariableAccessSyntax
 //@[053:0058) |   | └─IdentifierSyntax
 //@[053:0058) |   |   └─Token(Identifier) |array|
 //@[059:0061) |   ├─Token(Arrow) |=>|
@@ -297,11 +297,11 @@ func sayHello(name string) string => 'Hi ${name}!'
 //@[014:0025) |   | ├─TypedLocalVariableSyntax
 //@[014:0018) |   | | ├─IdentifierSyntax
 //@[014:0018) |   | | | └─Token(Identifier) |name|
-//@[019:0025) |   | | └─VariableAccessSyntax
+//@[019:0025) |   | | └─TypeVariableAccessSyntax
 //@[019:0025) |   | |   └─IdentifierSyntax
 //@[019:0025) |   | |     └─Token(Identifier) |string|
 //@[025:0026) |   | └─Token(RightParen) |)|
-//@[027:0033) |   ├─VariableAccessSyntax
+//@[027:0033) |   ├─TypeVariableAccessSyntax
 //@[027:0033) |   | └─IdentifierSyntax
 //@[027:0033) |   |   └─Token(Identifier) |string|
 //@[034:0036) |   ├─Token(Arrow) |=>|
@@ -317,7 +317,7 @@ output hellos array = map(['Evie', 'Casper'], sayHello) // this syntax not suppo
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0013) | ├─IdentifierSyntax
 //@[007:0013) | | └─Token(Identifier) |hellos|
-//@[014:0019) | ├─VariableAccessSyntax
+//@[014:0019) | ├─TypeVariableAccessSyntax
 //@[014:0019) | | └─IdentifierSyntax
 //@[014:0019) | |   └─Token(Identifier) |array|
 //@[020:0021) | ├─Token(Assignment) |=|
@@ -357,11 +357,11 @@ func sayHelloBadNewlines(
 //@[002:0013) |   | ├─TypedLocalVariableSyntax
 //@[002:0006) |   | | ├─IdentifierSyntax
 //@[002:0006) |   | | | └─Token(Identifier) |name|
-//@[007:0013) |   | | └─VariableAccessSyntax
+//@[007:0013) |   | | └─TypeVariableAccessSyntax
 //@[007:0013) |   | |   └─IdentifierSyntax
 //@[007:0013) |   | |     └─Token(Identifier) |string|
 //@[013:0014) |   | └─Token(RightParen) |)|
-//@[015:0021) |   ├─VariableAccessSyntax
+//@[015:0021) |   ├─TypeVariableAccessSyntax
 //@[015:0021) |   | └─IdentifierSyntax
 //@[015:0021) |   |   └─Token(Identifier) |string|
 //@[022:0024) |   ├─Token(Arrow) |=>|
@@ -381,15 +381,15 @@ type validStringLiteralUnion = 'foo'|'bar'|'baz'
 //@[029:0030) | ├─Token(Assignment) |=|
 //@[031:0048) | └─UnionTypeSyntax
 //@[031:0036) |   ├─UnionTypeMemberSyntax
-//@[031:0036) |   | └─StringSyntax
+//@[031:0036) |   | └─StringTypeLiteralSyntax
 //@[031:0036) |   |   └─Token(StringComplete) |'foo'|
 //@[036:0037) |   ├─Token(Pipe) |||
 //@[037:0042) |   ├─UnionTypeMemberSyntax
-//@[037:0042) |   | └─StringSyntax
+//@[037:0042) |   | └─StringTypeLiteralSyntax
 //@[037:0042) |   |   └─Token(StringComplete) |'bar'|
 //@[042:0043) |   ├─Token(Pipe) |||
 //@[043:0048) |   └─UnionTypeMemberSyntax
-//@[043:0048) |     └─StringSyntax
+//@[043:0048) |     └─StringTypeLiteralSyntax
 //@[043:0048) |       └─Token(StringComplete) |'baz'|
 //@[048:0049) ├─Token(NewLine) |\n|
 func invalidArgs(a validStringLiteralUnion, b string) string => a
@@ -403,18 +403,18 @@ func invalidArgs(a validStringLiteralUnion, b string) string => a
 //@[017:0042) |   | ├─TypedLocalVariableSyntax
 //@[017:0018) |   | | ├─IdentifierSyntax
 //@[017:0018) |   | | | └─Token(Identifier) |a|
-//@[019:0042) |   | | └─VariableAccessSyntax
+//@[019:0042) |   | | └─TypeVariableAccessSyntax
 //@[019:0042) |   | |   └─IdentifierSyntax
 //@[019:0042) |   | |     └─Token(Identifier) |validStringLiteralUnion|
 //@[042:0043) |   | ├─Token(Comma) |,|
 //@[044:0052) |   | ├─TypedLocalVariableSyntax
 //@[044:0045) |   | | ├─IdentifierSyntax
 //@[044:0045) |   | | | └─Token(Identifier) |b|
-//@[046:0052) |   | | └─VariableAccessSyntax
+//@[046:0052) |   | | └─TypeVariableAccessSyntax
 //@[046:0052) |   | |   └─IdentifierSyntax
 //@[046:0052) |   | |     └─Token(Identifier) |string|
 //@[052:0053) |   | └─Token(RightParen) |)|
-//@[054:0060) |   ├─VariableAccessSyntax
+//@[054:0060) |   ├─TypeVariableAccessSyntax
 //@[054:0060) |   | └─IdentifierSyntax
 //@[054:0060) |   |   └─Token(Identifier) |string|
 //@[061:0063) |   ├─Token(Arrow) |=>|
@@ -431,7 +431,7 @@ func invalidOutput() validStringLiteralUnion => 'foo'
 //@[018:0020) |   ├─TypedVariableBlockSyntax
 //@[018:0019) |   | ├─Token(LeftParen) |(|
 //@[019:0020) |   | └─Token(RightParen) |)|
-//@[021:0044) |   ├─VariableAccessSyntax
+//@[021:0044) |   ├─TypeVariableAccessSyntax
 //@[021:0044) |   | └─IdentifierSyntax
 //@[021:0044) |   |   └─Token(Identifier) |validStringLiteralUnion|
 //@[045:0047) |   ├─Token(Arrow) |=>|
@@ -448,7 +448,7 @@ func recursive() string => recursive()
 //@[014:0016) |   ├─TypedVariableBlockSyntax
 //@[014:0015) |   | ├─Token(LeftParen) |(|
 //@[015:0016) |   | └─Token(RightParen) |)|
-//@[017:0023) |   ├─VariableAccessSyntax
+//@[017:0023) |   ├─TypeVariableAccessSyntax
 //@[017:0023) |   | └─IdentifierSyntax
 //@[017:0023) |   |   └─Token(Identifier) |string|
 //@[024:0026) |   ├─Token(Arrow) |=>|
@@ -468,7 +468,7 @@ func recursiveA() string => recursiveB()
 //@[015:0017) |   ├─TypedVariableBlockSyntax
 //@[015:0016) |   | ├─Token(LeftParen) |(|
 //@[016:0017) |   | └─Token(RightParen) |)|
-//@[018:0024) |   ├─VariableAccessSyntax
+//@[018:0024) |   ├─TypeVariableAccessSyntax
 //@[018:0024) |   | └─IdentifierSyntax
 //@[018:0024) |   |   └─Token(Identifier) |string|
 //@[025:0027) |   ├─Token(Arrow) |=>|
@@ -487,7 +487,7 @@ func recursiveB() string => recursiveA()
 //@[015:0017) |   ├─TypedVariableBlockSyntax
 //@[015:0016) |   | ├─Token(LeftParen) |(|
 //@[016:0017) |   | └─Token(RightParen) |)|
-//@[018:0024) |   ├─VariableAccessSyntax
+//@[018:0024) |   ├─TypeVariableAccessSyntax
 //@[018:0024) |   | └─IdentifierSyntax
 //@[018:0024) |   |   └─Token(Identifier) |string|
 //@[025:0027) |   ├─Token(Arrow) |=>|
@@ -512,7 +512,7 @@ func onlyComma(,) string => 'foo'
 //@[015:0015) |   | | └─SkippedTriviaSyntax
 //@[015:0016) |   | ├─Token(Comma) |,|
 //@[016:0017) |   | └─Token(RightParen) |)|
-//@[018:0024) |   ├─VariableAccessSyntax
+//@[018:0024) |   ├─TypeVariableAccessSyntax
 //@[018:0024) |   | └─IdentifierSyntax
 //@[018:0024) |   |   └─Token(Identifier) |string|
 //@[025:0027) |   ├─Token(Arrow) |=>|
@@ -530,7 +530,7 @@ func trailingCommas(a string,,) string => 'foo'
 //@[020:0028) |   | ├─TypedLocalVariableSyntax
 //@[020:0021) |   | | ├─IdentifierSyntax
 //@[020:0021) |   | | | └─Token(Identifier) |a|
-//@[022:0028) |   | | └─VariableAccessSyntax
+//@[022:0028) |   | | └─TypeVariableAccessSyntax
 //@[022:0028) |   | |   └─IdentifierSyntax
 //@[022:0028) |   | |     └─Token(Identifier) |string|
 //@[028:0029) |   | ├─Token(Comma) |,|
@@ -540,7 +540,7 @@ func trailingCommas(a string,,) string => 'foo'
 //@[029:0029) |   | | └─SkippedTriviaSyntax
 //@[029:0030) |   | ├─Token(Comma) |,|
 //@[030:0031) |   | └─Token(RightParen) |)|
-//@[032:0038) |   ├─VariableAccessSyntax
+//@[032:0038) |   ├─TypeVariableAccessSyntax
 //@[032:0038) |   | └─IdentifierSyntax
 //@[032:0038) |   |   └─Token(Identifier) |string|
 //@[039:0041) |   ├─Token(Arrow) |=>|
@@ -560,7 +560,7 @@ func multiLineOnly(
 //@[002:0010) |   | ├─TypedLocalVariableSyntax
 //@[002:0003) |   | | ├─IdentifierSyntax
 //@[002:0003) |   | | | └─Token(Identifier) |a|
-//@[004:0010) |   | | └─VariableAccessSyntax
+//@[004:0010) |   | | └─TypeVariableAccessSyntax
 //@[004:0010) |   | |   └─IdentifierSyntax
 //@[004:0010) |   | |     └─Token(Identifier) |string|
 //@[010:0011) |   | ├─Token(NewLine) |\n|
@@ -590,7 +590,7 @@ func multiLineTrailingCommas(
 //@[002:0010) |   | ├─TypedLocalVariableSyntax
 //@[002:0003) |   | | ├─IdentifierSyntax
 //@[002:0003) |   | | | └─Token(Identifier) |a|
-//@[004:0010) |   | | └─VariableAccessSyntax
+//@[004:0010) |   | | └─TypeVariableAccessSyntax
 //@[004:0010) |   | |   └─IdentifierSyntax
 //@[004:0010) |   | |     └─Token(Identifier) |string|
 //@[010:0011) |   | ├─Token(Comma) |,|
@@ -602,7 +602,7 @@ func multiLineTrailingCommas(
 //@[002:0002) |   | | └─SkippedTriviaSyntax
 //@[002:0003) |   | ├─Token(Comma) |,|
 //@[003:0004) |   | └─Token(RightParen) |)|
-//@[005:0011) |   ├─VariableAccessSyntax
+//@[005:0011) |   ├─TypeVariableAccessSyntax
 //@[005:0011) |   | └─IdentifierSyntax
 //@[005:0011) |   |   └─Token(Identifier) |string|
 //@[012:0014) |   ├─Token(Arrow) |=>|
@@ -623,7 +623,7 @@ func lineBeforeComma(
 //@[002:0010) |   | ├─TypedLocalVariableSyntax
 //@[002:0003) |   | | ├─IdentifierSyntax
 //@[002:0003) |   | | | └─Token(Identifier) |a|
-//@[004:0010) |   | | └─VariableAccessSyntax
+//@[004:0010) |   | | └─TypeVariableAccessSyntax
 //@[004:0010) |   | |   └─IdentifierSyntax
 //@[004:0010) |   | |     └─Token(Identifier) |string|
 //@[010:0011) |   | ├─Token(NewLine) |\n|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.syntax.bicep
@@ -4,7 +4,7 @@ param ids array
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0009) | ├─IdentifierSyntax
 //@[006:0009) | | └─Token(Identifier) |ids|
-//@[010:0015) | └─VariableAccessSyntax
+//@[010:0015) | └─TypeVariableAccessSyntax
 //@[010:0015) |   └─IdentifierSyntax
 //@[010:0015) |     └─Token(Identifier) |array|
 //@[015:0017) ├─Token(NewLine) |\n\n|
@@ -1119,7 +1119,7 @@ output stgKeys array = map(range(0, 2), i => stg[i].listKeys().keys[0].value)
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0014) | ├─IdentifierSyntax
 //@[007:0014) | | └─Token(Identifier) |stgKeys|
-//@[015:0020) | ├─VariableAccessSyntax
+//@[015:0020) | ├─TypeVariableAccessSyntax
 //@[015:0020) | | └─IdentifierSyntax
 //@[015:0020) | |   └─Token(Identifier) |array|
 //@[021:0022) | ├─Token(Assignment) |=|
@@ -1182,7 +1182,7 @@ output stgKeys2 array = map(range(0, 2), j => stg[((j + 2) % 123)].listKeys().ke
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0015) | ├─IdentifierSyntax
 //@[007:0015) | | └─Token(Identifier) |stgKeys2|
-//@[016:0021) | ├─VariableAccessSyntax
+//@[016:0021) | ├─TypeVariableAccessSyntax
 //@[016:0021) | | └─IdentifierSyntax
 //@[016:0021) | |   └─Token(Identifier) |array|
 //@[022:0023) | ├─Token(Assignment) |=|
@@ -1259,7 +1259,7 @@ output stgKeys3 array = map(ids, id => listKeys(id, stg[0].apiVersion).keys[0].v
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0015) | ├─IdentifierSyntax
 //@[007:0015) | | └─Token(Identifier) |stgKeys3|
-//@[016:0021) | ├─VariableAccessSyntax
+//@[016:0021) | ├─TypeVariableAccessSyntax
 //@[016:0021) | | └─IdentifierSyntax
 //@[016:0021) | |   └─Token(Identifier) |array|
 //@[022:0023) | ├─Token(Assignment) |=|
@@ -1321,7 +1321,7 @@ output accessTiers array = map(range(0, 2), k => stg[k].properties.accessTier)
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0018) | ├─IdentifierSyntax
 //@[007:0018) | | └─Token(Identifier) |accessTiers|
-//@[019:0024) | ├─VariableAccessSyntax
+//@[019:0024) | ├─TypeVariableAccessSyntax
 //@[019:0024) | | └─IdentifierSyntax
 //@[019:0024) | |   └─Token(Identifier) |array|
 //@[025:0026) | ├─Token(Assignment) |=|
@@ -1373,7 +1373,7 @@ output accessTiers2 array = map(range(0, 2), x => map(range(0, 2), y => stg[x / 
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0019) | ├─IdentifierSyntax
 //@[007:0019) | | └─Token(Identifier) |accessTiers2|
-//@[020:0025) | ├─VariableAccessSyntax
+//@[020:0025) | ├─TypeVariableAccessSyntax
 //@[020:0025) | | └─IdentifierSyntax
 //@[020:0025) | |   └─Token(Identifier) |array|
 //@[026:0027) | ├─Token(Assignment) |=|
@@ -1455,7 +1455,7 @@ output accessTiers3 array = map(ids, foo => reference('${foo}').accessTier)
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0019) | ├─IdentifierSyntax
 //@[007:0019) | | └─Token(Identifier) |accessTiers3|
-//@[020:0025) | ├─VariableAccessSyntax
+//@[020:0025) | ├─TypeVariableAccessSyntax
 //@[020:0025) | | └─IdentifierSyntax
 //@[020:0025) | |   └─Token(Identifier) |array|
 //@[026:0027) | ├─Token(Assignment) |=|
@@ -1576,7 +1576,7 @@ output modOutputs array = map(range(0, 5), i => modLoop[i].outputs.foo)
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0017) | ├─IdentifierSyntax
 //@[007:0017) | | └─Token(Identifier) |modOutputs|
-//@[018:0023) | ├─VariableAccessSyntax
+//@[018:0023) | ├─TypeVariableAccessSyntax
 //@[018:0023) | | └─IdentifierSyntax
 //@[018:0023) | |   └─Token(Identifier) |array|
 //@[024:0025) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/main.syntax.bicep
@@ -3153,7 +3153,7 @@ output directRefToCollectionViaOutput array = nonexistentArrays
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00037) | ├─IdentifierSyntax
 //@[007:00037) | | └─Token(Identifier) |directRefToCollectionViaOutput|
-//@[038:00043) | ├─VariableAccessSyntax
+//@[038:00043) | ├─TypeVariableAccessSyntax
 //@[038:00043) | | └─IdentifierSyntax
 //@[038:00043) | |   └─Token(Identifier) |array|
 //@[044:00045) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/main.syntax.bicep
@@ -49,7 +49,7 @@ output missingValue string =
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0019) | ├─IdentifierSyntax
 //@[007:0019) | | └─Token(Identifier) |missingValue|
-//@[020:0026) | ├─VariableAccessSyntax
+//@[020:0026) | ├─TypeVariableAccessSyntax
 //@[020:0026) | | └─IdentifierSyntax
 //@[020:0026) | |   └─Token(Identifier) |string|
 //@[027:0028) | ├─Token(Assignment) |=|
@@ -63,7 +63,7 @@ output arrayCompletions array =
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0023) | ├─IdentifierSyntax
 //@[007:0023) | | └─Token(Identifier) |arrayCompletions|
-//@[024:0029) | ├─VariableAccessSyntax
+//@[024:0029) | ├─TypeVariableAccessSyntax
 //@[024:0029) | | └─IdentifierSyntax
 //@[024:0029) | |   └─Token(Identifier) |array|
 //@[030:0031) | ├─Token(Assignment) |=|
@@ -77,7 +77,7 @@ output objectCompletions object =
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0024) | ├─IdentifierSyntax
 //@[007:0024) | | └─Token(Identifier) |objectCompletions|
-//@[025:0031) | ├─VariableAccessSyntax
+//@[025:0031) | ├─TypeVariableAccessSyntax
 //@[025:0031) | | └─IdentifierSyntax
 //@[025:0031) | |   └─Token(Identifier) |object|
 //@[032:0033) | ├─Token(Assignment) |=|
@@ -91,7 +91,7 @@ output boolCompletions bool =
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0022) | ├─IdentifierSyntax
 //@[007:0022) | | └─Token(Identifier) |boolCompletions|
-//@[023:0027) | ├─VariableAccessSyntax
+//@[023:0027) | ├─TypeVariableAccessSyntax
 //@[023:0027) | | └─IdentifierSyntax
 //@[023:0027) | |   └─Token(Identifier) |bool|
 //@[028:0029) | ├─Token(Assignment) |=|
@@ -139,7 +139,7 @@ output partialType obj
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0018) | ├─IdentifierSyntax
 //@[007:0018) | | └─Token(Identifier) |partialType|
-//@[019:0022) | ├─VariableAccessSyntax
+//@[019:0022) | ├─TypeVariableAccessSyntax
 //@[019:0022) | | └─IdentifierSyntax
 //@[019:0022) | |   └─Token(Identifier) |obj|
 //@[022:0022) | ├─SkippedTriviaSyntax
@@ -166,7 +166,7 @@ output malformedType 3
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0020) | ├─IdentifierSyntax
 //@[007:0020) | | └─Token(Identifier) |malformedType|
-//@[021:0022) | ├─IntegerLiteralSyntax
+//@[021:0022) | ├─IntegerTypeLiteralSyntax
 //@[021:0022) | | └─Token(Integer) |3|
 //@[022:0022) | ├─SkippedTriviaSyntax
 //@[022:0022) | └─SkippedTriviaSyntax
@@ -179,7 +179,7 @@ output malformedType2 3 = 2 + null
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0021) | ├─IdentifierSyntax
 //@[007:0021) | | └─Token(Identifier) |malformedType2|
-//@[022:0023) | ├─IntegerLiteralSyntax
+//@[022:0023) | ├─IntegerTypeLiteralSyntax
 //@[022:0023) | | └─Token(Integer) |3|
 //@[024:0025) | ├─Token(Assignment) |=|
 //@[026:0034) | └─BinaryOperationSyntax
@@ -197,7 +197,7 @@ output malformedAssignment 2 = 2
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0026) | ├─IdentifierSyntax
 //@[007:0026) | | └─Token(Identifier) |malformedAssignment|
-//@[027:0028) | ├─IntegerLiteralSyntax
+//@[027:0028) | ├─IntegerTypeLiteralSyntax
 //@[027:0028) | | └─Token(Integer) |2|
 //@[029:0030) | ├─Token(Assignment) |=|
 //@[031:0032) | └─IntegerLiteralSyntax
@@ -211,7 +211,7 @@ output lol 2 = true
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |lol|
-//@[011:0012) | ├─IntegerLiteralSyntax
+//@[011:0012) | ├─IntegerTypeLiteralSyntax
 //@[011:0012) | | └─Token(Integer) |2|
 //@[013:0014) | ├─Token(Assignment) |=|
 //@[015:0019) | └─BooleanLiteralSyntax
@@ -225,7 +225,7 @@ output foo fluffy
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |foo|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |fluffy|
 //@[017:0017) | ├─SkippedTriviaSyntax
@@ -239,7 +239,7 @@ output foo string
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |foo|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[017:0017) | ├─SkippedTriviaSyntax
@@ -253,7 +253,7 @@ output foo string =
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |foo|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -267,7 +267,7 @@ output str string = true
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |str|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -279,7 +279,7 @@ output str string = false
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |str|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -291,7 +291,7 @@ output str string = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |str|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -306,7 +306,7 @@ output str string = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |str|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -321,7 +321,7 @@ output str string = 52
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |str|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -336,7 +336,7 @@ output i int = true
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |i|
-//@[009:0012) | ├─VariableAccessSyntax
+//@[009:0012) | ├─TypeVariableAccessSyntax
 //@[009:0012) | | └─IdentifierSyntax
 //@[009:0012) | |   └─Token(Identifier) |int|
 //@[013:0014) | ├─Token(Assignment) |=|
@@ -348,7 +348,7 @@ output i int = false
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |i|
-//@[009:0012) | ├─VariableAccessSyntax
+//@[009:0012) | ├─TypeVariableAccessSyntax
 //@[009:0012) | | └─IdentifierSyntax
 //@[009:0012) | |   └─Token(Identifier) |int|
 //@[013:0014) | ├─Token(Assignment) |=|
@@ -360,7 +360,7 @@ output i int = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |i|
-//@[009:0012) | ├─VariableAccessSyntax
+//@[009:0012) | ├─TypeVariableAccessSyntax
 //@[009:0012) | | └─IdentifierSyntax
 //@[009:0012) | |   └─Token(Identifier) |int|
 //@[013:0014) | ├─Token(Assignment) |=|
@@ -375,7 +375,7 @@ output i int = }
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |i|
-//@[009:0012) | ├─VariableAccessSyntax
+//@[009:0012) | ├─TypeVariableAccessSyntax
 //@[009:0012) | | └─IdentifierSyntax
 //@[009:0012) | |   └─Token(Identifier) |int|
 //@[013:0014) | ├─Token(Assignment) |=|
@@ -391,7 +391,7 @@ output i int = 'test'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |i|
-//@[009:0012) | ├─VariableAccessSyntax
+//@[009:0012) | ├─TypeVariableAccessSyntax
 //@[009:0012) | | └─IdentifierSyntax
 //@[009:0012) | |   └─Token(Identifier) |int|
 //@[013:0014) | ├─Token(Assignment) |=|
@@ -406,7 +406,7 @@ output b bool = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |b|
-//@[009:0013) | ├─VariableAccessSyntax
+//@[009:0013) | ├─TypeVariableAccessSyntax
 //@[009:0013) | | └─IdentifierSyntax
 //@[009:0013) | |   └─Token(Identifier) |bool|
 //@[014:0015) | ├─Token(Assignment) |=|
@@ -421,7 +421,7 @@ output b bool = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |b|
-//@[009:0013) | ├─VariableAccessSyntax
+//@[009:0013) | ├─TypeVariableAccessSyntax
 //@[009:0013) | | └─IdentifierSyntax
 //@[009:0013) | |   └─Token(Identifier) |bool|
 //@[014:0015) | ├─Token(Assignment) |=|
@@ -436,7 +436,7 @@ output b bool = 32
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |b|
-//@[009:0013) | ├─VariableAccessSyntax
+//@[009:0013) | ├─TypeVariableAccessSyntax
 //@[009:0013) | | └─IdentifierSyntax
 //@[009:0013) | |   └─Token(Identifier) |bool|
 //@[014:0015) | ├─Token(Assignment) |=|
@@ -448,7 +448,7 @@ output b bool = 'str'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |b|
-//@[009:0013) | ├─VariableAccessSyntax
+//@[009:0013) | ├─TypeVariableAccessSyntax
 //@[009:0013) | | └─IdentifierSyntax
 //@[009:0013) | |   └─Token(Identifier) |bool|
 //@[014:0015) | ├─Token(Assignment) |=|
@@ -463,7 +463,7 @@ output arr array = 32
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |arr|
-//@[011:0016) | ├─VariableAccessSyntax
+//@[011:0016) | ├─TypeVariableAccessSyntax
 //@[011:0016) | | └─IdentifierSyntax
 //@[011:0016) | |   └─Token(Identifier) |array|
 //@[017:0018) | ├─Token(Assignment) |=|
@@ -475,7 +475,7 @@ output arr array = true
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |arr|
-//@[011:0016) | ├─VariableAccessSyntax
+//@[011:0016) | ├─TypeVariableAccessSyntax
 //@[011:0016) | | └─IdentifierSyntax
 //@[011:0016) | |   └─Token(Identifier) |array|
 //@[017:0018) | ├─Token(Assignment) |=|
@@ -487,7 +487,7 @@ output arr array = false
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |arr|
-//@[011:0016) | ├─VariableAccessSyntax
+//@[011:0016) | ├─TypeVariableAccessSyntax
 //@[011:0016) | | └─IdentifierSyntax
 //@[011:0016) | |   └─Token(Identifier) |array|
 //@[017:0018) | ├─Token(Assignment) |=|
@@ -499,7 +499,7 @@ output arr array = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |arr|
-//@[011:0016) | ├─VariableAccessSyntax
+//@[011:0016) | ├─TypeVariableAccessSyntax
 //@[011:0016) | | └─IdentifierSyntax
 //@[011:0016) | |   └─Token(Identifier) |array|
 //@[017:0018) | ├─Token(Assignment) |=|
@@ -514,7 +514,7 @@ output arr array = 'str'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |arr|
-//@[011:0016) | ├─VariableAccessSyntax
+//@[011:0016) | ├─TypeVariableAccessSyntax
 //@[011:0016) | | └─IdentifierSyntax
 //@[011:0016) | |   └─Token(Identifier) |array|
 //@[017:0018) | ├─Token(Assignment) |=|
@@ -529,7 +529,7 @@ output o object = 32
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |o|
-//@[009:0015) | ├─VariableAccessSyntax
+//@[009:0015) | ├─TypeVariableAccessSyntax
 //@[009:0015) | | └─IdentifierSyntax
 //@[009:0015) | |   └─Token(Identifier) |object|
 //@[016:0017) | ├─Token(Assignment) |=|
@@ -541,7 +541,7 @@ output o object = true
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |o|
-//@[009:0015) | ├─VariableAccessSyntax
+//@[009:0015) | ├─TypeVariableAccessSyntax
 //@[009:0015) | | └─IdentifierSyntax
 //@[009:0015) | |   └─Token(Identifier) |object|
 //@[016:0017) | ├─Token(Assignment) |=|
@@ -553,7 +553,7 @@ output o object = false
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |o|
-//@[009:0015) | ├─VariableAccessSyntax
+//@[009:0015) | ├─TypeVariableAccessSyntax
 //@[009:0015) | | └─IdentifierSyntax
 //@[009:0015) | |   └─Token(Identifier) |object|
 //@[016:0017) | ├─Token(Assignment) |=|
@@ -565,7 +565,7 @@ output o object = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |o|
-//@[009:0015) | ├─VariableAccessSyntax
+//@[009:0015) | ├─TypeVariableAccessSyntax
 //@[009:0015) | | └─IdentifierSyntax
 //@[009:0015) | |   └─Token(Identifier) |object|
 //@[016:0017) | ├─Token(Assignment) |=|
@@ -580,7 +580,7 @@ output o object = 'str'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0008) | ├─IdentifierSyntax
 //@[007:0008) | | └─Token(Identifier) |o|
-//@[009:0015) | ├─VariableAccessSyntax
+//@[009:0015) | ├─TypeVariableAccessSyntax
 //@[009:0015) | | └─IdentifierSyntax
 //@[009:0015) | |   └─Token(Identifier) |object|
 //@[016:0017) | ├─Token(Assignment) |=|
@@ -595,7 +595,7 @@ output exp string = 2 + 3
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |exp|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |string|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -611,7 +611,7 @@ output union string = true ? 's' : 1
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0012) | ├─IdentifierSyntax
 //@[007:0012) | | └─Token(Identifier) |union|
-//@[013:0019) | ├─VariableAccessSyntax
+//@[013:0019) | ├─TypeVariableAccessSyntax
 //@[013:0019) | | └─IdentifierSyntax
 //@[013:0019) | |   └─Token(Identifier) |string|
 //@[020:0021) | ├─Token(Assignment) |=|
@@ -630,7 +630,7 @@ output bad int = true && !4
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |bad|
-//@[011:0014) | ├─VariableAccessSyntax
+//@[011:0014) | ├─TypeVariableAccessSyntax
 //@[011:0014) | | └─IdentifierSyntax
 //@[011:0014) | |   └─Token(Identifier) |int|
 //@[015:0016) | ├─Token(Assignment) |=|
@@ -648,7 +648,7 @@ output deeper bool = true ? -true : (14 && 's') + 10
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0013) | ├─IdentifierSyntax
 //@[007:0013) | | └─Token(Identifier) |deeper|
-//@[014:0018) | ├─VariableAccessSyntax
+//@[014:0018) | ├─TypeVariableAccessSyntax
 //@[014:0018) | | └─IdentifierSyntax
 //@[014:0018) | |   └─Token(Identifier) |bool|
 //@[019:0020) | ├─Token(Assignment) |=|
@@ -681,7 +681,7 @@ output myOutput string = 'hello'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0015) | ├─IdentifierSyntax
 //@[007:0015) | | └─Token(Identifier) |myOutput|
-//@[016:0022) | ├─VariableAccessSyntax
+//@[016:0022) | ├─TypeVariableAccessSyntax
 //@[016:0022) | | └─IdentifierSyntax
 //@[016:0022) | |   └─Token(Identifier) |string|
 //@[023:0024) | ├─Token(Assignment) |=|
@@ -732,7 +732,7 @@ output notAttachableDecorators int = 32
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0030) | ├─IdentifierSyntax
 //@[007:0030) | | └─Token(Identifier) |notAttachableDecorators|
-//@[031:0034) | ├─VariableAccessSyntax
+//@[031:0034) | ├─TypeVariableAccessSyntax
 //@[031:0034) | | └─IdentifierSyntax
 //@[031:0034) | |   └─Token(Identifier) |int|
 //@[035:0036) | ├─Token(Assignment) |=|
@@ -747,7 +747,7 @@ output noNestedLoops array = [for thing in things: {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0020) | ├─IdentifierSyntax
 //@[007:0020) | | └─Token(Identifier) |noNestedLoops|
-//@[021:0026) | ├─VariableAccessSyntax
+//@[021:0026) | ├─TypeVariableAccessSyntax
 //@[021:0026) | | └─IdentifierSyntax
 //@[021:0026) | |   └─Token(Identifier) |array|
 //@[027:0028) | ├─Token(Assignment) |=|
@@ -805,7 +805,7 @@ output noInnerLoopsInOutputs object = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0028) | ├─IdentifierSyntax
 //@[007:0028) | | └─Token(Identifier) |noInnerLoopsInOutputs|
-//@[029:0035) | ├─VariableAccessSyntax
+//@[029:0035) | ├─TypeVariableAccessSyntax
 //@[029:0035) | | └─IdentifierSyntax
 //@[029:0035) | |   └─Token(Identifier) |object|
 //@[036:0037) | ├─Token(Assignment) |=|
@@ -850,7 +850,7 @@ output noInnerLoopsInOutputs2 object = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0029) | ├─IdentifierSyntax
 //@[007:0029) | | └─Token(Identifier) |noInnerLoopsInOutputs2|
-//@[030:0036) | ├─VariableAccessSyntax
+//@[030:0036) | ├─TypeVariableAccessSyntax
 //@[030:0036) | | └─IdentifierSyntax
 //@[030:0036) | |   └─Token(Identifier) |object|
 //@[037:0038) | ├─Token(Assignment) |=|
@@ -959,7 +959,7 @@ output keyVaultSecretOutput string = kv.getSecret('mySecret')
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0027) | ├─IdentifierSyntax
 //@[007:0027) | | └─Token(Identifier) |keyVaultSecretOutput|
-//@[028:0034) | ├─VariableAccessSyntax
+//@[028:0034) | ├─TypeVariableAccessSyntax
 //@[028:0034) | | └─IdentifierSyntax
 //@[028:0034) | |   └─Token(Identifier) |string|
 //@[035:0036) | ├─Token(Assignment) |=|
@@ -981,7 +981,7 @@ output keyVaultSecretInterpolatedOutput string = '${kv.getSecret('mySecret')}'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0039) | ├─IdentifierSyntax
 //@[007:0039) | | └─Token(Identifier) |keyVaultSecretInterpolatedOutput|
-//@[040:0046) | ├─VariableAccessSyntax
+//@[040:0046) | ├─TypeVariableAccessSyntax
 //@[040:0046) | | └─IdentifierSyntax
 //@[040:0046) | |   └─Token(Identifier) |string|
 //@[047:0048) | ├─Token(Assignment) |=|
@@ -1006,7 +1006,7 @@ output keyVaultSecretObjectOutput object = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0033) | ├─IdentifierSyntax
 //@[007:0033) | | └─Token(Identifier) |keyVaultSecretObjectOutput|
-//@[034:0040) | ├─VariableAccessSyntax
+//@[034:0040) | ├─TypeVariableAccessSyntax
 //@[034:0040) | | └─IdentifierSyntax
 //@[034:0040) | |   └─Token(Identifier) |object|
 //@[041:0042) | ├─Token(Assignment) |=|
@@ -1039,7 +1039,7 @@ output keyVaultSecretArrayOutput array = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0032) | ├─IdentifierSyntax
 //@[007:0032) | | └─Token(Identifier) |keyVaultSecretArrayOutput|
-//@[033:0038) | ├─VariableAccessSyntax
+//@[033:0038) | ├─TypeVariableAccessSyntax
 //@[033:0038) | | └─IdentifierSyntax
 //@[033:0038) | |   └─Token(Identifier) |array|
 //@[039:0040) | ├─Token(Assignment) |=|
@@ -1069,7 +1069,7 @@ output keyVaultSecretArrayInterpolatedOutput array = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0044) | ├─IdentifierSyntax
 //@[007:0044) | | └─Token(Identifier) |keyVaultSecretArrayInterpolatedOutput|
-//@[045:0050) | ├─VariableAccessSyntax
+//@[045:0050) | ├─TypeVariableAccessSyntax
 //@[045:0050) | | └─IdentifierSyntax
 //@[045:0050) | |   └─Token(Identifier) |array|
 //@[051:0052) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/main.syntax.bicep
@@ -9,7 +9,7 @@ param myString string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0014) | ├─IdentifierSyntax
 //@[006:0014) | | └─Token(Identifier) |myString|
-//@[015:0021) | └─VariableAccessSyntax
+//@[015:0021) | └─TypeVariableAccessSyntax
 //@[015:0021) |   └─IdentifierSyntax
 //@[015:0021) |     └─Token(Identifier) |string|
 //@[021:0022) ├─Token(NewLine) |\n|
@@ -23,7 +23,7 @@ param myInt int
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0011) | ├─IdentifierSyntax
 //@[006:0011) | | └─Token(Identifier) |myInt|
-//@[012:0015) | └─VariableAccessSyntax
+//@[012:0015) | └─TypeVariableAccessSyntax
 //@[012:0015) |   └─IdentifierSyntax
 //@[012:0015) |     └─Token(Identifier) |int|
 //@[015:0016) ├─Token(NewLine) |\n|
@@ -49,7 +49,7 @@ param % string
 //@[006:0007) | ├─IdentifierSyntax
 //@[006:0007) | | └─SkippedTriviaSyntax
 //@[006:0007) | |   └─Token(Modulo) |%|
-//@[008:0014) | └─VariableAccessSyntax
+//@[008:0014) | └─TypeVariableAccessSyntax
 //@[008:0014) |   └─IdentifierSyntax
 //@[008:0014) |     └─Token(Identifier) |string|
 //@[014:0015) ├─Token(NewLine) |\n|
@@ -59,7 +59,7 @@ param % string 3 = 's'
 //@[006:0007) | ├─IdentifierSyntax
 //@[006:0007) | | └─SkippedTriviaSyntax
 //@[006:0007) | |   └─Token(Modulo) |%|
-//@[008:0014) | ├─VariableAccessSyntax
+//@[008:0014) | ├─TypeVariableAccessSyntax
 //@[008:0014) | | └─IdentifierSyntax
 //@[008:0014) | |   └─Token(Identifier) |string|
 //@[015:0022) | └─SkippedTriviaSyntax
@@ -73,7 +73,7 @@ param myBool bool
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0012) | ├─IdentifierSyntax
 //@[006:0012) | | └─Token(Identifier) |myBool|
-//@[013:0017) | └─VariableAccessSyntax
+//@[013:0017) | └─TypeVariableAccessSyntax
 //@[013:0017) |   └─IdentifierSyntax
 //@[013:0017) |     └─Token(Identifier) |bool|
 //@[017:0019) ├─Token(NewLine) |\n\n|
@@ -123,7 +123,7 @@ param partialType str
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |partialType|
-//@[018:0021) | └─VariableAccessSyntax
+//@[018:0021) | └─TypeVariableAccessSyntax
 //@[018:0021) |   └─IdentifierSyntax
 //@[018:0021) |     └─Token(Identifier) |str|
 //@[021:0023) ├─Token(NewLine) |\n\n|
@@ -133,7 +133,7 @@ param malformedType 44
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0019) | ├─IdentifierSyntax
 //@[006:0019) | | └─Token(Identifier) |malformedType|
-//@[020:0022) | └─IntegerLiteralSyntax
+//@[020:0022) | └─IntegerTypeLiteralSyntax
 //@[020:0022) |   └─Token(Integer) |44|
 //@[022:0024) ├─Token(NewLine) |\n\n|
 
@@ -144,7 +144,7 @@ param malformedType2 44 = f
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0020) | ├─IdentifierSyntax
 //@[006:0020) | | └─Token(Identifier) |malformedType2|
-//@[021:0023) | ├─IntegerLiteralSyntax
+//@[021:0023) | ├─IntegerTypeLiteralSyntax
 //@[021:0023) | | └─Token(Integer) |44|
 //@[024:0027) | └─ParameterDefaultValueSyntax
 //@[024:0025) |   ├─Token(Assignment) |=|
@@ -172,7 +172,7 @@ param malformedModifier 44
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |malformedModifier|
-//@[024:0026) | └─IntegerLiteralSyntax
+//@[024:0026) | └─IntegerTypeLiteralSyntax
 //@[024:0026) |   └─Token(Integer) |44|
 //@[026:0028) ├─Token(NewLine) |\n\n|
 
@@ -181,7 +181,7 @@ param myString2 string = 'string value'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |myString2|
-//@[016:0022) | ├─VariableAccessSyntax
+//@[016:0022) | ├─TypeVariableAccessSyntax
 //@[016:0022) | | └─IdentifierSyntax
 //@[016:0022) | |   └─Token(Identifier) |string|
 //@[023:0039) | └─ParameterDefaultValueSyntax
@@ -195,7 +195,7 @@ param wrongDefaultValue string = 42
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |wrongDefaultValue|
-//@[024:0030) | ├─VariableAccessSyntax
+//@[024:0030) | ├─TypeVariableAccessSyntax
 //@[024:0030) | | └─IdentifierSyntax
 //@[024:0030) | |   └─Token(Identifier) |string|
 //@[031:0035) | └─ParameterDefaultValueSyntax
@@ -209,7 +209,7 @@ param myInt2 int = 42
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0012) | ├─IdentifierSyntax
 //@[006:0012) | | └─Token(Identifier) |myInt2|
-//@[013:0016) | ├─VariableAccessSyntax
+//@[013:0016) | ├─TypeVariableAccessSyntax
 //@[013:0016) | | └─IdentifierSyntax
 //@[013:0016) | |   └─Token(Identifier) |int|
 //@[017:0021) | └─ParameterDefaultValueSyntax
@@ -222,7 +222,7 @@ param noValueAfterColon int =
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |noValueAfterColon|
-//@[024:0027) | ├─VariableAccessSyntax
+//@[024:0027) | ├─TypeVariableAccessSyntax
 //@[024:0027) | | └─IdentifierSyntax
 //@[024:0027) | |   └─Token(Identifier) |int|
 //@[028:0032) | └─ParameterDefaultValueSyntax
@@ -235,7 +235,7 @@ param myTruth bool = 'not a boolean'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0013) | ├─IdentifierSyntax
 //@[006:0013) | | └─Token(Identifier) |myTruth|
-//@[014:0018) | ├─VariableAccessSyntax
+//@[014:0018) | ├─TypeVariableAccessSyntax
 //@[014:0018) | | └─IdentifierSyntax
 //@[014:0018) | |   └─Token(Identifier) |bool|
 //@[019:0036) | └─ParameterDefaultValueSyntax
@@ -248,7 +248,7 @@ param myFalsehood bool = 'false'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |myFalsehood|
-//@[018:0022) | ├─VariableAccessSyntax
+//@[018:0022) | ├─TypeVariableAccessSyntax
 //@[018:0022) | | └─IdentifierSyntax
 //@[018:0022) | |   └─Token(Identifier) |bool|
 //@[023:0032) | └─ParameterDefaultValueSyntax
@@ -262,7 +262,7 @@ param wrongAssignmentToken string: 'hello'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0026) | ├─IdentifierSyntax
 //@[006:0026) | | └─Token(Identifier) |wrongAssignmentToken|
-//@[027:0033) | ├─VariableAccessSyntax
+//@[027:0033) | ├─TypeVariableAccessSyntax
 //@[027:0033) | | └─IdentifierSyntax
 //@[027:0033) | |   └─Token(Identifier) |string|
 //@[033:0042) | └─SkippedTriviaSyntax
@@ -275,7 +275,7 @@ param WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWh
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0267) | ├─IdentifierSyntax
 //@[006:0267) | | └─Token(Identifier) |WhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLongWhySoLong|
-//@[268:0274) | ├─VariableAccessSyntax
+//@[268:0274) | ├─TypeVariableAccessSyntax
 //@[268:0274) | | └─IdentifierSyntax
 //@[268:0274) | |   └─Token(Identifier) |string|
 //@[275:0287) | └─ParameterDefaultValueSyntax
@@ -291,7 +291,7 @@ param boolCompletions bool =
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0021) | ├─IdentifierSyntax
 //@[006:0021) | | └─Token(Identifier) |boolCompletions|
-//@[022:0026) | ├─VariableAccessSyntax
+//@[022:0026) | ├─TypeVariableAccessSyntax
 //@[022:0026) | | └─IdentifierSyntax
 //@[022:0026) | |   └─Token(Identifier) |bool|
 //@[027:0029) | └─ParameterDefaultValueSyntax
@@ -306,7 +306,7 @@ param arrayCompletions array =
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0022) | ├─IdentifierSyntax
 //@[006:0022) | | └─Token(Identifier) |arrayCompletions|
-//@[023:0028) | ├─VariableAccessSyntax
+//@[023:0028) | ├─TypeVariableAccessSyntax
 //@[023:0028) | | └─IdentifierSyntax
 //@[023:0028) | |   └─Token(Identifier) |array|
 //@[029:0031) | └─ParameterDefaultValueSyntax
@@ -321,7 +321,7 @@ param objectCompletions object =
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |objectCompletions|
-//@[024:0030) | ├─VariableAccessSyntax
+//@[024:0030) | ├─TypeVariableAccessSyntax
 //@[024:0030) | | └─IdentifierSyntax
 //@[024:0030) | |   └─Token(Identifier) |object|
 //@[031:0033) | └─ParameterDefaultValueSyntax
@@ -336,7 +336,7 @@ param wrongType fluffyBunny = 'what's up doc?'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0036) | └─ParameterDefaultValueSyntax
@@ -358,7 +358,7 @@ param wrongType fluffyBunny = 'what\s up doc?'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0046) | └─ParameterDefaultValueSyntax
@@ -374,7 +374,7 @@ param wrongType fluffyBunny = 'what\'s up doc?
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0046) | └─ParameterDefaultValueSyntax
@@ -390,7 +390,7 @@ param wrongType fluffyBunny = 'what\'s ${
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0041) | └─ParameterDefaultValueSyntax
@@ -405,7 +405,7 @@ param wrongType fluffyBunny = 'what\'s ${up
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0043) | └─ParameterDefaultValueSyntax
@@ -422,7 +422,7 @@ param wrongType fluffyBunny = 'what\'s ${up}
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0044) | └─ParameterDefaultValueSyntax
@@ -439,7 +439,7 @@ param wrongType fluffyBunny = 'what\'s ${'up
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0044) | └─ParameterDefaultValueSyntax
@@ -458,7 +458,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0046) | └─ParameterDefaultValueSyntax
@@ -475,7 +475,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0046) | └─ParameterDefaultValueSyntax
@@ -492,7 +492,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0049) | └─ParameterDefaultValueSyntax
@@ -511,7 +511,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc}
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0050) | └─ParameterDefaultValueSyntax
@@ -531,7 +531,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc}'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0051) | └─ParameterDefaultValueSyntax
@@ -551,7 +551,7 @@ param wrongType fluffyBunny = 'what\'s ${'up${doc}'}?
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0053) | └─ParameterDefaultValueSyntax
@@ -574,7 +574,7 @@ param wrongType fluffyBunny = '${{this: doesnt}.work}'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0054) | └─ParameterDefaultValueSyntax
@@ -601,7 +601,7 @@ param badInterpolatedString string = 'hello ${}!'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0027) | ├─IdentifierSyntax
 //@[006:0027) | | └─Token(Identifier) |badInterpolatedString|
-//@[028:0034) | ├─VariableAccessSyntax
+//@[028:0034) | ├─TypeVariableAccessSyntax
 //@[028:0034) | | └─IdentifierSyntax
 //@[028:0034) | |   └─Token(Identifier) |string|
 //@[035:0049) | └─ParameterDefaultValueSyntax
@@ -616,7 +616,7 @@ param badInterpolatedString2 string = 'hello ${a b c}!'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0028) | ├─IdentifierSyntax
 //@[006:0028) | | └─Token(Identifier) |badInterpolatedString2|
-//@[029:0035) | ├─VariableAccessSyntax
+//@[029:0035) | ├─TypeVariableAccessSyntax
 //@[029:0035) | | └─IdentifierSyntax
 //@[029:0035) | |   └─Token(Identifier) |string|
 //@[036:0055) | └─ParameterDefaultValueSyntax
@@ -638,7 +638,7 @@ param wrongType fluffyBunny = 'what\'s up doc?'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |wrongType|
-//@[016:0027) | ├─VariableAccessSyntax
+//@[016:0027) | ├─TypeVariableAccessSyntax
 //@[016:0027) | | └─IdentifierSyntax
 //@[016:0027) | |   └─Token(Identifier) |fluffyBunny|
 //@[028:0047) | └─ParameterDefaultValueSyntax
@@ -678,7 +678,7 @@ param someArray arra
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |someArray|
-//@[016:0020) | └─VariableAccessSyntax
+//@[016:0020) | └─TypeVariableAccessSyntax
 //@[016:0020) |   └─IdentifierSyntax
 //@[016:0020) |     └─Token(Identifier) |arra|
 //@[020:0022) ├─Token(NewLine) |\n\n|
@@ -721,7 +721,7 @@ param secureInt int
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |secureInt|
-//@[016:0019) | └─VariableAccessSyntax
+//@[016:0019) | └─TypeVariableAccessSyntax
 //@[016:0019) |   └─IdentifierSyntax
 //@[016:0019) |     └─Token(Identifier) |int|
 //@[019:0021) ├─Token(NewLine) |\n\n|
@@ -800,7 +800,7 @@ param wrongIntModifier int = true
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0022) | ├─IdentifierSyntax
 //@[006:0022) | | └─Token(Identifier) |wrongIntModifier|
-//@[023:0026) | ├─VariableAccessSyntax
+//@[023:0026) | ├─TypeVariableAccessSyntax
 //@[023:0026) | | └─IdentifierSyntax
 //@[023:0026) | |   └─Token(Identifier) |int|
 //@[027:0033) | └─ParameterDefaultValueSyntax
@@ -884,7 +884,7 @@ param wrongMetadataSchema string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0025) | ├─IdentifierSyntax
 //@[006:0025) | | └─Token(Identifier) |wrongMetadataSchema|
-//@[026:0032) | └─VariableAccessSyntax
+//@[026:0032) | └─TypeVariableAccessSyntax
 //@[026:0032) |   └─IdentifierSyntax
 //@[026:0032) |     └─Token(Identifier) |string|
 //@[032:0034) ├─Token(NewLine) |\n\n|
@@ -949,7 +949,7 @@ param expressionInModifier string = 2 + 3
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0026) | ├─IdentifierSyntax
 //@[006:0026) | | └─Token(Identifier) |expressionInModifier|
-//@[027:0033) | ├─VariableAccessSyntax
+//@[027:0033) | ├─TypeVariableAccessSyntax
 //@[027:0033) | | └─IdentifierSyntax
 //@[027:0033) | |   └─Token(Identifier) |string|
 //@[034:0041) | └─ParameterDefaultValueSyntax
@@ -1029,7 +1029,7 @@ param nonCompileTimeConstant string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0028) | ├─IdentifierSyntax
 //@[006:0028) | | └─Token(Identifier) |nonCompileTimeConstant|
-//@[029:0035) | └─VariableAccessSyntax
+//@[029:0035) | └─TypeVariableAccessSyntax
 //@[029:0035) |   └─IdentifierSyntax
 //@[029:0035) |     └─Token(Identifier) |string|
 //@[035:0038) ├─Token(NewLine) |\n\n\n|
@@ -1053,7 +1053,7 @@ param emptyAllowedString string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0024) | ├─IdentifierSyntax
 //@[006:0024) | | └─Token(Identifier) |emptyAllowedString|
-//@[025:0031) | └─VariableAccessSyntax
+//@[025:0031) | └─TypeVariableAccessSyntax
 //@[025:0031) |   └─IdentifierSyntax
 //@[025:0031) |     └─Token(Identifier) |string|
 //@[031:0033) ├─Token(NewLine) |\n\n|
@@ -1076,7 +1076,7 @@ param emptyAllowedInt int
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0021) | ├─IdentifierSyntax
 //@[006:0021) | | └─Token(Identifier) |emptyAllowedInt|
-//@[022:0025) | └─VariableAccessSyntax
+//@[022:0025) | └─TypeVariableAccessSyntax
 //@[022:0025) |   └─IdentifierSyntax
 //@[022:0025) |     └─Token(Identifier) |int|
 //@[025:0027) ├─Token(NewLine) |\n\n|
@@ -1088,7 +1088,7 @@ param paramDefaultOneCycle string = paramDefaultOneCycle
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0026) | ├─IdentifierSyntax
 //@[006:0026) | | └─Token(Identifier) |paramDefaultOneCycle|
-//@[027:0033) | ├─VariableAccessSyntax
+//@[027:0033) | ├─TypeVariableAccessSyntax
 //@[027:0033) | | └─IdentifierSyntax
 //@[027:0033) | |   └─Token(Identifier) |string|
 //@[034:0056) | └─ParameterDefaultValueSyntax
@@ -1105,7 +1105,7 @@ param paramDefaultTwoCycle1 string = paramDefaultTwoCycle2
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0027) | ├─IdentifierSyntax
 //@[006:0027) | | └─Token(Identifier) |paramDefaultTwoCycle1|
-//@[028:0034) | ├─VariableAccessSyntax
+//@[028:0034) | ├─TypeVariableAccessSyntax
 //@[028:0034) | | └─IdentifierSyntax
 //@[028:0034) | |   └─Token(Identifier) |string|
 //@[035:0058) | └─ParameterDefaultValueSyntax
@@ -1119,7 +1119,7 @@ param paramDefaultTwoCycle2 string = paramDefaultTwoCycle1
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0027) | ├─IdentifierSyntax
 //@[006:0027) | | └─Token(Identifier) |paramDefaultTwoCycle2|
-//@[028:0034) | ├─VariableAccessSyntax
+//@[028:0034) | ├─TypeVariableAccessSyntax
 //@[028:0034) | | └─IdentifierSyntax
 //@[028:0034) | |   └─Token(Identifier) |string|
 //@[035:0058) | └─ParameterDefaultValueSyntax
@@ -1155,7 +1155,7 @@ param paramModifierSelfCycle string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0028) | ├─IdentifierSyntax
 //@[006:0028) | | └─Token(Identifier) |paramModifierSelfCycle|
-//@[029:0035) | └─VariableAccessSyntax
+//@[029:0035) | └─TypeVariableAccessSyntax
 //@[029:0035) |   └─IdentifierSyntax
 //@[029:0035) |     └─Token(Identifier) |string|
 //@[035:0037) ├─Token(NewLine) |\n\n|
@@ -1198,7 +1198,7 @@ output sampleOutput string = 'hello'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0019) | ├─IdentifierSyntax
 //@[007:0019) | | └─Token(Identifier) |sampleOutput|
-//@[020:0026) | ├─VariableAccessSyntax
+//@[020:0026) | ├─TypeVariableAccessSyntax
 //@[020:0026) | | └─IdentifierSyntax
 //@[020:0026) | |   └─Token(Identifier) |string|
 //@[027:0028) | ├─Token(Assignment) |=|
@@ -1211,7 +1211,7 @@ param paramAccessingVar string = concat(sampleVar, 's')
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |paramAccessingVar|
-//@[024:0030) | ├─VariableAccessSyntax
+//@[024:0030) | ├─TypeVariableAccessSyntax
 //@[024:0030) | | └─IdentifierSyntax
 //@[024:0030) | |   └─Token(Identifier) |string|
 //@[031:0055) | └─ParameterDefaultValueSyntax
@@ -1236,7 +1236,7 @@ param paramAccessingResource string = sampleResource
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0028) | ├─IdentifierSyntax
 //@[006:0028) | | └─Token(Identifier) |paramAccessingResource|
-//@[029:0035) | ├─VariableAccessSyntax
+//@[029:0035) | ├─TypeVariableAccessSyntax
 //@[029:0035) | | └─IdentifierSyntax
 //@[029:0035) | |   └─Token(Identifier) |string|
 //@[036:0052) | └─ParameterDefaultValueSyntax
@@ -1251,7 +1251,7 @@ param paramAccessingOutput string = sampleOutput
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0026) | ├─IdentifierSyntax
 //@[006:0026) | | └─Token(Identifier) |paramAccessingOutput|
-//@[027:0033) | ├─VariableAccessSyntax
+//@[027:0033) | ├─TypeVariableAccessSyntax
 //@[027:0033) | | └─IdentifierSyntax
 //@[027:0033) | |   └─Token(Identifier) |string|
 //@[034:0048) | └─ParameterDefaultValueSyntax
@@ -1278,7 +1278,7 @@ param defaultValueOneLinerCompletions string =
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0037) | ├─IdentifierSyntax
 //@[006:0037) | | └─Token(Identifier) |defaultValueOneLinerCompletions|
-//@[038:0044) | ├─VariableAccessSyntax
+//@[038:0044) | ├─TypeVariableAccessSyntax
 //@[038:0044) | | └─IdentifierSyntax
 //@[038:0044) | |   └─Token(Identifier) |string|
 //@[045:0047) | └─ParameterDefaultValueSyntax
@@ -1343,7 +1343,7 @@ param commaOne string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0014) | ├─IdentifierSyntax
 //@[006:0014) | | └─Token(Identifier) |commaOne|
-//@[015:0021) | └─VariableAccessSyntax
+//@[015:0021) | └─TypeVariableAccessSyntax
 //@[015:0021) |   └─IdentifierSyntax
 //@[015:0021) |     └─Token(Identifier) |string|
 //@[021:0023) ├─Token(NewLine) |\n\n|
@@ -1386,7 +1386,7 @@ param incompleteDecorators string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0026) | ├─IdentifierSyntax
 //@[006:0026) | | └─Token(Identifier) |incompleteDecorators|
-//@[027:0033) | └─VariableAccessSyntax
+//@[027:0033) | └─TypeVariableAccessSyntax
 //@[027:0033) |   └─IdentifierSyntax
 //@[027:0033) |     └─Token(Identifier) |string|
 //@[033:0035) ├─Token(NewLine) |\n\n|
@@ -1455,7 +1455,7 @@ param someString string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0016) | ├─IdentifierSyntax
 //@[006:0016) | | └─Token(Identifier) |someString|
-//@[017:0023) | └─VariableAccessSyntax
+//@[017:0023) | └─TypeVariableAccessSyntax
 //@[017:0023) |   └─IdentifierSyntax
 //@[017:0023) |     └─Token(Identifier) |string|
 //@[023:0025) ├─Token(NewLine) |\n\n|
@@ -1524,7 +1524,7 @@ param someInteger int = 20
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |someInteger|
-//@[018:0021) | ├─VariableAccessSyntax
+//@[018:0021) | ├─TypeVariableAccessSyntax
 //@[018:0021) | | └─IdentifierSyntax
 //@[018:0021) | |   └─Token(Identifier) |int|
 //@[022:0026) | └─ParameterDefaultValueSyntax
@@ -1573,7 +1573,7 @@ param tooManyArguments1 int = 20
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |tooManyArguments1|
-//@[024:0027) | ├─VariableAccessSyntax
+//@[024:0027) | ├─TypeVariableAccessSyntax
 //@[024:0027) | | └─IdentifierSyntax
 //@[024:0027) | |   └─Token(Identifier) |int|
 //@[028:0032) | └─ParameterDefaultValueSyntax
@@ -1638,7 +1638,7 @@ param tooManyArguments2 string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |tooManyArguments2|
-//@[024:0030) | └─VariableAccessSyntax
+//@[024:0030) | └─TypeVariableAccessSyntax
 //@[024:0030) |   └─IdentifierSyntax
 //@[024:0030) |     └─Token(Identifier) |string|
 //@[030:0032) ├─Token(NewLine) |\n\n|
@@ -1694,7 +1694,7 @@ param nonConstantInDecorator string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0028) | ├─IdentifierSyntax
 //@[006:0028) | | └─Token(Identifier) |nonConstantInDecorator|
-//@[029:0035) | └─VariableAccessSyntax
+//@[029:0035) | └─TypeVariableAccessSyntax
 //@[029:0035) |   └─IdentifierSyntax
 //@[029:0035) |     └─Token(Identifier) |string|
 //@[035:0037) ├─Token(NewLine) |\n\n|
@@ -1749,7 +1749,7 @@ param unaryMinusOnFunction int
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0026) | ├─IdentifierSyntax
 //@[006:0026) | | └─Token(Identifier) |unaryMinusOnFunction|
-//@[027:0030) | └─VariableAccessSyntax
+//@[027:0030) | └─TypeVariableAccessSyntax
 //@[027:0030) |   └─IdentifierSyntax
 //@[027:0030) |     └─Token(Identifier) |int|
 //@[030:0032) ├─Token(NewLine) |\n\n|
@@ -1816,7 +1816,7 @@ param duplicateDecorators string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0025) | ├─IdentifierSyntax
 //@[006:0025) | | └─Token(Identifier) |duplicateDecorators|
-//@[026:0032) | └─VariableAccessSyntax
+//@[026:0032) | └─TypeVariableAccessSyntax
 //@[026:0032) |   └─IdentifierSyntax
 //@[026:0032) |     └─Token(Identifier) |string|
 //@[032:0034) ├─Token(NewLine) |\n\n|
@@ -1854,7 +1854,7 @@ param invalidLength string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0019) | ├─IdentifierSyntax
 //@[006:0019) | | └─Token(Identifier) |invalidLength|
-//@[020:0026) | └─VariableAccessSyntax
+//@[020:0026) | └─TypeVariableAccessSyntax
 //@[020:0026) |   └─IdentifierSyntax
 //@[020:0026) |     └─Token(Identifier) |string|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -1914,7 +1914,7 @@ param invalidPermutation array = [
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0024) | ├─IdentifierSyntax
 //@[006:0024) | | └─Token(Identifier) |invalidPermutation|
-//@[025:0030) | ├─VariableAccessSyntax
+//@[025:0030) | ├─TypeVariableAccessSyntax
 //@[025:0030) | | └─IdentifierSyntax
 //@[025:0030) | |   └─Token(Identifier) |array|
 //@[031:0060) | └─ParameterDefaultValueSyntax
@@ -1997,7 +1997,7 @@ param invalidDefaultWithAllowedArrayDecorator array = true
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0045) | ├─IdentifierSyntax
 //@[006:0045) | | └─Token(Identifier) |invalidDefaultWithAllowedArrayDecorator|
-//@[046:0051) | ├─VariableAccessSyntax
+//@[046:0051) | ├─TypeVariableAccessSyntax
 //@[046:0051) | | └─IdentifierSyntax
 //@[046:0051) | |   └─Token(Identifier) |array|
 //@[052:0058) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResourceDerivedTypes_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResourceDerivedTypes_LF/main.syntax.bicep
@@ -34,11 +34,11 @@ type invalid3 = resource<'abc', 'def'>
 //@[016:0024) |   | └─Token(Identifier) |resource|
 //@[024:0025) |   ├─Token(LeftChevron) |<|
 //@[025:0030) |   ├─ParameterizedTypeArgumentSyntax
-//@[025:0030) |   | └─StringSyntax
+//@[025:0030) |   | └─StringTypeLiteralSyntax
 //@[025:0030) |   |   └─Token(StringComplete) |'abc'|
 //@[030:0031) |   ├─Token(Comma) |,|
 //@[032:0037) |   ├─ParameterizedTypeArgumentSyntax
-//@[032:0037) |   | └─StringSyntax
+//@[032:0037) |   | └─StringTypeLiteralSyntax
 //@[032:0037) |   |   └─Token(StringComplete) |'def'|
 //@[037:0038) |   └─Token(RightChevron) |>|
 //@[038:0039) ├─Token(NewLine) |\n|
@@ -53,7 +53,7 @@ type invalid4 = resource<hello>
 //@[016:0024) |   | └─Token(Identifier) |resource|
 //@[024:0025) |   ├─Token(LeftChevron) |<|
 //@[025:0030) |   ├─ParameterizedTypeArgumentSyntax
-//@[025:0030) |   | └─VariableAccessSyntax
+//@[025:0030) |   | └─TypeVariableAccessSyntax
 //@[025:0030) |   |   └─IdentifierSyntax
 //@[025:0030) |   |     └─Token(Identifier) |hello|
 //@[030:0031) |   └─Token(RightChevron) |>|
@@ -69,7 +69,7 @@ type invalid5 = resource<'Microsoft.Storage/storageAccounts'>
 //@[016:0024) |   | └─Token(Identifier) |resource|
 //@[024:0025) |   ├─Token(LeftChevron) |<|
 //@[025:0060) |   ├─ParameterizedTypeArgumentSyntax
-//@[025:0060) |   | └─StringSyntax
+//@[025:0060) |   | └─StringTypeLiteralSyntax
 //@[025:0060) |   |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts'|
 //@[060:0061) |   └─Token(RightChevron) |>|
 //@[061:0062) ├─Token(NewLine) |\n|
@@ -84,7 +84,7 @@ type invalid6 = resource<'Microsoft.Storage/storageAccounts@'>
 //@[016:0024) |   | └─Token(Identifier) |resource|
 //@[024:0025) |   ├─Token(LeftChevron) |<|
 //@[025:0061) |   ├─ParameterizedTypeArgumentSyntax
-//@[025:0061) |   | └─StringSyntax
+//@[025:0061) |   | └─StringTypeLiteralSyntax
 //@[025:0061) |   |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@'|
 //@[061:0062) |   └─Token(RightChevron) |>|
 //@[062:0063) ├─Token(NewLine) |\n|
@@ -99,7 +99,7 @@ type invalid7 = resource<'Microsoft.Storage/storageAccounts@hello'>
 //@[016:0024) |   | └─Token(Identifier) |resource|
 //@[024:0025) |   ├─Token(LeftChevron) |<|
 //@[025:0066) |   ├─ParameterizedTypeArgumentSyntax
-//@[025:0066) |   | └─StringSyntax
+//@[025:0066) |   | └─StringTypeLiteralSyntax
 //@[025:0066) |   |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@hello'|
 //@[066:0067) |   └─Token(RightChevron) |>|
 //@[067:0068) ├─Token(NewLine) |\n|
@@ -114,7 +114,7 @@ type invalid8 = resource<'notARealNamespace:Microsoft.Storage/storageAccounts@20
 //@[016:0024) |   | └─Token(Identifier) |resource|
 //@[024:0025) |   ├─Token(LeftChevron) |<|
 //@[025:0089) |   ├─ParameterizedTypeArgumentSyntax
-//@[025:0089) |   | └─StringSyntax
+//@[025:0089) |   | └─StringTypeLiteralSyntax
 //@[025:0089) |   |   └─Token(StringComplete) |'notARealNamespace:Microsoft.Storage/storageAccounts@2022-09-01'|
 //@[089:0090) |   └─Token(RightChevron) |>|
 //@[090:0091) ├─Token(NewLine) |\n|
@@ -129,7 +129,7 @@ type invalid9 = resource<':Microsoft.Storage/storageAccounts@2022-09-01'>
 //@[016:0024) |   | └─Token(Identifier) |resource|
 //@[024:0025) |   ├─Token(LeftChevron) |<|
 //@[025:0072) |   ├─ParameterizedTypeArgumentSyntax
-//@[025:0072) |   | └─StringSyntax
+//@[025:0072) |   | └─StringTypeLiteralSyntax
 //@[025:0072) |   |   └─Token(StringComplete) |':Microsoft.Storage/storageAccounts@2022-09-01'|
 //@[072:0073) |   └─Token(RightChevron) |>|
 //@[073:0074) ├─Token(NewLine) |\n|
@@ -144,11 +144,11 @@ type invalid10 = resource<'abc' 'def'>
 //@[017:0025) |   | └─Token(Identifier) |resource|
 //@[025:0026) |   ├─Token(LeftChevron) |<|
 //@[026:0031) |   ├─ParameterizedTypeArgumentSyntax
-//@[026:0031) |   | └─StringSyntax
+//@[026:0031) |   | └─StringTypeLiteralSyntax
 //@[026:0031) |   |   └─Token(StringComplete) |'abc'|
 //@[032:0032) |   ├─SkippedTriviaSyntax
 //@[032:0037) |   ├─ParameterizedTypeArgumentSyntax
-//@[032:0037) |   | └─StringSyntax
+//@[032:0037) |   | └─StringTypeLiteralSyntax
 //@[032:0037) |   |   └─Token(StringComplete) |'def'|
 //@[037:0038) |   └─Token(RightChevron) |>|
 //@[038:0039) ├─Token(NewLine) |\n|
@@ -163,7 +163,7 @@ type invalid11 = resource<123>
 //@[017:0025) |   | └─Token(Identifier) |resource|
 //@[025:0026) |   ├─Token(LeftChevron) |<|
 //@[026:0029) |   ├─ParameterizedTypeArgumentSyntax
-//@[026:0029) |   | └─IntegerLiteralSyntax
+//@[026:0029) |   | └─IntegerTypeLiteralSyntax
 //@[026:0029) |   |   └─Token(Integer) |123|
 //@[029:0030) |   └─Token(RightChevron) |>|
 //@[030:0031) ├─Token(NewLine) |\n|
@@ -178,12 +178,12 @@ type invalid12 = resource<resourceGroup()>
 //@[017:0025) |   | └─Token(Identifier) |resource|
 //@[025:0026) |   ├─Token(LeftChevron) |<|
 //@[026:0039) |   ├─ParameterizedTypeArgumentSyntax
-//@[026:0039) |   | └─VariableAccessSyntax
+//@[026:0039) |   | └─TypeVariableAccessSyntax
 //@[026:0039) |   |   └─IdentifierSyntax
 //@[026:0039) |   |     └─Token(Identifier) |resourceGroup|
 //@[039:0039) |   ├─SkippedTriviaSyntax
 //@[039:0041) |   ├─ParameterizedTypeArgumentSyntax
-//@[039:0041) |   | └─ParenthesizedExpressionSyntax
+//@[039:0041) |   | └─ParenthesizedTypeSyntax
 //@[039:0040) |   |   ├─Token(LeftParen) |(|
 //@[040:0040) |   |   ├─SkippedTriviaSyntax
 //@[040:0041) |   |   └─Token(RightParen) |)|
@@ -202,7 +202,7 @@ type thisIsWeird = resource</*
 //@[027:0028) |   ├─Token(LeftChevron) |<|
 */'Astronomer.Astro/organizations@2023-08-01-preview'
 //@[002:0053) |   ├─ParameterizedTypeArgumentSyntax
-//@[002:0053) |   | └─StringSyntax
+//@[002:0053) |   | └─StringTypeLiteralSyntax
 //@[002:0053) |   |   └─Token(StringComplete) |'Astronomer.Astro/organizations@2023-08-01-preview'|
 //@[053:0053) |   ├─SkippedTriviaSyntax
 //@[053:0054) |   ├─Token(NewLine) |\n|
@@ -223,7 +223,7 @@ type interpolated = resource<'Microsoft.${'Storage'}/storageAccounts@2022-09-01'
 //@[020:0028) |   | └─Token(Identifier) |resource|
 //@[028:0029) |   ├─Token(LeftChevron) |<|
 //@[029:0080) |   ├─ParameterizedTypeArgumentSyntax
-//@[029:0080) |   | └─StringSyntax
+//@[029:0080) |   | └─StringTypeLiteralSyntax
 //@[029:0042) |   |   ├─Token(StringLeftPiece) |'Microsoft.${|
 //@[042:0051) |   |   ├─StringSyntax
 //@[042:0051) |   |   | └─Token(StringComplete) |'Storage'|
@@ -251,7 +251,7 @@ type shouldNotBeSealable = resource<'Microsoft.Storage/storageAccounts@2022-09-0
 //@[027:0035) |   | └─Token(Identifier) |resource|
 //@[035:0036) |   ├─Token(LeftChevron) |<|
 //@[036:0082) |   ├─ParameterizedTypeArgumentSyntax
-//@[036:0082) |   | └─StringSyntax
+//@[036:0082) |   | └─StringTypeLiteralSyntax
 //@[036:0082) |   |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2022-09-01'|
 //@[082:0083) |   └─Token(RightChevron) |>|
 //@[083:0085) ├─Token(NewLine) |\n\n|
@@ -287,7 +287,7 @@ type hello = {
 //@[007:0015) |   |   | └─Token(Identifier) |resource|
 //@[015:0016) |   |   ├─Token(LeftChevron) |<|
 //@[016:0067) |   |   ├─ParameterizedTypeArgumentSyntax
-//@[016:0067) |   |   | └─StringSyntax
+//@[016:0067) |   |   | └─StringTypeLiteralSyntax
 //@[016:0067) |   |   |   └─Token(StringComplete) |'Astronomer.Astro/organizations@2023-08-01-preview'|
 //@[067:0068) |   |   └─Token(RightChevron) |>|
 //@[068:0069) |   ├─Token(NewLine) |\n|
@@ -307,7 +307,7 @@ type typoInPropertyName = resource<'Microsoft.Storage/storageAccounts@2023-01-01
 //@[026:0034) |   | | └─Token(Identifier) |resource|
 //@[034:0035) |   | ├─Token(LeftChevron) |<|
 //@[035:0081) |   | ├─ParameterizedTypeArgumentSyntax
-//@[035:0081) |   | | └─StringSyntax
+//@[035:0081) |   | | └─StringTypeLiteralSyntax
 //@[035:0081) |   | |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2023-01-01'|
 //@[081:0082) |   | └─Token(RightChevron) |>|
 //@[082:0083) |   ├─Token(Dot) |.|
@@ -329,7 +329,7 @@ type typoInPropertyName2 = resource<'Microsoft.KeyVault/vaults@2022-07-01'>.prop
 //@[027:0035) |   | | | | | └─Token(Identifier) |resource|
 //@[035:0036) |   | | | | ├─Token(LeftChevron) |<|
 //@[036:0074) |   | | | | ├─ParameterizedTypeArgumentSyntax
-//@[036:0074) |   | | | | | └─StringSyntax
+//@[036:0074) |   | | | | | └─StringTypeLiteralSyntax
 //@[036:0074) |   | | | | |   └─Token(StringComplete) |'Microsoft.KeyVault/vaults@2022-07-01'|
 //@[074:0075) |   | | | | └─Token(RightChevron) |>|
 //@[075:0076) |   | | | ├─Token(Dot) |.|
@@ -360,7 +360,7 @@ type typoInPropertyName3 = resource<'Microsoft.KeyVault/vaults@2022-07-01'>.prop
 //@[027:0035) |   | | | | | └─Token(Identifier) |resource|
 //@[035:0036) |   | | | | ├─Token(LeftChevron) |<|
 //@[036:0074) |   | | | | ├─ParameterizedTypeArgumentSyntax
-//@[036:0074) |   | | | | | └─StringSyntax
+//@[036:0074) |   | | | | | └─StringTypeLiteralSyntax
 //@[036:0074) |   | | | | |   └─Token(StringComplete) |'Microsoft.KeyVault/vaults@2022-07-01'|
 //@[074:0075) |   | | | | └─Token(RightChevron) |>|
 //@[075:0076) |   | | | ├─Token(Dot) |.|
@@ -391,7 +391,7 @@ type typoInPropertyName4 = resource<'Microsoft.Web/customApis@2016-06-01'>.prope
 //@[027:0035) |   | | | | | └─Token(Identifier) |resource|
 //@[035:0036) |   | | | | ├─Token(LeftChevron) |<|
 //@[036:0073) |   | | | | ├─ParameterizedTypeArgumentSyntax
-//@[036:0073) |   | | | | | └─StringSyntax
+//@[036:0073) |   | | | | | └─StringTypeLiteralSyntax
 //@[036:0073) |   | | | | |   └─Token(StringComplete) |'Microsoft.Web/customApis@2016-06-01'|
 //@[073:0074) |   | | | | └─Token(RightChevron) |>|
 //@[074:0075) |   | | | ├─Token(Dot) |.|
@@ -421,7 +421,7 @@ type typoInPropertyName5 = resource<'Microsoft.Web/customApis@2016-06-01'>.prope
 //@[027:0035) |   | | | | | └─Token(Identifier) |resource|
 //@[035:0036) |   | | | | ├─Token(LeftChevron) |<|
 //@[036:0073) |   | | | | ├─ParameterizedTypeArgumentSyntax
-//@[036:0073) |   | | | | | └─StringSyntax
+//@[036:0073) |   | | | | | └─StringTypeLiteralSyntax
 //@[036:0073) |   | | | | |   └─Token(StringComplete) |'Microsoft.Web/customApis@2016-06-01'|
 //@[073:0074) |   | | | | └─Token(RightChevron) |>|
 //@[074:0075) |   | | | ├─Token(Dot) |.|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.syntax.bicep
@@ -946,7 +946,7 @@ param resrefpar string = foo.id
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00015) | ├─IdentifierSyntax
 //@[006:00015) | | └─Token(Identifier) |resrefpar|
-//@[016:00022) | ├─VariableAccessSyntax
+//@[016:00022) | ├─TypeVariableAccessSyntax
 //@[016:00022) | | └─IdentifierSyntax
 //@[016:00022) | |   └─Token(Identifier) |string|
 //@[023:00031) | └─ParameterDefaultValueSyntax
@@ -965,7 +965,7 @@ output resrefout bool = bar.id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00016) | ├─IdentifierSyntax
 //@[007:00016) | | └─Token(Identifier) |resrefout|
-//@[017:00021) | ├─VariableAccessSyntax
+//@[017:00021) | ├─TypeVariableAccessSyntax
 //@[017:00021) | | └─IdentifierSyntax
 //@[017:00021) | |   └─Token(Identifier) |bool|
 //@[022:00023) | ├─Token(Assignment) |=|
@@ -9038,7 +9038,7 @@ output directRefViaOutput array = union(premiumStorages, stuffs)
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00025) | ├─IdentifierSyntax
 //@[007:00025) | | └─Token(Identifier) |directRefViaOutput|
-//@[026:00031) | ├─VariableAccessSyntax
+//@[026:00031) | ├─TypeVariableAccessSyntax
 //@[026:00031) | | └─IdentifierSyntax
 //@[026:00031) | |   └─Token(Identifier) |array|
 //@[032:00033) | ├─Token(Assignment) |=|
@@ -11351,7 +11351,7 @@ param dataCollectionRule object
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00024) | ├─IdentifierSyntax
 //@[006:00024) | | └─Token(Identifier) |dataCollectionRule|
-//@[025:00031) | └─VariableAccessSyntax
+//@[025:00031) | └─TypeVariableAccessSyntax
 //@[025:00031) |   └─IdentifierSyntax
 //@[025:00031) |     └─Token(Identifier) |object|
 //@[031:00033) ├─Token(NewLine) |\r\n|
@@ -11360,7 +11360,7 @@ param tags object
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00010) | ├─IdentifierSyntax
 //@[006:00010) | | └─Token(Identifier) |tags|
-//@[011:00017) | └─VariableAccessSyntax
+//@[011:00017) | └─TypeVariableAccessSyntax
 //@[011:00017) |   └─IdentifierSyntax
 //@[011:00017) |     └─Token(Identifier) |object|
 //@[017:00021) ├─Token(NewLine) |\r\n\r\n|
@@ -11950,7 +11950,7 @@ param issue4668_kind string = 'AzureCLI'
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00020) | ├─IdentifierSyntax
 //@[006:00020) | | └─Token(Identifier) |issue4668_kind|
-//@[021:00027) | ├─VariableAccessSyntax
+//@[021:00027) | ├─TypeVariableAccessSyntax
 //@[021:00027) | | └─IdentifierSyntax
 //@[021:00027) | |   └─Token(Identifier) |string|
 //@[028:00040) | └─ParameterDefaultValueSyntax
@@ -11975,7 +11975,7 @@ param issue4668_identity object
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00024) | ├─IdentifierSyntax
 //@[006:00024) | | └─Token(Identifier) |issue4668_identity|
-//@[025:00031) | └─VariableAccessSyntax
+//@[025:00031) | └─TypeVariableAccessSyntax
 //@[025:00031) |   └─IdentifierSyntax
 //@[025:00031) |     └─Token(Identifier) |object|
 //@[031:00033) ├─Token(NewLine) |\r\n|
@@ -11996,7 +11996,7 @@ param issue4668_properties object
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00026) | ├─IdentifierSyntax
 //@[006:00026) | | └─Token(Identifier) |issue4668_properties|
-//@[027:00033) | └─VariableAccessSyntax
+//@[027:00033) | └─TypeVariableAccessSyntax
 //@[027:00033) |   └─IdentifierSyntax
 //@[027:00033) |     └─Token(Identifier) |object|
 //@[033:00035) ├─Token(NewLine) |\r\n|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidRuntimeValueUsages_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidRuntimeValueUsages_LF/main.syntax.bicep
@@ -190,7 +190,7 @@ param intParam int = 0
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0014) | ├─IdentifierSyntax
 //@[06:0014) | | └─Token(Identifier) |intParam|
-//@[15:0018) | ├─VariableAccessSyntax
+//@[15:0018) | ├─TypeVariableAccessSyntax
 //@[15:0018) | | └─IdentifierSyntax
 //@[15:0018) | |   └─Token(Identifier) |int|
 //@[19:0022) | └─ParameterDefaultValueSyntax
@@ -203,7 +203,7 @@ param strParam string = 'id'
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0014) | ├─IdentifierSyntax
 //@[06:0014) | | └─Token(Identifier) |strParam|
-//@[15:0021) | ├─VariableAccessSyntax
+//@[15:0021) | ├─TypeVariableAccessSyntax
 //@[15:0021) | | └─IdentifierSyntax
 //@[15:0021) | |   └─Token(Identifier) |string|
 //@[22:0028) | └─ParameterDefaultValueSyntax
@@ -216,7 +216,7 @@ param strParam2 string = 'd'
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0015) | ├─IdentifierSyntax
 //@[06:0015) | | └─Token(Identifier) |strParam2|
-//@[16:0022) | ├─VariableAccessSyntax
+//@[16:0022) | ├─TypeVariableAccessSyntax
 //@[16:0022) | | └─IdentifierSyntax
 //@[16:0022) | |   └─Token(Identifier) |string|
 //@[23:0028) | └─ParameterDefaultValueSyntax
@@ -229,7 +229,7 @@ param cond bool = false
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0010) | ├─IdentifierSyntax
 //@[06:0010) | | └─Token(Identifier) |cond|
-//@[11:0015) | ├─VariableAccessSyntax
+//@[11:0015) | ├─TypeVariableAccessSyntax
 //@[11:0015) | | └─IdentifierSyntax
 //@[11:0015) | |   └─Token(Identifier) |bool|
 //@[16:0023) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.syntax.bicep
@@ -33,7 +33,7 @@ type resource = bool
 //@[005:0013) | ├─IdentifierSyntax
 //@[005:0013) | | └─Token(Identifier) |resource|
 //@[014:0015) | ├─Token(Assignment) |=|
-//@[016:0020) | └─VariableAccessSyntax
+//@[016:0020) | └─TypeVariableAccessSyntax
 //@[016:0020) |   └─IdentifierSyntax
 //@[016:0020) |     └─Token(Identifier) |bool|
 //@[020:0022) ├─Token(NewLine) |\n\n|
@@ -53,7 +53,7 @@ type sealedString = string
 //@[005:0017) | ├─IdentifierSyntax
 //@[005:0017) | | └─Token(Identifier) |sealedString|
 //@[018:0019) | ├─Token(Assignment) |=|
-//@[020:0026) | └─VariableAccessSyntax
+//@[020:0026) | └─TypeVariableAccessSyntax
 //@[020:0026) |   └─IdentifierSyntax
 //@[020:0026) |     └─Token(Identifier) |string|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -80,7 +80,7 @@ type sealedDictionary = {
 //@[001:0010) |   ├─ObjectTypeAdditionalPropertiesSyntax
 //@[001:0002) |   | ├─Token(Asterisk) |*|
 //@[002:0003) |   | ├─Token(Colon) |:|
-//@[004:0010) |   | └─VariableAccessSyntax
+//@[004:0010) |   | └─TypeVariableAccessSyntax
 //@[004:0010) |   |   └─IdentifierSyntax
 //@[004:0010) |   |     └─Token(Identifier) |string|
 //@[010:0011) |   ├─Token(NewLine) |\n|
@@ -96,11 +96,11 @@ type disallowedUnion = 'foo'|21
 //@[021:0022) | ├─Token(Assignment) |=|
 //@[023:0031) | └─UnionTypeSyntax
 //@[023:0028) |   ├─UnionTypeMemberSyntax
-//@[023:0028) |   | └─StringSyntax
+//@[023:0028) |   | └─StringTypeLiteralSyntax
 //@[023:0028) |   |   └─Token(StringComplete) |'foo'|
 //@[028:0029) |   ├─Token(Pipe) |||
 //@[029:0031) |   └─UnionTypeMemberSyntax
-//@[029:0031) |     └─IntegerLiteralSyntax
+//@[029:0031) |     └─IntegerTypeLiteralSyntax
 //@[029:0031) |       └─Token(Integer) |21|
 //@[031:0033) ├─Token(NewLine) |\n\n|
 
@@ -112,15 +112,15 @@ type validStringLiteralUnion = 'foo'|'bar'|'baz'
 //@[029:0030) | ├─Token(Assignment) |=|
 //@[031:0048) | └─UnionTypeSyntax
 //@[031:0036) |   ├─UnionTypeMemberSyntax
-//@[031:0036) |   | └─StringSyntax
+//@[031:0036) |   | └─StringTypeLiteralSyntax
 //@[031:0036) |   |   └─Token(StringComplete) |'foo'|
 //@[036:0037) |   ├─Token(Pipe) |||
 //@[037:0042) |   ├─UnionTypeMemberSyntax
-//@[037:0042) |   | └─StringSyntax
+//@[037:0042) |   | └─StringTypeLiteralSyntax
 //@[037:0042) |   |   └─Token(StringComplete) |'bar'|
 //@[042:0043) |   ├─Token(Pipe) |||
 //@[043:0048) |   └─UnionTypeMemberSyntax
-//@[043:0048) |     └─StringSyntax
+//@[043:0048) |     └─StringTypeLiteralSyntax
 //@[043:0048) |       └─Token(StringComplete) |'baz'|
 //@[048:0050) ├─Token(NewLine) |\n\n|
 
@@ -132,12 +132,12 @@ type validUnionInvalidAddition = validStringLiteralUnion|10
 //@[031:0032) | ├─Token(Assignment) |=|
 //@[033:0059) | └─UnionTypeSyntax
 //@[033:0056) |   ├─UnionTypeMemberSyntax
-//@[033:0056) |   | └─VariableAccessSyntax
+//@[033:0056) |   | └─TypeVariableAccessSyntax
 //@[033:0056) |   |   └─IdentifierSyntax
 //@[033:0056) |   |     └─Token(Identifier) |validStringLiteralUnion|
 //@[056:0057) |   ├─Token(Pipe) |||
 //@[057:0059) |   └─UnionTypeMemberSyntax
-//@[057:0059) |     └─IntegerLiteralSyntax
+//@[057:0059) |     └─IntegerTypeLiteralSyntax
 //@[057:0059) |       └─Token(Integer) |10|
 //@[059:0061) ├─Token(NewLine) |\n\n|
 
@@ -149,12 +149,12 @@ type invalidUnionInvalidAddition = disallowedUnion|true
 //@[033:0034) | ├─Token(Assignment) |=|
 //@[035:0055) | └─UnionTypeSyntax
 //@[035:0050) |   ├─UnionTypeMemberSyntax
-//@[035:0050) |   | └─VariableAccessSyntax
+//@[035:0050) |   | └─TypeVariableAccessSyntax
 //@[035:0050) |   |   └─IdentifierSyntax
 //@[035:0050) |   |     └─Token(Identifier) |disallowedUnion|
 //@[050:0051) |   ├─Token(Pipe) |||
 //@[051:0055) |   └─UnionTypeMemberSyntax
-//@[051:0055) |     └─BooleanLiteralSyntax
+//@[051:0055) |     └─BooleanTypeLiteralSyntax
 //@[051:0055) |       └─Token(TrueKeyword) |true|
 //@[055:0057) ├─Token(NewLine) |\n\n|
 
@@ -164,7 +164,7 @@ type nullLiteral = null
 //@[005:0016) | ├─IdentifierSyntax
 //@[005:0016) | | └─Token(Identifier) |nullLiteral|
 //@[017:0018) | ├─Token(Assignment) |=|
-//@[019:0023) | └─NullLiteralSyntax
+//@[019:0023) | └─NullTypeLiteralSyntax
 //@[019:0023) |   └─Token(NullKeyword) |null|
 //@[023:0025) ├─Token(NewLine) |\n\n|
 
@@ -176,11 +176,11 @@ type unionOfNulls = null|null
 //@[018:0019) | ├─Token(Assignment) |=|
 //@[020:0029) | └─UnionTypeSyntax
 //@[020:0024) |   ├─UnionTypeMemberSyntax
-//@[020:0024) |   | └─NullLiteralSyntax
+//@[020:0024) |   | └─NullTypeLiteralSyntax
 //@[020:0024) |   |   └─Token(NullKeyword) |null|
 //@[024:0025) |   ├─Token(Pipe) |||
 //@[025:0029) |   └─UnionTypeMemberSyntax
-//@[025:0029) |     └─NullLiteralSyntax
+//@[025:0029) |     └─NullTypeLiteralSyntax
 //@[025:0029) |       └─Token(NullKeyword) |null|
 //@[029:0031) ├─Token(NewLine) |\n\n|
 
@@ -202,7 +202,7 @@ type lengthConstrainedInt = int
 //@[005:0025) | ├─IdentifierSyntax
 //@[005:0025) | | └─Token(Identifier) |lengthConstrainedInt|
 //@[026:0027) | ├─Token(Assignment) |=|
-//@[028:0031) | └─VariableAccessSyntax
+//@[028:0031) | └─TypeVariableAccessSyntax
 //@[028:0031) |   └─IdentifierSyntax
 //@[028:0031) |     └─Token(Identifier) |int|
 //@[031:0033) ├─Token(NewLine) |\n\n|
@@ -225,7 +225,7 @@ type valueConstrainedString = string
 //@[005:0027) | ├─IdentifierSyntax
 //@[005:0027) | | └─Token(Identifier) |valueConstrainedString|
 //@[028:0029) | ├─Token(Assignment) |=|
-//@[030:0036) | └─VariableAccessSyntax
+//@[030:0036) | └─TypeVariableAccessSyntax
 //@[030:0036) |   └─IdentifierSyntax
 //@[030:0036) |     └─Token(Identifier) |string|
 //@[036:0038) ├─Token(NewLine) |\n\n|
@@ -236,7 +236,7 @@ type tautology = tautology
 //@[005:0014) | ├─IdentifierSyntax
 //@[005:0014) | | └─Token(Identifier) |tautology|
 //@[015:0016) | ├─Token(Assignment) |=|
-//@[017:0026) | └─VariableAccessSyntax
+//@[017:0026) | └─TypeVariableAccessSyntax
 //@[017:0026) |   └─IdentifierSyntax
 //@[017:0026) |     └─Token(Identifier) |tautology|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -249,12 +249,12 @@ type tautologicalUnion = tautologicalUnion|'foo'
 //@[023:0024) | ├─Token(Assignment) |=|
 //@[025:0048) | └─UnionTypeSyntax
 //@[025:0042) |   ├─UnionTypeMemberSyntax
-//@[025:0042) |   | └─VariableAccessSyntax
+//@[025:0042) |   | └─TypeVariableAccessSyntax
 //@[025:0042) |   |   └─IdentifierSyntax
 //@[025:0042) |   |     └─Token(Identifier) |tautologicalUnion|
 //@[042:0043) |   ├─Token(Pipe) |||
 //@[043:0048) |   └─UnionTypeMemberSyntax
-//@[043:0048) |     └─StringSyntax
+//@[043:0048) |     └─StringTypeLiteralSyntax
 //@[043:0048) |       └─Token(StringComplete) |'foo'|
 //@[048:0050) ├─Token(NewLine) |\n\n|
 
@@ -266,7 +266,7 @@ type tautologicalArray = tautologicalArray[]
 //@[023:0024) | ├─Token(Assignment) |=|
 //@[025:0044) | └─ArrayTypeSyntax
 //@[025:0042) |   ├─ArrayTypeMemberSyntax
-//@[025:0042) |   | └─VariableAccessSyntax
+//@[025:0042) |   | └─TypeVariableAccessSyntax
 //@[025:0042) |   |   └─IdentifierSyntax
 //@[025:0042) |   |     └─Token(Identifier) |tautologicalArray|
 //@[042:0043) |   ├─Token(LeftSquare) |[|
@@ -279,7 +279,7 @@ type directCycleStart = directCycleReturn
 //@[005:0021) | ├─IdentifierSyntax
 //@[005:0021) | | └─Token(Identifier) |directCycleStart|
 //@[022:0023) | ├─Token(Assignment) |=|
-//@[024:0041) | └─VariableAccessSyntax
+//@[024:0041) | └─TypeVariableAccessSyntax
 //@[024:0041) |   └─IdentifierSyntax
 //@[024:0041) |     └─Token(Identifier) |directCycleReturn|
 //@[041:0043) ├─Token(NewLine) |\n\n|
@@ -290,7 +290,7 @@ type directCycleReturn = directCycleStart
 //@[005:0022) | ├─IdentifierSyntax
 //@[005:0022) | | └─Token(Identifier) |directCycleReturn|
 //@[023:0024) | ├─Token(Assignment) |=|
-//@[025:0041) | └─VariableAccessSyntax
+//@[025:0041) | └─TypeVariableAccessSyntax
 //@[025:0041) |   └─IdentifierSyntax
 //@[025:0041) |     └─Token(Identifier) |directCycleStart|
 //@[041:0043) ├─Token(NewLine) |\n\n|
@@ -301,7 +301,7 @@ type cycleRoot = connector
 //@[005:0014) | ├─IdentifierSyntax
 //@[005:0014) | | └─Token(Identifier) |cycleRoot|
 //@[015:0016) | ├─Token(Assignment) |=|
-//@[017:0026) | └─VariableAccessSyntax
+//@[017:0026) | └─TypeVariableAccessSyntax
 //@[017:0026) |   └─IdentifierSyntax
 //@[017:0026) |     └─Token(Identifier) |connector|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -312,7 +312,7 @@ type connector = cycleBack
 //@[005:0014) | ├─IdentifierSyntax
 //@[005:0014) | | └─Token(Identifier) |connector|
 //@[015:0016) | ├─Token(Assignment) |=|
-//@[017:0026) | └─VariableAccessSyntax
+//@[017:0026) | └─TypeVariableAccessSyntax
 //@[017:0026) |   └─IdentifierSyntax
 //@[017:0026) |     └─Token(Identifier) |cycleBack|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -323,7 +323,7 @@ type cycleBack = cycleRoot
 //@[005:0014) | ├─IdentifierSyntax
 //@[005:0014) | | └─Token(Identifier) |cycleBack|
 //@[015:0016) | ├─Token(Assignment) |=|
-//@[017:0026) | └─VariableAccessSyntax
+//@[017:0026) | └─TypeVariableAccessSyntax
 //@[017:0026) |   └─IdentifierSyntax
 //@[017:0026) |     └─Token(Identifier) |cycleRoot|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -351,7 +351,7 @@ type objectWithInvalidPropertyDecorators = {
 //@[002:0009) |   | ├─IdentifierSyntax
 //@[002:0009) |   | | └─Token(Identifier) |fooProp|
 //@[009:0010) |   | ├─Token(Colon) |:|
-//@[011:0017) |   | └─VariableAccessSyntax
+//@[011:0017) |   | └─TypeVariableAccessSyntax
 //@[011:0017) |   |   └─IdentifierSyntax
 //@[011:0017) |   |     └─Token(Identifier) |string|
 //@[017:0019) |   ├─Token(NewLine) |\n\n|
@@ -370,7 +370,7 @@ type objectWithInvalidPropertyDecorators = {
 //@[002:0009) |   | ├─IdentifierSyntax
 //@[002:0009) |   | | └─Token(Identifier) |barProp|
 //@[009:0010) |   | ├─Token(Colon) |:|
-//@[011:0017) |   | └─VariableAccessSyntax
+//@[011:0017) |   | └─TypeVariableAccessSyntax
 //@[011:0017) |   |   └─IdentifierSyntax
 //@[011:0017) |   |     └─Token(Identifier) |string|
 //@[017:0019) |   ├─Token(NewLine) |\n\n|
@@ -404,7 +404,7 @@ type objectWithInvalidPropertyDecorators = {
 //@[002:0012) |   | ├─IdentifierSyntax
 //@[002:0012) |   | | └─Token(Identifier) |krispyProp|
 //@[012:0013) |   | ├─Token(Colon) |:|
-//@[014:0020) |   | └─VariableAccessSyntax
+//@[014:0020) |   | └─TypeVariableAccessSyntax
 //@[014:0020) |   |   └─IdentifierSyntax
 //@[014:0020) |   |     └─Token(Identifier) |string|
 //@[020:0021) |   ├─Token(NewLine) |\n|
@@ -426,7 +426,7 @@ type objectWithInvalidRecursion = {
 //@[002:0026) |   | ├─IdentifierSyntax
 //@[002:0026) |   | | └─Token(Identifier) |requiredAndRecursiveProp|
 //@[026:0027) |   | ├─Token(Colon) |:|
-//@[028:0054) |   | └─VariableAccessSyntax
+//@[028:0054) |   | └─TypeVariableAccessSyntax
 //@[028:0054) |   |   └─IdentifierSyntax
 //@[028:0054) |   |     └─Token(Identifier) |objectWithInvalidRecursion|
 //@[054:0055) |   ├─Token(NewLine) |\n|
@@ -442,7 +442,7 @@ type arrayWithInvalidMember = objectWithInvalidRecursion[]
 //@[028:0029) | ├─Token(Assignment) |=|
 //@[030:0058) | └─ArrayTypeSyntax
 //@[030:0056) |   ├─ArrayTypeMemberSyntax
-//@[030:0056) |   | └─VariableAccessSyntax
+//@[030:0056) |   | └─TypeVariableAccessSyntax
 //@[030:0056) |   |   └─IdentifierSyntax
 //@[030:0056) |   |     └─Token(Identifier) |objectWithInvalidRecursion|
 //@[056:0057) |   ├─Token(LeftSquare) |[|
@@ -463,7 +463,7 @@ param sealedStringParam string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |sealedStringParam|
-//@[024:0030) | └─VariableAccessSyntax
+//@[024:0030) | └─TypeVariableAccessSyntax
 //@[024:0030) |   └─IdentifierSyntax
 //@[024:0030) |     └─Token(Identifier) |string|
 //@[030:0032) ├─Token(NewLine) |\n\n|
@@ -475,13 +475,13 @@ param disallowedUnionParam 'foo'|-99
 //@[006:0026) | | └─Token(Identifier) |disallowedUnionParam|
 //@[027:0036) | └─UnionTypeSyntax
 //@[027:0032) |   ├─UnionTypeMemberSyntax
-//@[027:0032) |   | └─StringSyntax
+//@[027:0032) |   | └─StringTypeLiteralSyntax
 //@[027:0032) |   |   └─Token(StringComplete) |'foo'|
 //@[032:0033) |   ├─Token(Pipe) |||
 //@[033:0036) |   └─UnionTypeMemberSyntax
-//@[033:0036) |     └─UnaryOperationSyntax
+//@[033:0036) |     └─UnaryTypeOperationSyntax
 //@[033:0034) |       ├─Token(Minus) |-|
-//@[034:0036) |       └─IntegerLiteralSyntax
+//@[034:0036) |       └─IntegerTypeLiteralSyntax
 //@[034:0036) |         └─Token(Integer) |99|
 //@[036:0038) ├─Token(NewLine) |\n\n|
 
@@ -490,7 +490,7 @@ param objectWithInvalidRecursionParam objectWithInvalidRecursion
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0037) | ├─IdentifierSyntax
 //@[006:0037) | | └─Token(Identifier) |objectWithInvalidRecursionParam|
-//@[038:0064) | └─VariableAccessSyntax
+//@[038:0064) | └─TypeVariableAccessSyntax
 //@[038:0064) |   └─IdentifierSyntax
 //@[038:0064) |     └─Token(Identifier) |objectWithInvalidRecursion|
 //@[064:0066) ├─Token(NewLine) |\n\n|
@@ -509,7 +509,7 @@ type typeA = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'a'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: string
@@ -517,7 +517,7 @@ type typeA = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0015) |   | └─VariableAccessSyntax
+//@[009:0015) |   | └─TypeVariableAccessSyntax
 //@[009:0015) |   |   └─IdentifierSyntax
 //@[009:0015) |   |     └─Token(Identifier) |string|
 //@[015:0016) |   ├─Token(NewLine) |\n|
@@ -539,7 +539,7 @@ type typeB = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'b'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: int
@@ -547,7 +547,7 @@ type typeB = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0012) |   | └─VariableAccessSyntax
+//@[009:0012) |   | └─TypeVariableAccessSyntax
 //@[009:0012) |   |   └─IdentifierSyntax
 //@[009:0012) |   |     └─Token(Identifier) |int|
 //@[012:0013) |   ├─Token(NewLine) |\n|
@@ -575,12 +575,12 @@ type unionAB = typeA | typeB
 //@[013:0014) | ├─Token(Assignment) |=|
 //@[015:0028) | └─UnionTypeSyntax
 //@[015:0020) |   ├─UnionTypeMemberSyntax
-//@[015:0020) |   | └─VariableAccessSyntax
+//@[015:0020) |   | └─TypeVariableAccessSyntax
 //@[015:0020) |   |   └─IdentifierSyntax
 //@[015:0020) |   |     └─Token(Identifier) |typeA|
 //@[021:0022) |   ├─Token(Pipe) |||
 //@[023:0028) |   └─UnionTypeMemberSyntax
-//@[023:0028) |     └─VariableAccessSyntax
+//@[023:0028) |     └─TypeVariableAccessSyntax
 //@[023:0028) |       └─IdentifierSyntax
 //@[023:0028) |         └─Token(Identifier) |typeB|
 //@[028:0030) ├─Token(NewLine) |\n\n|
@@ -599,7 +599,7 @@ type typeC = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'c'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: bool
@@ -607,7 +607,7 @@ type typeC = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0013) |   | └─VariableAccessSyntax
+//@[009:0013) |   | └─TypeVariableAccessSyntax
 //@[009:0013) |   |   └─IdentifierSyntax
 //@[009:0013) |   |     └─Token(Identifier) |bool|
 //@[013:0014) |   ├─Token(NewLine) |\n|
@@ -616,7 +616,7 @@ type typeC = {
 //@[002:0008) |   | ├─IdentifierSyntax
 //@[002:0008) |   | | └─Token(Identifier) |value2|
 //@[008:0009) |   | ├─Token(Colon) |:|
-//@[010:0016) |   | └─VariableAccessSyntax
+//@[010:0016) |   | └─TypeVariableAccessSyntax
 //@[010:0016) |   |   └─IdentifierSyntax
 //@[010:0016) |   |     └─Token(Identifier) |string|
 //@[016:0017) |   ├─Token(NewLine) |\n|
@@ -638,7 +638,7 @@ type typeD = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'d'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: object
@@ -646,7 +646,7 @@ type typeD = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0015) |   | └─VariableAccessSyntax
+//@[009:0015) |   | └─TypeVariableAccessSyntax
 //@[009:0015) |   |   └─IdentifierSyntax
 //@[009:0015) |   |     └─Token(Identifier) |object|
 //@[015:0016) |   ├─Token(NewLine) |\n|
@@ -668,14 +668,14 @@ type typeE = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'e'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   *: string
 //@[002:0011) |   ├─ObjectTypeAdditionalPropertiesSyntax
 //@[002:0003) |   | ├─Token(Asterisk) |*|
 //@[003:0004) |   | ├─Token(Colon) |:|
-//@[005:0011) |   | └─VariableAccessSyntax
+//@[005:0011) |   | └─TypeVariableAccessSyntax
 //@[005:0011) |   |   └─IdentifierSyntax
 //@[005:0011) |   |     └─Token(Identifier) |string|
 //@[011:0012) |   ├─Token(NewLine) |\n|
@@ -697,7 +697,7 @@ type typeF = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0009) |   | └─IntegerLiteralSyntax
+//@[008:0009) |   | └─IntegerTypeLiteralSyntax
 //@[008:0009) |   |   └─Token(Integer) |0|
 //@[009:0010) |   ├─Token(NewLine) |\n|
   value: string
@@ -705,7 +705,7 @@ type typeF = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0015) |   | └─VariableAccessSyntax
+//@[009:0015) |   | └─TypeVariableAccessSyntax
 //@[009:0015) |   |   └─IdentifierSyntax
 //@[009:0015) |   |     └─Token(Identifier) |string|
 //@[015:0016) |   ├─Token(NewLine) |\n|
@@ -728,7 +728,7 @@ type typeG = {
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
 //@[008:0012) |   | └─NullableTypeSyntax
-//@[008:0011) |   |   ├─StringSyntax
+//@[008:0011) |   |   ├─StringTypeLiteralSyntax
 //@[008:0011) |   |   | └─Token(StringComplete) |'g'|
 //@[011:0012) |   |   └─Token(Question) |?|
 //@[012:0013) |   ├─Token(NewLine) |\n|
@@ -737,7 +737,7 @@ type typeG = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0015) |   | └─VariableAccessSyntax
+//@[009:0015) |   | └─TypeVariableAccessSyntax
 //@[009:0015) |   |   └─IdentifierSyntax
 //@[009:0015) |   |     └─Token(Identifier) |string|
 //@[015:0016) |   ├─Token(NewLine) |\n|
@@ -754,12 +754,12 @@ type primitiveUnion = | bool | bool
 //@[022:0035) | └─UnionTypeSyntax
 //@[022:0023) |   ├─Token(Pipe) |||
 //@[024:0028) |   ├─UnionTypeMemberSyntax
-//@[024:0028) |   | └─VariableAccessSyntax
+//@[024:0028) |   | └─TypeVariableAccessSyntax
 //@[024:0028) |   |   └─IdentifierSyntax
 //@[024:0028) |   |     └─Token(Identifier) |bool|
 //@[029:0030) |   ├─Token(Pipe) |||
 //@[031:0035) |   └─UnionTypeMemberSyntax
-//@[031:0035) |     └─VariableAccessSyntax
+//@[031:0035) |     └─TypeVariableAccessSyntax
 //@[031:0035) |       └─IdentifierSyntax
 //@[031:0035) |         └─Token(Identifier) |bool|
 //@[035:0037) ├─Token(NewLine) |\n\n|
@@ -772,12 +772,12 @@ type objectUnion = typeA | typeB
 //@[017:0018) | ├─Token(Assignment) |=|
 //@[019:0032) | └─UnionTypeSyntax
 //@[019:0024) |   ├─UnionTypeMemberSyntax
-//@[019:0024) |   | └─VariableAccessSyntax
+//@[019:0024) |   | └─TypeVariableAccessSyntax
 //@[019:0024) |   |   └─IdentifierSyntax
 //@[019:0024) |   |     └─Token(Identifier) |typeA|
 //@[025:0026) |   ├─Token(Pipe) |||
 //@[027:0032) |   └─UnionTypeMemberSyntax
-//@[027:0032) |     └─VariableAccessSyntax
+//@[027:0032) |     └─TypeVariableAccessSyntax
 //@[027:0032) |       └─IdentifierSyntax
 //@[027:0032) |         └─Token(Identifier) |typeB|
 //@[032:0034) ├─Token(NewLine) |\n\n|
@@ -799,12 +799,12 @@ type noDiscriminatorParam = typeA | typeB
 //@[026:0027) | ├─Token(Assignment) |=|
 //@[028:0041) | └─UnionTypeSyntax
 //@[028:0033) |   ├─UnionTypeMemberSyntax
-//@[028:0033) |   | └─VariableAccessSyntax
+//@[028:0033) |   | └─TypeVariableAccessSyntax
 //@[028:0033) |   |   └─IdentifierSyntax
 //@[028:0033) |   |     └─Token(Identifier) |typeA|
 //@[034:0035) |   ├─Token(Pipe) |||
 //@[036:0041) |   └─UnionTypeMemberSyntax
-//@[036:0041) |     └─VariableAccessSyntax
+//@[036:0041) |     └─TypeVariableAccessSyntax
 //@[036:0041) |       └─IdentifierSyntax
 //@[036:0041) |         └─Token(Identifier) |typeB|
 //@[041:0043) ├─Token(NewLine) |\n\n|
@@ -829,12 +829,12 @@ type wrongDiscriminatorParamType = typeA | typeB
 //@[033:0034) | ├─Token(Assignment) |=|
 //@[035:0048) | └─UnionTypeSyntax
 //@[035:0040) |   ├─UnionTypeMemberSyntax
-//@[035:0040) |   | └─VariableAccessSyntax
+//@[035:0040) |   | └─TypeVariableAccessSyntax
 //@[035:0040) |   |   └─IdentifierSyntax
 //@[035:0040) |   |     └─Token(Identifier) |typeA|
 //@[041:0042) |   ├─Token(Pipe) |||
 //@[043:0048) |   └─UnionTypeMemberSyntax
-//@[043:0048) |     └─VariableAccessSyntax
+//@[043:0048) |     └─TypeVariableAccessSyntax
 //@[043:0048) |       └─IdentifierSyntax
 //@[043:0048) |         └─Token(Identifier) |typeB|
 //@[048:0050) ├─Token(NewLine) |\n\n|
@@ -859,12 +859,12 @@ type discriminatorPropertyNotExistAtAll = typeA | typeB
 //@[040:0041) | ├─Token(Assignment) |=|
 //@[042:0055) | └─UnionTypeSyntax
 //@[042:0047) |   ├─UnionTypeMemberSyntax
-//@[042:0047) |   | └─VariableAccessSyntax
+//@[042:0047) |   | └─TypeVariableAccessSyntax
 //@[042:0047) |   |   └─IdentifierSyntax
 //@[042:0047) |   |     └─Token(Identifier) |typeA|
 //@[048:0049) |   ├─Token(Pipe) |||
 //@[050:0055) |   └─UnionTypeMemberSyntax
-//@[050:0055) |     └─VariableAccessSyntax
+//@[050:0055) |     └─TypeVariableAccessSyntax
 //@[050:0055) |       └─IdentifierSyntax
 //@[050:0055) |         └─Token(Identifier) |typeB|
 //@[055:0057) ├─Token(NewLine) |\n\n|
@@ -887,7 +887,7 @@ type discriminatorPropertyMismatch = unionAB
 //@[005:0034) | ├─IdentifierSyntax
 //@[005:0034) | | └─Token(Identifier) |discriminatorPropertyMismatch|
 //@[035:0036) | ├─Token(Assignment) |=|
-//@[037:0044) | └─VariableAccessSyntax
+//@[037:0044) | └─TypeVariableAccessSyntax
 //@[037:0044) |   └─IdentifierSyntax
 //@[037:0044) |     └─Token(Identifier) |unionAB|
 //@[044:0046) ├─Token(NewLine) |\n\n|
@@ -912,7 +912,7 @@ type discriminatorPropertyNotExistOnAtLeastOne = typeA | { value: bool }
 //@[047:0048) | ├─Token(Assignment) |=|
 //@[049:0072) | └─UnionTypeSyntax
 //@[049:0054) |   ├─UnionTypeMemberSyntax
-//@[049:0054) |   | └─VariableAccessSyntax
+//@[049:0054) |   | └─TypeVariableAccessSyntax
 //@[049:0054) |   |   └─IdentifierSyntax
 //@[049:0054) |   |     └─Token(Identifier) |typeA|
 //@[055:0056) |   ├─Token(Pipe) |||
@@ -923,7 +923,7 @@ type discriminatorPropertyNotExistOnAtLeastOne = typeA | { value: bool }
 //@[059:0064) |       | ├─IdentifierSyntax
 //@[059:0064) |       | | └─Token(Identifier) |value|
 //@[064:0065) |       | ├─Token(Colon) |:|
-//@[066:0070) |       | └─VariableAccessSyntax
+//@[066:0070) |       | └─TypeVariableAccessSyntax
 //@[066:0070) |       |   └─IdentifierSyntax
 //@[066:0070) |       |     └─Token(Identifier) |bool|
 //@[071:0072) |       └─Token(RightBrace) |}|
@@ -947,7 +947,7 @@ type discriminatorWithOnlyOneMember = typeA
 //@[005:0035) | ├─IdentifierSyntax
 //@[005:0035) | | └─Token(Identifier) |discriminatorWithOnlyOneMember|
 //@[036:0037) | ├─Token(Assignment) |=|
-//@[038:0043) | └─VariableAccessSyntax
+//@[038:0043) | └─TypeVariableAccessSyntax
 //@[038:0043) |   └─IdentifierSyntax
 //@[038:0043) |     └─Token(Identifier) |typeA|
 //@[043:0045) ├─Token(NewLine) |\n\n|
@@ -972,12 +972,12 @@ type discriminatorPropertyNotRequiredStringLiteral1 = typeA | typeF
 //@[052:0053) | ├─Token(Assignment) |=|
 //@[054:0067) | └─UnionTypeSyntax
 //@[054:0059) |   ├─UnionTypeMemberSyntax
-//@[054:0059) |   | └─VariableAccessSyntax
+//@[054:0059) |   | └─TypeVariableAccessSyntax
 //@[054:0059) |   |   └─IdentifierSyntax
 //@[054:0059) |   |     └─Token(Identifier) |typeA|
 //@[060:0061) |   ├─Token(Pipe) |||
 //@[062:0067) |   └─UnionTypeMemberSyntax
-//@[062:0067) |     └─VariableAccessSyntax
+//@[062:0067) |     └─TypeVariableAccessSyntax
 //@[062:0067) |       └─IdentifierSyntax
 //@[062:0067) |         └─Token(Identifier) |typeF|
 //@[067:0069) ├─Token(NewLine) |\n\n|
@@ -1002,12 +1002,12 @@ type discriminatorPropertyNotRequiredStringLiteral2 = typeA | typeG
 //@[052:0053) | ├─Token(Assignment) |=|
 //@[054:0067) | └─UnionTypeSyntax
 //@[054:0059) |   ├─UnionTypeMemberSyntax
-//@[054:0059) |   | └─VariableAccessSyntax
+//@[054:0059) |   | └─TypeVariableAccessSyntax
 //@[054:0059) |   |   └─IdentifierSyntax
 //@[054:0059) |   |     └─Token(Identifier) |typeA|
 //@[060:0061) |   ├─Token(Pipe) |||
 //@[062:0067) |   └─UnionTypeMemberSyntax
-//@[062:0067) |     └─VariableAccessSyntax
+//@[062:0067) |     └─TypeVariableAccessSyntax
 //@[062:0067) |       └─IdentifierSyntax
 //@[062:0067) |         └─Token(Identifier) |typeG|
 //@[067:0069) ├─Token(NewLine) |\n\n|
@@ -1032,12 +1032,12 @@ type discriminatorDuplicatedMember1 = typeA | typeA
 //@[036:0037) | ├─Token(Assignment) |=|
 //@[038:0051) | └─UnionTypeSyntax
 //@[038:0043) |   ├─UnionTypeMemberSyntax
-//@[038:0043) |   | └─VariableAccessSyntax
+//@[038:0043) |   | └─TypeVariableAccessSyntax
 //@[038:0043) |   |   └─IdentifierSyntax
 //@[038:0043) |   |     └─Token(Identifier) |typeA|
 //@[044:0045) |   ├─Token(Pipe) |||
 //@[046:0051) |   └─UnionTypeMemberSyntax
-//@[046:0051) |     └─VariableAccessSyntax
+//@[046:0051) |     └─TypeVariableAccessSyntax
 //@[046:0051) |       └─IdentifierSyntax
 //@[046:0051) |         └─Token(Identifier) |typeA|
 //@[051:0053) ├─Token(NewLine) |\n\n|
@@ -1062,7 +1062,7 @@ type discriminatorDuplicatedMember2 = typeA | { type: 'a', config: object }
 //@[036:0037) | ├─Token(Assignment) |=|
 //@[038:0075) | └─UnionTypeSyntax
 //@[038:0043) |   ├─UnionTypeMemberSyntax
-//@[038:0043) |   | └─VariableAccessSyntax
+//@[038:0043) |   | └─TypeVariableAccessSyntax
 //@[038:0043) |   |   └─IdentifierSyntax
 //@[038:0043) |   |     └─Token(Identifier) |typeA|
 //@[044:0045) |   ├─Token(Pipe) |||
@@ -1073,14 +1073,14 @@ type discriminatorDuplicatedMember2 = typeA | { type: 'a', config: object }
 //@[048:0052) |       | ├─IdentifierSyntax
 //@[048:0052) |       | | └─Token(Identifier) |type|
 //@[052:0053) |       | ├─Token(Colon) |:|
-//@[054:0057) |       | └─StringSyntax
+//@[054:0057) |       | └─StringTypeLiteralSyntax
 //@[054:0057) |       |   └─Token(StringComplete) |'a'|
 //@[057:0058) |       ├─Token(Comma) |,|
 //@[059:0073) |       ├─ObjectTypePropertySyntax
 //@[059:0065) |       | ├─IdentifierSyntax
 //@[059:0065) |       | | └─Token(Identifier) |config|
 //@[065:0066) |       | ├─Token(Colon) |:|
-//@[067:0073) |       | └─VariableAccessSyntax
+//@[067:0073) |       | └─TypeVariableAccessSyntax
 //@[067:0073) |       |   └─IdentifierSyntax
 //@[067:0073) |       |     └─Token(Identifier) |object|
 //@[074:0075) |       └─Token(RightBrace) |}|
@@ -1106,12 +1106,12 @@ type discriminatorOnlyOneNonNullMember1 = typeA | null
 //@[040:0041) | ├─Token(Assignment) |=|
 //@[042:0054) | └─UnionTypeSyntax
 //@[042:0047) |   ├─UnionTypeMemberSyntax
-//@[042:0047) |   | └─VariableAccessSyntax
+//@[042:0047) |   | └─TypeVariableAccessSyntax
 //@[042:0047) |   |   └─IdentifierSyntax
 //@[042:0047) |   |     └─Token(Identifier) |typeA|
 //@[048:0049) |   ├─Token(Pipe) |||
 //@[050:0054) |   └─UnionTypeMemberSyntax
-//@[050:0054) |     └─NullLiteralSyntax
+//@[050:0054) |     └─NullTypeLiteralSyntax
 //@[050:0054) |       └─Token(NullKeyword) |null|
 //@[054:0056) ├─Token(NewLine) |\n\n|
 
@@ -1134,9 +1134,9 @@ type discriminatorOnlyOneNonNullMember2 = (typeA)?
 //@[005:0039) | | └─Token(Identifier) |discriminatorOnlyOneNonNullMember2|
 //@[040:0041) | ├─Token(Assignment) |=|
 //@[042:0050) | └─NullableTypeSyntax
-//@[042:0049) |   ├─ParenthesizedExpressionSyntax
+//@[042:0049) |   ├─ParenthesizedTypeSyntax
 //@[042:0043) |   | ├─Token(LeftParen) |(|
-//@[043:0048) |   | ├─VariableAccessSyntax
+//@[043:0048) |   | ├─TypeVariableAccessSyntax
 //@[043:0048) |   | | └─IdentifierSyntax
 //@[043:0048) |   | |   └─Token(Identifier) |typeA|
 //@[048:0049) |   | └─Token(RightParen) |)|
@@ -1163,12 +1163,12 @@ type discriminatorMemberHasAdditionalProperties = typeA | typeE
 //@[048:0049) | ├─Token(Assignment) |=|
 //@[050:0063) | └─UnionTypeSyntax
 //@[050:0055) |   ├─UnionTypeMemberSyntax
-//@[050:0055) |   | └─VariableAccessSyntax
+//@[050:0055) |   | └─TypeVariableAccessSyntax
 //@[050:0055) |   |   └─IdentifierSyntax
 //@[050:0055) |   |     └─Token(Identifier) |typeA|
 //@[056:0057) |   ├─Token(Pipe) |||
 //@[058:0063) |   └─UnionTypeMemberSyntax
-//@[058:0063) |     └─VariableAccessSyntax
+//@[058:0063) |     └─TypeVariableAccessSyntax
 //@[058:0063) |       └─IdentifierSyntax
 //@[058:0063) |         └─Token(Identifier) |typeE|
 //@[063:0065) ├─Token(NewLine) |\n\n|
@@ -1193,12 +1193,12 @@ type discriminatorSelfCycle1 = typeA | discriminatorSelfCycle1
 //@[029:0030) | ├─Token(Assignment) |=|
 //@[031:0062) | └─UnionTypeSyntax
 //@[031:0036) |   ├─UnionTypeMemberSyntax
-//@[031:0036) |   | └─VariableAccessSyntax
+//@[031:0036) |   | └─TypeVariableAccessSyntax
 //@[031:0036) |   |   └─IdentifierSyntax
 //@[031:0036) |   |     └─Token(Identifier) |typeA|
 //@[037:0038) |   ├─Token(Pipe) |||
 //@[039:0062) |   └─UnionTypeMemberSyntax
-//@[039:0062) |     └─VariableAccessSyntax
+//@[039:0062) |     └─TypeVariableAccessSyntax
 //@[039:0062) |       └─IdentifierSyntax
 //@[039:0062) |         └─Token(Identifier) |discriminatorSelfCycle1|
 //@[062:0064) ├─Token(NewLine) |\n\n|
@@ -1222,16 +1222,16 @@ type discriminatorSelfCycle2 = (typeA | discriminatorSelfCycle2)?
 //@[005:0028) | | └─Token(Identifier) |discriminatorSelfCycle2|
 //@[029:0030) | ├─Token(Assignment) |=|
 //@[031:0065) | └─NullableTypeSyntax
-//@[031:0064) |   ├─ParenthesizedExpressionSyntax
+//@[031:0064) |   ├─ParenthesizedTypeSyntax
 //@[031:0032) |   | ├─Token(LeftParen) |(|
 //@[032:0063) |   | ├─UnionTypeSyntax
 //@[032:0037) |   | | ├─UnionTypeMemberSyntax
-//@[032:0037) |   | | | └─VariableAccessSyntax
+//@[032:0037) |   | | | └─TypeVariableAccessSyntax
 //@[032:0037) |   | | |   └─IdentifierSyntax
 //@[032:0037) |   | | |     └─Token(Identifier) |typeA|
 //@[038:0039) |   | | ├─Token(Pipe) |||
 //@[040:0063) |   | | └─UnionTypeMemberSyntax
-//@[040:0063) |   | |   └─VariableAccessSyntax
+//@[040:0063) |   | |   └─TypeVariableAccessSyntax
 //@[040:0063) |   | |     └─IdentifierSyntax
 //@[040:0063) |   | |       └─Token(Identifier) |discriminatorSelfCycle2|
 //@[063:0064) |   | └─Token(RightParen) |)|
@@ -1258,12 +1258,12 @@ type discriminatorTopLevelCycleA = typeA | discriminatorTopLevelCycleB
 //@[033:0034) | ├─Token(Assignment) |=|
 //@[035:0070) | └─UnionTypeSyntax
 //@[035:0040) |   ├─UnionTypeMemberSyntax
-//@[035:0040) |   | └─VariableAccessSyntax
+//@[035:0040) |   | └─TypeVariableAccessSyntax
 //@[035:0040) |   |   └─IdentifierSyntax
 //@[035:0040) |   |     └─Token(Identifier) |typeA|
 //@[041:0042) |   ├─Token(Pipe) |||
 //@[043:0070) |   └─UnionTypeMemberSyntax
-//@[043:0070) |     └─VariableAccessSyntax
+//@[043:0070) |     └─TypeVariableAccessSyntax
 //@[043:0070) |       └─IdentifierSyntax
 //@[043:0070) |         └─Token(Identifier) |discriminatorTopLevelCycleB|
 //@[070:0071) ├─Token(NewLine) |\n|
@@ -1287,12 +1287,12 @@ type discriminatorTopLevelCycleB = typeB | discriminatorTopLevelCycleA
 //@[033:0034) | ├─Token(Assignment) |=|
 //@[035:0070) | └─UnionTypeSyntax
 //@[035:0040) |   ├─UnionTypeMemberSyntax
-//@[035:0040) |   | └─VariableAccessSyntax
+//@[035:0040) |   | └─TypeVariableAccessSyntax
 //@[035:0040) |   |   └─IdentifierSyntax
 //@[035:0040) |   |     └─Token(Identifier) |typeB|
 //@[041:0042) |   ├─Token(Pipe) |||
 //@[043:0070) |   └─UnionTypeMemberSyntax
-//@[043:0070) |     └─VariableAccessSyntax
+//@[043:0070) |     └─TypeVariableAccessSyntax
 //@[043:0070) |       └─IdentifierSyntax
 //@[043:0070) |         └─Token(Identifier) |discriminatorTopLevelCycleA|
 //@[070:0072) ├─Token(NewLine) |\n\n|
@@ -1317,7 +1317,7 @@ type discriminatorInnerSelfCycle1 = typeA | {
 //@[034:0035) | ├─Token(Assignment) |=|
 //@[036:0097) | └─UnionTypeSyntax
 //@[036:0041) |   ├─UnionTypeMemberSyntax
-//@[036:0041) |   | └─VariableAccessSyntax
+//@[036:0041) |   | └─TypeVariableAccessSyntax
 //@[036:0041) |   |   └─IdentifierSyntax
 //@[036:0041) |   |     └─Token(Identifier) |typeA|
 //@[042:0043) |   ├─Token(Pipe) |||
@@ -1330,7 +1330,7 @@ type discriminatorInnerSelfCycle1 = typeA | {
 //@[002:0006) |       | ├─IdentifierSyntax
 //@[002:0006) |       | | └─Token(Identifier) |type|
 //@[006:0007) |       | ├─Token(Colon) |:|
-//@[008:0011) |       | └─StringSyntax
+//@[008:0011) |       | └─StringTypeLiteralSyntax
 //@[008:0011) |       |   └─Token(StringComplete) |'b'|
 //@[011:0012) |       ├─Token(NewLine) |\n|
   value: discriminatorInnerSelfCycle1
@@ -1338,7 +1338,7 @@ type discriminatorInnerSelfCycle1 = typeA | {
 //@[002:0007) |       | ├─IdentifierSyntax
 //@[002:0007) |       | | └─Token(Identifier) |value|
 //@[007:0008) |       | ├─Token(Colon) |:|
-//@[009:0037) |       | └─VariableAccessSyntax
+//@[009:0037) |       | └─TypeVariableAccessSyntax
 //@[009:0037) |       |   └─IdentifierSyntax
 //@[009:0037) |       |     └─Token(Identifier) |discriminatorInnerSelfCycle1|
 //@[037:0038) |       ├─Token(NewLine) |\n|
@@ -1360,7 +1360,7 @@ type discriminatorInnerSelfCycle2Helper = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'b'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: discriminatorInnerSelfCycle2
@@ -1368,7 +1368,7 @@ type discriminatorInnerSelfCycle2Helper = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0037) |   | └─VariableAccessSyntax
+//@[009:0037) |   | └─TypeVariableAccessSyntax
 //@[009:0037) |   |   └─IdentifierSyntax
 //@[009:0037) |   |     └─Token(Identifier) |discriminatorInnerSelfCycle2|
 //@[037:0038) |   ├─Token(NewLine) |\n|
@@ -1395,12 +1395,12 @@ type discriminatorInnerSelfCycle2 = typeA | discriminatorInnerSelfCycle2Helper
 //@[034:0035) | ├─Token(Assignment) |=|
 //@[036:0078) | └─UnionTypeSyntax
 //@[036:0041) |   ├─UnionTypeMemberSyntax
-//@[036:0041) |   | └─VariableAccessSyntax
+//@[036:0041) |   | └─TypeVariableAccessSyntax
 //@[036:0041) |   |   └─IdentifierSyntax
 //@[036:0041) |   |     └─Token(Identifier) |typeA|
 //@[042:0043) |   ├─Token(Pipe) |||
 //@[044:0078) |   └─UnionTypeMemberSyntax
-//@[044:0078) |     └─VariableAccessSyntax
+//@[044:0078) |     └─TypeVariableAccessSyntax
 //@[044:0078) |       └─IdentifierSyntax
 //@[044:0078) |         └─Token(Identifier) |discriminatorInnerSelfCycle2Helper|
 //@[078:0080) ├─Token(NewLine) |\n\n|
@@ -1426,12 +1426,12 @@ type discriminatorTupleBadType1 = [typeA, typeB]
 //@[034:0048) | └─TupleTypeSyntax
 //@[034:0035) |   ├─Token(LeftSquare) |[|
 //@[035:0040) |   ├─TupleTypeItemSyntax
-//@[035:0040) |   | └─VariableAccessSyntax
+//@[035:0040) |   | └─TypeVariableAccessSyntax
 //@[035:0040) |   |   └─IdentifierSyntax
 //@[035:0040) |   |     └─Token(Identifier) |typeA|
 //@[040:0041) |   ├─Token(Comma) |,|
 //@[042:0047) |   ├─TupleTypeItemSyntax
-//@[042:0047) |   | └─VariableAccessSyntax
+//@[042:0047) |   | └─TypeVariableAccessSyntax
 //@[042:0047) |   |   └─IdentifierSyntax
 //@[042:0047) |   |     └─Token(Identifier) |typeB|
 //@[047:0048) |   └─Token(RightSquare) |]|
@@ -1460,12 +1460,12 @@ type discriminatorTupleBadType2 = [typeA | typeB]
 //@[035:0048) |   ├─TupleTypeItemSyntax
 //@[035:0048) |   | └─UnionTypeSyntax
 //@[035:0040) |   |   ├─UnionTypeMemberSyntax
-//@[035:0040) |   |   | └─VariableAccessSyntax
+//@[035:0040) |   |   | └─TypeVariableAccessSyntax
 //@[035:0040) |   |   |   └─IdentifierSyntax
 //@[035:0040) |   |   |     └─Token(Identifier) |typeA|
 //@[041:0042) |   |   ├─Token(Pipe) |||
 //@[043:0048) |   |   └─UnionTypeMemberSyntax
-//@[043:0048) |   |     └─VariableAccessSyntax
+//@[043:0048) |   |     └─TypeVariableAccessSyntax
 //@[043:0048) |   |       └─IdentifierSyntax
 //@[043:0048) |   |         └─Token(Identifier) |typeB|
 //@[048:0049) |   └─Token(RightSquare) |]|
@@ -1494,24 +1494,24 @@ type discriminatorTupleBadType3 = [typeA | typeB, typeC | typeD]
 //@[035:0048) |   ├─TupleTypeItemSyntax
 //@[035:0048) |   | └─UnionTypeSyntax
 //@[035:0040) |   |   ├─UnionTypeMemberSyntax
-//@[035:0040) |   |   | └─VariableAccessSyntax
+//@[035:0040) |   |   | └─TypeVariableAccessSyntax
 //@[035:0040) |   |   |   └─IdentifierSyntax
 //@[035:0040) |   |   |     └─Token(Identifier) |typeA|
 //@[041:0042) |   |   ├─Token(Pipe) |||
 //@[043:0048) |   |   └─UnionTypeMemberSyntax
-//@[043:0048) |   |     └─VariableAccessSyntax
+//@[043:0048) |   |     └─TypeVariableAccessSyntax
 //@[043:0048) |   |       └─IdentifierSyntax
 //@[043:0048) |   |         └─Token(Identifier) |typeB|
 //@[048:0049) |   ├─Token(Comma) |,|
 //@[050:0063) |   ├─TupleTypeItemSyntax
 //@[050:0063) |   | └─UnionTypeSyntax
 //@[050:0055) |   |   ├─UnionTypeMemberSyntax
-//@[050:0055) |   |   | └─VariableAccessSyntax
+//@[050:0055) |   |   | └─TypeVariableAccessSyntax
 //@[050:0055) |   |   |   └─IdentifierSyntax
 //@[050:0055) |   |   |     └─Token(Identifier) |typeC|
 //@[056:0057) |   |   ├─Token(Pipe) |||
 //@[058:0063) |   |   └─UnionTypeMemberSyntax
-//@[058:0063) |   |     └─VariableAccessSyntax
+//@[058:0063) |   |     └─TypeVariableAccessSyntax
 //@[058:0063) |   |       └─IdentifierSyntax
 //@[058:0063) |   |         └─Token(Identifier) |typeD|
 //@[063:0064) |   └─Token(RightSquare) |]|
@@ -1542,7 +1542,7 @@ type discriminatorInlineAdditionalPropsBadType1 = {
   *: typeA
 //@[002:0003) |   | ├─Token(Asterisk) |*|
 //@[003:0004) |   | ├─Token(Colon) |:|
-//@[005:0010) |   | └─VariableAccessSyntax
+//@[005:0010) |   | └─TypeVariableAccessSyntax
 //@[005:0010) |   |   └─IdentifierSyntax
 //@[005:0010) |   |     └─Token(Identifier) |typeA|
 //@[010:0011) |   ├─Token(NewLine) |\n|
@@ -1577,12 +1577,12 @@ type discriminatorInlineAdditionalPropsBadType2 = {
 //@[003:0004) |   | ├─Token(Colon) |:|
 //@[005:0018) |   | └─UnionTypeSyntax
 //@[005:0010) |   |   ├─UnionTypeMemberSyntax
-//@[005:0010) |   |   | └─VariableAccessSyntax
+//@[005:0010) |   |   | └─TypeVariableAccessSyntax
 //@[005:0010) |   |   |   └─IdentifierSyntax
 //@[005:0010) |   |   |     └─Token(Identifier) |typeA|
 //@[011:0012) |   |   ├─Token(Pipe) |||
 //@[013:0018) |   |   └─UnionTypeMemberSyntax
-//@[013:0018) |   |     └─VariableAccessSyntax
+//@[013:0018) |   |     └─TypeVariableAccessSyntax
 //@[013:0018) |   |       └─IdentifierSyntax
 //@[013:0018) |   |         └─Token(Identifier) |typeA|
 //@[018:0019) |   ├─Token(NewLine) |\n|
@@ -1615,7 +1615,7 @@ type discriminatorInlineAdditionalPropsBadType3 = {
   *: string
 //@[002:0003) |   | ├─Token(Asterisk) |*|
 //@[003:0004) |   | ├─Token(Colon) |:|
-//@[005:0011) |   | └─VariableAccessSyntax
+//@[005:0011) |   | └─TypeVariableAccessSyntax
 //@[005:0011) |   |   └─IdentifierSyntax
 //@[005:0011) |   |     └─Token(Identifier) |string|
 //@[011:0012) |   ├─Token(NewLine) |\n|
@@ -1649,14 +1649,14 @@ type discriminatedUnionDuplicateMemberInsensitive = { type: 'a', value: string }
 //@[054:0058) |   |   | ├─IdentifierSyntax
 //@[054:0058) |   |   | | └─Token(Identifier) |type|
 //@[058:0059) |   |   | ├─Token(Colon) |:|
-//@[060:0063) |   |   | └─StringSyntax
+//@[060:0063) |   |   | └─StringTypeLiteralSyntax
 //@[060:0063) |   |   |   └─Token(StringComplete) |'a'|
 //@[063:0064) |   |   ├─Token(Comma) |,|
 //@[065:0078) |   |   ├─ObjectTypePropertySyntax
 //@[065:0070) |   |   | ├─IdentifierSyntax
 //@[065:0070) |   |   | | └─Token(Identifier) |value|
 //@[070:0071) |   |   | ├─Token(Colon) |:|
-//@[072:0078) |   |   | └─VariableAccessSyntax
+//@[072:0078) |   |   | └─TypeVariableAccessSyntax
 //@[072:0078) |   |   |   └─IdentifierSyntax
 //@[072:0078) |   |   |     └─Token(Identifier) |string|
 //@[079:0080) |   |   └─Token(RightBrace) |}|
@@ -1668,14 +1668,14 @@ type discriminatedUnionDuplicateMemberInsensitive = { type: 'a', value: string }
 //@[085:0089) |       | ├─IdentifierSyntax
 //@[085:0089) |       | | └─Token(Identifier) |type|
 //@[089:0090) |       | ├─Token(Colon) |:|
-//@[091:0094) |       | └─StringSyntax
+//@[091:0094) |       | └─StringTypeLiteralSyntax
 //@[091:0094) |       |   └─Token(StringComplete) |'A'|
 //@[094:0095) |       ├─Token(Comma) |,|
 //@[096:0106) |       ├─ObjectTypePropertySyntax
 //@[096:0101) |       | ├─IdentifierSyntax
 //@[096:0101) |       | | └─Token(Identifier) |value|
 //@[101:0102) |       | ├─Token(Colon) |:|
-//@[103:0106) |       | └─VariableAccessSyntax
+//@[103:0106) |       | └─TypeVariableAccessSyntax
 //@[103:0106) |       |   └─IdentifierSyntax
 //@[103:0106) |       |     └─Token(Identifier) |int|
 //@[107:0108) |       └─Token(RightBrace) |}|
@@ -1707,14 +1707,14 @@ type discriminatedUnionCaseSensitiveDiscriminator = { type: 'a', value: string }
 //@[054:0058) |   |   | ├─IdentifierSyntax
 //@[054:0058) |   |   | | └─Token(Identifier) |type|
 //@[058:0059) |   |   | ├─Token(Colon) |:|
-//@[060:0063) |   |   | └─StringSyntax
+//@[060:0063) |   |   | └─StringTypeLiteralSyntax
 //@[060:0063) |   |   |   └─Token(StringComplete) |'a'|
 //@[063:0064) |   |   ├─Token(Comma) |,|
 //@[065:0078) |   |   ├─ObjectTypePropertySyntax
 //@[065:0070) |   |   | ├─IdentifierSyntax
 //@[065:0070) |   |   | | └─Token(Identifier) |value|
 //@[070:0071) |   |   | ├─Token(Colon) |:|
-//@[072:0078) |   |   | └─VariableAccessSyntax
+//@[072:0078) |   |   | └─TypeVariableAccessSyntax
 //@[072:0078) |   |   |   └─IdentifierSyntax
 //@[072:0078) |   |   |     └─Token(Identifier) |string|
 //@[079:0080) |   |   └─Token(RightBrace) |}|
@@ -1726,14 +1726,14 @@ type discriminatedUnionCaseSensitiveDiscriminator = { type: 'a', value: string }
 //@[085:0089) |       | ├─IdentifierSyntax
 //@[085:0089) |       | | └─Token(Identifier) |type|
 //@[089:0090) |       | ├─Token(Colon) |:|
-//@[091:0094) |       | └─StringSyntax
+//@[091:0094) |       | └─StringTypeLiteralSyntax
 //@[091:0094) |       |   └─Token(StringComplete) |'b'|
 //@[094:0095) |       ├─Token(Comma) |,|
 //@[096:0106) |       ├─ObjectTypePropertySyntax
 //@[096:0101) |       | ├─IdentifierSyntax
 //@[096:0101) |       | | └─Token(Identifier) |value|
 //@[101:0102) |       | ├─Token(Colon) |:|
-//@[103:0106) |       | └─VariableAccessSyntax
+//@[103:0106) |       | └─TypeVariableAccessSyntax
 //@[103:0106) |       |   └─IdentifierSyntax
 //@[103:0106) |       |     └─Token(Identifier) |int|
 //@[107:0108) |       └─Token(RightBrace) |}|
@@ -1756,7 +1756,7 @@ param discriminatorParamBadType1 typeA
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0032) | ├─IdentifierSyntax
 //@[006:0032) | | └─Token(Identifier) |discriminatorParamBadType1|
-//@[033:0038) | └─VariableAccessSyntax
+//@[033:0038) | └─TypeVariableAccessSyntax
 //@[033:0038) |   └─IdentifierSyntax
 //@[033:0038) |     └─Token(Identifier) |typeA|
 //@[038:0040) ├─Token(NewLine) |\n\n|
@@ -1780,11 +1780,11 @@ param discriminatorParamBadType2 'a' | 'b'
 //@[006:0032) | | └─Token(Identifier) |discriminatorParamBadType2|
 //@[033:0042) | └─UnionTypeSyntax
 //@[033:0036) |   ├─UnionTypeMemberSyntax
-//@[033:0036) |   | └─StringSyntax
+//@[033:0036) |   | └─StringTypeLiteralSyntax
 //@[033:0036) |   |   └─Token(StringComplete) |'a'|
 //@[037:0038) |   ├─Token(Pipe) |||
 //@[039:0042) |   └─UnionTypeMemberSyntax
-//@[039:0042) |     └─StringSyntax
+//@[039:0042) |     └─StringTypeLiteralSyntax
 //@[039:0042) |       └─Token(StringComplete) |'b'|
 //@[042:0044) ├─Token(NewLine) |\n\n|
 
@@ -1805,7 +1805,7 @@ output discriminatorOutputBadType1 typeA = { type: 'a', value: 'a' }
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0034) | ├─IdentifierSyntax
 //@[007:0034) | | └─Token(Identifier) |discriminatorOutputBadType1|
-//@[035:0040) | ├─VariableAccessSyntax
+//@[035:0040) | ├─TypeVariableAccessSyntax
 //@[035:0040) | | └─IdentifierSyntax
 //@[035:0040) | |   └─Token(Identifier) |typeA|
 //@[041:0042) | ├─Token(Assignment) |=|
@@ -1844,7 +1844,7 @@ output discriminatorOutputBadType2 object = { prop: 'value' }
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0034) | ├─IdentifierSyntax
 //@[007:0034) | | └─Token(Identifier) |discriminatorOutputBadType2|
-//@[035:0041) | ├─VariableAccessSyntax
+//@[035:0041) | ├─TypeVariableAccessSyntax
 //@[035:0041) | | └─IdentifierSyntax
 //@[035:0041) | |   └─Token(Identifier) |object|
 //@[042:0043) | ├─Token(Assignment) |=|
@@ -1867,7 +1867,7 @@ type strings = string[]
 //@[013:0014) | ├─Token(Assignment) |=|
 //@[015:0023) | └─ArrayTypeSyntax
 //@[015:0021) |   ├─ArrayTypeMemberSyntax
-//@[015:0021) |   | └─VariableAccessSyntax
+//@[015:0021) |   | └─TypeVariableAccessSyntax
 //@[015:0021) |   |   └─IdentifierSyntax
 //@[015:0021) |   |     └─Token(Identifier) |string|
 //@[021:0022) |   ├─Token(LeftSquare) |[|
@@ -1881,7 +1881,7 @@ type invalidTupleAccess = strings[0]
 //@[005:0023) | | └─Token(Identifier) |invalidTupleAccess|
 //@[024:0025) | ├─Token(Assignment) |=|
 //@[026:0036) | └─TypeArrayAccessSyntax
-//@[026:0033) |   ├─VariableAccessSyntax
+//@[026:0033) |   ├─TypeVariableAccessSyntax
 //@[026:0033) |   | └─IdentifierSyntax
 //@[026:0033) |   |   └─Token(Identifier) |strings|
 //@[033:0034) |   ├─Token(LeftSquare) |[|
@@ -1899,12 +1899,12 @@ type stringTuple = [string, string]
 //@[019:0035) | └─TupleTypeSyntax
 //@[019:0020) |   ├─Token(LeftSquare) |[|
 //@[020:0026) |   ├─TupleTypeItemSyntax
-//@[020:0026) |   | └─VariableAccessSyntax
+//@[020:0026) |   | └─TypeVariableAccessSyntax
 //@[020:0026) |   |   └─IdentifierSyntax
 //@[020:0026) |   |     └─Token(Identifier) |string|
 //@[026:0027) |   ├─Token(Comma) |,|
 //@[028:0034) |   ├─TupleTypeItemSyntax
-//@[028:0034) |   | └─VariableAccessSyntax
+//@[028:0034) |   | └─TypeVariableAccessSyntax
 //@[028:0034) |   |   └─IdentifierSyntax
 //@[028:0034) |   |     └─Token(Identifier) |string|
 //@[034:0035) |   └─Token(RightSquare) |]|
@@ -1917,7 +1917,7 @@ type invalidItemTypeAccess = stringTuple[*]
 //@[005:0026) | | └─Token(Identifier) |invalidItemTypeAccess|
 //@[027:0028) | ├─Token(Assignment) |=|
 //@[029:0043) | └─TypeItemsAccessSyntax
-//@[029:0040) |   ├─VariableAccessSyntax
+//@[029:0040) |   ├─TypeVariableAccessSyntax
 //@[029:0040) |   | └─IdentifierSyntax
 //@[029:0040) |   |   └─Token(Identifier) |stringTuple|
 //@[040:0041) |   ├─Token(LeftSquare) |[|
@@ -1939,7 +1939,7 @@ type anObject = {
 //@[002:0010) |   | ├─IdentifierSyntax
 //@[002:0010) |   | | └─Token(Identifier) |property|
 //@[010:0011) |   | ├─Token(Colon) |:|
-//@[012:0018) |   | └─VariableAccessSyntax
+//@[012:0018) |   | └─TypeVariableAccessSyntax
 //@[012:0018) |   |   └─IdentifierSyntax
 //@[012:0018) |   |     └─Token(Identifier) |string|
 //@[018:0019) |   ├─Token(NewLine) |\n|
@@ -1954,7 +1954,7 @@ type invalidAdditionalPropertiesAccess = anObject.*
 //@[005:0038) | | └─Token(Identifier) |invalidAdditionalPropertiesAccess|
 //@[039:0040) | ├─Token(Assignment) |=|
 //@[041:0051) | └─TypeAdditionalPropertiesAccessSyntax
-//@[041:0049) |   ├─VariableAccessSyntax
+//@[041:0049) |   ├─TypeVariableAccessSyntax
 //@[041:0049) |   | └─IdentifierSyntax
 //@[041:0049) |   |   └─Token(Identifier) |anObject|
 //@[049:0050) |   ├─Token(Dot) |.|
@@ -1974,7 +1974,7 @@ type stringDict = {
 //@[002:0011) |   ├─ObjectTypeAdditionalPropertiesSyntax
 //@[002:0003) |   | ├─Token(Asterisk) |*|
 //@[003:0004) |   | ├─Token(Colon) |:|
-//@[005:0011) |   | └─VariableAccessSyntax
+//@[005:0011) |   | └─TypeVariableAccessSyntax
 //@[005:0011) |   |   └─IdentifierSyntax
 //@[005:0011) |   |     └─Token(Identifier) |string|
 //@[011:0012) |   ├─Token(NewLine) |\n|
@@ -1989,7 +1989,7 @@ type invalidPropertyAccess = stringDict.property
 //@[005:0026) | | └─Token(Identifier) |invalidPropertyAccess|
 //@[027:0028) | ├─Token(Assignment) |=|
 //@[029:0048) | └─TypePropertyAccessSyntax
-//@[029:0039) |   ├─VariableAccessSyntax
+//@[029:0039) |   ├─TypeVariableAccessSyntax
 //@[029:0039) |   | └─IdentifierSyntax
 //@[029:0039) |   |   └─Token(Identifier) |stringDict|
 //@[039:0040) |   ├─Token(Dot) |.|

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.syntax.bicep
@@ -1295,7 +1295,7 @@ output doggoGreetings array = [for item in mapObject: item.greeting]
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0021) | ├─IdentifierSyntax
 //@[007:0021) | | └─Token(Identifier) |doggoGreetings|
-//@[022:0027) | ├─VariableAccessSyntax
+//@[022:0027) | ├─TypeVariableAccessSyntax
 //@[022:0027) | | └─IdentifierSyntax
 //@[022:0027) | |   └─Token(Identifier) |array|
 //@[028:0029) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/LoadFunctions_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/LoadFunctions_CRLF/main.syntax.bicep
@@ -1259,7 +1259,7 @@ output testYamlString string = testYamlString
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0021) | ├─IdentifierSyntax
 //@[007:0021) | | └─Token(Identifier) |testYamlString|
-//@[022:0028) | ├─VariableAccessSyntax
+//@[022:0028) | ├─TypeVariableAccessSyntax
 //@[022:0028) | | └─IdentifierSyntax
 //@[022:0028) | |   └─Token(Identifier) |string|
 //@[029:0030) | ├─Token(Assignment) |=|
@@ -1272,7 +1272,7 @@ output testYamlInt int = testYamlInt
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0018) | ├─IdentifierSyntax
 //@[007:0018) | | └─Token(Identifier) |testYamlInt|
-//@[019:0022) | ├─VariableAccessSyntax
+//@[019:0022) | ├─TypeVariableAccessSyntax
 //@[019:0022) | | └─IdentifierSyntax
 //@[019:0022) | |   └─Token(Identifier) |int|
 //@[023:0024) | ├─Token(Assignment) |=|
@@ -1285,7 +1285,7 @@ output testYamlBool bool = testYamlBool
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0019) | ├─IdentifierSyntax
 //@[007:0019) | | └─Token(Identifier) |testYamlBool|
-//@[020:0024) | ├─VariableAccessSyntax
+//@[020:0024) | ├─TypeVariableAccessSyntax
 //@[020:0024) | | └─IdentifierSyntax
 //@[020:0024) | |   └─Token(Identifier) |bool|
 //@[025:0026) | ├─Token(Assignment) |=|
@@ -1298,7 +1298,7 @@ output testYamlArrayInt array = testYamlArrayInt
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0023) | ├─IdentifierSyntax
 //@[007:0023) | | └─Token(Identifier) |testYamlArrayInt|
-//@[024:0029) | ├─VariableAccessSyntax
+//@[024:0029) | ├─TypeVariableAccessSyntax
 //@[024:0029) | | └─IdentifierSyntax
 //@[024:0029) | |   └─Token(Identifier) |array|
 //@[030:0031) | ├─Token(Assignment) |=|
@@ -1311,7 +1311,7 @@ output testYamlArrayIntVal int = testYamlArrayIntVal
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0026) | ├─IdentifierSyntax
 //@[007:0026) | | └─Token(Identifier) |testYamlArrayIntVal|
-//@[027:0030) | ├─VariableAccessSyntax
+//@[027:0030) | ├─TypeVariableAccessSyntax
 //@[027:0030) | | └─IdentifierSyntax
 //@[027:0030) | |   └─Token(Identifier) |int|
 //@[031:0032) | ├─Token(Assignment) |=|
@@ -1324,7 +1324,7 @@ output testYamlArrayString array = testYamlArrayString
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0026) | ├─IdentifierSyntax
 //@[007:0026) | | └─Token(Identifier) |testYamlArrayString|
-//@[027:0032) | ├─VariableAccessSyntax
+//@[027:0032) | ├─TypeVariableAccessSyntax
 //@[027:0032) | | └─IdentifierSyntax
 //@[027:0032) | |   └─Token(Identifier) |array|
 //@[033:0034) | ├─Token(Assignment) |=|
@@ -1337,7 +1337,7 @@ output testYamlArrayStringVal string = testYamlArrayStringVal
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0029) | ├─IdentifierSyntax
 //@[007:0029) | | └─Token(Identifier) |testYamlArrayStringVal|
-//@[030:0036) | ├─VariableAccessSyntax
+//@[030:0036) | ├─TypeVariableAccessSyntax
 //@[030:0036) | | └─IdentifierSyntax
 //@[030:0036) | |   └─Token(Identifier) |string|
 //@[037:0038) | ├─Token(Assignment) |=|
@@ -1350,7 +1350,7 @@ output testYamlArrayBool array = testYamlArrayBool
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0024) | ├─IdentifierSyntax
 //@[007:0024) | | └─Token(Identifier) |testYamlArrayBool|
-//@[025:0030) | ├─VariableAccessSyntax
+//@[025:0030) | ├─TypeVariableAccessSyntax
 //@[025:0030) | | └─IdentifierSyntax
 //@[025:0030) | |   └─Token(Identifier) |array|
 //@[031:0032) | ├─Token(Assignment) |=|
@@ -1363,7 +1363,7 @@ output testYamlArrayBoolVal bool = testYamlArrayBoolVal
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0027) | ├─IdentifierSyntax
 //@[007:0027) | | └─Token(Identifier) |testYamlArrayBoolVal|
-//@[028:0032) | ├─VariableAccessSyntax
+//@[028:0032) | ├─TypeVariableAccessSyntax
 //@[028:0032) | | └─IdentifierSyntax
 //@[028:0032) | |   └─Token(Identifier) |bool|
 //@[033:0034) | ├─Token(Assignment) |=|
@@ -1376,7 +1376,7 @@ output testYamlObject object = testYamlObject
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0021) | ├─IdentifierSyntax
 //@[007:0021) | | └─Token(Identifier) |testYamlObject|
-//@[022:0028) | ├─VariableAccessSyntax
+//@[022:0028) | ├─TypeVariableAccessSyntax
 //@[022:0028) | | └─IdentifierSyntax
 //@[022:0028) | |   └─Token(Identifier) |object|
 //@[029:0030) | ├─Token(Assignment) |=|
@@ -1389,7 +1389,7 @@ output testYamlObjectNestedString string = testYamlObjectNestedString
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0033) | ├─IdentifierSyntax
 //@[007:0033) | | └─Token(Identifier) |testYamlObjectNestedString|
-//@[034:0040) | ├─VariableAccessSyntax
+//@[034:0040) | ├─TypeVariableAccessSyntax
 //@[034:0040) | | └─IdentifierSyntax
 //@[034:0040) | |   └─Token(Identifier) |string|
 //@[041:0042) | ├─Token(Assignment) |=|
@@ -1402,7 +1402,7 @@ output testYamlObjectNestedInt int = testYamlObjectNestedInt
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0030) | ├─IdentifierSyntax
 //@[007:0030) | | └─Token(Identifier) |testYamlObjectNestedInt|
-//@[031:0034) | ├─VariableAccessSyntax
+//@[031:0034) | ├─TypeVariableAccessSyntax
 //@[031:0034) | | └─IdentifierSyntax
 //@[031:0034) | |   └─Token(Identifier) |int|
 //@[035:0036) | ├─Token(Assignment) |=|
@@ -1415,7 +1415,7 @@ output testYamlObjectNestedBool bool = testYamlObjectNestedBool
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0031) | ├─IdentifierSyntax
 //@[007:0031) | | └─Token(Identifier) |testYamlObjectNestedBool|
-//@[032:0036) | ├─VariableAccessSyntax
+//@[032:0036) | ├─TypeVariableAccessSyntax
 //@[032:0036) | | └─IdentifierSyntax
 //@[032:0036) | |   └─Token(Identifier) |bool|
 //@[037:0038) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/LoopsIndexed_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/LoopsIndexed_LF/main.syntax.bicep
@@ -4,7 +4,7 @@ param name string
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00010) | ├─IdentifierSyntax
 //@[006:00010) | | └─Token(Identifier) |name|
-//@[011:00017) | └─VariableAccessSyntax
+//@[011:00017) | └─TypeVariableAccessSyntax
 //@[011:00017) |   └─IdentifierSyntax
 //@[011:00017) |     └─Token(Identifier) |string|
 //@[017:00018) ├─Token(NewLine) |\n|
@@ -13,7 +13,7 @@ param accounts array
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00014) | ├─IdentifierSyntax
 //@[006:00014) | | └─Token(Identifier) |accounts|
-//@[015:00020) | └─VariableAccessSyntax
+//@[015:00020) | └─TypeVariableAccessSyntax
 //@[015:00020) |   └─IdentifierSyntax
 //@[015:00020) |     └─Token(Identifier) |array|
 //@[020:00021) ├─Token(NewLine) |\n|
@@ -22,7 +22,7 @@ param index int
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00011) | ├─IdentifierSyntax
 //@[006:00011) | | └─Token(Identifier) |index|
-//@[012:00015) | └─VariableAccessSyntax
+//@[012:00015) | └─TypeVariableAccessSyntax
 //@[012:00015) |   └─IdentifierSyntax
 //@[012:00015) |     └─Token(Identifier) |int|
 //@[015:00017) ├─Token(NewLine) |\n\n|
@@ -641,7 +641,7 @@ output indexedCollectionBlobEndpoint string = storageAccounts[index].properties.
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00036) | ├─IdentifierSyntax
 //@[007:00036) | | └─Token(Identifier) |indexedCollectionBlobEndpoint|
-//@[037:00043) | ├─VariableAccessSyntax
+//@[037:00043) | ├─TypeVariableAccessSyntax
 //@[037:00043) | | └─IdentifierSyntax
 //@[037:00043) | |   └─Token(Identifier) |string|
 //@[044:00045) | ├─Token(Assignment) |=|
@@ -672,7 +672,7 @@ output indexedCollectionName string = storageAccounts[index].name
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00028) | ├─IdentifierSyntax
 //@[007:00028) | | └─Token(Identifier) |indexedCollectionName|
-//@[029:00035) | ├─VariableAccessSyntax
+//@[029:00035) | ├─TypeVariableAccessSyntax
 //@[029:00035) | | └─IdentifierSyntax
 //@[029:00035) | |   └─Token(Identifier) |string|
 //@[036:00037) | ├─Token(Assignment) |=|
@@ -695,7 +695,7 @@ output indexedCollectionId string = storageAccounts[index].id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00026) | ├─IdentifierSyntax
 //@[007:00026) | | └─Token(Identifier) |indexedCollectionId|
-//@[027:00033) | ├─VariableAccessSyntax
+//@[027:00033) | ├─TypeVariableAccessSyntax
 //@[027:00033) | | └─IdentifierSyntax
 //@[027:00033) | |   └─Token(Identifier) |string|
 //@[034:00035) | ├─Token(Assignment) |=|
@@ -718,7 +718,7 @@ output indexedCollectionType string = storageAccounts[index].type
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00028) | ├─IdentifierSyntax
 //@[007:00028) | | └─Token(Identifier) |indexedCollectionType|
-//@[029:00035) | ├─VariableAccessSyntax
+//@[029:00035) | ├─TypeVariableAccessSyntax
 //@[029:00035) | | └─IdentifierSyntax
 //@[029:00035) | |   └─Token(Identifier) |string|
 //@[036:00037) | ├─Token(Assignment) |=|
@@ -741,7 +741,7 @@ output indexedCollectionVersion string = storageAccounts[index].apiVersion
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00031) | ├─IdentifierSyntax
 //@[007:00031) | | └─Token(Identifier) |indexedCollectionVersion|
-//@[032:00038) | ├─VariableAccessSyntax
+//@[032:00038) | ├─TypeVariableAccessSyntax
 //@[032:00038) | | └─IdentifierSyntax
 //@[032:00038) | |   └─Token(Identifier) |string|
 //@[039:00040) | ├─Token(Assignment) |=|
@@ -767,7 +767,7 @@ output indexedCollectionIdentity object = storageAccounts[index].identity
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00032) | ├─IdentifierSyntax
 //@[007:00032) | | └─Token(Identifier) |indexedCollectionIdentity|
-//@[033:00039) | ├─VariableAccessSyntax
+//@[033:00039) | ├─TypeVariableAccessSyntax
 //@[033:00039) | | └─IdentifierSyntax
 //@[033:00039) | |   └─Token(Identifier) |object|
 //@[040:00041) | ├─Token(Assignment) |=|
@@ -793,7 +793,7 @@ output indexedEndpointPair object = {
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00026) | ├─IdentifierSyntax
 //@[007:00026) | | └─Token(Identifier) |indexedEndpointPair|
-//@[027:00033) | ├─VariableAccessSyntax
+//@[027:00033) | ├─TypeVariableAccessSyntax
 //@[027:00033) | | └─IdentifierSyntax
 //@[027:00033) | |   └─Token(Identifier) |object|
 //@[034:00035) | ├─Token(Assignment) |=|
@@ -869,7 +869,7 @@ output indexViaReference string = storageAccounts[int(storageAccounts[index].pro
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00024) | ├─IdentifierSyntax
 //@[007:00024) | | └─Token(Identifier) |indexViaReference|
-//@[025:00031) | ├─VariableAccessSyntax
+//@[025:00031) | ├─TypeVariableAccessSyntax
 //@[025:00031) | | └─IdentifierSyntax
 //@[025:00031) | |   └─Token(Identifier) |string|
 //@[032:00033) | ├─Token(Assignment) |=|
@@ -2300,7 +2300,7 @@ output indexedModulesName string = moduleCollectionWithSingleDependency[index].n
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00025) | ├─IdentifierSyntax
 //@[007:00025) | | └─Token(Identifier) |indexedModulesName|
-//@[026:00032) | ├─VariableAccessSyntax
+//@[026:00032) | ├─TypeVariableAccessSyntax
 //@[026:00032) | | └─IdentifierSyntax
 //@[026:00032) | |   └─Token(Identifier) |string|
 //@[033:00034) | ├─Token(Assignment) |=|
@@ -2323,7 +2323,7 @@ output indexedModuleOutput string = moduleCollectionWithSingleDependency[index *
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00026) | ├─IdentifierSyntax
 //@[007:00026) | | └─Token(Identifier) |indexedModuleOutput|
-//@[027:00033) | ├─VariableAccessSyntax
+//@[027:00033) | ├─TypeVariableAccessSyntax
 //@[027:00033) | | └─IdentifierSyntax
 //@[027:00033) | |   └─Token(Identifier) |string|
 //@[034:00035) | ├─Token(Assignment) |=|
@@ -2416,7 +2416,7 @@ output existingIndexedResourceName string = existingStorageAccounts[index * 0].n
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00034) | ├─IdentifierSyntax
 //@[007:00034) | | └─Token(Identifier) |existingIndexedResourceName|
-//@[035:00041) | ├─VariableAccessSyntax
+//@[035:00041) | ├─TypeVariableAccessSyntax
 //@[035:00041) | | └─IdentifierSyntax
 //@[035:00041) | |   └─Token(Identifier) |string|
 //@[042:00043) | ├─Token(Assignment) |=|
@@ -2443,7 +2443,7 @@ output existingIndexedResourceId string = existingStorageAccounts[index * 1].id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00032) | ├─IdentifierSyntax
 //@[007:00032) | | └─Token(Identifier) |existingIndexedResourceId|
-//@[033:00039) | ├─VariableAccessSyntax
+//@[033:00039) | ├─TypeVariableAccessSyntax
 //@[033:00039) | | └─IdentifierSyntax
 //@[033:00039) | |   └─Token(Identifier) |string|
 //@[040:00041) | ├─Token(Assignment) |=|
@@ -2470,7 +2470,7 @@ output existingIndexedResourceType string = existingStorageAccounts[index+2].typ
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00034) | ├─IdentifierSyntax
 //@[007:00034) | | └─Token(Identifier) |existingIndexedResourceType|
-//@[035:00041) | ├─VariableAccessSyntax
+//@[035:00041) | ├─TypeVariableAccessSyntax
 //@[035:00041) | | └─IdentifierSyntax
 //@[035:00041) | |   └─Token(Identifier) |string|
 //@[042:00043) | ├─Token(Assignment) |=|
@@ -2497,7 +2497,7 @@ output existingIndexedResourceApiVersion string = existingStorageAccounts[index-
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00040) | ├─IdentifierSyntax
 //@[007:00040) | | └─Token(Identifier) |existingIndexedResourceApiVersion|
-//@[041:00047) | ├─VariableAccessSyntax
+//@[041:00047) | ├─TypeVariableAccessSyntax
 //@[041:00047) | | └─IdentifierSyntax
 //@[041:00047) | |   └─Token(Identifier) |string|
 //@[048:00049) | ├─Token(Assignment) |=|
@@ -2524,7 +2524,7 @@ output existingIndexedResourceLocation string = existingStorageAccounts[index/2]
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00038) | ├─IdentifierSyntax
 //@[007:00038) | | └─Token(Identifier) |existingIndexedResourceLocation|
-//@[039:00045) | ├─VariableAccessSyntax
+//@[039:00045) | ├─TypeVariableAccessSyntax
 //@[039:00045) | | └─IdentifierSyntax
 //@[039:00045) | |   └─Token(Identifier) |string|
 //@[046:00047) | ├─Token(Assignment) |=|
@@ -2551,7 +2551,7 @@ output existingIndexedResourceAccessTier string = existingStorageAccounts[index%
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00040) | ├─IdentifierSyntax
 //@[007:00040) | | └─Token(Identifier) |existingIndexedResourceAccessTier|
-//@[041:00047) | ├─VariableAccessSyntax
+//@[041:00047) | ├─TypeVariableAccessSyntax
 //@[041:00047) | | └─IdentifierSyntax
 //@[041:00047) | |   └─Token(Identifier) |string|
 //@[048:00049) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/Loops_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Loops_LF/main.syntax.bicep
@@ -4,7 +4,7 @@ param name string
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00010) | ├─IdentifierSyntax
 //@[006:00010) | | └─Token(Identifier) |name|
-//@[011:00017) | └─VariableAccessSyntax
+//@[011:00017) | └─TypeVariableAccessSyntax
 //@[011:00017) |   └─IdentifierSyntax
 //@[011:00017) |     └─Token(Identifier) |string|
 //@[017:00018) ├─Token(NewLine) |\n|
@@ -13,7 +13,7 @@ param accounts array
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00014) | ├─IdentifierSyntax
 //@[006:00014) | | └─Token(Identifier) |accounts|
-//@[015:00020) | └─VariableAccessSyntax
+//@[015:00020) | └─TypeVariableAccessSyntax
 //@[015:00020) |   └─IdentifierSyntax
 //@[015:00020) |     └─Token(Identifier) |array|
 //@[020:00021) ├─Token(NewLine) |\n|
@@ -22,7 +22,7 @@ param index int
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00011) | ├─IdentifierSyntax
 //@[006:00011) | | └─Token(Identifier) |index|
-//@[012:00015) | └─VariableAccessSyntax
+//@[012:00015) | └─TypeVariableAccessSyntax
 //@[012:00015) |   └─IdentifierSyntax
 //@[012:00015) |     └─Token(Identifier) |int|
 //@[015:00017) ├─Token(NewLine) |\n\n|
@@ -590,7 +590,7 @@ output indexedCollectionBlobEndpoint string = storageAccounts[index].properties.
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00036) | ├─IdentifierSyntax
 //@[007:00036) | | └─Token(Identifier) |indexedCollectionBlobEndpoint|
-//@[037:00043) | ├─VariableAccessSyntax
+//@[037:00043) | ├─TypeVariableAccessSyntax
 //@[037:00043) | | └─IdentifierSyntax
 //@[037:00043) | |   └─Token(Identifier) |string|
 //@[044:00045) | ├─Token(Assignment) |=|
@@ -621,7 +621,7 @@ output indexedCollectionName string = storageAccounts[index].name
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00028) | ├─IdentifierSyntax
 //@[007:00028) | | └─Token(Identifier) |indexedCollectionName|
-//@[029:00035) | ├─VariableAccessSyntax
+//@[029:00035) | ├─TypeVariableAccessSyntax
 //@[029:00035) | | └─IdentifierSyntax
 //@[029:00035) | |   └─Token(Identifier) |string|
 //@[036:00037) | ├─Token(Assignment) |=|
@@ -644,7 +644,7 @@ output indexedCollectionId string = storageAccounts[index].id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00026) | ├─IdentifierSyntax
 //@[007:00026) | | └─Token(Identifier) |indexedCollectionId|
-//@[027:00033) | ├─VariableAccessSyntax
+//@[027:00033) | ├─TypeVariableAccessSyntax
 //@[027:00033) | | └─IdentifierSyntax
 //@[027:00033) | |   └─Token(Identifier) |string|
 //@[034:00035) | ├─Token(Assignment) |=|
@@ -667,7 +667,7 @@ output indexedCollectionType string = storageAccounts[index].type
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00028) | ├─IdentifierSyntax
 //@[007:00028) | | └─Token(Identifier) |indexedCollectionType|
-//@[029:00035) | ├─VariableAccessSyntax
+//@[029:00035) | ├─TypeVariableAccessSyntax
 //@[029:00035) | | └─IdentifierSyntax
 //@[029:00035) | |   └─Token(Identifier) |string|
 //@[036:00037) | ├─Token(Assignment) |=|
@@ -690,7 +690,7 @@ output indexedCollectionVersion string = storageAccounts[index].apiVersion
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00031) | ├─IdentifierSyntax
 //@[007:00031) | | └─Token(Identifier) |indexedCollectionVersion|
-//@[032:00038) | ├─VariableAccessSyntax
+//@[032:00038) | ├─TypeVariableAccessSyntax
 //@[032:00038) | | └─IdentifierSyntax
 //@[032:00038) | |   └─Token(Identifier) |string|
 //@[039:00040) | ├─Token(Assignment) |=|
@@ -716,7 +716,7 @@ output indexedCollectionIdentity object = storageAccounts[index].identity
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00032) | ├─IdentifierSyntax
 //@[007:00032) | | └─Token(Identifier) |indexedCollectionIdentity|
-//@[033:00039) | ├─VariableAccessSyntax
+//@[033:00039) | ├─TypeVariableAccessSyntax
 //@[033:00039) | | └─IdentifierSyntax
 //@[033:00039) | |   └─Token(Identifier) |object|
 //@[040:00041) | ├─Token(Assignment) |=|
@@ -742,7 +742,7 @@ output indexedEndpointPair object = {
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00026) | ├─IdentifierSyntax
 //@[007:00026) | | └─Token(Identifier) |indexedEndpointPair|
-//@[027:00033) | ├─VariableAccessSyntax
+//@[027:00033) | ├─TypeVariableAccessSyntax
 //@[027:00033) | | └─IdentifierSyntax
 //@[027:00033) | |   └─Token(Identifier) |object|
 //@[034:00035) | ├─Token(Assignment) |=|
@@ -818,7 +818,7 @@ output indexViaReference string = storageAccounts[int(storageAccounts[index].pro
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00024) | ├─IdentifierSyntax
 //@[007:00024) | | └─Token(Identifier) |indexViaReference|
-//@[025:00031) | ├─VariableAccessSyntax
+//@[025:00031) | ├─TypeVariableAccessSyntax
 //@[025:00031) | | └─IdentifierSyntax
 //@[025:00031) | |   └─Token(Identifier) |string|
 //@[032:00033) | ├─Token(Assignment) |=|
@@ -2136,7 +2136,7 @@ output indexedModulesName string = moduleCollectionWithSingleDependency[index].n
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00025) | ├─IdentifierSyntax
 //@[007:00025) | | └─Token(Identifier) |indexedModulesName|
-//@[026:00032) | ├─VariableAccessSyntax
+//@[026:00032) | ├─TypeVariableAccessSyntax
 //@[026:00032) | | └─IdentifierSyntax
 //@[026:00032) | |   └─Token(Identifier) |string|
 //@[033:00034) | ├─Token(Assignment) |=|
@@ -2159,7 +2159,7 @@ output indexedModuleOutput string = moduleCollectionWithSingleDependency[index *
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00026) | ├─IdentifierSyntax
 //@[007:00026) | | └─Token(Identifier) |indexedModuleOutput|
-//@[027:00033) | ├─VariableAccessSyntax
+//@[027:00033) | ├─TypeVariableAccessSyntax
 //@[027:00033) | | └─IdentifierSyntax
 //@[027:00033) | |   └─Token(Identifier) |string|
 //@[034:00035) | ├─Token(Assignment) |=|
@@ -2241,7 +2241,7 @@ output existingIndexedResourceName string = existingStorageAccounts[index * 0].n
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00034) | ├─IdentifierSyntax
 //@[007:00034) | | └─Token(Identifier) |existingIndexedResourceName|
-//@[035:00041) | ├─VariableAccessSyntax
+//@[035:00041) | ├─TypeVariableAccessSyntax
 //@[035:00041) | | └─IdentifierSyntax
 //@[035:00041) | |   └─Token(Identifier) |string|
 //@[042:00043) | ├─Token(Assignment) |=|
@@ -2268,7 +2268,7 @@ output existingIndexedResourceId string = existingStorageAccounts[index * 1].id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00032) | ├─IdentifierSyntax
 //@[007:00032) | | └─Token(Identifier) |existingIndexedResourceId|
-//@[033:00039) | ├─VariableAccessSyntax
+//@[033:00039) | ├─TypeVariableAccessSyntax
 //@[033:00039) | | └─IdentifierSyntax
 //@[033:00039) | |   └─Token(Identifier) |string|
 //@[040:00041) | ├─Token(Assignment) |=|
@@ -2295,7 +2295,7 @@ output existingIndexedResourceType string = existingStorageAccounts[index+2].typ
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00034) | ├─IdentifierSyntax
 //@[007:00034) | | └─Token(Identifier) |existingIndexedResourceType|
-//@[035:00041) | ├─VariableAccessSyntax
+//@[035:00041) | ├─TypeVariableAccessSyntax
 //@[035:00041) | | └─IdentifierSyntax
 //@[035:00041) | |   └─Token(Identifier) |string|
 //@[042:00043) | ├─Token(Assignment) |=|
@@ -2322,7 +2322,7 @@ output existingIndexedResourceApiVersion string = existingStorageAccounts[index-
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00040) | ├─IdentifierSyntax
 //@[007:00040) | | └─Token(Identifier) |existingIndexedResourceApiVersion|
-//@[041:00047) | ├─VariableAccessSyntax
+//@[041:00047) | ├─TypeVariableAccessSyntax
 //@[041:00047) | | └─IdentifierSyntax
 //@[041:00047) | |   └─Token(Identifier) |string|
 //@[048:00049) | ├─Token(Assignment) |=|
@@ -2349,7 +2349,7 @@ output existingIndexedResourceLocation string = existingStorageAccounts[index/2]
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00038) | ├─IdentifierSyntax
 //@[007:00038) | | └─Token(Identifier) |existingIndexedResourceLocation|
-//@[039:00045) | ├─VariableAccessSyntax
+//@[039:00045) | ├─TypeVariableAccessSyntax
 //@[039:00045) | | └─IdentifierSyntax
 //@[039:00045) | |   └─Token(Identifier) |string|
 //@[046:00047) | ├─Token(Assignment) |=|
@@ -2376,7 +2376,7 @@ output existingIndexedResourceAccessTier string = existingStorageAccounts[index%
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00040) | ├─IdentifierSyntax
 //@[007:00040) | | └─Token(Identifier) |existingIndexedResourceAccessTier|
-//@[041:00047) | ├─VariableAccessSyntax
+//@[041:00047) | ├─TypeVariableAccessSyntax
 //@[041:00047) | | └─IdentifierSyntax
 //@[041:00047) | |   └─Token(Identifier) |string|
 //@[048:00049) | ├─Token(Assignment) |=|
@@ -3724,7 +3724,7 @@ output lastNameServers array = filteredIndexedZones[length(accounts) - 1].proper
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00022) | ├─IdentifierSyntax
 //@[007:00022) | | └─Token(Identifier) |lastNameServers|
-//@[023:00028) | ├─VariableAccessSyntax
+//@[023:00028) | ├─TypeVariableAccessSyntax
 //@[023:00028) | | └─IdentifierSyntax
 //@[023:00028) | |   └─Token(Identifier) |array|
 //@[029:00030) | ├─Token(Assignment) |=|
@@ -3851,7 +3851,7 @@ output lastModuleOutput string = filteredIndexedModules[length(accounts) - 1].ou
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |lastModuleOutput|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/Metadata_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Metadata_CRLF/main.syntax.bicep
@@ -255,7 +255,7 @@ param foo string
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:009) | ├─IdentifierSyntax
 //@[06:009) | | └─Token(Identifier) |foo|
-//@[10:016) | └─VariableAccessSyntax
+//@[10:016) | └─TypeVariableAccessSyntax
 //@[10:016) |   └─IdentifierSyntax
 //@[10:016) |     └─Token(Identifier) |string|
 //@[16:018) ├─Token(NewLine) |\r\n|

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesSubscription_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesSubscription_LF/main.syntax.bicep
@@ -12,7 +12,7 @@ param prefix string = 'majastrz'
 //@[00:005) | ├─Token(Identifier) |param|
 //@[06:012) | ├─IdentifierSyntax
 //@[06:012) | | └─Token(Identifier) |prefix|
-//@[13:019) | ├─VariableAccessSyntax
+//@[13:019) | ├─TypeVariableAccessSyntax
 //@[13:019) | | └─IdentifierSyntax
 //@[13:019) | |   └─Token(Identifier) |string|
 //@[20:032) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopes_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopes_LF/main.syntax.bicep
@@ -213,7 +213,7 @@ output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0030) | ├─IdentifierSyntax
 //@[007:0030) | | └─Token(Identifier) |myManagementGroupOutput|
-//@[031:0037) | ├─VariableAccessSyntax
+//@[031:0037) | ├─TypeVariableAccessSyntax
 //@[031:0037) | | └─IdentifierSyntax
 //@[031:0037) | |   └─Token(Identifier) |string|
 //@[038:0039) | ├─Token(Assignment) |=|
@@ -234,7 +234,7 @@ output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0027) | ├─IdentifierSyntax
 //@[007:0027) | | └─Token(Identifier) |mySubscriptionOutput|
-//@[028:0034) | ├─VariableAccessSyntax
+//@[028:0034) | ├─TypeVariableAccessSyntax
 //@[028:0034) | | └─IdentifierSyntax
 //@[028:0034) | |   └─Token(Identifier) |string|
 //@[035:0036) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.syntax.bicep
@@ -22,7 +22,7 @@ param deployTimeSuffix string = newGuid()
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0022) | ├─IdentifierSyntax
 //@[006:0022) | | └─Token(Identifier) |deployTimeSuffix|
-//@[023:0029) | ├─VariableAccessSyntax
+//@[023:0029) | ├─TypeVariableAccessSyntax
 //@[023:0029) | | └─IdentifierSyntax
 //@[023:0029) | |   └─Token(Identifier) |string|
 //@[030:0041) | └─ParameterDefaultValueSyntax
@@ -931,7 +931,7 @@ output stringOutputA string = modATest.outputs.stringOutputA
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0020) | ├─IdentifierSyntax
 //@[007:0020) | | └─Token(Identifier) |stringOutputA|
-//@[021:0027) | ├─VariableAccessSyntax
+//@[021:0027) | ├─TypeVariableAccessSyntax
 //@[021:0027) | | └─IdentifierSyntax
 //@[021:0027) | |   └─Token(Identifier) |string|
 //@[028:0029) | ├─Token(Assignment) |=|
@@ -952,7 +952,7 @@ output stringOutputB string = modATest.outputs.stringOutputB
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0020) | ├─IdentifierSyntax
 //@[007:0020) | | └─Token(Identifier) |stringOutputB|
-//@[021:0027) | ├─VariableAccessSyntax
+//@[021:0027) | ├─TypeVariableAccessSyntax
 //@[021:0027) | | └─IdentifierSyntax
 //@[021:0027) | |   └─Token(Identifier) |string|
 //@[028:0029) | ├─Token(Assignment) |=|
@@ -973,7 +973,7 @@ output objOutput object = modATest.outputs.objOutput
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0016) | ├─IdentifierSyntax
 //@[007:0016) | | └─Token(Identifier) |objOutput|
-//@[017:0023) | ├─VariableAccessSyntax
+//@[017:0023) | ├─TypeVariableAccessSyntax
 //@[017:0023) | | └─IdentifierSyntax
 //@[017:0023) | |   └─Token(Identifier) |object|
 //@[024:0025) | ├─Token(Assignment) |=|
@@ -994,7 +994,7 @@ output arrayOutput array = modATest.outputs.arrayOutput
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0018) | ├─IdentifierSyntax
 //@[007:0018) | | └─Token(Identifier) |arrayOutput|
-//@[019:0024) | ├─VariableAccessSyntax
+//@[019:0024) | ├─TypeVariableAccessSyntax
 //@[019:0024) | | └─IdentifierSyntax
 //@[019:0024) | |   └─Token(Identifier) |array|
 //@[025:0026) | ├─Token(Assignment) |=|
@@ -1015,7 +1015,7 @@ output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputO
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0030) | ├─IdentifierSyntax
 //@[007:0030) | | └─Token(Identifier) |modCalculatedNameOutput|
-//@[031:0037) | ├─VariableAccessSyntax
+//@[031:0037) | ├─TypeVariableAccessSyntax
 //@[031:0037) | | └─IdentifierSyntax
 //@[031:0037) | |   └─Token(Identifier) |object|
 //@[038:0039) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.syntax.bicep
@@ -246,7 +246,7 @@ output referenceBasicChild string = basicParent::basicChild.properties.size
 //@[00:0006) | ├─Token(Identifier) |output|
 //@[07:0026) | ├─IdentifierSyntax
 //@[07:0026) | | └─Token(Identifier) |referenceBasicChild|
-//@[27:0033) | ├─VariableAccessSyntax
+//@[27:0033) | ├─TypeVariableAccessSyntax
 //@[27:0033) | | └─IdentifierSyntax
 //@[27:0033) | |   └─Token(Identifier) |string|
 //@[34:0035) | ├─Token(Assignment) |=|
@@ -273,7 +273,7 @@ output referenceBasicGrandchild string = basicParent::basicChild::basicGrandchil
 //@[00:0006) | ├─Token(Identifier) |output|
 //@[07:0031) | ├─IdentifierSyntax
 //@[07:0031) | | └─Token(Identifier) |referenceBasicGrandchild|
-//@[32:0038) | ├─VariableAccessSyntax
+//@[32:0038) | ├─TypeVariableAccessSyntax
 //@[32:0038) | | └─IdentifierSyntax
 //@[32:0038) | |   └─Token(Identifier) |string|
 //@[39:0040) | ├─Token(Assignment) |=|
@@ -419,7 +419,7 @@ param createParent bool
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0018) | ├─IdentifierSyntax
 //@[06:0018) | | └─Token(Identifier) |createParent|
-//@[19:0023) | └─VariableAccessSyntax
+//@[19:0023) | └─TypeVariableAccessSyntax
 //@[19:0023) |   └─IdentifierSyntax
 //@[19:0023) |     └─Token(Identifier) |bool|
 //@[23:0024) ├─Token(NewLine) |\n|
@@ -428,7 +428,7 @@ param createChild bool
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0017) | ├─IdentifierSyntax
 //@[06:0017) | | └─Token(Identifier) |createChild|
-//@[18:0022) | └─VariableAccessSyntax
+//@[18:0022) | └─TypeVariableAccessSyntax
 //@[18:0022) |   └─IdentifierSyntax
 //@[18:0022) |     └─Token(Identifier) |bool|
 //@[22:0023) ├─Token(NewLine) |\n|
@@ -437,7 +437,7 @@ param createGrandchild bool
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0022) | ├─IdentifierSyntax
 //@[06:0022) | | └─Token(Identifier) |createGrandchild|
-//@[23:0027) | └─VariableAccessSyntax
+//@[23:0027) | └─TypeVariableAccessSyntax
 //@[23:0027) |   └─IdentifierSyntax
 //@[23:0027) |     └─Token(Identifier) |bool|
 //@[27:0028) ├─Token(NewLine) |\n|
@@ -664,7 +664,7 @@ output loopChildOutput string = loopParent::loopChild[0].name
 //@[00:0006) | ├─Token(Identifier) |output|
 //@[07:0022) | ├─IdentifierSyntax
 //@[07:0022) | | └─Token(Identifier) |loopChildOutput|
-//@[23:0029) | ├─VariableAccessSyntax
+//@[23:0029) | ├─TypeVariableAccessSyntax
 //@[23:0029) | | └─IdentifierSyntax
 //@[23:0029) | |   └─Token(Identifier) |string|
 //@[30:0031) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/NewlineSensitivity_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/NewlineSensitivity_LF/main.syntax.bicep
@@ -28,7 +28,7 @@ param foo string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0009) | ├─IdentifierSyntax
 //@[06:0009) | | └─Token(Identifier) |foo|
-//@[10:0016) | └─VariableAccessSyntax
+//@[10:0016) | └─TypeVariableAccessSyntax
 //@[10:0016) |   └─IdentifierSyntax
 //@[10:0016) |     └─Token(Identifier) |string|
 //@[16:0018) ├─Token(NewLine) |\n\n|

--- a/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.syntax.bicep
@@ -22,7 +22,7 @@ output myStr string = 'hello'
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0012) | ├─IdentifierSyntax
 //@[007:0012) | | └─Token(Identifier) |myStr|
-//@[013:0019) | ├─VariableAccessSyntax
+//@[013:0019) | ├─TypeVariableAccessSyntax
 //@[013:0019) | | └─IdentifierSyntax
 //@[013:0019) | |   └─Token(Identifier) |string|
 //@[020:0021) | ├─Token(Assignment) |=|
@@ -51,7 +51,7 @@ output myInt int = 7
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0012) | ├─IdentifierSyntax
 //@[007:0012) | | └─Token(Identifier) |myInt|
-//@[013:0016) | ├─VariableAccessSyntax
+//@[013:0016) | ├─TypeVariableAccessSyntax
 //@[013:0016) | | └─IdentifierSyntax
 //@[013:0016) | |   └─Token(Identifier) |int|
 //@[017:0018) | ├─Token(Assignment) |=|
@@ -63,7 +63,7 @@ output myOtherInt int = 20 / 13 + 80 % -4
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0017) | ├─IdentifierSyntax
 //@[007:0017) | | └─Token(Identifier) |myOtherInt|
-//@[018:0021) | ├─VariableAccessSyntax
+//@[018:0021) | ├─TypeVariableAccessSyntax
 //@[018:0021) | | └─IdentifierSyntax
 //@[018:0021) | |   └─Token(Identifier) |int|
 //@[022:0023) | ├─Token(Assignment) |=|
@@ -106,7 +106,7 @@ output myBool bool = !false
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0013) | ├─IdentifierSyntax
 //@[007:0013) | | └─Token(Identifier) |myBool|
-//@[014:0018) | ├─VariableAccessSyntax
+//@[014:0018) | ├─TypeVariableAccessSyntax
 //@[014:0018) | | └─IdentifierSyntax
 //@[014:0018) | |   └─Token(Identifier) |bool|
 //@[019:0020) | ├─Token(Assignment) |=|
@@ -120,7 +120,7 @@ output myOtherBool bool = true
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0018) | ├─IdentifierSyntax
 //@[007:0018) | | └─Token(Identifier) |myOtherBool|
-//@[019:0023) | ├─VariableAccessSyntax
+//@[019:0023) | ├─TypeVariableAccessSyntax
 //@[019:0023) | | └─IdentifierSyntax
 //@[019:0023) | |   └─Token(Identifier) |bool|
 //@[024:0025) | ├─Token(Assignment) |=|
@@ -149,7 +149,7 @@ output suchEmpty array = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0016) | ├─IdentifierSyntax
 //@[007:0016) | | └─Token(Identifier) |suchEmpty|
-//@[017:0022) | ├─VariableAccessSyntax
+//@[017:0022) | ├─TypeVariableAccessSyntax
 //@[017:0022) | | └─IdentifierSyntax
 //@[017:0022) | |   └─Token(Identifier) |array|
 //@[023:0024) | ├─Token(Assignment) |=|
@@ -165,7 +165,7 @@ output suchEmpty2 object = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0017) | ├─IdentifierSyntax
 //@[007:0017) | | └─Token(Identifier) |suchEmpty2|
-//@[018:0024) | ├─VariableAccessSyntax
+//@[018:0024) | ├─TypeVariableAccessSyntax
 //@[018:0024) | | └─IdentifierSyntax
 //@[018:0024) | |   └─Token(Identifier) |object|
 //@[025:0026) | ├─Token(Assignment) |=|
@@ -197,7 +197,7 @@ output obj object = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0010) | ├─IdentifierSyntax
 //@[007:0010) | | └─Token(Identifier) |obj|
-//@[011:0017) | ├─VariableAccessSyntax
+//@[011:0017) | ├─TypeVariableAccessSyntax
 //@[011:0017) | | └─IdentifierSyntax
 //@[011:0017) | |   └─Token(Identifier) |object|
 //@[018:0019) | ├─Token(Assignment) |=|
@@ -311,7 +311,7 @@ output myArr array = [
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0012) | ├─IdentifierSyntax
 //@[007:0012) | | └─Token(Identifier) |myArr|
-//@[013:0018) | ├─VariableAccessSyntax
+//@[013:0018) | ├─TypeVariableAccessSyntax
 //@[013:0018) | | └─IdentifierSyntax
 //@[013:0018) | |   └─Token(Identifier) |array|
 //@[019:0020) | ├─Token(Assignment) |=|
@@ -349,7 +349,7 @@ output rgLocation string = resourceGroup().location
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0017) | ├─IdentifierSyntax
 //@[007:0017) | | └─Token(Identifier) |rgLocation|
-//@[018:0024) | ├─VariableAccessSyntax
+//@[018:0024) | ├─TypeVariableAccessSyntax
 //@[018:0024) | | └─IdentifierSyntax
 //@[018:0024) | |   └─Token(Identifier) |string|
 //@[025:0026) | ├─Token(Assignment) |=|
@@ -369,7 +369,7 @@ output isWestUs bool = resourceGroup().location != 'westus' ? false : true
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0015) | ├─IdentifierSyntax
 //@[007:0015) | | └─Token(Identifier) |isWestUs|
-//@[016:0020) | ├─VariableAccessSyntax
+//@[016:0020) | ├─TypeVariableAccessSyntax
 //@[016:0020) | | └─IdentifierSyntax
 //@[016:0020) | |   └─Token(Identifier) |bool|
 //@[021:0022) | ├─Token(Assignment) |=|
@@ -400,7 +400,7 @@ output expressionBasedIndexer string = {
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0029) | ├─IdentifierSyntax
 //@[007:0029) | | └─Token(Identifier) |expressionBasedIndexer|
-//@[030:0036) | ├─VariableAccessSyntax
+//@[030:0036) | ├─TypeVariableAccessSyntax
 //@[030:0036) | | └─IdentifierSyntax
 //@[030:0036) | |   └─Token(Identifier) |string|
 //@[037:0038) | ├─Token(Assignment) |=|
@@ -504,7 +504,7 @@ output primaryKey string = listKeys(resourceId('Mock.RP/type', 'nigel'), '2020-0
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0017) | ├─IdentifierSyntax
 //@[007:0017) | | └─Token(Identifier) |primaryKey|
-//@[018:0024) | ├─VariableAccessSyntax
+//@[018:0024) | ├─TypeVariableAccessSyntax
 //@[018:0024) | | └─IdentifierSyntax
 //@[018:0024) | |   └─Token(Identifier) |string|
 //@[025:0026) | ├─Token(Assignment) |=|
@@ -540,7 +540,7 @@ output secondaryKey string = secondaryKeyIntermediateVar
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0019) | ├─IdentifierSyntax
 //@[007:0019) | | └─Token(Identifier) |secondaryKey|
-//@[020:0026) | ├─VariableAccessSyntax
+//@[020:0026) | ├─TypeVariableAccessSyntax
 //@[020:0026) | | └─IdentifierSyntax
 //@[020:0026) | |   └─Token(Identifier) |string|
 //@[027:0028) | ├─Token(Assignment) |=|
@@ -563,7 +563,7 @@ param paramWithOverlappingOutput string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0032) | ├─IdentifierSyntax
 //@[006:0032) | | └─Token(Identifier) |paramWithOverlappingOutput|
-//@[033:0039) | └─VariableAccessSyntax
+//@[033:0039) | └─TypeVariableAccessSyntax
 //@[033:0039) |   └─IdentifierSyntax
 //@[033:0039) |     └─Token(Identifier) |string|
 //@[039:0043) ├─Token(NewLine) |\r\n\r\n|
@@ -573,7 +573,7 @@ output varWithOverlappingOutput string = varWithOverlappingOutput
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0031) | ├─IdentifierSyntax
 //@[007:0031) | | └─Token(Identifier) |varWithOverlappingOutput|
-//@[032:0038) | ├─VariableAccessSyntax
+//@[032:0038) | ├─TypeVariableAccessSyntax
 //@[032:0038) | | └─IdentifierSyntax
 //@[032:0038) | |   └─Token(Identifier) |string|
 //@[039:0040) | ├─Token(Assignment) |=|
@@ -586,7 +586,7 @@ output paramWithOverlappingOutput string = paramWithOverlappingOutput
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0033) | ├─IdentifierSyntax
 //@[007:0033) | | └─Token(Identifier) |paramWithOverlappingOutput|
-//@[034:0040) | ├─VariableAccessSyntax
+//@[034:0040) | ├─TypeVariableAccessSyntax
 //@[034:0040) | | └─IdentifierSyntax
 //@[034:0040) | |   └─Token(Identifier) |string|
 //@[041:0042) | ├─Token(Assignment) |=|
@@ -602,7 +602,7 @@ output generatedArray array = [for i in range(0,10): i]
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0021) | ├─IdentifierSyntax
 //@[007:0021) | | └─Token(Identifier) |generatedArray|
-//@[022:0027) | ├─VariableAccessSyntax
+//@[022:0027) | ├─TypeVariableAccessSyntax
 //@[022:0027) | | └─IdentifierSyntax
 //@[022:0027) | |   └─Token(Identifier) |array|
 //@[028:0029) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_CRLF/main.syntax.bicep
@@ -11,7 +11,7 @@ param myString string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0014) | ├─IdentifierSyntax
 //@[06:0014) | | └─Token(Identifier) |myString|
-//@[15:0021) | └─VariableAccessSyntax
+//@[15:0021) | └─TypeVariableAccessSyntax
 //@[15:0021) |   └─IdentifierSyntax
 //@[15:0021) |     └─Token(Identifier) |string|
 //@[21:0023) ├─Token(NewLine) |\r\n|
@@ -20,7 +20,7 @@ param myInt int
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0011) | ├─IdentifierSyntax
 //@[06:0011) | | └─Token(Identifier) |myInt|
-//@[12:0015) | └─VariableAccessSyntax
+//@[12:0015) | └─TypeVariableAccessSyntax
 //@[12:0015) |   └─IdentifierSyntax
 //@[12:0015) |     └─Token(Identifier) |int|
 //@[15:0017) ├─Token(NewLine) |\r\n|
@@ -29,7 +29,7 @@ param myBool bool
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0012) | ├─IdentifierSyntax
 //@[06:0012) | | └─Token(Identifier) |myBool|
-//@[13:0017) | └─VariableAccessSyntax
+//@[13:0017) | └─TypeVariableAccessSyntax
 //@[13:0017) |   └─IdentifierSyntax
 //@[13:0017) |     └─Token(Identifier) |bool|
 //@[17:0021) ├─Token(NewLine) |\r\n\r\n|
@@ -41,7 +41,7 @@ param myString2 string = 'string value'
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0015) | ├─IdentifierSyntax
 //@[06:0015) | | └─Token(Identifier) |myString2|
-//@[16:0022) | ├─VariableAccessSyntax
+//@[16:0022) | ├─TypeVariableAccessSyntax
 //@[16:0022) | | └─IdentifierSyntax
 //@[16:0022) | |   └─Token(Identifier) |string|
 //@[23:0039) | └─ParameterDefaultValueSyntax
@@ -54,7 +54,7 @@ param myInt2 int = 42
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0012) | ├─IdentifierSyntax
 //@[06:0012) | | └─Token(Identifier) |myInt2|
-//@[13:0016) | ├─VariableAccessSyntax
+//@[13:0016) | ├─TypeVariableAccessSyntax
 //@[13:0016) | | └─IdentifierSyntax
 //@[13:0016) | |   └─Token(Identifier) |int|
 //@[17:0021) | └─ParameterDefaultValueSyntax
@@ -67,7 +67,7 @@ param myTruth bool = true
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0013) | ├─IdentifierSyntax
 //@[06:0013) | | └─Token(Identifier) |myTruth|
-//@[14:0018) | ├─VariableAccessSyntax
+//@[14:0018) | ├─TypeVariableAccessSyntax
 //@[14:0018) | | └─IdentifierSyntax
 //@[14:0018) | |   └─Token(Identifier) |bool|
 //@[19:0025) | └─ParameterDefaultValueSyntax
@@ -80,7 +80,7 @@ param myFalsehood bool = false
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0017) | ├─IdentifierSyntax
 //@[06:0017) | | └─Token(Identifier) |myFalsehood|
-//@[18:0022) | ├─VariableAccessSyntax
+//@[18:0022) | ├─TypeVariableAccessSyntax
 //@[18:0022) | | └─IdentifierSyntax
 //@[18:0022) | |   └─Token(Identifier) |bool|
 //@[23:0030) | └─ParameterDefaultValueSyntax
@@ -93,7 +93,7 @@ param myEscapedString string = 'First line\r\nSecond\ttabbed\tline'
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0021) | ├─IdentifierSyntax
 //@[06:0021) | | └─Token(Identifier) |myEscapedString|
-//@[22:0028) | ├─VariableAccessSyntax
+//@[22:0028) | ├─TypeVariableAccessSyntax
 //@[22:0028) | | └─IdentifierSyntax
 //@[22:0028) | |   └─Token(Identifier) |string|
 //@[29:0067) | └─ParameterDefaultValueSyntax
@@ -109,7 +109,7 @@ param foo object = {
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0009) | ├─IdentifierSyntax
 //@[06:0009) | | └─Token(Identifier) |foo|
-//@[10:0016) | ├─VariableAccessSyntax
+//@[10:0016) | ├─TypeVariableAccessSyntax
 //@[10:0016) | | └─IdentifierSyntax
 //@[10:0016) | |   └─Token(Identifier) |object|
 //@[17:0253) | └─ParameterDefaultValueSyntax
@@ -242,7 +242,7 @@ param myArrayParam array = [
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0018) | ├─IdentifierSyntax
 //@[06:0018) | | └─Token(Identifier) |myArrayParam|
-//@[19:0024) | ├─VariableAccessSyntax
+//@[19:0024) | ├─TypeVariableAccessSyntax
 //@[19:0024) | | └─IdentifierSyntax
 //@[19:0024) | |   └─Token(Identifier) |array|
 //@[25:0052) | └─ParameterDefaultValueSyntax
@@ -285,7 +285,7 @@ param password string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0014) | ├─IdentifierSyntax
 //@[06:0014) | | └─Token(Identifier) |password|
-//@[15:0021) | └─VariableAccessSyntax
+//@[15:0021) | └─TypeVariableAccessSyntax
 //@[15:0021) |   └─IdentifierSyntax
 //@[15:0021) |     └─Token(Identifier) |string|
 //@[21:0025) ├─Token(NewLine) |\r\n\r\n|
@@ -306,7 +306,7 @@ param secretObject object
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0018) | ├─IdentifierSyntax
 //@[06:0018) | | └─Token(Identifier) |secretObject|
-//@[19:0025) | └─VariableAccessSyntax
+//@[19:0025) | └─TypeVariableAccessSyntax
 //@[19:0025) |   └─IdentifierSyntax
 //@[19:0025) |     └─Token(Identifier) |object|
 //@[25:0029) ├─Token(NewLine) |\r\n\r\n|
@@ -343,7 +343,7 @@ param storageSku string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0016) | ├─IdentifierSyntax
 //@[06:0016) | | └─Token(Identifier) |storageSku|
-//@[17:0023) | └─VariableAccessSyntax
+//@[17:0023) | └─TypeVariableAccessSyntax
 //@[17:0023) |   └─IdentifierSyntax
 //@[17:0023) |     └─Token(Identifier) |string|
 //@[23:0027) ├─Token(NewLine) |\r\n\r\n|
@@ -379,7 +379,7 @@ param storageName string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0017) | ├─IdentifierSyntax
 //@[06:0017) | | └─Token(Identifier) |storageName|
-//@[18:0024) | └─VariableAccessSyntax
+//@[18:0024) | └─TypeVariableAccessSyntax
 //@[18:0024) |   └─IdentifierSyntax
 //@[18:0024) |     └─Token(Identifier) |string|
 //@[24:0028) ├─Token(NewLine) |\r\n\r\n|
@@ -415,7 +415,7 @@ param someArray array
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0015) | ├─IdentifierSyntax
 //@[06:0015) | | └─Token(Identifier) |someArray|
-//@[16:0021) | └─VariableAccessSyntax
+//@[16:0021) | └─TypeVariableAccessSyntax
 //@[16:0021) |   └─IdentifierSyntax
 //@[16:0021) |     └─Token(Identifier) |array|
 //@[21:0025) ├─Token(NewLine) |\r\n\r\n|
@@ -440,7 +440,7 @@ param emptyMetadata string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0019) | ├─IdentifierSyntax
 //@[06:0019) | | └─Token(Identifier) |emptyMetadata|
-//@[20:0026) | └─VariableAccessSyntax
+//@[20:0026) | └─TypeVariableAccessSyntax
 //@[20:0026) |   └─IdentifierSyntax
 //@[20:0026) |     └─Token(Identifier) |string|
 //@[26:0030) ├─Token(NewLine) |\r\n\r\n|
@@ -475,7 +475,7 @@ param description string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0017) | ├─IdentifierSyntax
 //@[06:0017) | | └─Token(Identifier) |description|
-//@[18:0024) | └─VariableAccessSyntax
+//@[18:0024) | └─TypeVariableAccessSyntax
 //@[18:0024) |   └─IdentifierSyntax
 //@[18:0024) |     └─Token(Identifier) |string|
 //@[24:0028) ├─Token(NewLine) |\r\n\r\n|
@@ -501,7 +501,7 @@ param description2 string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0018) | ├─IdentifierSyntax
 //@[06:0018) | | └─Token(Identifier) |description2|
-//@[19:0025) | └─VariableAccessSyntax
+//@[19:0025) | └─TypeVariableAccessSyntax
 //@[19:0025) |   └─IdentifierSyntax
 //@[19:0025) |     └─Token(Identifier) |string|
 //@[25:0029) ├─Token(NewLine) |\r\n\r\n|
@@ -582,7 +582,7 @@ param additionalMetadata string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0024) | ├─IdentifierSyntax
 //@[06:0024) | | └─Token(Identifier) |additionalMetadata|
-//@[25:0031) | └─VariableAccessSyntax
+//@[25:0031) | └─TypeVariableAccessSyntax
 //@[25:0031) |   └─IdentifierSyntax
 //@[25:0031) |     └─Token(Identifier) |string|
 //@[31:0035) ├─Token(NewLine) |\r\n\r\n|
@@ -680,7 +680,7 @@ param someParameter string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0019) | ├─IdentifierSyntax
 //@[06:0019) | | └─Token(Identifier) |someParameter|
-//@[20:0026) | └─VariableAccessSyntax
+//@[20:0026) | └─TypeVariableAccessSyntax
 //@[20:0026) |   └─IdentifierSyntax
 //@[20:0026) |     └─Token(Identifier) |string|
 //@[26:0030) ├─Token(NewLine) |\r\n\r\n|
@@ -690,7 +690,7 @@ param defaultExpression bool = 18 != (true || false)
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0023) | ├─IdentifierSyntax
 //@[06:0023) | | └─Token(Identifier) |defaultExpression|
-//@[24:0028) | ├─VariableAccessSyntax
+//@[24:0028) | ├─TypeVariableAccessSyntax
 //@[24:0028) | | └─IdentifierSyntax
 //@[24:0028) | |   └─Token(Identifier) |bool|
 //@[29:0052) | └─ParameterDefaultValueSyntax
@@ -740,7 +740,7 @@ param stringLiteral string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0019) | ├─IdentifierSyntax
 //@[06:0019) | | └─Token(Identifier) |stringLiteral|
-//@[20:0026) | └─VariableAccessSyntax
+//@[20:0026) | └─TypeVariableAccessSyntax
 //@[20:0026) |   └─IdentifierSyntax
 //@[20:0026) |     └─Token(Identifier) |string|
 //@[26:0030) ├─Token(NewLine) |\r\n\r\n|
@@ -780,7 +780,7 @@ param stringLiteralWithAllowedValuesSuperset string = stringLiteral
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0044) | ├─IdentifierSyntax
 //@[06:0044) | | └─Token(Identifier) |stringLiteralWithAllowedValuesSuperset|
-//@[45:0051) | ├─VariableAccessSyntax
+//@[45:0051) | ├─TypeVariableAccessSyntax
 //@[45:0051) | | └─IdentifierSyntax
 //@[45:0051) | |   └─Token(Identifier) |string|
 //@[52:0067) | └─ParameterDefaultValueSyntax
@@ -853,7 +853,7 @@ param decoratedString string
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0021) | ├─IdentifierSyntax
 //@[06:0021) | | └─Token(Identifier) |decoratedString|
-//@[22:0028) | └─VariableAccessSyntax
+//@[22:0028) | └─TypeVariableAccessSyntax
 //@[22:0028) |   └─IdentifierSyntax
 //@[22:0028) |     └─Token(Identifier) |string|
 //@[28:0032) ├─Token(NewLine) |\r\n\r\n|
@@ -875,7 +875,7 @@ param decoratedInt int = 123
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0018) | ├─IdentifierSyntax
 //@[06:0018) | | └─Token(Identifier) |decoratedInt|
-//@[19:0022) | ├─VariableAccessSyntax
+//@[19:0022) | ├─TypeVariableAccessSyntax
 //@[19:0022) | | └─IdentifierSyntax
 //@[19:0022) | |   └─Token(Identifier) |int|
 //@[23:0028) | └─ParameterDefaultValueSyntax
@@ -919,7 +919,7 @@ param negativeValues int
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0020) | ├─IdentifierSyntax
 //@[06:0020) | | └─Token(Identifier) |negativeValues|
-//@[21:0024) | └─VariableAccessSyntax
+//@[21:0024) | └─TypeVariableAccessSyntax
 //@[21:0024) |   └─IdentifierSyntax
 //@[21:0024) |     └─Token(Identifier) |int|
 //@[24:0028) ├─Token(NewLine) |\r\n\r\n|
@@ -1003,7 +1003,7 @@ param decoratedBool bool = (true && false) != true
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0019) | ├─IdentifierSyntax
 //@[06:0019) | | └─Token(Identifier) |decoratedBool|
-//@[20:0024) | ├─VariableAccessSyntax
+//@[20:0024) | ├─TypeVariableAccessSyntax
 //@[20:0024) | | └─IdentifierSyntax
 //@[20:0024) | |   └─Token(Identifier) |bool|
 //@[25:0050) | └─ParameterDefaultValueSyntax
@@ -1037,7 +1037,7 @@ param decoratedObject object = {
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0021) | ├─IdentifierSyntax
 //@[06:0021) | | └─Token(Identifier) |decoratedObject|
-//@[22:0028) | ├─VariableAccessSyntax
+//@[22:0028) | ├─TypeVariableAccessSyntax
 //@[22:0028) | | └─IdentifierSyntax
 //@[22:0028) | |   └─Token(Identifier) |object|
 //@[29:0265) | └─ParameterDefaultValueSyntax
@@ -1227,7 +1227,7 @@ param decoratedArray array = [
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0020) | ├─IdentifierSyntax
 //@[06:0020) | | └─Token(Identifier) |decoratedArray|
-//@[21:0026) | ├─VariableAccessSyntax
+//@[21:0026) | ├─TypeVariableAccessSyntax
 //@[21:0026) | | └─IdentifierSyntax
 //@[21:0026) | |   └─Token(Identifier) |array|
 //@[27:0062) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.syntax.bicep
@@ -30,7 +30,7 @@ param myString string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0014) | ├─IdentifierSyntax
 //@[006:0014) | | └─Token(Identifier) |myString|
-//@[015:0021) | └─VariableAccessSyntax
+//@[015:0021) | └─TypeVariableAccessSyntax
 //@[015:0021) |   └─IdentifierSyntax
 //@[015:0021) |     └─Token(Identifier) |string|
 //@[021:0022) ├─Token(NewLine) |\n|
@@ -39,7 +39,7 @@ param myInt int
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0011) | ├─IdentifierSyntax
 //@[006:0011) | | └─Token(Identifier) |myInt|
-//@[012:0015) | └─VariableAccessSyntax
+//@[012:0015) | └─TypeVariableAccessSyntax
 //@[012:0015) |   └─IdentifierSyntax
 //@[012:0015) |     └─Token(Identifier) |int|
 //@[015:0016) ├─Token(NewLine) |\n|
@@ -48,7 +48,7 @@ param myBool bool
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0012) | ├─IdentifierSyntax
 //@[006:0012) | | └─Token(Identifier) |myBool|
-//@[013:0017) | └─VariableAccessSyntax
+//@[013:0017) | └─TypeVariableAccessSyntax
 //@[013:0017) |   └─IdentifierSyntax
 //@[013:0017) |     └─Token(Identifier) |bool|
 //@[017:0019) ├─Token(NewLine) |\n\n|
@@ -99,7 +99,7 @@ param myString2 string = 'string value'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |myString2|
-//@[016:0022) | ├─VariableAccessSyntax
+//@[016:0022) | ├─TypeVariableAccessSyntax
 //@[016:0022) | | └─IdentifierSyntax
 //@[016:0022) | |   └─Token(Identifier) |string|
 //@[023:0039) | └─ParameterDefaultValueSyntax
@@ -112,7 +112,7 @@ param myInt2 int = 42
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0012) | ├─IdentifierSyntax
 //@[006:0012) | | └─Token(Identifier) |myInt2|
-//@[013:0016) | ├─VariableAccessSyntax
+//@[013:0016) | ├─TypeVariableAccessSyntax
 //@[013:0016) | | └─IdentifierSyntax
 //@[013:0016) | |   └─Token(Identifier) |int|
 //@[017:0021) | └─ParameterDefaultValueSyntax
@@ -125,7 +125,7 @@ param myTruth bool = true
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0013) | ├─IdentifierSyntax
 //@[006:0013) | | └─Token(Identifier) |myTruth|
-//@[014:0018) | ├─VariableAccessSyntax
+//@[014:0018) | ├─TypeVariableAccessSyntax
 //@[014:0018) | | └─IdentifierSyntax
 //@[014:0018) | |   └─Token(Identifier) |bool|
 //@[019:0025) | └─ParameterDefaultValueSyntax
@@ -138,7 +138,7 @@ param myFalsehood bool = false
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |myFalsehood|
-//@[018:0022) | ├─VariableAccessSyntax
+//@[018:0022) | ├─TypeVariableAccessSyntax
 //@[018:0022) | | └─IdentifierSyntax
 //@[018:0022) | |   └─Token(Identifier) |bool|
 //@[023:0030) | └─ParameterDefaultValueSyntax
@@ -151,7 +151,7 @@ param myEscapedString string = 'First line\r\nSecond\ttabbed\tline'
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0021) | ├─IdentifierSyntax
 //@[006:0021) | | └─Token(Identifier) |myEscapedString|
-//@[022:0028) | ├─VariableAccessSyntax
+//@[022:0028) | ├─TypeVariableAccessSyntax
 //@[022:0028) | | └─IdentifierSyntax
 //@[022:0028) | |   └─Token(Identifier) |string|
 //@[029:0067) | └─ParameterDefaultValueSyntax
@@ -214,7 +214,7 @@ param foo object = {
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0009) | ├─IdentifierSyntax
 //@[006:0009) | | └─Token(Identifier) |foo|
-//@[010:0016) | ├─VariableAccessSyntax
+//@[010:0016) | ├─TypeVariableAccessSyntax
 //@[010:0016) | | └─IdentifierSyntax
 //@[010:0016) | |   └─Token(Identifier) |object|
 //@[017:0232) | └─ParameterDefaultValueSyntax
@@ -347,7 +347,7 @@ param myArrayParam array = [
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0018) | ├─IdentifierSyntax
 //@[006:0018) | | └─Token(Identifier) |myArrayParam|
-//@[019:0024) | ├─VariableAccessSyntax
+//@[019:0024) | ├─TypeVariableAccessSyntax
 //@[019:0024) | | └─IdentifierSyntax
 //@[019:0024) | |   └─Token(Identifier) |array|
 //@[025:0048) | └─ParameterDefaultValueSyntax
@@ -390,7 +390,7 @@ param password string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0014) | ├─IdentifierSyntax
 //@[006:0014) | | └─Token(Identifier) |password|
-//@[015:0021) | └─VariableAccessSyntax
+//@[015:0021) | └─TypeVariableAccessSyntax
 //@[015:0021) |   └─IdentifierSyntax
 //@[015:0021) |     └─Token(Identifier) |string|
 //@[021:0023) ├─Token(NewLine) |\n\n|
@@ -411,7 +411,7 @@ param secretObject object
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0018) | ├─IdentifierSyntax
 //@[006:0018) | | └─Token(Identifier) |secretObject|
-//@[019:0025) | └─VariableAccessSyntax
+//@[019:0025) | └─TypeVariableAccessSyntax
 //@[019:0025) |   └─IdentifierSyntax
 //@[019:0025) |     └─Token(Identifier) |object|
 //@[025:0027) ├─Token(NewLine) |\n\n|
@@ -448,7 +448,7 @@ param storageSku string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0016) | ├─IdentifierSyntax
 //@[006:0016) | | └─Token(Identifier) |storageSku|
-//@[017:0023) | └─VariableAccessSyntax
+//@[017:0023) | └─TypeVariableAccessSyntax
 //@[017:0023) |   └─IdentifierSyntax
 //@[017:0023) |     └─Token(Identifier) |string|
 //@[023:0025) ├─Token(NewLine) |\n\n|
@@ -488,7 +488,7 @@ param intEnum int
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0013) | ├─IdentifierSyntax
 //@[006:0013) | | └─Token(Identifier) |intEnum|
-//@[014:0017) | └─VariableAccessSyntax
+//@[014:0017) | └─TypeVariableAccessSyntax
 //@[014:0017) |   └─IdentifierSyntax
 //@[014:0017) |     └─Token(Identifier) |int|
 //@[017:0019) ├─Token(NewLine) |\n\n|
@@ -524,7 +524,7 @@ param storageName string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |storageName|
-//@[018:0024) | └─VariableAccessSyntax
+//@[018:0024) | └─TypeVariableAccessSyntax
 //@[018:0024) |   └─IdentifierSyntax
 //@[018:0024) |     └─Token(Identifier) |string|
 //@[024:0026) ├─Token(NewLine) |\n\n|
@@ -560,7 +560,7 @@ param someArray array
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0015) | ├─IdentifierSyntax
 //@[006:0015) | | └─Token(Identifier) |someArray|
-//@[016:0021) | └─VariableAccessSyntax
+//@[016:0021) | └─TypeVariableAccessSyntax
 //@[016:0021) |   └─IdentifierSyntax
 //@[016:0021) |     └─Token(Identifier) |array|
 //@[021:0023) ├─Token(NewLine) |\n\n|
@@ -585,7 +585,7 @@ param emptyMetadata string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0019) | ├─IdentifierSyntax
 //@[006:0019) | | └─Token(Identifier) |emptyMetadata|
-//@[020:0026) | └─VariableAccessSyntax
+//@[020:0026) | └─TypeVariableAccessSyntax
 //@[020:0026) |   └─IdentifierSyntax
 //@[020:0026) |     └─Token(Identifier) |string|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -620,7 +620,7 @@ param description string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0017) | ├─IdentifierSyntax
 //@[006:0017) | | └─Token(Identifier) |description|
-//@[018:0024) | └─VariableAccessSyntax
+//@[018:0024) | └─TypeVariableAccessSyntax
 //@[018:0024) |   └─IdentifierSyntax
 //@[018:0024) |     └─Token(Identifier) |string|
 //@[024:0026) ├─Token(NewLine) |\n\n|
@@ -646,7 +646,7 @@ param description2 string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0018) | ├─IdentifierSyntax
 //@[006:0018) | | └─Token(Identifier) |description2|
-//@[019:0025) | └─VariableAccessSyntax
+//@[019:0025) | └─TypeVariableAccessSyntax
 //@[019:0025) |   └─IdentifierSyntax
 //@[019:0025) |     └─Token(Identifier) |string|
 //@[025:0027) ├─Token(NewLine) |\n\n|
@@ -727,7 +727,7 @@ param additionalMetadata string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0024) | ├─IdentifierSyntax
 //@[006:0024) | | └─Token(Identifier) |additionalMetadata|
-//@[025:0031) | └─VariableAccessSyntax
+//@[025:0031) | └─TypeVariableAccessSyntax
 //@[025:0031) |   └─IdentifierSyntax
 //@[025:0031) |     └─Token(Identifier) |string|
 //@[031:0033) ├─Token(NewLine) |\n\n|
@@ -825,7 +825,7 @@ param someParameter string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0019) | ├─IdentifierSyntax
 //@[006:0019) | | └─Token(Identifier) |someParameter|
-//@[020:0026) | └─VariableAccessSyntax
+//@[020:0026) | └─TypeVariableAccessSyntax
 //@[020:0026) |   └─IdentifierSyntax
 //@[020:0026) |     └─Token(Identifier) |string|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -835,7 +835,7 @@ param defaultExpression bool = 18 != (true || false)
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0023) | ├─IdentifierSyntax
 //@[006:0023) | | └─Token(Identifier) |defaultExpression|
-//@[024:0028) | ├─VariableAccessSyntax
+//@[024:0028) | ├─TypeVariableAccessSyntax
 //@[024:0028) | | └─IdentifierSyntax
 //@[024:0028) | |   └─Token(Identifier) |bool|
 //@[029:0052) | └─ParameterDefaultValueSyntax
@@ -885,7 +885,7 @@ param stringLiteral string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0019) | ├─IdentifierSyntax
 //@[006:0019) | | └─Token(Identifier) |stringLiteral|
-//@[020:0026) | └─VariableAccessSyntax
+//@[020:0026) | └─TypeVariableAccessSyntax
 //@[020:0026) |   └─IdentifierSyntax
 //@[020:0026) |     └─Token(Identifier) |string|
 //@[026:0028) ├─Token(NewLine) |\n\n|
@@ -929,7 +929,7 @@ param stringLiteralWithAllowedValuesSuperset string = stringLiteral
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0044) | ├─IdentifierSyntax
 //@[006:0044) | | └─Token(Identifier) |stringLiteralWithAllowedValuesSuperset|
-//@[045:0051) | ├─VariableAccessSyntax
+//@[045:0051) | ├─TypeVariableAccessSyntax
 //@[045:0051) | | └─IdentifierSyntax
 //@[045:0051) | |   └─Token(Identifier) |string|
 //@[052:0067) | └─ParameterDefaultValueSyntax
@@ -1002,7 +1002,7 @@ param decoratedString string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0021) | ├─IdentifierSyntax
 //@[006:0021) | | └─Token(Identifier) |decoratedString|
-//@[022:0028) | └─VariableAccessSyntax
+//@[022:0028) | └─TypeVariableAccessSyntax
 //@[022:0028) |   └─IdentifierSyntax
 //@[022:0028) |     └─Token(Identifier) |string|
 //@[028:0030) ├─Token(NewLine) |\n\n|
@@ -1024,7 +1024,7 @@ param decoratedInt int = 123
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0018) | ├─IdentifierSyntax
 //@[006:0018) | | └─Token(Identifier) |decoratedInt|
-//@[019:0022) | ├─VariableAccessSyntax
+//@[019:0022) | ├─TypeVariableAccessSyntax
 //@[019:0022) | | └─IdentifierSyntax
 //@[019:0022) | |   └─Token(Identifier) |int|
 //@[023:0028) | └─ParameterDefaultValueSyntax
@@ -1068,7 +1068,7 @@ param negativeValues int
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0020) | ├─IdentifierSyntax
 //@[006:0020) | | └─Token(Identifier) |negativeValues|
-//@[021:0024) | └─VariableAccessSyntax
+//@[021:0024) | └─TypeVariableAccessSyntax
 //@[021:0024) |   └─IdentifierSyntax
 //@[021:0024) |     └─Token(Identifier) |int|
 //@[024:0026) ├─Token(NewLine) |\n\n|
@@ -1152,7 +1152,7 @@ param decoratedBool bool = /* comment1 */ /* comment2*/      /* comment3 */ /* c
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0019) | ├─IdentifierSyntax
 //@[006:0019) | | └─Token(Identifier) |decoratedBool|
-//@[020:0024) | ├─VariableAccessSyntax
+//@[020:0024) | ├─TypeVariableAccessSyntax
 //@[020:0024) | | └─IdentifierSyntax
 //@[020:0024) | |   └─Token(Identifier) |bool|
 //@[025:0114) | └─ParameterDefaultValueSyntax
@@ -1186,7 +1186,7 @@ param decoratedObject object = {
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0021) | ├─IdentifierSyntax
 //@[006:0021) | | └─Token(Identifier) |decoratedObject|
-//@[022:0028) | ├─VariableAccessSyntax
+//@[022:0028) | ├─TypeVariableAccessSyntax
 //@[022:0028) | | └─IdentifierSyntax
 //@[022:0028) | |   └─Token(Identifier) |object|
 //@[029:0244) | └─ParameterDefaultValueSyntax
@@ -1376,7 +1376,7 @@ param decoratedArray array = [
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0020) | ├─IdentifierSyntax
 //@[006:0020) | | └─Token(Identifier) |decoratedArray|
-//@[021:0026) | ├─VariableAccessSyntax
+//@[021:0026) | ├─TypeVariableAccessSyntax
 //@[021:0026) | | └─IdentifierSyntax
 //@[021:0026) | |   └─Token(Identifier) |array|
 //@[027:0059) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/Registry_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Registry_LF/main.syntax.bicep
@@ -693,7 +693,7 @@ output siteUrls array = [for (site, i) in websites: siteDeploy[i].outputs.siteUr
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0015) | ├─IdentifierSyntax
 //@[007:0015) | | └─Token(Identifier) |siteUrls|
-//@[016:0021) | ├─VariableAccessSyntax
+//@[016:0021) | ├─TypeVariableAccessSyntax
 //@[016:0021) | | └─IdentifierSyntax
 //@[016:0021) | |   └─Token(Identifier) |array|
 //@[022:0023) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/ResourceDerivedTypes_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourceDerivedTypes_LF/main.syntax.bicep
@@ -11,7 +11,7 @@ type foo = resource<'Microsoft.Storage/storageAccounts@2023-01-01'>.name
 //@[11:0019) |   | | └─Token(Identifier) |resource|
 //@[19:0020) |   | ├─Token(LeftChevron) |<|
 //@[20:0066) |   | ├─ParameterizedTypeArgumentSyntax
-//@[20:0066) |   | | └─StringSyntax
+//@[20:0066) |   | | └─StringTypeLiteralSyntax
 //@[20:0066) |   | |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2023-01-01'|
 //@[66:0067) |   | └─Token(RightChevron) |>|
 //@[67:0068) |   ├─Token(Dot) |.|
@@ -39,7 +39,7 @@ type test = {
 //@[08:0016) |   |   | | └─Token(Identifier) |resource|
 //@[16:0017) |   |   | ├─Token(LeftChevron) |<|
 //@[17:0063) |   |   | ├─ParameterizedTypeArgumentSyntax
-//@[17:0063) |   |   | | └─StringSyntax
+//@[17:0063) |   |   | | └─StringTypeLiteralSyntax
 //@[17:0063) |   |   | |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2023-01-01'|
 //@[63:0064) |   |   | └─Token(RightChevron) |>|
 //@[64:0065) |   |   ├─Token(Dot) |.|
@@ -53,7 +53,7 @@ type test = {
 //@[06:0007) |   | ├─Token(Colon) |:|
 //@[08:0073) |   | └─TypePropertyAccessSyntax
 //@[08:0068) |   |   ├─InstanceParameterizedTypeInstantiationSyntax
-//@[08:0011) |   |   | ├─VariableAccessSyntax
+//@[08:0011) |   |   | ├─TypeVariableAccessSyntax
 //@[08:0011) |   |   | | └─IdentifierSyntax
 //@[08:0011) |   |   | |   └─Token(Identifier) |sys|
 //@[11:0012) |   |   | ├─Token(Dot) |.|
@@ -61,7 +61,7 @@ type test = {
 //@[12:0020) |   |   | | └─Token(Identifier) |resource|
 //@[20:0021) |   |   | ├─Token(LeftChevron) |<|
 //@[21:0067) |   |   | ├─ParameterizedTypeArgumentSyntax
-//@[21:0067) |   |   | | └─StringSyntax
+//@[21:0067) |   |   | | └─StringTypeLiteralSyntax
 //@[21:0067) |   |   | |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2022-09-01'|
 //@[67:0068) |   |   | └─Token(RightChevron) |>|
 //@[68:0069) |   |   ├─Token(Dot) |.|
@@ -74,7 +74,7 @@ type test = {
 //@[02:0006) |   | | └─Token(Identifier) |resC|
 //@[06:0007) |   | ├─Token(Colon) |:|
 //@[08:0017) |   | └─TypePropertyAccessSyntax
-//@[08:0011) |   |   ├─VariableAccessSyntax
+//@[08:0011) |   |   ├─TypeVariableAccessSyntax
 //@[08:0011) |   |   | └─IdentifierSyntax
 //@[08:0011) |   |   |   └─Token(Identifier) |sys|
 //@[11:0012) |   |   ├─Token(Dot) |.|
@@ -88,7 +88,7 @@ type test = {
 //@[06:0007) |   | ├─Token(Colon) |:|
 //@[08:0076) |   | └─TypePropertyAccessSyntax
 //@[08:0071) |   |   ├─InstanceParameterizedTypeInstantiationSyntax
-//@[08:0011) |   |   | ├─VariableAccessSyntax
+//@[08:0011) |   |   | ├─TypeVariableAccessSyntax
 //@[08:0011) |   |   | | └─IdentifierSyntax
 //@[08:0011) |   |   | |   └─Token(Identifier) |sys|
 //@[11:0012) |   |   | ├─Token(Dot) |.|
@@ -96,7 +96,7 @@ type test = {
 //@[12:0020) |   |   | | └─Token(Identifier) |resource|
 //@[20:0021) |   |   | ├─Token(LeftChevron) |<|
 //@[21:0070) |   |   | ├─ParameterizedTypeArgumentSyntax
-//@[21:0070) |   |   | | └─StringSyntax
+//@[21:0070) |   |   | | └─StringTypeLiteralSyntax
 //@[21:0070) |   |   | |   └─Token(StringComplete) |'az:Microsoft.Storage/storageAccounts@2022-09-01'|
 //@[70:0071) |   |   | └─Token(RightChevron) |>|
 //@[71:0072) |   |   ├─Token(Dot) |.|
@@ -130,7 +130,7 @@ type strangeFormattings = {
 
   'Astronomer.Astro/organizations@2023-08-01-preview'
 //@[02:0053) |   |   | ├─ParameterizedTypeArgumentSyntax
-//@[02:0053) |   |   | | └─StringSyntax
+//@[02:0053) |   |   | | └─StringTypeLiteralSyntax
 //@[02:0053) |   |   | |   └─Token(StringComplete) |'Astronomer.Astro/organizations@2023-08-01-preview'|
 //@[53:0055) |   |   | ├─Token(NewLine) |\n\n|
 
@@ -151,7 +151,7 @@ type strangeFormattings = {
 //@[09:0017) |   |   | | └─Token(Identifier) |resource|
 //@[21:0022) |   |   | ├─Token(LeftChevron) |<|
 //@[22:0068) |   |   | ├─ParameterizedTypeArgumentSyntax
-//@[22:0068) |   |   | | └─StringSyntax
+//@[22:0068) |   |   | | └─StringTypeLiteralSyntax
 //@[22:0068) |   |   | |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2023-01-01'|
 //@[68:0069) |   |   | └─Token(RightChevron) |>|
 //@[69:0070) |   |   ├─Token(Dot) |.|
@@ -169,7 +169,7 @@ type strangeFormattings = {
 //@[09:0017) |   |   | | └─Token(Identifier) |resource|
 //@[17:0018) |   |   | ├─Token(LeftChevron) |<|
 //@[26:0072) |   |   | ├─ParameterizedTypeArgumentSyntax
-//@[26:0072) |   |   | | └─StringSyntax
+//@[26:0072) |   |   | | └─StringTypeLiteralSyntax
 //@[26:0072) |   |   | |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2023-01-01'|
 //@[81:0082) |   |   | └─Token(RightChevron) |>|
 //@[82:0083) |   |   ├─Token(Dot) |.|
@@ -207,7 +207,7 @@ type test2 = resource<
 
      'Astronomer.Astro/organizations@2023-08-01-preview'
 //@[05:0056) |   | ├─ParameterizedTypeArgumentSyntax
-//@[05:0056) |   | | └─StringSyntax
+//@[05:0056) |   | | └─StringTypeLiteralSyntax
 //@[05:0056) |   | |   └─Token(StringComplete) |'Astronomer.Astro/organizations@2023-08-01-preview'|
 //@[56:0058) |   | ├─Token(NewLine) |\n\n|
 
@@ -229,7 +229,7 @@ param bar resource<'Microsoft.Resources/tags@2022-09-01'>.properties = {
 //@[10:0018) | | | | └─Token(Identifier) |resource|
 //@[18:0019) | | | ├─Token(LeftChevron) |<|
 //@[19:0056) | | | ├─ParameterizedTypeArgumentSyntax
-//@[19:0056) | | | | └─StringSyntax
+//@[19:0056) | | | | └─StringTypeLiteralSyntax
 //@[19:0056) | | | |   └─Token(StringComplete) |'Microsoft.Resources/tags@2022-09-01'|
 //@[56:0057) | | | └─Token(RightChevron) |>|
 //@[57:0058) | | ├─Token(Dot) |.|
@@ -282,7 +282,7 @@ output baz resource<'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31
 //@[11:0019) | | | | └─Token(Identifier) |resource|
 //@[19:0020) | | | ├─Token(LeftChevron) |<|
 //@[20:0081) | | | ├─ParameterizedTypeArgumentSyntax
-//@[20:0081) | | | | └─StringSyntax
+//@[20:0081) | | | | └─StringTypeLiteralSyntax
 //@[20:0081) | | | |   └─Token(StringComplete) |'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31'|
 //@[81:0082) | | | └─Token(RightChevron) |>|
 //@[82:0083) | | ├─Token(Dot) |.|
@@ -305,7 +305,7 @@ type storageAccountName = resource<'Microsoft.Storage/storageAccounts@2023-01-01
 //@[26:0034) |   | | └─Token(Identifier) |resource|
 //@[34:0035) |   | ├─Token(LeftChevron) |<|
 //@[35:0081) |   | ├─ParameterizedTypeArgumentSyntax
-//@[35:0081) |   | | └─StringSyntax
+//@[35:0081) |   | | └─StringTypeLiteralSyntax
 //@[35:0081) |   | |   └─Token(StringComplete) |'Microsoft.Storage/storageAccounts@2023-01-01'|
 //@[81:0082) |   | └─Token(RightChevron) |>|
 //@[82:0083) |   ├─Token(Dot) |.|
@@ -326,7 +326,7 @@ type accessPolicy = resource<'Microsoft.KeyVault/vaults@2022-07-01'>.properties.
 //@[20:0028) |   | | | | └─Token(Identifier) |resource|
 //@[28:0029) |   | | | ├─Token(LeftChevron) |<|
 //@[29:0067) |   | | | ├─ParameterizedTypeArgumentSyntax
-//@[29:0067) |   | | | | └─StringSyntax
+//@[29:0067) |   | | | | └─StringTypeLiteralSyntax
 //@[29:0067) |   | | | |   └─Token(StringComplete) |'Microsoft.KeyVault/vaults@2022-07-01'|
 //@[67:0068) |   | | | └─Token(RightChevron) |>|
 //@[68:0069) |   | | ├─Token(Dot) |.|
@@ -353,7 +353,7 @@ type tag = resource<'Microsoft.Resources/tags@2022-09-01'>.properties.tags.*
 //@[11:0019) |   | | | | └─Token(Identifier) |resource|
 //@[19:0020) |   | | | ├─Token(LeftChevron) |<|
 //@[20:0057) |   | | | ├─ParameterizedTypeArgumentSyntax
-//@[20:0057) |   | | | | └─StringSyntax
+//@[20:0057) |   | | | | └─StringTypeLiteralSyntax
 //@[20:0057) |   | | | |   └─Token(StringComplete) |'Microsoft.Resources/tags@2022-09-01'|
 //@[57:0058) |   | | | └─Token(RightChevron) |>|
 //@[58:0059) |   | | ├─Token(Dot) |.|

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesManagementGroup_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesManagementGroup_CRLF/main.syntax.bicep
@@ -12,7 +12,7 @@ param ownerPrincipalId string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0022) | ├─IdentifierSyntax
 //@[006:0022) | | └─Token(Identifier) |ownerPrincipalId|
-//@[023:0029) | └─VariableAccessSyntax
+//@[023:0029) | └─TypeVariableAccessSyntax
 //@[023:0029) |   └─IdentifierSyntax
 //@[023:0029) |     └─Token(Identifier) |string|
 //@[029:0033) ├─Token(NewLine) |\r\n\r\n|
@@ -22,7 +22,7 @@ param contributorPrincipals array
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0027) | ├─IdentifierSyntax
 //@[006:0027) | | └─Token(Identifier) |contributorPrincipals|
-//@[028:0033) | └─VariableAccessSyntax
+//@[028:0033) | └─TypeVariableAccessSyntax
 //@[028:0033) |   └─IdentifierSyntax
 //@[028:0033) |     └─Token(Identifier) |array|
 //@[033:0035) ├─Token(NewLine) |\r\n|
@@ -31,7 +31,7 @@ param readerPrincipals array
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0022) | ├─IdentifierSyntax
 //@[006:0022) | | └─Token(Identifier) |readerPrincipals|
-//@[023:0028) | └─VariableAccessSyntax
+//@[023:0028) | └─TypeVariableAccessSyntax
 //@[023:0028) |   └─IdentifierSyntax
 //@[023:0028) |     └─Token(Identifier) |array|
 //@[028:0032) ├─Token(NewLine) |\r\n\r\n|

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesSubscription_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesSubscription_CRLF/main.syntax.bicep
@@ -12,7 +12,7 @@ param ownerPrincipalId string
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0022) | ├─IdentifierSyntax
 //@[006:0022) | | └─Token(Identifier) |ownerPrincipalId|
-//@[023:0029) | └─VariableAccessSyntax
+//@[023:0029) | └─TypeVariableAccessSyntax
 //@[023:0029) |   └─IdentifierSyntax
 //@[023:0029) |     └─Token(Identifier) |string|
 //@[029:0033) ├─Token(NewLine) |\r\n\r\n|
@@ -22,7 +22,7 @@ param contributorPrincipals array
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0027) | ├─IdentifierSyntax
 //@[006:0027) | | └─Token(Identifier) |contributorPrincipals|
-//@[028:0033) | └─VariableAccessSyntax
+//@[028:0033) | └─TypeVariableAccessSyntax
 //@[028:0033) |   └─IdentifierSyntax
 //@[028:0033) |     └─Token(Identifier) |array|
 //@[033:0035) ├─Token(NewLine) |\r\n|
@@ -31,7 +31,7 @@ param readerPrincipals array
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0022) | ├─IdentifierSyntax
 //@[006:0022) | | └─Token(Identifier) |readerPrincipals|
-//@[023:0028) | └─VariableAccessSyntax
+//@[023:0028) | └─TypeVariableAccessSyntax
 //@[023:0028) |   └─IdentifierSyntax
 //@[023:0028) |     └─Token(Identifier) |array|
 //@[028:0032) ├─Token(NewLine) |\r\n\r\n|

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesTenant_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesTenant_CRLF/main.syntax.bicep
@@ -427,7 +427,7 @@ output managementGroupIds array = [for i in range(0, length(managementGroups)): 
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0025) | ├─IdentifierSyntax
 //@[007:0025) | | └─Token(Identifier) |managementGroupIds|
-//@[026:0031) | ├─VariableAccessSyntax
+//@[026:0031) | ├─TypeVariableAccessSyntax
 //@[026:0031) | | └─IdentifierSyntax
 //@[026:0031) | |   └─Token(Identifier) |array|
 //@[032:0033) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.syntax.bicep
@@ -463,7 +463,7 @@ param applicationName string = 'to-do-app${uniqueString(resourceGroup().id)}'
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00021) | ├─IdentifierSyntax
 //@[006:00021) | | └─Token(Identifier) |applicationName|
-//@[022:00028) | ├─VariableAccessSyntax
+//@[022:00028) | ├─TypeVariableAccessSyntax
 //@[022:00028) | | └─IdentifierSyntax
 //@[022:00028) | |   └─Token(Identifier) |string|
 //@[029:00077) | └─ParameterDefaultValueSyntax
@@ -503,7 +503,7 @@ param appServicePlanTier string
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00024) | ├─IdentifierSyntax
 //@[006:00024) | | └─Token(Identifier) |appServicePlanTier|
-//@[025:00031) | └─VariableAccessSyntax
+//@[025:00031) | └─TypeVariableAccessSyntax
 //@[025:00031) |   └─IdentifierSyntax
 //@[025:00031) |     └─Token(Identifier) |string|
 //@[031:00033) ├─Token(NewLine) |\r\n|
@@ -512,7 +512,7 @@ param appServicePlanInstances int
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00029) | ├─IdentifierSyntax
 //@[006:00029) | | └─Token(Identifier) |appServicePlanInstances|
-//@[030:00033) | └─VariableAccessSyntax
+//@[030:00033) | └─TypeVariableAccessSyntax
 //@[030:00033) |   └─IdentifierSyntax
 //@[030:00033) |     └─Token(Identifier) |int|
 //@[033:00037) ├─Token(NewLine) |\r\n\r\n|
@@ -691,7 +691,7 @@ param webSiteName string
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00017) | ├─IdentifierSyntax
 //@[006:00017) | | └─Token(Identifier) |webSiteName|
-//@[018:00024) | └─VariableAccessSyntax
+//@[018:00024) | └─TypeVariableAccessSyntax
 //@[018:00024) |   └─IdentifierSyntax
 //@[018:00024) |     └─Token(Identifier) |string|
 //@[024:00026) ├─Token(NewLine) |\r\n|
@@ -700,7 +700,7 @@ param cosmosDb object
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00014) | ├─IdentifierSyntax
 //@[006:00014) | | └─Token(Identifier) |cosmosDb|
-//@[015:00021) | └─VariableAccessSyntax
+//@[015:00021) | └─TypeVariableAccessSyntax
 //@[015:00021) |   └─IdentifierSyntax
 //@[015:00021) |     └─Token(Identifier) |object|
 //@[021:00023) ├─Token(NewLine) |\r\n|
@@ -938,7 +938,7 @@ output siteApiVersion string = site.apiVersion
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00021) | ├─IdentifierSyntax
 //@[007:00021) | | └─Token(Identifier) |siteApiVersion|
-//@[022:00028) | ├─VariableAccessSyntax
+//@[022:00028) | ├─TypeVariableAccessSyntax
 //@[022:00028) | | └─IdentifierSyntax
 //@[022:00028) | |   └─Token(Identifier) |string|
 //@[029:00030) | ├─Token(Assignment) |=|
@@ -955,7 +955,7 @@ output siteType string = site.type
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00015) | ├─IdentifierSyntax
 //@[007:00015) | | └─Token(Identifier) |siteType|
-//@[016:00022) | ├─VariableAccessSyntax
+//@[016:00022) | ├─TypeVariableAccessSyntax
 //@[016:00022) | | └─IdentifierSyntax
 //@[016:00022) | |   └─Token(Identifier) |string|
 //@[023:00024) | ├─Token(Assignment) |=|
@@ -1643,7 +1643,7 @@ param shouldDeployVm bool = true
 //@[000:00005) | ├─Token(Identifier) |param|
 //@[006:00020) | ├─IdentifierSyntax
 //@[006:00020) | | └─Token(Identifier) |shouldDeployVm|
-//@[021:00025) | ├─VariableAccessSyntax
+//@[021:00025) | ├─TypeVariableAccessSyntax
 //@[021:00025) | | └─IdentifierSyntax
 //@[021:00025) | |   └─Token(Identifier) |bool|
 //@[026:00032) | └─ParameterDefaultValueSyntax
@@ -3366,7 +3366,7 @@ output p1_subnet1prefix string = p1_subnet1.properties.addressPrefix
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p1_subnet1prefix|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3387,7 +3387,7 @@ output p1_subnet1name string = p1_subnet1.name
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00021) | ├─IdentifierSyntax
 //@[007:00021) | | └─Token(Identifier) |p1_subnet1name|
-//@[022:00028) | ├─VariableAccessSyntax
+//@[022:00028) | ├─TypeVariableAccessSyntax
 //@[022:00028) | | └─IdentifierSyntax
 //@[022:00028) | |   └─Token(Identifier) |string|
 //@[029:00030) | ├─Token(Assignment) |=|
@@ -3404,7 +3404,7 @@ output p1_subnet1type string = p1_subnet1.type
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00021) | ├─IdentifierSyntax
 //@[007:00021) | | └─Token(Identifier) |p1_subnet1type|
-//@[022:00028) | ├─VariableAccessSyntax
+//@[022:00028) | ├─TypeVariableAccessSyntax
 //@[022:00028) | | └─IdentifierSyntax
 //@[022:00028) | |   └─Token(Identifier) |string|
 //@[029:00030) | ├─Token(Assignment) |=|
@@ -3421,7 +3421,7 @@ output p1_subnet1id string = p1_subnet1.id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00019) | ├─IdentifierSyntax
 //@[007:00019) | | └─Token(Identifier) |p1_subnet1id|
-//@[020:00026) | ├─VariableAccessSyntax
+//@[020:00026) | ├─TypeVariableAccessSyntax
 //@[020:00026) | | └─IdentifierSyntax
 //@[020:00026) | |   └─Token(Identifier) |string|
 //@[027:00028) | ├─Token(Assignment) |=|
@@ -3560,7 +3560,7 @@ output p2_res2childprop string = p2_res2child.properties.someProp
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p2_res2childprop|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3581,7 +3581,7 @@ output p2_res2childname string = p2_res2child.name
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p2_res2childname|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3598,7 +3598,7 @@ output p2_res2childtype string = p2_res2child.type
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p2_res2childtype|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3615,7 +3615,7 @@ output p2_res2childid string = p2_res2child.id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00021) | ├─IdentifierSyntax
 //@[007:00021) | | └─Token(Identifier) |p2_res2childid|
-//@[022:00028) | ├─VariableAccessSyntax
+//@[022:00028) | ├─TypeVariableAccessSyntax
 //@[022:00028) | | └─IdentifierSyntax
 //@[022:00028) | |   └─Token(Identifier) |string|
 //@[029:00030) | ├─Token(Assignment) |=|
@@ -3691,7 +3691,7 @@ output p3_res1childprop string = p3_child1.properties.someProp
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p3_res1childprop|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3712,7 +3712,7 @@ output p3_res1childname string = p3_child1.name
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p3_res1childname|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3729,7 +3729,7 @@ output p3_res1childtype string = p3_child1.type
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p3_res1childtype|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3746,7 +3746,7 @@ output p3_res1childid string = p3_child1.id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00021) | ├─IdentifierSyntax
 //@[007:00021) | | └─Token(Identifier) |p3_res1childid|
-//@[022:00028) | ├─VariableAccessSyntax
+//@[022:00028) | ├─TypeVariableAccessSyntax
 //@[022:00028) | | └─IdentifierSyntax
 //@[022:00028) | |   └─Token(Identifier) |string|
 //@[029:00030) | ├─Token(Assignment) |=|
@@ -3834,7 +3834,7 @@ output p4_res1childprop string = p4_child1.properties.someProp
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p4_res1childprop|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3855,7 +3855,7 @@ output p4_res1childname string = p4_child1.name
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p4_res1childname|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3872,7 +3872,7 @@ output p4_res1childtype string = p4_child1.type
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00023) | ├─IdentifierSyntax
 //@[007:00023) | | └─Token(Identifier) |p4_res1childtype|
-//@[024:00030) | ├─VariableAccessSyntax
+//@[024:00030) | ├─TypeVariableAccessSyntax
 //@[024:00030) | | └─IdentifierSyntax
 //@[024:00030) | |   └─Token(Identifier) |string|
 //@[031:00032) | ├─Token(Assignment) |=|
@@ -3889,7 +3889,7 @@ output p4_res1childid string = p4_child1.id
 //@[000:00006) | ├─Token(Identifier) |output|
 //@[007:00021) | ├─IdentifierSyntax
 //@[007:00021) | | └─Token(Identifier) |p4_res1childid|
-//@[022:00028) | ├─VariableAccessSyntax
+//@[022:00028) | ├─TypeVariableAccessSyntax
 //@[022:00028) | | └─IdentifierSyntax
 //@[022:00028) | |   └─Token(Identifier) |string|
 //@[029:00030) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.syntax.bicep
@@ -70,7 +70,7 @@ type foo = {
 //@[002:0012) |   | ├─IdentifierSyntax
 //@[002:0012) |   | | └─Token(Identifier) |stringProp|
 //@[012:0013) |   | ├─Token(Colon) |:|
-//@[014:0020) |   | └─VariableAccessSyntax
+//@[014:0020) |   | └─TypeVariableAccessSyntax
 //@[014:0020) |   |   └─IdentifierSyntax
 //@[014:0020) |   |     └─Token(Identifier) |string|
 //@[020:0022) |   ├─Token(NewLine) |\n\n|
@@ -100,7 +100,7 @@ type foo = {
 //@[004:0011) |   |   | ├─IdentifierSyntax
 //@[004:0011) |   |   | | └─Token(Identifier) |intProp|
 //@[011:0012) |   |   | ├─Token(Colon) |:|
-//@[013:0016) |   |   | └─VariableAccessSyntax
+//@[013:0016) |   |   | └─TypeVariableAccessSyntax
 //@[013:0016) |   |   |   └─IdentifierSyntax
 //@[013:0016) |   |   |     └─Token(Identifier) |int|
 //@[016:0018) |   |   ├─Token(NewLine) |\n\n|
@@ -115,7 +115,7 @@ type foo = {
 //@[023:0029) |   |   |   | ├─ArrayTypeMemberSyntax
 //@[023:0029) |   |   |   | | └─ArrayTypeSyntax
 //@[023:0026) |   |   |   | |   ├─ArrayTypeMemberSyntax
-//@[023:0026) |   |   |   | |   | └─VariableAccessSyntax
+//@[023:0026) |   |   |   | |   | └─TypeVariableAccessSyntax
 //@[023:0026) |   |   |   | |   |   └─IdentifierSyntax
 //@[023:0026) |   |   |   | |   |     └─Token(Identifier) |int|
 //@[027:0028) |   |   |   | |   ├─Token(LeftSquare) |[|
@@ -133,7 +133,7 @@ type foo = {
 //@[002:0013) |   | ├─IdentifierSyntax
 //@[002:0013) |   | | └─Token(Identifier) |typeRefProp|
 //@[013:0014) |   | ├─Token(Colon) |:|
-//@[015:0018) |   | └─VariableAccessSyntax
+//@[015:0018) |   | └─TypeVariableAccessSyntax
 //@[015:0018) |   |   └─IdentifierSyntax
 //@[015:0018) |   |     └─Token(Identifier) |bar|
 //@[018:0020) |   ├─Token(NewLine) |\n\n|
@@ -143,7 +143,7 @@ type foo = {
 //@[002:0013) |   | ├─IdentifierSyntax
 //@[002:0013) |   | | └─Token(Identifier) |literalProp|
 //@[013:0014) |   | ├─Token(Colon) |:|
-//@[015:0024) |   | └─StringSyntax
+//@[015:0024) |   | └─StringTypeLiteralSyntax
 //@[015:0024) |   |   └─Token(StringComplete) |'literal'|
 //@[024:0026) |   ├─Token(NewLine) |\n\n|
 
@@ -153,7 +153,7 @@ type foo = {
 //@[002:0011) |   | | └─Token(Identifier) |recursion|
 //@[011:0012) |   | ├─Token(Colon) |:|
 //@[013:0017) |   | └─NullableTypeSyntax
-//@[013:0016) |   |   ├─VariableAccessSyntax
+//@[013:0016) |   |   ├─TypeVariableAccessSyntax
 //@[013:0016) |   |   | └─IdentifierSyntax
 //@[013:0016) |   |   |   └─Token(Identifier) |foo|
 //@[016:0017) |   |   └─Token(Question) |?|
@@ -170,7 +170,7 @@ type fooProperty = foo.objectProp.intProp
 //@[017:0018) | ├─Token(Assignment) |=|
 //@[019:0041) | └─TypePropertyAccessSyntax
 //@[019:0033) |   ├─TypePropertyAccessSyntax
-//@[019:0022) |   | ├─VariableAccessSyntax
+//@[019:0022) |   | ├─TypeVariableAccessSyntax
 //@[019:0022) |   | | └─IdentifierSyntax
 //@[019:0022) |   | |   └─Token(Identifier) |foo|
 //@[022:0023) |   | ├─Token(Dot) |.|
@@ -298,7 +298,7 @@ type bar = int[][][][]
 //@[011:0016) |   |   |   ├─ArrayTypeMemberSyntax
 //@[011:0016) |   |   |   | └─ArrayTypeSyntax
 //@[011:0014) |   |   |   |   ├─ArrayTypeMemberSyntax
-//@[011:0014) |   |   |   |   | └─VariableAccessSyntax
+//@[011:0014) |   |   |   |   | └─TypeVariableAccessSyntax
 //@[011:0014) |   |   |   |   |   └─IdentifierSyntax
 //@[011:0014) |   |   |   |   |     └─Token(Identifier) |int|
 //@[014:0015) |   |   |   |   ├─Token(LeftSquare) |[|
@@ -318,7 +318,7 @@ type barElement = bar[*]
 //@[005:0015) | | └─Token(Identifier) |barElement|
 //@[016:0017) | ├─Token(Assignment) |=|
 //@[018:0024) | └─TypeItemsAccessSyntax
-//@[018:0021) |   ├─VariableAccessSyntax
+//@[018:0021) |   ├─TypeVariableAccessSyntax
 //@[018:0021) |   | └─IdentifierSyntax
 //@[018:0021) |   |   └─Token(Identifier) |bar|
 //@[021:0022) |   ├─Token(LeftSquare) |[|
@@ -334,15 +334,15 @@ type aUnion = 'snap'|'crackle'|'pop'
 //@[012:0013) | ├─Token(Assignment) |=|
 //@[014:0036) | └─UnionTypeSyntax
 //@[014:0020) |   ├─UnionTypeMemberSyntax
-//@[014:0020) |   | └─StringSyntax
+//@[014:0020) |   | └─StringTypeLiteralSyntax
 //@[014:0020) |   |   └─Token(StringComplete) |'snap'|
 //@[020:0021) |   ├─Token(Pipe) |||
 //@[021:0030) |   ├─UnionTypeMemberSyntax
-//@[021:0030) |   | └─StringSyntax
+//@[021:0030) |   | └─StringTypeLiteralSyntax
 //@[021:0030) |   |   └─Token(StringComplete) |'crackle'|
 //@[030:0031) |   ├─Token(Pipe) |||
 //@[031:0036) |   └─UnionTypeMemberSyntax
-//@[031:0036) |     └─StringSyntax
+//@[031:0036) |     └─StringTypeLiteralSyntax
 //@[031:0036) |       └─Token(StringComplete) |'pop'|
 //@[036:0038) ├─Token(NewLine) |\n\n|
 
@@ -355,7 +355,7 @@ type singleMemberUnion = | 'alone'
 //@[025:0034) | └─UnionTypeSyntax
 //@[025:0026) |   ├─Token(Pipe) |||
 //@[027:0034) |   └─UnionTypeMemberSyntax
-//@[027:0034) |     └─StringSyntax
+//@[027:0034) |     └─StringTypeLiteralSyntax
 //@[027:0034) |       └─Token(StringComplete) |'alone'|
 //@[034:0036) ├─Token(NewLine) |\n\n|
 
@@ -367,20 +367,20 @@ type expandedUnion = aUnion|'fizz'|'buzz'|'pop'
 //@[019:0020) | ├─Token(Assignment) |=|
 //@[021:0047) | └─UnionTypeSyntax
 //@[021:0027) |   ├─UnionTypeMemberSyntax
-//@[021:0027) |   | └─VariableAccessSyntax
+//@[021:0027) |   | └─TypeVariableAccessSyntax
 //@[021:0027) |   |   └─IdentifierSyntax
 //@[021:0027) |   |     └─Token(Identifier) |aUnion|
 //@[027:0028) |   ├─Token(Pipe) |||
 //@[028:0034) |   ├─UnionTypeMemberSyntax
-//@[028:0034) |   | └─StringSyntax
+//@[028:0034) |   | └─StringTypeLiteralSyntax
 //@[028:0034) |   |   └─Token(StringComplete) |'fizz'|
 //@[034:0035) |   ├─Token(Pipe) |||
 //@[035:0041) |   ├─UnionTypeMemberSyntax
-//@[035:0041) |   | └─StringSyntax
+//@[035:0041) |   | └─StringTypeLiteralSyntax
 //@[035:0041) |   |   └─Token(StringComplete) |'buzz'|
 //@[041:0042) |   ├─Token(Pipe) |||
 //@[042:0047) |   └─UnionTypeMemberSyntax
-//@[042:0047) |     └─StringSyntax
+//@[042:0047) |     └─StringTypeLiteralSyntax
 //@[042:0047) |       └─Token(StringComplete) |'pop'|
 //@[047:0049) ├─Token(NewLine) |\n\n|
 
@@ -395,15 +395,15 @@ type tupleUnion = ['foo', 'bar', 'baz']
 //@[018:0039) |   | └─TupleTypeSyntax
 //@[018:0019) |   |   ├─Token(LeftSquare) |[|
 //@[019:0024) |   |   ├─TupleTypeItemSyntax
-//@[019:0024) |   |   | └─StringSyntax
+//@[019:0024) |   |   | └─StringTypeLiteralSyntax
 //@[019:0024) |   |   |   └─Token(StringComplete) |'foo'|
 //@[024:0025) |   |   ├─Token(Comma) |,|
 //@[026:0031) |   |   ├─TupleTypeItemSyntax
-//@[026:0031) |   |   | └─StringSyntax
+//@[026:0031) |   |   | └─StringTypeLiteralSyntax
 //@[026:0031) |   |   |   └─Token(StringComplete) |'bar'|
 //@[031:0032) |   |   ├─Token(Comma) |,|
 //@[033:0038) |   |   ├─TupleTypeItemSyntax
-//@[033:0038) |   |   | └─StringSyntax
+//@[033:0038) |   |   | └─StringTypeLiteralSyntax
 //@[033:0038) |   |   |   └─Token(StringComplete) |'baz'|
 //@[038:0039) |   |   └─Token(RightSquare) |]|
 //@[039:0040) |   ├─Token(NewLine) |\n|
@@ -413,11 +413,11 @@ type tupleUnion = ['foo', 'bar', 'baz']
 //@[001:0017) |   | └─TupleTypeSyntax
 //@[001:0002) |   |   ├─Token(LeftSquare) |[|
 //@[002:0008) |   |   ├─TupleTypeItemSyntax
-//@[002:0008) |   |   | └─StringSyntax
+//@[002:0008) |   |   | └─StringTypeLiteralSyntax
 //@[002:0008) |   |   |   └─Token(StringComplete) |'fizz'|
 //@[008:0009) |   |   ├─Token(Comma) |,|
 //@[010:0016) |   |   ├─TupleTypeItemSyntax
-//@[010:0016) |   |   | └─StringSyntax
+//@[010:0016) |   |   | └─StringTypeLiteralSyntax
 //@[010:0016) |   |   |   └─Token(StringComplete) |'buzz'|
 //@[016:0017) |   |   └─Token(RightSquare) |]|
 //@[017:0018) |   ├─Token(NewLine) |\n|
@@ -427,15 +427,15 @@ type tupleUnion = ['foo', 'bar', 'baz']
 //@[001:0027) |     └─TupleTypeSyntax
 //@[001:0002) |       ├─Token(LeftSquare) |[|
 //@[002:0008) |       ├─TupleTypeItemSyntax
-//@[002:0008) |       | └─StringSyntax
+//@[002:0008) |       | └─StringTypeLiteralSyntax
 //@[002:0008) |       |   └─Token(StringComplete) |'snap'|
 //@[008:0009) |       ├─Token(Comma) |,|
 //@[010:0019) |       ├─TupleTypeItemSyntax
-//@[010:0019) |       | └─StringSyntax
+//@[010:0019) |       | └─StringTypeLiteralSyntax
 //@[010:0019) |       |   └─Token(StringComplete) |'crackle'|
 //@[019:0020) |       ├─Token(Comma) |,|
 //@[021:0026) |       ├─TupleTypeItemSyntax
-//@[021:0026) |       | └─StringSyntax
+//@[021:0026) |       | └─StringTypeLiteralSyntax
 //@[021:0026) |       |   └─Token(StringComplete) |'pop'|
 //@[026:0027) |       └─Token(RightSquare) |]|
 //@[027:0029) ├─Token(NewLine) |\n\n|
@@ -448,15 +448,15 @@ type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!tr
 //@[016:0017) | ├─Token(Assignment) |=|
 //@[018:0090) | └─ArrayTypeSyntax
 //@[018:0088) |   ├─ArrayTypeMemberSyntax
-//@[018:0088) |   | └─ParenthesizedExpressionSyntax
+//@[018:0088) |   | └─ParenthesizedTypeSyntax
 //@[018:0019) |   |   ├─Token(LeftParen) |(|
 //@[019:0087) |   |   ├─UnionTypeSyntax
 //@[019:0030) |   |   | ├─UnionTypeMemberSyntax
-//@[019:0030) |   |   | | └─StringSyntax
+//@[019:0030) |   |   | | └─StringTypeLiteralSyntax
 //@[019:0030) |   |   | |   └─Token(StringComplete) |'heffalump'|
 //@[030:0031) |   |   | ├─Token(Pipe) |||
 //@[031:0039) |   |   | ├─UnionTypeMemberSyntax
-//@[031:0039) |   |   | | └─StringSyntax
+//@[031:0039) |   |   | | └─StringTypeLiteralSyntax
 //@[031:0039) |   |   | |   └─Token(StringComplete) |'woozle'|
 //@[039:0040) |   |   | ├─Token(Pipe) |||
 //@[040:0064) |   |   | ├─UnionTypeMemberSyntax
@@ -466,39 +466,39 @@ type mixedArray = ('heffalump'|'woozle'|{ shape: '*', size: '*'}|10|-10|true|!tr
 //@[042:0047) |   |   | |   | ├─IdentifierSyntax
 //@[042:0047) |   |   | |   | | └─Token(Identifier) |shape|
 //@[047:0048) |   |   | |   | ├─Token(Colon) |:|
-//@[049:0052) |   |   | |   | └─StringSyntax
+//@[049:0052) |   |   | |   | └─StringTypeLiteralSyntax
 //@[049:0052) |   |   | |   |   └─Token(StringComplete) |'*'|
 //@[052:0053) |   |   | |   ├─Token(Comma) |,|
 //@[054:0063) |   |   | |   ├─ObjectTypePropertySyntax
 //@[054:0058) |   |   | |   | ├─IdentifierSyntax
 //@[054:0058) |   |   | |   | | └─Token(Identifier) |size|
 //@[058:0059) |   |   | |   | ├─Token(Colon) |:|
-//@[060:0063) |   |   | |   | └─StringSyntax
+//@[060:0063) |   |   | |   | └─StringTypeLiteralSyntax
 //@[060:0063) |   |   | |   |   └─Token(StringComplete) |'*'|
 //@[063:0064) |   |   | |   └─Token(RightBrace) |}|
 //@[064:0065) |   |   | ├─Token(Pipe) |||
 //@[065:0067) |   |   | ├─UnionTypeMemberSyntax
-//@[065:0067) |   |   | | └─IntegerLiteralSyntax
+//@[065:0067) |   |   | | └─IntegerTypeLiteralSyntax
 //@[065:0067) |   |   | |   └─Token(Integer) |10|
 //@[067:0068) |   |   | ├─Token(Pipe) |||
 //@[068:0071) |   |   | ├─UnionTypeMemberSyntax
-//@[068:0071) |   |   | | └─UnaryOperationSyntax
+//@[068:0071) |   |   | | └─UnaryTypeOperationSyntax
 //@[068:0069) |   |   | |   ├─Token(Minus) |-|
-//@[069:0071) |   |   | |   └─IntegerLiteralSyntax
+//@[069:0071) |   |   | |   └─IntegerTypeLiteralSyntax
 //@[069:0071) |   |   | |     └─Token(Integer) |10|
 //@[071:0072) |   |   | ├─Token(Pipe) |||
 //@[072:0076) |   |   | ├─UnionTypeMemberSyntax
-//@[072:0076) |   |   | | └─BooleanLiteralSyntax
+//@[072:0076) |   |   | | └─BooleanTypeLiteralSyntax
 //@[072:0076) |   |   | |   └─Token(TrueKeyword) |true|
 //@[076:0077) |   |   | ├─Token(Pipe) |||
 //@[077:0082) |   |   | ├─UnionTypeMemberSyntax
-//@[077:0082) |   |   | | └─UnaryOperationSyntax
+//@[077:0082) |   |   | | └─UnaryTypeOperationSyntax
 //@[077:0078) |   |   | |   ├─Token(Exclamation) |!|
-//@[078:0082) |   |   | |   └─BooleanLiteralSyntax
+//@[078:0082) |   |   | |   └─BooleanTypeLiteralSyntax
 //@[078:0082) |   |   | |     └─Token(TrueKeyword) |true|
 //@[082:0083) |   |   | ├─Token(Pipe) |||
 //@[083:0087) |   |   | └─UnionTypeMemberSyntax
-//@[083:0087) |   |   |   └─NullLiteralSyntax
+//@[083:0087) |   |   |   └─NullTypeLiteralSyntax
 //@[083:0087) |   |   |     └─Token(NullKeyword) |null|
 //@[087:0088) |   |   └─Token(RightParen) |)|
 //@[088:0089) |   ├─Token(LeftSquare) |[|
@@ -511,7 +511,7 @@ type bool = string
 //@[005:0009) | ├─IdentifierSyntax
 //@[005:0009) | | └─Token(Identifier) |bool|
 //@[010:0011) | ├─Token(Assignment) |=|
-//@[012:0018) | └─VariableAccessSyntax
+//@[012:0018) | └─TypeVariableAccessSyntax
 //@[012:0018) |   └─IdentifierSyntax
 //@[012:0018) |     └─Token(Identifier) |string|
 //@[018:0020) ├─Token(NewLine) |\n\n|
@@ -529,7 +529,7 @@ param inlineObjectParam {
 //@[002:0005) | | | ├─IdentifierSyntax
 //@[002:0005) | | | | └─Token(Identifier) |foo|
 //@[005:0006) | | | ├─Token(Colon) |:|
-//@[007:0013) | | | └─VariableAccessSyntax
+//@[007:0013) | | | └─TypeVariableAccessSyntax
 //@[007:0013) | | |   └─IdentifierSyntax
 //@[007:0013) | | |     └─Token(Identifier) |string|
 //@[013:0014) | | ├─Token(NewLine) |\n|
@@ -540,23 +540,23 @@ param inlineObjectParam {
 //@[005:0006) | | | ├─Token(Colon) |:|
 //@[007:0026) | | | └─UnionTypeSyntax
 //@[007:0010) | | |   ├─UnionTypeMemberSyntax
-//@[007:0010) | | |   | └─IntegerLiteralSyntax
+//@[007:0010) | | |   | └─IntegerTypeLiteralSyntax
 //@[007:0010) | | |   |   └─Token(Integer) |100|
 //@[010:0011) | | |   ├─Token(Pipe) |||
 //@[011:0014) | | |   ├─UnionTypeMemberSyntax
-//@[011:0014) | | |   | └─IntegerLiteralSyntax
+//@[011:0014) | | |   | └─IntegerTypeLiteralSyntax
 //@[011:0014) | | |   |   └─Token(Integer) |200|
 //@[014:0015) | | |   ├─Token(Pipe) |||
 //@[015:0018) | | |   ├─UnionTypeMemberSyntax
-//@[015:0018) | | |   | └─IntegerLiteralSyntax
+//@[015:0018) | | |   | └─IntegerTypeLiteralSyntax
 //@[015:0018) | | |   |   └─Token(Integer) |300|
 //@[018:0019) | | |   ├─Token(Pipe) |||
 //@[019:0022) | | |   ├─UnionTypeMemberSyntax
-//@[019:0022) | | |   | └─IntegerLiteralSyntax
+//@[019:0022) | | |   | └─IntegerTypeLiteralSyntax
 //@[019:0022) | | |   |   └─Token(Integer) |400|
 //@[022:0023) | | |   ├─Token(Pipe) |||
 //@[023:0026) | | |   └─UnionTypeMemberSyntax
-//@[023:0026) | | |     └─IntegerLiteralSyntax
+//@[023:0026) | | |     └─IntegerTypeLiteralSyntax
 //@[023:0026) | | |       └─Token(Integer) |500|
 //@[026:0027) | | ├─Token(NewLine) |\n|
   baz: sys.bool
@@ -565,7 +565,7 @@ param inlineObjectParam {
 //@[002:0005) | | | | └─Token(Identifier) |baz|
 //@[005:0006) | | | ├─Token(Colon) |:|
 //@[007:0015) | | | └─TypePropertyAccessSyntax
-//@[007:0010) | | |   ├─VariableAccessSyntax
+//@[007:0010) | | |   ├─TypeVariableAccessSyntax
 //@[007:0010) | | |   | └─IdentifierSyntax
 //@[007:0010) | | |   |   └─Token(Identifier) |sys|
 //@[010:0011) | | |   ├─Token(Dot) |.|
@@ -620,7 +620,7 @@ param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
 //@[018:0026) | | |   | ├─IdentifierSyntax
 //@[018:0026) | | |   | | └─Token(Identifier) |property|
 //@[026:0027) | | |   | ├─Token(Colon) |:|
-//@[028:0034) | | |   | └─StringSyntax
+//@[028:0034) | | |   | └─StringTypeLiteralSyntax
 //@[028:0034) | | |   |   └─Token(StringComplete) |'ping'|
 //@[034:0035) | | |   └─Token(RightBrace) |}|
 //@[035:0036) | | ├─Token(Pipe) |||
@@ -631,7 +631,7 @@ param unionParam {property: 'ping'}|{property: 'pong'} = {property: 'pong'}
 //@[037:0045) | |     | ├─IdentifierSyntax
 //@[037:0045) | |     | | └─Token(Identifier) |property|
 //@[045:0046) | |     | ├─Token(Colon) |:|
-//@[047:0053) | |     | └─StringSyntax
+//@[047:0053) | |     | └─StringTypeLiteralSyntax
 //@[047:0053) | |     |   └─Token(StringComplete) |'pong'|
 //@[053:0054) | |     └─Token(RightBrace) |}|
 //@[055:0075) | └─ParameterDefaultValueSyntax
@@ -652,7 +652,7 @@ param paramUsingType mixedArray
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0020) | ├─IdentifierSyntax
 //@[006:0020) | | └─Token(Identifier) |paramUsingType|
-//@[021:0031) | └─VariableAccessSyntax
+//@[021:0031) | └─TypeVariableAccessSyntax
 //@[021:0031) |   └─IdentifierSyntax
 //@[021:0031) |     └─Token(Identifier) |mixedArray|
 //@[031:0033) ├─Token(NewLine) |\n\n|
@@ -662,7 +662,7 @@ output outputUsingType mixedArray = paramUsingType
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0022) | ├─IdentifierSyntax
 //@[007:0022) | | └─Token(Identifier) |outputUsingType|
-//@[023:0033) | ├─VariableAccessSyntax
+//@[023:0033) | ├─TypeVariableAccessSyntax
 //@[023:0033) | | └─IdentifierSyntax
 //@[023:0033) | |   └─Token(Identifier) |mixedArray|
 //@[034:0035) | ├─Token(Assignment) |=|
@@ -694,7 +694,7 @@ type tuple = [
 //@[035:0036) |   | |   └─Token(RightParen) |)|
 //@[036:0037) |   | ├─Token(NewLine) |\n|
     string
-//@[004:0010) |   | └─VariableAccessSyntax
+//@[004:0010) |   | └─TypeVariableAccessSyntax
 //@[004:0010) |   |   └─IdentifierSyntax
 //@[004:0010) |   |     └─Token(Identifier) |string|
 //@[010:0012) |   ├─Token(NewLine) |\n\n|
@@ -713,7 +713,7 @@ type tuple = [
 //@[054:0055) |   | |   └─Token(RightParen) |)|
 //@[055:0056) |   | ├─Token(NewLine) |\n|
     bar
-//@[004:0007) |   | └─VariableAccessSyntax
+//@[004:0007) |   | └─TypeVariableAccessSyntax
 //@[004:0007) |   |   └─IdentifierSyntax
 //@[004:0007) |   |     └─Token(Identifier) |bar|
 //@[007:0008) |   ├─Token(NewLine) |\n|
@@ -728,7 +728,7 @@ type tupleSecondItem = tuple[1]
 //@[005:0020) | | └─Token(Identifier) |tupleSecondItem|
 //@[021:0022) | ├─Token(Assignment) |=|
 //@[023:0031) | └─TypeArrayAccessSyntax
-//@[023:0028) |   ├─VariableAccessSyntax
+//@[023:0028) |   ├─TypeVariableAccessSyntax
 //@[023:0028) |   | └─IdentifierSyntax
 //@[023:0028) |   |   └─Token(Identifier) |tuple|
 //@[028:0029) |   ├─Token(LeftSquare) |[|
@@ -750,7 +750,7 @@ type stringStringDictionary = {
 //@[004:0013) |   ├─ObjectTypeAdditionalPropertiesSyntax
 //@[004:0005) |   | ├─Token(Asterisk) |*|
 //@[005:0006) |   | ├─Token(Colon) |:|
-//@[007:0013) |   | └─VariableAccessSyntax
+//@[007:0013) |   | └─TypeVariableAccessSyntax
 //@[007:0013) |   |   └─IdentifierSyntax
 //@[007:0013) |   |     └─Token(Identifier) |string|
 //@[013:0014) |   ├─Token(NewLine) |\n|
@@ -765,7 +765,7 @@ type stringStringDictionaryValue = stringStringDictionary.*
 //@[005:0032) | | └─Token(Identifier) |stringStringDictionaryValue|
 //@[033:0034) | ├─Token(Assignment) |=|
 //@[035:0059) | └─TypeAdditionalPropertiesAccessSyntax
-//@[035:0057) |   ├─VariableAccessSyntax
+//@[035:0057) |   ├─TypeVariableAccessSyntax
 //@[035:0057) |   | └─IdentifierSyntax
 //@[035:0057) |   |   └─Token(Identifier) |stringStringDictionary|
 //@[057:0058) |   ├─Token(Dot) |.|
@@ -802,7 +802,7 @@ type constrainedInt = int
 //@[005:0019) | ├─IdentifierSyntax
 //@[005:0019) | | └─Token(Identifier) |constrainedInt|
 //@[020:0021) | ├─Token(Assignment) |=|
-//@[022:0025) | └─VariableAccessSyntax
+//@[022:0025) | └─TypeVariableAccessSyntax
 //@[022:0025) |   └─IdentifierSyntax
 //@[022:0025) |     └─Token(Identifier) |int|
 //@[025:0027) ├─Token(NewLine) |\n\n|
@@ -814,7 +814,7 @@ param mightIncludeNull ({key: 'value'} | null)[]
 //@[006:0022) | | └─Token(Identifier) |mightIncludeNull|
 //@[023:0048) | └─ArrayTypeSyntax
 //@[023:0046) |   ├─ArrayTypeMemberSyntax
-//@[023:0046) |   | └─ParenthesizedExpressionSyntax
+//@[023:0046) |   | └─ParenthesizedTypeSyntax
 //@[023:0024) |   |   ├─Token(LeftParen) |(|
 //@[024:0045) |   |   ├─UnionTypeSyntax
 //@[024:0038) |   |   | ├─UnionTypeMemberSyntax
@@ -824,12 +824,12 @@ param mightIncludeNull ({key: 'value'} | null)[]
 //@[025:0028) |   |   | |   | ├─IdentifierSyntax
 //@[025:0028) |   |   | |   | | └─Token(Identifier) |key|
 //@[028:0029) |   |   | |   | ├─Token(Colon) |:|
-//@[030:0037) |   |   | |   | └─StringSyntax
+//@[030:0037) |   |   | |   | └─StringTypeLiteralSyntax
 //@[030:0037) |   |   | |   |   └─Token(StringComplete) |'value'|
 //@[037:0038) |   |   | |   └─Token(RightBrace) |}|
 //@[039:0040) |   |   | ├─Token(Pipe) |||
 //@[041:0045) |   |   | └─UnionTypeMemberSyntax
-//@[041:0045) |   |   |   └─NullLiteralSyntax
+//@[041:0045) |   |   |   └─NullTypeLiteralSyntax
 //@[041:0045) |   |   |     └─Token(NullKeyword) |null|
 //@[045:0046) |   |   └─Token(RightParen) |)|
 //@[046:0047) |   ├─Token(LeftSquare) |[|
@@ -863,7 +863,7 @@ output nonNull string = nonNull
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0014) | ├─IdentifierSyntax
 //@[007:0014) | | └─Token(Identifier) |nonNull|
-//@[015:0021) | ├─VariableAccessSyntax
+//@[015:0021) | ├─TypeVariableAccessSyntax
 //@[015:0021) | | └─IdentifierSyntax
 //@[015:0021) | |   └─Token(Identifier) |string|
 //@[022:0023) | ├─Token(Assignment) |=|
@@ -921,7 +921,7 @@ output maybeNull string? = maybeNull
 //@[007:0016) | ├─IdentifierSyntax
 //@[007:0016) | | └─Token(Identifier) |maybeNull|
 //@[017:0024) | ├─NullableTypeSyntax
-//@[017:0023) | | ├─VariableAccessSyntax
+//@[017:0023) | | ├─TypeVariableAccessSyntax
 //@[017:0023) | | | └─IdentifierSyntax
 //@[017:0023) | | |   └─Token(Identifier) |string|
 //@[023:0024) | | └─Token(Question) |?|
@@ -938,7 +938,7 @@ type nullable = string?
 //@[005:0013) | | └─Token(Identifier) |nullable|
 //@[014:0015) | ├─Token(Assignment) |=|
 //@[016:0023) | └─NullableTypeSyntax
-//@[016:0022) |   ├─VariableAccessSyntax
+//@[016:0022) |   ├─TypeVariableAccessSyntax
 //@[016:0022) |   | └─IdentifierSyntax
 //@[016:0022) |   |   └─Token(Identifier) |string|
 //@[022:0023) |   └─Token(Question) |?|
@@ -950,8 +950,8 @@ type nonNullable = nullable!
 //@[005:0016) | ├─IdentifierSyntax
 //@[005:0016) | | └─Token(Identifier) |nonNullable|
 //@[017:0018) | ├─Token(Assignment) |=|
-//@[019:0028) | └─NonNullAssertionSyntax
-//@[019:0027) |   ├─VariableAccessSyntax
+//@[019:0028) | └─NonNullableTypeSyntax
+//@[019:0027) |   ├─TypeVariableAccessSyntax
 //@[019:0027) |   | └─IdentifierSyntax
 //@[019:0027) |   |   └─Token(Identifier) |nullable|
 //@[027:0028) |   └─Token(Exclamation) |!|
@@ -971,7 +971,7 @@ type typeA = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'a'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: string
@@ -979,7 +979,7 @@ type typeA = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0015) |   | └─VariableAccessSyntax
+//@[009:0015) |   | └─TypeVariableAccessSyntax
 //@[009:0015) |   |   └─IdentifierSyntax
 //@[009:0015) |   |     └─Token(Identifier) |string|
 //@[015:0016) |   ├─Token(NewLine) |\n|
@@ -1001,7 +1001,7 @@ type typeB = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'b'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: int
@@ -1009,7 +1009,7 @@ type typeB = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0012) |   | └─VariableAccessSyntax
+//@[009:0012) |   | └─TypeVariableAccessSyntax
 //@[009:0012) |   |   └─IdentifierSyntax
 //@[009:0012) |   |     └─Token(Identifier) |int|
 //@[012:0013) |   ├─Token(NewLine) |\n|
@@ -1031,7 +1031,7 @@ type typeC = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'c'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: bool
@@ -1039,7 +1039,7 @@ type typeC = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0013) |   | └─VariableAccessSyntax
+//@[009:0013) |   | └─TypeVariableAccessSyntax
 //@[009:0013) |   |   └─IdentifierSyntax
 //@[009:0013) |   |     └─Token(Identifier) |bool|
 //@[013:0014) |   ├─Token(NewLine) |\n|
@@ -1048,7 +1048,7 @@ type typeC = {
 //@[002:0008) |   | ├─IdentifierSyntax
 //@[002:0008) |   | | └─Token(Identifier) |value2|
 //@[008:0009) |   | ├─Token(Colon) |:|
-//@[010:0016) |   | └─VariableAccessSyntax
+//@[010:0016) |   | └─TypeVariableAccessSyntax
 //@[010:0016) |   |   └─IdentifierSyntax
 //@[010:0016) |   |     └─Token(Identifier) |string|
 //@[016:0017) |   ├─Token(NewLine) |\n|
@@ -1070,7 +1070,7 @@ type typeD = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'d'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: object
@@ -1078,7 +1078,7 @@ type typeD = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |value|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0015) |   | └─VariableAccessSyntax
+//@[009:0015) |   | └─TypeVariableAccessSyntax
 //@[009:0015) |   |   └─IdentifierSyntax
 //@[009:0015) |   |     └─Token(Identifier) |object|
 //@[015:0016) |   ├─Token(NewLine) |\n|
@@ -1100,7 +1100,7 @@ type typeE = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'e'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   value: 'a' | 'b'
@@ -1110,11 +1110,11 @@ type typeE = {
 //@[007:0008) |   | ├─Token(Colon) |:|
 //@[009:0018) |   | └─UnionTypeSyntax
 //@[009:0012) |   |   ├─UnionTypeMemberSyntax
-//@[009:0012) |   |   | └─StringSyntax
+//@[009:0012) |   |   | └─StringTypeLiteralSyntax
 //@[009:0012) |   |   |   └─Token(StringComplete) |'a'|
 //@[013:0014) |   |   ├─Token(Pipe) |||
 //@[015:0018) |   |   └─UnionTypeMemberSyntax
-//@[015:0018) |   |     └─StringSyntax
+//@[015:0018) |   |     └─StringTypeLiteralSyntax
 //@[015:0018) |   |       └─Token(StringComplete) |'b'|
 //@[018:0019) |   ├─Token(NewLine) |\n|
 }
@@ -1135,14 +1135,14 @@ type typeF = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'f'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   *: string
 //@[002:0011) |   ├─ObjectTypeAdditionalPropertiesSyntax
 //@[002:0003) |   | ├─Token(Asterisk) |*|
 //@[003:0004) |   | ├─Token(Colon) |:|
-//@[005:0011) |   | └─VariableAccessSyntax
+//@[005:0011) |   | └─TypeVariableAccessSyntax
 //@[005:0011) |   |   └─IdentifierSyntax
 //@[005:0011) |   |     └─Token(Identifier) |string|
 //@[011:0012) |   ├─Token(NewLine) |\n|
@@ -1170,12 +1170,12 @@ type discriminatedUnion1 = typeA | typeB
 //@[025:0026) | ├─Token(Assignment) |=|
 //@[027:0040) | └─UnionTypeSyntax
 //@[027:0032) |   ├─UnionTypeMemberSyntax
-//@[027:0032) |   | └─VariableAccessSyntax
+//@[027:0032) |   | └─TypeVariableAccessSyntax
 //@[027:0032) |   |   └─IdentifierSyntax
 //@[027:0032) |   |     └─Token(Identifier) |typeA|
 //@[033:0034) |   ├─Token(Pipe) |||
 //@[035:0040) |   └─UnionTypeMemberSyntax
-//@[035:0040) |     └─VariableAccessSyntax
+//@[035:0040) |     └─TypeVariableAccessSyntax
 //@[035:0040) |       └─IdentifierSyntax
 //@[035:0040) |         └─Token(Identifier) |typeB|
 //@[040:0042) ├─Token(NewLine) |\n\n|
@@ -1206,14 +1206,14 @@ type discriminatedUnion2 = { type: 'c', value: string } | { type: 'd', value: bo
 //@[029:0033) |   |   | ├─IdentifierSyntax
 //@[029:0033) |   |   | | └─Token(Identifier) |type|
 //@[033:0034) |   |   | ├─Token(Colon) |:|
-//@[035:0038) |   |   | └─StringSyntax
+//@[035:0038) |   |   | └─StringTypeLiteralSyntax
 //@[035:0038) |   |   |   └─Token(StringComplete) |'c'|
 //@[038:0039) |   |   ├─Token(Comma) |,|
 //@[040:0053) |   |   ├─ObjectTypePropertySyntax
 //@[040:0045) |   |   | ├─IdentifierSyntax
 //@[040:0045) |   |   | | └─Token(Identifier) |value|
 //@[045:0046) |   |   | ├─Token(Colon) |:|
-//@[047:0053) |   |   | └─VariableAccessSyntax
+//@[047:0053) |   |   | └─TypeVariableAccessSyntax
 //@[047:0053) |   |   |   └─IdentifierSyntax
 //@[047:0053) |   |   |     └─Token(Identifier) |string|
 //@[054:0055) |   |   └─Token(RightBrace) |}|
@@ -1225,14 +1225,14 @@ type discriminatedUnion2 = { type: 'c', value: string } | { type: 'd', value: bo
 //@[060:0064) |       | ├─IdentifierSyntax
 //@[060:0064) |       | | └─Token(Identifier) |type|
 //@[064:0065) |       | ├─Token(Colon) |:|
-//@[066:0069) |       | └─StringSyntax
+//@[066:0069) |       | └─StringTypeLiteralSyntax
 //@[066:0069) |       |   └─Token(StringComplete) |'d'|
 //@[069:0070) |       ├─Token(Comma) |,|
 //@[071:0082) |       ├─ObjectTypePropertySyntax
 //@[071:0076) |       | ├─IdentifierSyntax
 //@[071:0076) |       | | └─Token(Identifier) |value|
 //@[076:0077) |       | ├─Token(Colon) |:|
-//@[078:0082) |       | └─VariableAccessSyntax
+//@[078:0082) |       | └─TypeVariableAccessSyntax
 //@[078:0082) |       |   └─IdentifierSyntax
 //@[078:0082) |       |     └─Token(Identifier) |bool|
 //@[083:0084) |       └─Token(RightBrace) |}|
@@ -1258,12 +1258,12 @@ type discriminatedUnion3 = discriminatedUnion1 | discriminatedUnion2 | { type: '
 //@[025:0026) | ├─Token(Assignment) |=|
 //@[027:0099) | └─UnionTypeSyntax
 //@[027:0046) |   ├─UnionTypeMemberSyntax
-//@[027:0046) |   | └─VariableAccessSyntax
+//@[027:0046) |   | └─TypeVariableAccessSyntax
 //@[027:0046) |   |   └─IdentifierSyntax
 //@[027:0046) |   |     └─Token(Identifier) |discriminatedUnion1|
 //@[047:0048) |   ├─Token(Pipe) |||
 //@[049:0068) |   ├─UnionTypeMemberSyntax
-//@[049:0068) |   | └─VariableAccessSyntax
+//@[049:0068) |   | └─TypeVariableAccessSyntax
 //@[049:0068) |   |   └─IdentifierSyntax
 //@[049:0068) |   |     └─Token(Identifier) |discriminatedUnion2|
 //@[069:0070) |   ├─Token(Pipe) |||
@@ -1274,14 +1274,14 @@ type discriminatedUnion3 = discriminatedUnion1 | discriminatedUnion2 | { type: '
 //@[073:0077) |       | ├─IdentifierSyntax
 //@[073:0077) |       | | └─Token(Identifier) |type|
 //@[077:0078) |       | ├─Token(Colon) |:|
-//@[079:0082) |       | └─StringSyntax
+//@[079:0082) |       | └─StringTypeLiteralSyntax
 //@[079:0082) |       |   └─Token(StringComplete) |'e'|
 //@[082:0083) |       ├─Token(Comma) |,|
 //@[084:0097) |       ├─ObjectTypePropertySyntax
 //@[084:0089) |       | ├─IdentifierSyntax
 //@[084:0089) |       | | └─Token(Identifier) |value|
 //@[089:0090) |       | ├─Token(Colon) |:|
-//@[091:0097) |       | └─VariableAccessSyntax
+//@[091:0097) |       | └─TypeVariableAccessSyntax
 //@[091:0097) |       |   └─IdentifierSyntax
 //@[091:0097) |       |     └─Token(Identifier) |string|
 //@[098:0099) |       └─Token(RightBrace) |}|
@@ -1307,21 +1307,21 @@ type discriminatedUnion4 = discriminatedUnion1 | (discriminatedUnion2 | typeE)
 //@[025:0026) | ├─Token(Assignment) |=|
 //@[027:0078) | └─UnionTypeSyntax
 //@[027:0046) |   ├─UnionTypeMemberSyntax
-//@[027:0046) |   | └─VariableAccessSyntax
+//@[027:0046) |   | └─TypeVariableAccessSyntax
 //@[027:0046) |   |   └─IdentifierSyntax
 //@[027:0046) |   |     └─Token(Identifier) |discriminatedUnion1|
 //@[047:0048) |   ├─Token(Pipe) |||
 //@[049:0078) |   └─UnionTypeMemberSyntax
-//@[049:0078) |     └─ParenthesizedExpressionSyntax
+//@[049:0078) |     └─ParenthesizedTypeSyntax
 //@[049:0050) |       ├─Token(LeftParen) |(|
 //@[050:0077) |       ├─UnionTypeSyntax
 //@[050:0069) |       | ├─UnionTypeMemberSyntax
-//@[050:0069) |       | | └─VariableAccessSyntax
+//@[050:0069) |       | | └─TypeVariableAccessSyntax
 //@[050:0069) |       | |   └─IdentifierSyntax
 //@[050:0069) |       | |     └─Token(Identifier) |discriminatedUnion2|
 //@[070:0071) |       | ├─Token(Pipe) |||
 //@[072:0077) |       | └─UnionTypeMemberSyntax
-//@[072:0077) |       |   └─VariableAccessSyntax
+//@[072:0077) |       |   └─TypeVariableAccessSyntax
 //@[072:0077) |       |     └─IdentifierSyntax
 //@[072:0077) |       |       └─Token(Identifier) |typeE|
 //@[077:0078) |       └─Token(RightParen) |)|
@@ -1346,16 +1346,16 @@ type discriminatedUnion5 = (typeA | typeB)?
 //@[005:0024) | | └─Token(Identifier) |discriminatedUnion5|
 //@[025:0026) | ├─Token(Assignment) |=|
 //@[027:0043) | └─NullableTypeSyntax
-//@[027:0042) |   ├─ParenthesizedExpressionSyntax
+//@[027:0042) |   ├─ParenthesizedTypeSyntax
 //@[027:0028) |   | ├─Token(LeftParen) |(|
 //@[028:0041) |   | ├─UnionTypeSyntax
 //@[028:0033) |   | | ├─UnionTypeMemberSyntax
-//@[028:0033) |   | | | └─VariableAccessSyntax
+//@[028:0033) |   | | | └─TypeVariableAccessSyntax
 //@[028:0033) |   | | |   └─IdentifierSyntax
 //@[028:0033) |   | | |     └─Token(Identifier) |typeA|
 //@[034:0035) |   | | ├─Token(Pipe) |||
 //@[036:0041) |   | | └─UnionTypeMemberSyntax
-//@[036:0041) |   | |   └─VariableAccessSyntax
+//@[036:0041) |   | |   └─TypeVariableAccessSyntax
 //@[036:0041) |   | |     └─IdentifierSyntax
 //@[036:0041) |   | |       └─Token(Identifier) |typeB|
 //@[041:0042) |   | └─Token(RightParen) |)|
@@ -1380,17 +1380,17 @@ type discriminatedUnion6 = (typeA | typeB)!
 //@[005:0024) | ├─IdentifierSyntax
 //@[005:0024) | | └─Token(Identifier) |discriminatedUnion6|
 //@[025:0026) | ├─Token(Assignment) |=|
-//@[027:0043) | └─NonNullAssertionSyntax
-//@[027:0042) |   ├─ParenthesizedExpressionSyntax
+//@[027:0043) | └─NonNullableTypeSyntax
+//@[027:0042) |   ├─ParenthesizedTypeSyntax
 //@[027:0028) |   | ├─Token(LeftParen) |(|
 //@[028:0041) |   | ├─UnionTypeSyntax
 //@[028:0033) |   | | ├─UnionTypeMemberSyntax
-//@[028:0033) |   | | | └─VariableAccessSyntax
+//@[028:0033) |   | | | └─TypeVariableAccessSyntax
 //@[028:0033) |   | | |   └─IdentifierSyntax
 //@[028:0033) |   | | |     └─Token(Identifier) |typeA|
 //@[034:0035) |   | | ├─Token(Pipe) |||
 //@[036:0041) |   | | └─UnionTypeMemberSyntax
-//@[036:0041) |   | |   └─VariableAccessSyntax
+//@[036:0041) |   | |   └─TypeVariableAccessSyntax
 //@[036:0041) |   | |     └─IdentifierSyntax
 //@[036:0041) |   | |       └─Token(Identifier) |typeB|
 //@[041:0042) |   | └─Token(RightParen) |)|
@@ -1425,12 +1425,12 @@ type inlineDiscriminatedUnion1 = {
 //@[006:0007) |   | ├─Token(Colon) |:|
 //@[008:0021) |   | └─UnionTypeSyntax
 //@[008:0013) |   |   ├─UnionTypeMemberSyntax
-//@[008:0013) |   |   | └─VariableAccessSyntax
+//@[008:0013) |   |   | └─TypeVariableAccessSyntax
 //@[008:0013) |   |   |   └─IdentifierSyntax
 //@[008:0013) |   |   |     └─Token(Identifier) |typeA|
 //@[014:0015) |   |   ├─Token(Pipe) |||
 //@[016:0021) |   |   └─UnionTypeMemberSyntax
-//@[016:0021) |   |     └─VariableAccessSyntax
+//@[016:0021) |   |     └─TypeVariableAccessSyntax
 //@[016:0021) |   |       └─IdentifierSyntax
 //@[016:0021) |   |         └─Token(Identifier) |typeC|
 //@[021:0022) |   ├─Token(NewLine) |\n|
@@ -1472,20 +1472,20 @@ type inlineDiscriminatedUnion2 = {
 //@[010:0014) |   |   |   | ├─IdentifierSyntax
 //@[010:0014) |   |   |   | | └─Token(Identifier) |type|
 //@[014:0015) |   |   |   | ├─Token(Colon) |:|
-//@[016:0019) |   |   |   | └─StringSyntax
+//@[016:0019) |   |   |   | └─StringTypeLiteralSyntax
 //@[016:0019) |   |   |   |   └─Token(StringComplete) |'a'|
 //@[019:0020) |   |   |   ├─Token(Comma) |,|
 //@[021:0032) |   |   |   ├─ObjectTypePropertySyntax
 //@[021:0026) |   |   |   | ├─IdentifierSyntax
 //@[021:0026) |   |   |   | | └─Token(Identifier) |value|
 //@[026:0027) |   |   |   | ├─Token(Colon) |:|
-//@[028:0032) |   |   |   | └─VariableAccessSyntax
+//@[028:0032) |   |   |   | └─TypeVariableAccessSyntax
 //@[028:0032) |   |   |   |   └─IdentifierSyntax
 //@[028:0032) |   |   |   |     └─Token(Identifier) |bool|
 //@[033:0034) |   |   |   └─Token(RightBrace) |}|
 //@[035:0036) |   |   ├─Token(Pipe) |||
 //@[037:0042) |   |   └─UnionTypeMemberSyntax
-//@[037:0042) |   |     └─VariableAccessSyntax
+//@[037:0042) |   |     └─TypeVariableAccessSyntax
 //@[037:0042) |   |       └─IdentifierSyntax
 //@[037:0042) |   |         └─Token(Identifier) |typeB|
 //@[042:0043) |   ├─Token(NewLine) |\n|
@@ -1521,7 +1521,7 @@ type inlineDiscriminatedUnion3 = {
 //@[002:0006) |   |   | ├─IdentifierSyntax
 //@[002:0006) |   |   | | └─Token(Identifier) |type|
 //@[006:0007) |   |   | ├─Token(Colon) |:|
-//@[008:0011) |   |   | └─StringSyntax
+//@[008:0011) |   |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   |   └─Token(StringComplete) |'a'|
 //@[011:0012) |   |   ├─Token(NewLine) |\n|
   @discriminator('type')
@@ -1549,20 +1549,20 @@ type inlineDiscriminatedUnion3 = {
 //@[010:0014) |   |   |   |   | ├─IdentifierSyntax
 //@[010:0014) |   |   |   |   | | └─Token(Identifier) |type|
 //@[014:0015) |   |   |   |   | ├─Token(Colon) |:|
-//@[016:0019) |   |   |   |   | └─StringSyntax
+//@[016:0019) |   |   |   |   | └─StringTypeLiteralSyntax
 //@[016:0019) |   |   |   |   |   └─Token(StringComplete) |'a'|
 //@[019:0020) |   |   |   |   ├─Token(Comma) |,|
 //@[021:0032) |   |   |   |   ├─ObjectTypePropertySyntax
 //@[021:0026) |   |   |   |   | ├─IdentifierSyntax
 //@[021:0026) |   |   |   |   | | └─Token(Identifier) |value|
 //@[026:0027) |   |   |   |   | ├─Token(Colon) |:|
-//@[028:0032) |   |   |   |   | └─VariableAccessSyntax
+//@[028:0032) |   |   |   |   | └─TypeVariableAccessSyntax
 //@[028:0032) |   |   |   |   |   └─IdentifierSyntax
 //@[028:0032) |   |   |   |   |     └─Token(Identifier) |bool|
 //@[033:0034) |   |   |   |   └─Token(RightBrace) |}|
 //@[035:0036) |   |   |   ├─Token(Pipe) |||
 //@[037:0042) |   |   |   └─UnionTypeMemberSyntax
-//@[037:0042) |   |   |     └─VariableAccessSyntax
+//@[037:0042) |   |   |     └─TypeVariableAccessSyntax
 //@[037:0042) |   |   |       └─IdentifierSyntax
 //@[037:0042) |   |   |         └─Token(Identifier) |typeB|
 //@[042:0043) |   |   ├─Token(NewLine) |\n|
@@ -1578,7 +1578,7 @@ type inlineDiscriminatedUnion3 = {
 //@[002:0006) |       | ├─IdentifierSyntax
 //@[002:0006) |       | | └─Token(Identifier) |type|
 //@[006:0007) |       | ├─Token(Colon) |:|
-//@[008:0011) |       | └─StringSyntax
+//@[008:0011) |       | └─StringTypeLiteralSyntax
 //@[008:0011) |       |   └─Token(StringComplete) |'b'|
 //@[011:0012) |       ├─Token(NewLine) |\n|
   @discriminator('type')
@@ -1600,12 +1600,12 @@ type inlineDiscriminatedUnion3 = {
 //@[006:0007) |       | ├─Token(Colon) |:|
 //@[008:0049) |       | └─UnionTypeSyntax
 //@[008:0027) |       |   ├─UnionTypeMemberSyntax
-//@[008:0027) |       |   | └─VariableAccessSyntax
+//@[008:0027) |       |   | └─TypeVariableAccessSyntax
 //@[008:0027) |       |   |   └─IdentifierSyntax
 //@[008:0027) |       |   |     └─Token(Identifier) |discriminatedUnion1|
 //@[028:0029) |       |   ├─Token(Pipe) |||
 //@[030:0049) |       |   └─UnionTypeMemberSyntax
-//@[030:0049) |       |     └─VariableAccessSyntax
+//@[030:0049) |       |     └─TypeVariableAccessSyntax
 //@[030:0049) |       |       └─IdentifierSyntax
 //@[030:0049) |       |         └─Token(Identifier) |discriminatedUnion2|
 //@[049:0050) |       ├─Token(NewLine) |\n|
@@ -1640,16 +1640,16 @@ type inlineDiscriminatedUnion4 = {
 //@[002:0006) |   | | └─Token(Identifier) |prop|
 //@[006:0007) |   | ├─Token(Colon) |:|
 //@[008:0024) |   | └─NullableTypeSyntax
-//@[008:0023) |   |   ├─ParenthesizedExpressionSyntax
+//@[008:0023) |   |   ├─ParenthesizedTypeSyntax
 //@[008:0009) |   |   | ├─Token(LeftParen) |(|
 //@[009:0022) |   |   | ├─UnionTypeSyntax
 //@[009:0014) |   |   | | ├─UnionTypeMemberSyntax
-//@[009:0014) |   |   | | | └─VariableAccessSyntax
+//@[009:0014) |   |   | | | └─TypeVariableAccessSyntax
 //@[009:0014) |   |   | | |   └─IdentifierSyntax
 //@[009:0014) |   |   | | |     └─Token(Identifier) |typeA|
 //@[015:0016) |   |   | | ├─Token(Pipe) |||
 //@[017:0022) |   |   | | └─UnionTypeMemberSyntax
-//@[017:0022) |   |   | |   └─VariableAccessSyntax
+//@[017:0022) |   |   | |   └─TypeVariableAccessSyntax
 //@[017:0022) |   |   | |     └─IdentifierSyntax
 //@[017:0022) |   |   | |       └─Token(Identifier) |typeC|
 //@[022:0023) |   |   | └─Token(RightParen) |)|
@@ -1673,7 +1673,7 @@ type discriminatorUnionAsPropertyType = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |prop1|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0028) |   | └─VariableAccessSyntax
+//@[009:0028) |   | └─TypeVariableAccessSyntax
 //@[009:0028) |   |   └─IdentifierSyntax
 //@[009:0028) |   |     └─Token(Identifier) |discriminatedUnion1|
 //@[028:0029) |   ├─Token(NewLine) |\n|
@@ -1682,7 +1682,7 @@ type discriminatorUnionAsPropertyType = {
 //@[002:0007) |   | ├─IdentifierSyntax
 //@[002:0007) |   | | └─Token(Identifier) |prop2|
 //@[007:0008) |   | ├─Token(Colon) |:|
-//@[009:0028) |   | └─VariableAccessSyntax
+//@[009:0028) |   | └─TypeVariableAccessSyntax
 //@[009:0028) |   |   └─IdentifierSyntax
 //@[009:0028) |   |     └─Token(Identifier) |discriminatedUnion3|
 //@[028:0029) |   ├─Token(NewLine) |\n|
@@ -1717,12 +1717,12 @@ type discriminatedUnionInlineAdditionalProps1 = {
 //@[003:0004) |   | ├─Token(Colon) |:|
 //@[005:0018) |   | └─UnionTypeSyntax
 //@[005:0010) |   |   ├─UnionTypeMemberSyntax
-//@[005:0010) |   |   | └─VariableAccessSyntax
+//@[005:0010) |   |   | └─TypeVariableAccessSyntax
 //@[005:0010) |   |   |   └─IdentifierSyntax
 //@[005:0010) |   |   |     └─Token(Identifier) |typeA|
 //@[011:0012) |   |   ├─Token(Pipe) |||
 //@[013:0018) |   |   └─UnionTypeMemberSyntax
-//@[013:0018) |   |     └─VariableAccessSyntax
+//@[013:0018) |   |     └─TypeVariableAccessSyntax
 //@[013:0018) |   |       └─IdentifierSyntax
 //@[013:0018) |   |         └─Token(Identifier) |typeB|
 //@[018:0019) |   ├─Token(NewLine) |\n|
@@ -1756,16 +1756,16 @@ type discriminatedUnionInlineAdditionalProps2 = {
 //@[002:0003) |   | ├─Token(Asterisk) |*|
 //@[003:0004) |   | ├─Token(Colon) |:|
 //@[005:0021) |   | └─NullableTypeSyntax
-//@[005:0020) |   |   ├─ParenthesizedExpressionSyntax
+//@[005:0020) |   |   ├─ParenthesizedTypeSyntax
 //@[005:0006) |   |   | ├─Token(LeftParen) |(|
 //@[006:0019) |   |   | ├─UnionTypeSyntax
 //@[006:0011) |   |   | | ├─UnionTypeMemberSyntax
-//@[006:0011) |   |   | | | └─VariableAccessSyntax
+//@[006:0011) |   |   | | | └─TypeVariableAccessSyntax
 //@[006:0011) |   |   | | |   └─IdentifierSyntax
 //@[006:0011) |   |   | | |     └─Token(Identifier) |typeA|
 //@[012:0013) |   |   | | ├─Token(Pipe) |||
 //@[014:0019) |   |   | | └─UnionTypeMemberSyntax
-//@[014:0019) |   |   | |   └─VariableAccessSyntax
+//@[014:0019) |   |   | |   └─TypeVariableAccessSyntax
 //@[014:0019) |   |   | |     └─IdentifierSyntax
 //@[014:0019) |   |   | |       └─Token(Identifier) |typeB|
 //@[019:0020) |   |   | └─Token(RightParen) |)|
@@ -1795,12 +1795,12 @@ type discriminatorMemberHasAdditionalProperties1 = typeA | typeF | { type: 'g', 
 //@[049:0050) | ├─Token(Assignment) |=|
 //@[051:0088) | └─UnionTypeSyntax
 //@[051:0056) |   ├─UnionTypeMemberSyntax
-//@[051:0056) |   | └─VariableAccessSyntax
+//@[051:0056) |   | └─TypeVariableAccessSyntax
 //@[051:0056) |   |   └─IdentifierSyntax
 //@[051:0056) |   |     └─Token(Identifier) |typeA|
 //@[057:0058) |   ├─Token(Pipe) |||
 //@[059:0064) |   ├─UnionTypeMemberSyntax
-//@[059:0064) |   | └─VariableAccessSyntax
+//@[059:0064) |   | └─TypeVariableAccessSyntax
 //@[059:0064) |   |   └─IdentifierSyntax
 //@[059:0064) |   |     └─Token(Identifier) |typeF|
 //@[065:0066) |   ├─Token(Pipe) |||
@@ -1811,13 +1811,13 @@ type discriminatorMemberHasAdditionalProperties1 = typeA | typeF | { type: 'g', 
 //@[069:0073) |       | ├─IdentifierSyntax
 //@[069:0073) |       | | └─Token(Identifier) |type|
 //@[073:0074) |       | ├─Token(Colon) |:|
-//@[075:0078) |       | └─StringSyntax
+//@[075:0078) |       | └─StringTypeLiteralSyntax
 //@[075:0078) |       |   └─Token(StringComplete) |'g'|
 //@[078:0079) |       ├─Token(Comma) |,|
 //@[080:0086) |       ├─ObjectTypeAdditionalPropertiesSyntax
 //@[080:0081) |       | ├─Token(Asterisk) |*|
 //@[081:0082) |       | ├─Token(Colon) |:|
-//@[083:0086) |       | └─VariableAccessSyntax
+//@[083:0086) |       | └─TypeVariableAccessSyntax
 //@[083:0086) |       |   └─IdentifierSyntax
 //@[083:0086) |       |     └─Token(Identifier) |int|
 //@[087:0088) |       └─Token(RightBrace) |}|
@@ -1843,7 +1843,7 @@ type discriminatorInnerSelfOptionalCycle1 = typeA | {
 //@[042:0043) | ├─Token(Assignment) |=|
 //@[044:0114) | └─UnionTypeSyntax
 //@[044:0049) |   ├─UnionTypeMemberSyntax
-//@[044:0049) |   | └─VariableAccessSyntax
+//@[044:0049) |   | └─TypeVariableAccessSyntax
 //@[044:0049) |   |   └─IdentifierSyntax
 //@[044:0049) |   |     └─Token(Identifier) |typeA|
 //@[050:0051) |   ├─Token(Pipe) |||
@@ -1856,7 +1856,7 @@ type discriminatorInnerSelfOptionalCycle1 = typeA | {
 //@[002:0006) |       | ├─IdentifierSyntax
 //@[002:0006) |       | | └─Token(Identifier) |type|
 //@[006:0007) |       | ├─Token(Colon) |:|
-//@[008:0011) |       | └─StringSyntax
+//@[008:0011) |       | └─StringTypeLiteralSyntax
 //@[008:0011) |       |   └─Token(StringComplete) |'b'|
 //@[011:0012) |       ├─Token(NewLine) |\n|
   value: discriminatorInnerSelfOptionalCycle1?
@@ -1865,7 +1865,7 @@ type discriminatorInnerSelfOptionalCycle1 = typeA | {
 //@[002:0007) |       | | └─Token(Identifier) |value|
 //@[007:0008) |       | ├─Token(Colon) |:|
 //@[009:0046) |       | └─NullableTypeSyntax
-//@[009:0045) |       |   ├─VariableAccessSyntax
+//@[009:0045) |       |   ├─TypeVariableAccessSyntax
 //@[009:0045) |       |   | └─IdentifierSyntax
 //@[009:0045) |       |   |   └─Token(Identifier) |discriminatorInnerSelfOptionalCycle1|
 //@[045:0046) |       |   └─Token(Question) |?|
@@ -1888,7 +1888,7 @@ type discriminatedUnionMemberOptionalCycle1 = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'b'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   @discriminator('type')
@@ -1909,16 +1909,16 @@ type discriminatedUnionMemberOptionalCycle1 = {
 //@[002:0006) |   | | └─Token(Identifier) |prop|
 //@[006:0007) |   | ├─Token(Colon) |:|
 //@[008:0057) |   | └─NullableTypeSyntax
-//@[008:0056) |   |   ├─ParenthesizedExpressionSyntax
+//@[008:0056) |   |   ├─ParenthesizedTypeSyntax
 //@[008:0009) |   |   | ├─Token(LeftParen) |(|
 //@[009:0055) |   |   | ├─UnionTypeSyntax
 //@[009:0014) |   |   | | ├─UnionTypeMemberSyntax
-//@[009:0014) |   |   | | | └─VariableAccessSyntax
+//@[009:0014) |   |   | | | └─TypeVariableAccessSyntax
 //@[009:0014) |   |   | | |   └─IdentifierSyntax
 //@[009:0014) |   |   | | |     └─Token(Identifier) |typeA|
 //@[015:0016) |   |   | | ├─Token(Pipe) |||
 //@[017:0055) |   |   | | └─UnionTypeMemberSyntax
-//@[017:0055) |   |   | |   └─VariableAccessSyntax
+//@[017:0055) |   |   | |   └─TypeVariableAccessSyntax
 //@[017:0055) |   |   | |     └─IdentifierSyntax
 //@[017:0055) |   |   | |       └─Token(Identifier) |discriminatedUnionMemberOptionalCycle1|
 //@[055:0056) |   |   | └─Token(RightParen) |)|
@@ -1942,7 +1942,7 @@ type discriminatedUnionMemberOptionalCycle2 = {
 //@[002:0006) |   | ├─IdentifierSyntax
 //@[002:0006) |   | | └─Token(Identifier) |type|
 //@[006:0007) |   | ├─Token(Colon) |:|
-//@[008:0011) |   | └─StringSyntax
+//@[008:0011) |   | └─StringTypeLiteralSyntax
 //@[008:0011) |   |   └─Token(StringComplete) |'b'|
 //@[011:0012) |   ├─Token(NewLine) |\n|
   @discriminator('type')
@@ -1963,12 +1963,12 @@ type discriminatedUnionMemberOptionalCycle2 = {
 //@[003:0004) |   | ├─Token(Colon) |:|
 //@[005:0051) |   | └─UnionTypeSyntax
 //@[005:0010) |   |   ├─UnionTypeMemberSyntax
-//@[005:0010) |   |   | └─VariableAccessSyntax
+//@[005:0010) |   |   | └─TypeVariableAccessSyntax
 //@[005:0010) |   |   |   └─IdentifierSyntax
 //@[005:0010) |   |   |     └─Token(Identifier) |typeA|
 //@[011:0012) |   |   ├─Token(Pipe) |||
 //@[013:0051) |   |   └─UnionTypeMemberSyntax
-//@[013:0051) |   |     └─VariableAccessSyntax
+//@[013:0051) |   |     └─TypeVariableAccessSyntax
 //@[013:0051) |   |       └─IdentifierSyntax
 //@[013:0051) |   |         └─Token(Identifier) |discriminatedUnionMemberOptionalCycle1|
 //@[051:0052) |   ├─Token(NewLine) |\n|
@@ -1987,13 +1987,13 @@ type discriminatedUnionTuple1 = [
 //@[033:0034) |   ├─Token(NewLine) |\n|
   discriminatedUnion1
 //@[002:0021) |   ├─TupleTypeItemSyntax
-//@[002:0021) |   | └─VariableAccessSyntax
+//@[002:0021) |   | └─TypeVariableAccessSyntax
 //@[002:0021) |   |   └─IdentifierSyntax
 //@[002:0021) |   |     └─Token(Identifier) |discriminatedUnion1|
 //@[021:0022) |   ├─Token(NewLine) |\n|
   string
 //@[002:0008) |   ├─TupleTypeItemSyntax
-//@[002:0008) |   | └─VariableAccessSyntax
+//@[002:0008) |   | └─TypeVariableAccessSyntax
 //@[002:0008) |   |   └─IdentifierSyntax
 //@[002:0008) |   |     └─Token(Identifier) |string|
 //@[008:0009) |   ├─Token(NewLine) |\n|
@@ -2026,12 +2026,12 @@ type discriminatedUnionInlineTuple1 = [
   typeA | typeB | { type: 'c', value: object }
 //@[002:0046) |   | └─UnionTypeSyntax
 //@[002:0007) |   |   ├─UnionTypeMemberSyntax
-//@[002:0007) |   |   | └─VariableAccessSyntax
+//@[002:0007) |   |   | └─TypeVariableAccessSyntax
 //@[002:0007) |   |   |   └─IdentifierSyntax
 //@[002:0007) |   |   |     └─Token(Identifier) |typeA|
 //@[008:0009) |   |   ├─Token(Pipe) |||
 //@[010:0015) |   |   ├─UnionTypeMemberSyntax
-//@[010:0015) |   |   | └─VariableAccessSyntax
+//@[010:0015) |   |   | └─TypeVariableAccessSyntax
 //@[010:0015) |   |   |   └─IdentifierSyntax
 //@[010:0015) |   |   |     └─Token(Identifier) |typeB|
 //@[016:0017) |   |   ├─Token(Pipe) |||
@@ -2042,21 +2042,21 @@ type discriminatedUnionInlineTuple1 = [
 //@[020:0024) |   |       | ├─IdentifierSyntax
 //@[020:0024) |   |       | | └─Token(Identifier) |type|
 //@[024:0025) |   |       | ├─Token(Colon) |:|
-//@[026:0029) |   |       | └─StringSyntax
+//@[026:0029) |   |       | └─StringTypeLiteralSyntax
 //@[026:0029) |   |       |   └─Token(StringComplete) |'c'|
 //@[029:0030) |   |       ├─Token(Comma) |,|
 //@[031:0044) |   |       ├─ObjectTypePropertySyntax
 //@[031:0036) |   |       | ├─IdentifierSyntax
 //@[031:0036) |   |       | | └─Token(Identifier) |value|
 //@[036:0037) |   |       | ├─Token(Colon) |:|
-//@[038:0044) |   |       | └─VariableAccessSyntax
+//@[038:0044) |   |       | └─TypeVariableAccessSyntax
 //@[038:0044) |   |       |   └─IdentifierSyntax
 //@[038:0044) |   |       |     └─Token(Identifier) |object|
 //@[045:0046) |   |       └─Token(RightBrace) |}|
 //@[046:0047) |   ├─Token(NewLine) |\n|
   string
 //@[002:0008) |   ├─TupleTypeItemSyntax
-//@[002:0008) |   | └─VariableAccessSyntax
+//@[002:0008) |   | └─TypeVariableAccessSyntax
 //@[002:0008) |   |   └─IdentifierSyntax
 //@[002:0008) |   |     └─Token(Identifier) |string|
 //@[008:0009) |   ├─Token(NewLine) |\n|
@@ -2069,7 +2069,7 @@ param paramDiscriminatedUnionTypeAlias1 discriminatedUnion1
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0039) | ├─IdentifierSyntax
 //@[006:0039) | | └─Token(Identifier) |paramDiscriminatedUnionTypeAlias1|
-//@[040:0059) | └─VariableAccessSyntax
+//@[040:0059) | └─TypeVariableAccessSyntax
 //@[040:0059) |   └─IdentifierSyntax
 //@[040:0059) |     └─Token(Identifier) |discriminatedUnion1|
 //@[059:0060) ├─Token(NewLine) |\n|
@@ -2078,7 +2078,7 @@ param paramDiscriminatedUnionTypeAlias2 discriminatedUnion5
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0039) | ├─IdentifierSyntax
 //@[006:0039) | | └─Token(Identifier) |paramDiscriminatedUnionTypeAlias2|
-//@[040:0059) | └─VariableAccessSyntax
+//@[040:0059) | └─TypeVariableAccessSyntax
 //@[040:0059) |   └─IdentifierSyntax
 //@[040:0059) |     └─Token(Identifier) |discriminatedUnion5|
 //@[059:0061) ├─Token(NewLine) |\n\n|
@@ -2102,12 +2102,12 @@ param paramInlineDiscriminatedUnion1 typeA | typeB
 //@[006:0036) | | └─Token(Identifier) |paramInlineDiscriminatedUnion1|
 //@[037:0050) | └─UnionTypeSyntax
 //@[037:0042) |   ├─UnionTypeMemberSyntax
-//@[037:0042) |   | └─VariableAccessSyntax
+//@[037:0042) |   | └─TypeVariableAccessSyntax
 //@[037:0042) |   |   └─IdentifierSyntax
 //@[037:0042) |   |     └─Token(Identifier) |typeA|
 //@[043:0044) |   ├─Token(Pipe) |||
 //@[045:0050) |   └─UnionTypeMemberSyntax
-//@[045:0050) |     └─VariableAccessSyntax
+//@[045:0050) |     └─TypeVariableAccessSyntax
 //@[045:0050) |       └─IdentifierSyntax
 //@[045:0050) |         └─Token(Identifier) |typeB|
 //@[050:0052) ├─Token(NewLine) |\n\n|
@@ -2129,16 +2129,16 @@ param paramInlineDiscriminatedUnion2 (typeA | typeB) = { type: 'b', value: 0 }
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0036) | ├─IdentifierSyntax
 //@[006:0036) | | └─Token(Identifier) |paramInlineDiscriminatedUnion2|
-//@[037:0052) | ├─ParenthesizedExpressionSyntax
+//@[037:0052) | ├─ParenthesizedTypeSyntax
 //@[037:0038) | | ├─Token(LeftParen) |(|
 //@[038:0051) | | ├─UnionTypeSyntax
 //@[038:0043) | | | ├─UnionTypeMemberSyntax
-//@[038:0043) | | | | └─VariableAccessSyntax
+//@[038:0043) | | | | └─TypeVariableAccessSyntax
 //@[038:0043) | | | |   └─IdentifierSyntax
 //@[038:0043) | | | |     └─Token(Identifier) |typeA|
 //@[044:0045) | | | ├─Token(Pipe) |||
 //@[046:0051) | | | └─UnionTypeMemberSyntax
-//@[046:0051) | | |   └─VariableAccessSyntax
+//@[046:0051) | | |   └─TypeVariableAccessSyntax
 //@[046:0051) | | |     └─IdentifierSyntax
 //@[046:0051) | | |       └─Token(Identifier) |typeB|
 //@[051:0052) | | └─Token(RightParen) |)|
@@ -2180,16 +2180,16 @@ param paramInlineDiscriminatedUnion3 (typeA | typeB)?
 //@[006:0036) | ├─IdentifierSyntax
 //@[006:0036) | | └─Token(Identifier) |paramInlineDiscriminatedUnion3|
 //@[037:0053) | └─NullableTypeSyntax
-//@[037:0052) |   ├─ParenthesizedExpressionSyntax
+//@[037:0052) |   ├─ParenthesizedTypeSyntax
 //@[037:0038) |   | ├─Token(LeftParen) |(|
 //@[038:0051) |   | ├─UnionTypeSyntax
 //@[038:0043) |   | | ├─UnionTypeMemberSyntax
-//@[038:0043) |   | | | └─VariableAccessSyntax
+//@[038:0043) |   | | | └─TypeVariableAccessSyntax
 //@[038:0043) |   | | |   └─IdentifierSyntax
 //@[038:0043) |   | | |     └─Token(Identifier) |typeA|
 //@[044:0045) |   | | ├─Token(Pipe) |||
 //@[046:0051) |   | | └─UnionTypeMemberSyntax
-//@[046:0051) |   | |   └─VariableAccessSyntax
+//@[046:0051) |   | |   └─TypeVariableAccessSyntax
 //@[046:0051) |   | |     └─IdentifierSyntax
 //@[046:0051) |   | |       └─Token(Identifier) |typeB|
 //@[051:0052) |   | └─Token(RightParen) |)|
@@ -2201,7 +2201,7 @@ output outputDiscriminatedUnionTypeAlias1 discriminatedUnion1 = { type: 'a', val
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0041) | ├─IdentifierSyntax
 //@[007:0041) | | └─Token(Identifier) |outputDiscriminatedUnionTypeAlias1|
-//@[042:0061) | ├─VariableAccessSyntax
+//@[042:0061) | ├─TypeVariableAccessSyntax
 //@[042:0061) | | └─IdentifierSyntax
 //@[042:0061) | |   └─Token(Identifier) |discriminatedUnion1|
 //@[062:0063) | ├─Token(Assignment) |=|
@@ -2239,7 +2239,7 @@ output outputDiscriminatedUnionTypeAlias2 discriminatedUnion1 = { type: 'a', val
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0041) | ├─IdentifierSyntax
 //@[007:0041) | | └─Token(Identifier) |outputDiscriminatedUnionTypeAlias2|
-//@[042:0061) | ├─VariableAccessSyntax
+//@[042:0061) | ├─TypeVariableAccessSyntax
 //@[042:0061) | | └─IdentifierSyntax
 //@[042:0061) | |   └─Token(Identifier) |discriminatedUnion1|
 //@[062:0063) | ├─Token(Assignment) |=|
@@ -2265,7 +2265,7 @@ output outputDiscriminatedUnionTypeAlias3 discriminatedUnion5 = null
 //@[000:0006) | ├─Token(Identifier) |output|
 //@[007:0041) | ├─IdentifierSyntax
 //@[007:0041) | | └─Token(Identifier) |outputDiscriminatedUnionTypeAlias3|
-//@[042:0061) | ├─VariableAccessSyntax
+//@[042:0061) | ├─TypeVariableAccessSyntax
 //@[042:0061) | | └─IdentifierSyntax
 //@[042:0061) | |   └─Token(Identifier) |discriminatedUnion5|
 //@[062:0063) | ├─Token(Assignment) |=|
@@ -2292,12 +2292,12 @@ output outputInlineDiscriminatedUnion1 typeA | typeB | { type: 'c', value: int }
 //@[007:0038) | | └─Token(Identifier) |outputInlineDiscriminatedUnion1|
 //@[039:0080) | ├─UnionTypeSyntax
 //@[039:0044) | | ├─UnionTypeMemberSyntax
-//@[039:0044) | | | └─VariableAccessSyntax
+//@[039:0044) | | | └─TypeVariableAccessSyntax
 //@[039:0044) | | |   └─IdentifierSyntax
 //@[039:0044) | | |     └─Token(Identifier) |typeA|
 //@[045:0046) | | ├─Token(Pipe) |||
 //@[047:0052) | | ├─UnionTypeMemberSyntax
-//@[047:0052) | | | └─VariableAccessSyntax
+//@[047:0052) | | | └─TypeVariableAccessSyntax
 //@[047:0052) | | |   └─IdentifierSyntax
 //@[047:0052) | | |     └─Token(Identifier) |typeB|
 //@[053:0054) | | ├─Token(Pipe) |||
@@ -2308,14 +2308,14 @@ output outputInlineDiscriminatedUnion1 typeA | typeB | { type: 'c', value: int }
 //@[057:0061) | |     | ├─IdentifierSyntax
 //@[057:0061) | |     | | └─Token(Identifier) |type|
 //@[061:0062) | |     | ├─Token(Colon) |:|
-//@[063:0066) | |     | └─StringSyntax
+//@[063:0066) | |     | └─StringTypeLiteralSyntax
 //@[063:0066) | |     |   └─Token(StringComplete) |'c'|
 //@[066:0067) | |     ├─Token(Comma) |,|
 //@[068:0078) | |     ├─ObjectTypePropertySyntax
 //@[068:0073) | |     | ├─IdentifierSyntax
 //@[068:0073) | |     | | └─Token(Identifier) |value|
 //@[073:0074) | |     | ├─Token(Colon) |:|
-//@[075:0078) | |     | └─VariableAccessSyntax
+//@[075:0078) | |     | └─TypeVariableAccessSyntax
 //@[075:0078) | |     |   └─IdentifierSyntax
 //@[075:0078) | |     |     └─Token(Identifier) |int|
 //@[079:0080) | |     └─Token(RightBrace) |}|
@@ -2357,17 +2357,17 @@ output outputInlineDiscriminatedUnion2 typeA | typeB | ({ type: 'c', value: int 
 //@[007:0038) | | └─Token(Identifier) |outputInlineDiscriminatedUnion2|
 //@[039:0082) | ├─UnionTypeSyntax
 //@[039:0044) | | ├─UnionTypeMemberSyntax
-//@[039:0044) | | | └─VariableAccessSyntax
+//@[039:0044) | | | └─TypeVariableAccessSyntax
 //@[039:0044) | | |   └─IdentifierSyntax
 //@[039:0044) | | |     └─Token(Identifier) |typeA|
 //@[045:0046) | | ├─Token(Pipe) |||
 //@[047:0052) | | ├─UnionTypeMemberSyntax
-//@[047:0052) | | | └─VariableAccessSyntax
+//@[047:0052) | | | └─TypeVariableAccessSyntax
 //@[047:0052) | | |   └─IdentifierSyntax
 //@[047:0052) | | |     └─Token(Identifier) |typeB|
 //@[053:0054) | | ├─Token(Pipe) |||
 //@[055:0082) | | └─UnionTypeMemberSyntax
-//@[055:0082) | |   └─ParenthesizedExpressionSyntax
+//@[055:0082) | |   └─ParenthesizedTypeSyntax
 //@[055:0056) | |     ├─Token(LeftParen) |(|
 //@[056:0081) | |     ├─ObjectTypeSyntax
 //@[056:0057) | |     | ├─Token(LeftBrace) |{|
@@ -2375,14 +2375,14 @@ output outputInlineDiscriminatedUnion2 typeA | typeB | ({ type: 'c', value: int 
 //@[058:0062) | |     | | ├─IdentifierSyntax
 //@[058:0062) | |     | | | └─Token(Identifier) |type|
 //@[062:0063) | |     | | ├─Token(Colon) |:|
-//@[064:0067) | |     | | └─StringSyntax
+//@[064:0067) | |     | | └─StringTypeLiteralSyntax
 //@[064:0067) | |     | |   └─Token(StringComplete) |'c'|
 //@[067:0068) | |     | ├─Token(Comma) |,|
 //@[069:0079) | |     | ├─ObjectTypePropertySyntax
 //@[069:0074) | |     | | ├─IdentifierSyntax
 //@[069:0074) | |     | | | └─Token(Identifier) |value|
 //@[074:0075) | |     | | ├─Token(Colon) |:|
-//@[076:0079) | |     | | └─VariableAccessSyntax
+//@[076:0079) | |     | | └─TypeVariableAccessSyntax
 //@[076:0079) | |     | |   └─IdentifierSyntax
 //@[076:0079) | |     | |     └─Token(Identifier) |int|
 //@[080:0081) | |     | └─Token(RightBrace) |}|
@@ -2424,16 +2424,16 @@ output outputInlineDiscriminatedUnion3 (typeA | typeB)? = null
 //@[007:0038) | ├─IdentifierSyntax
 //@[007:0038) | | └─Token(Identifier) |outputInlineDiscriminatedUnion3|
 //@[039:0055) | ├─NullableTypeSyntax
-//@[039:0054) | | ├─ParenthesizedExpressionSyntax
+//@[039:0054) | | ├─ParenthesizedTypeSyntax
 //@[039:0040) | | | ├─Token(LeftParen) |(|
 //@[040:0053) | | | ├─UnionTypeSyntax
 //@[040:0045) | | | | ├─UnionTypeMemberSyntax
-//@[040:0045) | | | | | └─VariableAccessSyntax
+//@[040:0045) | | | | | └─TypeVariableAccessSyntax
 //@[040:0045) | | | | |   └─IdentifierSyntax
 //@[040:0045) | | | | |     └─Token(Identifier) |typeA|
 //@[046:0047) | | | | ├─Token(Pipe) |||
 //@[048:0053) | | | | └─UnionTypeMemberSyntax
-//@[048:0053) | | | |   └─VariableAccessSyntax
+//@[048:0053) | | | |   └─TypeVariableAccessSyntax
 //@[048:0053) | | | |     └─IdentifierSyntax
 //@[048:0053) | | | |       └─Token(Identifier) |typeB|
 //@[053:0054) | | | └─Token(RightParen) |)|

--- a/src/Bicep.Core.Samples/Files/baselines/Unicode_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Unicode_LF/main.syntax.bicep
@@ -95,7 +95,7 @@ output concatUnicodeStrings string = concat('Θμ', '二头肌', 'α')
 //@[00:006) | ├─Token(Identifier) |output|
 //@[07:027) | ├─IdentifierSyntax
 //@[07:027) | | └─Token(Identifier) |concatUnicodeStrings|
-//@[28:034) | ├─VariableAccessSyntax
+//@[28:034) | ├─TypeVariableAccessSyntax
 //@[28:034) | | └─IdentifierSyntax
 //@[28:034) | |   └─Token(Identifier) |string|
 //@[35:036) | ├─Token(Assignment) |=|
@@ -121,7 +121,7 @@ output interpolateUnicodeStrings string = 'Θμ二${emojis}头肌${ninjaCat}α'
 //@[00:006) | ├─Token(Identifier) |output|
 //@[07:032) | ├─IdentifierSyntax
 //@[07:032) | | └─Token(Identifier) |interpolateUnicodeStrings|
-//@[33:039) | ├─VariableAccessSyntax
+//@[33:039) | ├─TypeVariableAccessSyntax
 //@[33:039) | | └─IdentifierSyntax
 //@[33:039) | |   └─Token(Identifier) |string|
 //@[40:041) | ├─Token(Assignment) |=|

--- a/src/Bicep.Core.Samples/Files/baselines/ValidDeployTimeUsages_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ValidDeployTimeUsages_LF/main.syntax.bicep
@@ -190,7 +190,7 @@ param cond bool = false
 //@[00:0005) | ├─Token(Identifier) |param|
 //@[06:0010) | ├─IdentifierSyntax
 //@[06:0010) | | └─Token(Identifier) |cond|
-//@[11:0015) | ├─VariableAccessSyntax
+//@[11:0015) | ├─TypeVariableAccessSyntax
 //@[11:0015) | | └─IdentifierSyntax
 //@[11:0015) | |   └─Token(Identifier) |bool|
 //@[16:0023) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.syntax.bicep
@@ -1602,7 +1602,7 @@ param parameters bool = true
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0016) | ├─IdentifierSyntax
 //@[006:0016) | | └─Token(Identifier) |parameters|
-//@[017:0021) | ├─VariableAccessSyntax
+//@[017:0021) | ├─TypeVariableAccessSyntax
 //@[017:0021) | | └─IdentifierSyntax
 //@[017:0021) | |   └─Token(Identifier) |bool|
 //@[022:0028) | └─ParameterDefaultValueSyntax
@@ -1678,7 +1678,7 @@ param mod bool = true
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0009) | ├─IdentifierSyntax
 //@[006:0009) | | └─Token(Identifier) |mod|
-//@[010:0014) | ├─VariableAccessSyntax
+//@[010:0014) | ├─TypeVariableAccessSyntax
 //@[010:0014) | | └─IdentifierSyntax
 //@[010:0014) | |   └─Token(Identifier) |bool|
 //@[015:0021) | └─ParameterDefaultValueSyntax
@@ -1727,7 +1727,7 @@ param equals bool = true
 //@[000:0005) | ├─Token(Identifier) |param|
 //@[006:0012) | ├─IdentifierSyntax
 //@[006:0012) | | └─Token(Identifier) |equals|
-//@[013:0017) | ├─VariableAccessSyntax
+//@[013:0017) | ├─TypeVariableAccessSyntax
 //@[013:0017) | | └─IdentifierSyntax
 //@[013:0017) | |   └─Token(Identifier) |bool|
 //@[018:0024) | └─ParameterDefaultValueSyntax

--- a/src/Bicep.Core.UnitTests/Syntax/SyntaxHierarchyTests.cs
+++ b/src/Bicep.Core.UnitTests/Syntax/SyntaxHierarchyTests.cs
@@ -52,7 +52,7 @@ namespace Bicep.Core.UnitTests.Syntax
             var varIdSyntax = nodes.OfType<IdentifierSyntax>().Single(id => string.Equals(id.IdentifierName, "bar"));
             hierarchy.GetParent(varIdSyntax).Should().BeSameAs(varDecl);
 
-            var paramTypeSyntax = nodes.OfType<VariableAccessSyntax>().Single();
+            var paramTypeSyntax = nodes.OfType<TypeVariableAccessSyntax>().Single();
             hierarchy.GetParent(paramTypeSyntax).Should().BeSameAs(paramDecl);
 
             var paramTypeIdSyntax = nodes.OfType<IdentifierSyntax>().Single(id => string.Equals(id.IdentifierName, "string"));

--- a/src/Bicep.Core.UnitTests/TypeSystem/OperatorTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/OperatorTests.cs
@@ -65,7 +65,7 @@ namespace Bicep.Core.UnitTests.TypeSystem
         public void Unary_operator_resolves_correct_type(UnaryOperationSyntax expression, TypeSymbol operandType, TypeSymbol expected, IEnumerable<DiagnosticMatcherData> expectedDiagnostics)
         {
             var diagnosticsWriter = ToListDiagnosticWriter.Create();
-            var actual = OperationReturnTypeEvaluator.TryFoldUnaryExpression(expression, operandType, diagnosticsWriter);
+            var actual = OperationReturnTypeEvaluator.TryFoldUnaryExpression(expression.Operator, operandType, diagnosticsWriter);
             actual.Should().Be(expected);
 
             if (diagnosticsWriter.GetDiagnostics().Any() || expectedDiagnostics.Any())

--- a/src/Bicep.Core/Analyzers/Linter/Rules/ArtifactsParametersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/ArtifactsParametersRule.cs
@@ -218,7 +218,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         private static string? GetParameterType(SemanticModel model, ParameterSymbol parameterSymbol)
         {
             if (parameterSymbol.DeclaringSyntax is ParameterDeclarationSyntax parameterDeclaration
-               && parameterDeclaration.Type is VariableAccessSyntax typeSyntax)
+               && parameterDeclaration.Type is TypeVariableAccessSyntax typeSyntax)
             {
                 if (model.HasParsingError(typeSyntax))
                 {

--- a/src/Bicep.Core/Emit/PlaceholderParametersBicepParamWriter.cs
+++ b/src/Bicep.Core/Emit/PlaceholderParametersBicepParamWriter.cs
@@ -78,7 +78,7 @@ namespace Bicep.Core.Emit
                 return defaultValue;
             }
 
-            if (syntax.Type is VariableAccessSyntax variableAccessSyntax)
+            if (syntax.Type is TypeVariableAccessSyntax variableAccessSyntax)
             {
                 var allowedDecorator = syntax.Decorators.Where(e => e.Expression is FunctionCallSyntax functionCallSyntax && functionCallSyntax.Name.IdentifierName == "allowed").Select(e => e.Arguments).FirstOrDefault();
 

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -245,7 +245,7 @@ public class ExpressionBuilder
     private TypeExpression ConvertTypeWithoutLowering(SyntaxBase syntax)
         => syntax switch
         {
-            VariableAccessSyntax variableAccess => Context.SemanticModel.Binder.GetSymbolInfo(syntax) switch
+            TypeVariableAccessSyntax variableAccess => Context.SemanticModel.Binder.GetSymbolInfo(syntax) switch
             {
                 AmbientTypeSymbol ambientType => new AmbientTypeReferenceExpression(syntax, ambientType.Name, UnwrapType(ambientType.Type)),
                 TypeAliasSymbol typeAlias => new TypeAliasReferenceExpression(syntax, typeAlias, UnwrapType(typeAlias.Type)),
@@ -253,16 +253,16 @@ public class ExpressionBuilder
                 Symbol otherwise => throw new ArgumentException($"Encountered unexpected symbol of type {otherwise.GetType()} in a type expression."),
                 _ => throw new ArgumentException($"Unable to locate symbol for name '{variableAccess.Name.IdentifierName}'.")
             },
-            StringSyntax @string => new StringLiteralTypeExpression(@string, GetTypeInfo<StringLiteralType>(@string)),
-            IntegerLiteralSyntax @int => new IntegerLiteralTypeExpression(@int, GetTypeInfo<IntegerLiteralType>(@int)),
-            BooleanLiteralSyntax @bool => new BooleanLiteralTypeExpression(@bool, GetTypeInfo<BooleanLiteralType>(@bool)),
-            UnaryOperationSyntax unaryOperation => Context.SemanticModel.GetTypeInfo(unaryOperation) switch
+            StringTypeLiteralSyntax @string => new StringLiteralTypeExpression(@string, GetTypeInfo<StringLiteralType>(@string)),
+            IntegerTypeLiteralSyntax @int => new IntegerLiteralTypeExpression(@int, GetTypeInfo<IntegerLiteralType>(@int)),
+            BooleanTypeLiteralSyntax @bool => new BooleanLiteralTypeExpression(@bool, GetTypeInfo<BooleanLiteralType>(@bool)),
+            UnaryTypeOperationSyntax unaryOperation => Context.SemanticModel.GetTypeInfo(unaryOperation) switch
             {
                 IntegerLiteralType intOperation => new IntegerLiteralTypeExpression(syntax, intOperation),
                 BooleanLiteralType boolOperation => new BooleanLiteralTypeExpression(syntax, boolOperation),
                 _ => throw new ArgumentException($"Failed to convert syntax of type {syntax.GetType()}"),
             },
-            NullLiteralSyntax @null => new NullLiteralTypeExpression(@null, GetTypeInfo<NullType>(@null)),
+            NullTypeLiteralSyntax @null => new NullLiteralTypeExpression(@null, GetTypeInfo<NullType>(@null)),
             ResourceTypeSyntax resource => new ResourceTypeExpression(resource, GetTypeInfo<ResourceType>(resource)),
             ObjectTypeSyntax objectTypeSyntax => new ObjectTypeExpression(syntax,
                 GetTypeInfo<ObjectType>(syntax),
@@ -293,8 +293,8 @@ public class ExpressionBuilder
                     new UnionType(string.Empty, ImmutableArray.Create<ITypeReference>(otherwise)),
                     ImmutableArray.CreateRange(unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)))),
             },
-            ParenthesizedExpressionSyntax parenthesizedExpression => ConvertTypeWithoutLowering(parenthesizedExpression.Expression),
-            NonNullAssertionSyntax nonNullAssertion => new NonNullableTypeExpression(nonNullAssertion, ConvertTypeWithoutLowering(nonNullAssertion.BaseExpression)),
+            ParenthesizedTypeSyntax parenthesizedExpression => ConvertTypeWithoutLowering(parenthesizedExpression.Expression),
+            NonNullableTypeSyntax nonNullableTypeSyntax => new NonNullableTypeExpression(nonNullableTypeSyntax, ConvertTypeWithoutLowering(nonNullableTypeSyntax.Base)),
             TypePropertyAccessSyntax propertyAccess => ConvertTypePropertyAccess(propertyAccess),
             TypeAdditionalPropertiesAccessSyntax additionalPropertiesAccess => ConvertTypeAdditionalPropertiesAccess(additionalPropertiesAccess),
             TypeArrayAccessSyntax arrayAccess => ConvertTypeArrayAccess(arrayAccess),

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.SyntaxVisitor.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.SyntaxVisitor.cs
@@ -174,6 +174,22 @@ namespace Bicep.Core.PrettyPrintV2
 
         public void VisitTypeItemsAccessSyntax(TypeItemsAccessSyntax syntax) => this.Apply(syntax, LayoutTypeItemsAccessSyntax);
 
+        public void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax) => this.Layout(syntax.Name);
+
+        public void VisitStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax) => this.Apply(syntax, LayoutStringTypeLiteralSyntax);
+
+        public void VisitIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax) => this.Layout(syntax.Literal);
+
+        public void VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax) => this.Layout(syntax.Literal);
+
+        public void VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax) => this.Layout(syntax.NullKeyword);
+
+        public void VisitUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax) => this.Apply(syntax, LayoutUnaryTypeOperationSyntax);
+
+        public void VisitNonNullableTypeSyntax(NonNullableTypeSyntax syntax) => this.Apply(syntax, LayoutNonNullableTypeSyntax);
+
+        public void VisitParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax) => this.Apply(syntax, LayoutParenthesizedTypeSyntax);
+
         public IEnumerable<Document> Layout(SyntaxBase syntax)
         {
             syntax.Accept(this);

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
@@ -603,6 +603,33 @@ namespace Bicep.Core.PrettyPrintV2
         private IEnumerable<Document> LayoutTypeItemsAccessSyntax(TypeItemsAccessSyntax syntax) =>
             this.Glue(syntax.BaseExpression, syntax.OpenSquare, syntax.Asterisk, syntax.CloseSquare);
 
+        private IEnumerable<Document> LayoutStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax)
+        {
+            var leadingTrivia = this.LayoutLeadingTrivia(syntax.StringTokens[0].LeadingTrivia);
+            var trailingTrivia = this.LayoutTrailingTrivia(syntax.StringTokens[^1].TrailingTrivia, out var suffix);
+
+            var writer = new StringWriter();
+
+            for (var i = 0; i < syntax.Expressions.Length; i++)
+            {
+                writer.Write(syntax.StringTokens[i].Text.ReplaceLineEndings(this.context.Newline));
+                SyntaxStringifier.StringifyTo(writer, syntax.Expressions[i], this.context.Newline);
+            }
+
+            writer.Write(syntax.StringTokens[^1].Text.ReplaceLineEndings(this.context.Newline));
+
+            return LayoutWithLeadingAndTrailingTrivia(writer.ToString(), leadingTrivia, trailingTrivia, suffix);
+        }
+
+        private IEnumerable<Document> LayoutUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax)
+            => this.Glue(syntax.OperatorToken, syntax.Expression);
+
+        private IEnumerable<Document> LayoutNonNullableTypeSyntax(NonNullableTypeSyntax syntax)
+            => this.Glue(syntax.Base, syntax.NonNullabilityMarker);
+
+        private IEnumerable<Document> LayoutParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax)
+            => this.Glue(syntax.OpenParen, syntax.Expression, syntax.CloseParen);
+
         private IEnumerable<Document> LayoutLeadingNodes(IEnumerable<SyntaxBase> leadingNodes) =>
             this.LayoutMany(leadingNodes)
                 .Where(x => x != HardLine); // Remove empty lines between decorators.

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -295,6 +295,16 @@ namespace Bicep.Core.Semantics
             this.bindings.Add(syntax, symbol);
         }
 
+        public override void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+        {
+            base.VisitTypeVariableAccessSyntax(syntax);
+
+            var symbol = this.LookupSymbolByName(syntax.Name, false);
+
+            // bind what we got - the type checker will validate if it fits
+            this.bindings.Add(syntax, symbol);
+        }
+
         protected override void VisitInternal(SyntaxBase syntax)
         {
             // any node can be a binding scope

--- a/src/Bicep.Core/Semantics/SymbolicReferenceCollector.cs
+++ b/src/Bicep.Core/Semantics/SymbolicReferenceCollector.cs
@@ -43,4 +43,13 @@ internal class SymbolicReferenceCollector : AstVisitor
 
         base.VisitFunctionCallSyntax(syntax);
     }
+
+    public override void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+    {
+        if (binder.GetSymbolInfo(syntax) is DeclaredSymbol signified)
+        {
+            references.GetOrAdd(signified, _ => ImmutableSortedSet.CreateBuilder<SyntaxBase>(SyntaxSourceOrderComparer.Instance))
+                .Add(syntax);
+        }
+    }
 }

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -454,5 +454,45 @@ namespace Bicep.Core.Syntax
         {
             this.Visit(syntax.BaseExpression);
         }
+
+        public override void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+        {
+            this.Visit(syntax.Name);
+        }
+
+        public override void VisitStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax)
+        {
+            for (int i = 0; i < syntax.StringTokens.Length + syntax.Expressions.Length; i++)
+            {
+                this.Visit(i % 2 == 0 ? syntax.StringTokens[i / 2] : syntax.Expressions[i / 2]);
+            }
+        }
+
+        public override void VisitIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax)
+        {
+        }
+
+        public override void VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax)
+        {
+        }
+
+        public override void VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax)
+        {
+        }
+
+        public override void VisitUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax)
+        {
+            this.Visit(syntax.Expression);
+        }
+
+        public override void VisitNonNullableTypeSyntax(NonNullableTypeSyntax syntax)
+        {
+            this.Visit(syntax.Base);
+        }
+
+        public override void VisitParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax)
+        {
+            this.Visit(syntax.Expression);
+        }
     }
 }

--- a/src/Bicep.Core/Syntax/BooleanTypeLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/BooleanTypeLiteralSyntax.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax;
+
+public class BooleanTypeLiteralSyntax : TypeSyntax
+{
+    public BooleanTypeLiteralSyntax(Token literal, bool value)
+    {
+        Literal = literal;
+        Value = value;
+    }
+
+    public bool Value { get; }
+
+    public Token Literal { get; }
+
+    public override void Accept(ISyntaxVisitor visitor)
+        => visitor.VisitBooleanTypeLiteralSyntax(this);
+
+    public override TextSpan Span
+        => TextSpan.Between(Literal, Literal);
+}

--- a/src/Bicep.Core/Syntax/CstVisitor.cs
+++ b/src/Bicep.Core/Syntax/CstVisitor.cs
@@ -569,5 +569,52 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.Asterisk);
             this.Visit(syntax.CloseSquare);
         }
+
+        public override void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+        {
+            this.Visit(syntax.Name);
+        }
+
+        public override void VisitStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax)
+        {
+            for (int i = 0; i < syntax.StringTokens.Length + syntax.Expressions.Length; i++)
+            {
+                this.Visit(i % 2 == 0 ? syntax.StringTokens[i / 2] : syntax.Expressions[i / 2]);
+            }
+        }
+
+        public override void VisitIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax)
+        {
+            this.Visit(syntax.Literal);
+        }
+
+        public override void VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax)
+        {
+            this.Visit(syntax.Literal);
+        }
+
+        public override void VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax)
+        {
+            this.Visit(syntax.NullKeyword);
+        }
+
+        public override void VisitUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax)
+        {
+            this.Visit(syntax.OperatorToken);
+            this.Visit(syntax.Expression);
+        }
+
+        public override void VisitNonNullableTypeSyntax(NonNullableTypeSyntax syntax)
+        {
+            this.Visit(syntax.Base);
+            this.Visit(syntax.NonNullabilityMarker);
+        }
+
+        public override void VisitParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax)
+        {
+            this.Visit(syntax.OpenParen);
+            this.Visit(syntax.Expression);
+            this.Visit(syntax.CloseParen);
+        }
     }
 }

--- a/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
@@ -155,5 +155,21 @@ namespace Bicep.Core.Syntax
         void VisitTypeArrayAccessSyntax(TypeArrayAccessSyntax syntax);
 
         void VisitTypeItemsAccessSyntax(TypeItemsAccessSyntax syntax);
+
+        void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax);
+
+        void VisitStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax);
+
+        void VisitIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax);
+
+        void VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax);
+
+        void VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax);
+
+        void VisitUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax);
+
+        void VisitNonNullableTypeSyntax(NonNullableTypeSyntax syntax);
+
+        void VisitParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax);
     }
 }

--- a/src/Bicep.Core/Syntax/IntegerTypeLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/IntegerTypeLiteralSyntax.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax;
+
+public class IntegerTypeLiteralSyntax : TypeSyntax
+{
+    public IntegerTypeLiteralSyntax(Token literal, ulong value)
+    {
+        Literal = literal;
+        Value = value;
+    }
+
+    public Token Literal { get; }
+
+    public ulong Value { get; }
+
+    public override void Accept(ISyntaxVisitor visitor)
+        => visitor.VisitIntegerTypeLiteralSyntax(this);
+
+    public override TextSpan Span
+        => TextSpan.Between(Literal, Literal);
+}

--- a/src/Bicep.Core/Syntax/NonNullableTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/NonNullableTypeSyntax.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax;
+
+public class NonNullableTypeSyntax : TypeSyntax
+{
+    public NonNullableTypeSyntax(SyntaxBase @base, Token nonNullabilityMarker)
+    {
+        AssertTokenType(nonNullabilityMarker, nameof(nonNullabilityMarker), TokenType.Exclamation);
+
+        Base = @base;
+        NonNullabilityMarker = nonNullabilityMarker;
+    }
+
+    public SyntaxBase Base { get; }
+
+    public Token NonNullabilityMarker { get; }
+
+    public override void Accept(ISyntaxVisitor visitor) => visitor.VisitNonNullableTypeSyntax(this);
+
+    public override TextSpan Span => TextSpan.Between(Base, NonNullabilityMarker);
+}

--- a/src/Bicep.Core/Syntax/NullTypeLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/NullTypeLiteralSyntax.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class NullTypeLiteralSyntax : TypeSyntax
+    {
+        public NullTypeLiteralSyntax(Token nullKeyword)
+        {
+            AssertTokenType(nullKeyword, nameof(nullKeyword), TokenType.NullKeyword);
+
+            this.NullKeyword = nullKeyword;
+        }
+
+        public Token NullKeyword { get; }
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitNullTypeLiteralSyntax(this);
+
+        public override TextSpan Span => this.NullKeyword.Span;
+    }
+}

--- a/src/Bicep.Core/Syntax/ParameterizedTypeArgumentSyntax.cs
+++ b/src/Bicep.Core/Syntax/ParameterizedTypeArgumentSyntax.cs
@@ -4,7 +4,7 @@ using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax;
 
-public class ParameterizedTypeArgumentSyntax : ExpressionSyntax
+public class ParameterizedTypeArgumentSyntax : TypeSyntax
 {
     public ParameterizedTypeArgumentSyntax(SyntaxBase expression)
     {

--- a/src/Bicep.Core/Syntax/ParenthesizedTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/ParenthesizedTypeSyntax.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class ParenthesizedTypeSyntax : TypeSyntax
+    {
+        public ParenthesizedTypeSyntax(Token openParen, SyntaxBase expression, SyntaxBase closeParen)
+        {
+            AssertTokenType(openParen, nameof(openParen), TokenType.LeftParen);
+            AssertSyntaxType(closeParen, nameof(closeParen), typeof(Token), typeof(SkippedTriviaSyntax));
+
+            if (closeParen is Token closeParenToken)
+            {
+                AssertTokenType(closeParenToken, nameof(closeParen), TokenType.RightParen);
+            }
+
+            this.OpenParen = openParen;
+            this.Expression = expression;
+            this.CloseParen = closeParen;
+        }
+
+        public Token OpenParen { get; }
+
+        public SyntaxBase Expression { get; }
+
+        public SyntaxBase CloseParen { get; }
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitParenthesizedTypeSyntax(this);
+
+        public override TextSpan Span => TextSpan.Between(this.OpenParen, this.CloseParen);
+    }
+}

--- a/src/Bicep.Core/Syntax/StringTypeLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/StringTypeLiteralSyntax.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Immutable;
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class StringTypeLiteralSyntax(IEnumerable<Token> stringTokens, IEnumerable<SyntaxBase> expressions, IEnumerable<string> segmentValues) : TypeSyntax
+    {
+        public ImmutableArray<Token> StringTokens { get; } = stringTokens.ToImmutableArray();
+
+        public ImmutableArray<SyntaxBase> Expressions { get; } = expressions.ToImmutableArray();
+
+        public ImmutableArray<string> SegmentValues { get; } = segmentValues.ToImmutableArray();
+
+        public override void Accept(ISyntaxVisitor visitor)
+            => visitor.VisitStringTypeLiteralSyntax(this);
+
+        public override TextSpan Span
+            => TextSpan.Between(StringTokens.First(), StringTokens.Last());
+
+        /// <summary>
+        /// Returns the span between the quotes for a string token.
+        /// </summary>
+        public TextSpan GetInnerSpan()
+        {
+            var skipChars = StringTokens.First().Type == TokenType.MultilineString ? 3 : 1;
+            var outerSpan = Span;
+
+            return new(outerSpan.Position + skipChars, outerSpan.Length - (skipChars * 2));
+        }
+    }
+}

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -1252,5 +1252,128 @@ namespace Bicep.Core.Syntax
             return new ParameterizedTypeArgumentSyntax(expression);
         }
         void ISyntaxVisitor.VisitParameterizedTypeArgumentSyntax(ParameterizedTypeArgumentSyntax syntax) => ReplaceCurrent(syntax, ReplaceParameterizedTypeArgumentSyntax);
+
+        protected virtual SyntaxBase ReplaceTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.Name, out var name);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new TypeVariableAccessSyntax(name);
+        }
+        void ISyntaxVisitor.VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceTypeVariableAccessSyntax);
+
+        protected virtual SyntaxBase ReplaceStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.StringTokens, out var stringTokens);
+            hasChanges |= TryRewrite(syntax.Expressions, out var expressions);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            var segmentValues = Lexer.TryGetRawStringSegments(stringTokens.ToArray());
+            if (segmentValues == null)
+            {
+                throw new ArgumentException($"Failed to parse string tokens");
+            }
+
+            return new StringTypeLiteralSyntax(stringTokens, expressions, segmentValues);
+        }
+        void ISyntaxVisitor.VisitStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceStringTypeLiteralSyntax);
+
+        protected virtual SyntaxBase ReplaceIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.Literal, out var literal);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new IntegerTypeLiteralSyntax(literal, ulong.Parse(literal.Text));
+        }
+        void ISyntaxVisitor.VisitIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceIntegerTypeLiteralSyntax);
+
+        protected virtual SyntaxBase ReplaceBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.Literal, out var literal);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new BooleanTypeLiteralSyntax(literal, bool.Parse(literal.Text));
+        }
+        void ISyntaxVisitor.VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceBooleanTypeLiteralSyntax);
+
+        protected virtual SyntaxBase ReplaceNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.NullKeyword, out var nullKeyword);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new NullTypeLiteralSyntax(nullKeyword);
+        }
+        void ISyntaxVisitor.VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceNullTypeLiteralSyntax);
+
+        protected virtual SyntaxBase ReplaceUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.OperatorToken, out var operatorToken);
+            hasChanges |= TryRewrite(syntax.Expression, out var expression);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new UnaryTypeOperationSyntax(operatorToken, expression);
+        }
+        void ISyntaxVisitor.VisitUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceUnaryTypeOperationSyntax);
+
+        protected virtual SyntaxBase ReplaceNonNullableTypeSyntax(NonNullableTypeSyntax syntax)
+        {
+            var hasChanges = TryRewrite(syntax.Base, out var baseExpression);
+            hasChanges |= TryRewriteStrict(syntax.NonNullabilityMarker, out var nonNullabilityMarker);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new NonNullableTypeSyntax(baseExpression, nonNullabilityMarker);
+        }
+        void ISyntaxVisitor.VisitNonNullableTypeSyntax(NonNullableTypeSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceNonNullableTypeSyntax);
+
+        protected virtual SyntaxBase ReplaceParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax)
+        {
+            var hasChanges = TryRewriteStrict(syntax.OpenParen, out var openParen);
+            hasChanges |= TryRewrite(syntax.Expression, out var expression);
+            hasChanges |= TryRewrite(syntax.CloseParen, out var closeParen);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new ParenthesizedTypeSyntax(openParen, expression, closeParen);
+        }
+        void ISyntaxVisitor.VisitParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax)
+            => ReplaceCurrent(syntax, ReplaceParenthesizedTypeSyntax);
     }
 }

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -160,6 +160,22 @@ namespace Bicep.Core.Syntax
 
         public abstract void VisitTypeItemsAccessSyntax(TypeItemsAccessSyntax syntax);
 
+        public abstract void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax);
+
+        public abstract void VisitStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax);
+
+        public abstract void VisitIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax);
+
+        public abstract void VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax);
+
+        public abstract void VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax);
+
+        public abstract void VisitUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax);
+
+        public abstract void VisitNonNullableTypeSyntax(NonNullableTypeSyntax syntax);
+
+        public abstract void VisitParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax);
+
         public void Visit(SyntaxBase? node)
         {
             if (node == null)

--- a/src/Bicep.Core/Syntax/TypeVariableAccessSyntax.cs
+++ b/src/Bicep.Core/Syntax/TypeVariableAccessSyntax.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Navigation;
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    /// <summary>
+    /// Represents a reference to a variable or parameter
+    /// </summary>
+    public class TypeVariableAccessSyntax : TypeSyntax, ISymbolReference
+    {
+        public TypeVariableAccessSyntax(IdentifierSyntax name)
+        {
+            this.Name = name;
+        }
+
+        public IdentifierSyntax Name { get; }
+
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitTypeVariableAccessSyntax(this);
+
+        public override TextSpan Span => this.Name.Span;
+    }
+}

--- a/src/Bicep.Core/Syntax/UnaryTypeOperationSyntax.cs
+++ b/src/Bicep.Core/Syntax/UnaryTypeOperationSyntax.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax;
+
+public class UnaryTypeOperationSyntax : TypeSyntax
+{
+    public UnaryTypeOperationSyntax(Token operatorToken, SyntaxBase expression)
+    {
+        if (Operators.TokenTypeToUnaryOperator.ContainsKey(operatorToken.Type) == false)
+        {
+            throw new ArgumentException($"{nameof(operatorToken)} is of type '{operatorToken.Type}' which does not represent a valid unary operator.");
+        }
+
+        this.OperatorToken = operatorToken;
+        this.Expression = expression;
+    }
+
+    public Token OperatorToken { get; }
+
+    public SyntaxBase Expression { get; }
+
+    public UnaryOperator Operator => Operators.TokenTypeToUnaryOperator[this.OperatorToken.Type];
+
+    public override void Accept(ISyntaxVisitor visitor) => visitor.VisitUnaryTypeOperationSyntax(this);
+
+    public override TextSpan Span => TextSpan.Between(OperatorToken, Expression);
+}

--- a/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CyclicCheckVisitor.cs
@@ -128,6 +128,21 @@ namespace Bicep.Core.TypeSystem
             base.VisitVariableAccessSyntax(syntax);
         }
 
+        public override void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+        {
+            if (!currentDeclarations.TryPeek(out var currentDeclaration))
+            {
+                return;
+            }
+
+            if (!selfReferencePermitted)
+            {
+                declarationAccessDict[currentDeclaration].Add(syntax);
+            }
+
+            base.VisitTypeVariableAccessSyntax(syntax);
+        }
+
         public override void VisitResourceAccessSyntax(ResourceAccessSyntax syntax)
         {
             if (!currentDeclarations.TryPeek(out var currentDeclaration))

--- a/src/Bicep.Core/TypeSystem/CyclicTypeCheckVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/CyclicTypeCheckVisitor.cs
@@ -60,6 +60,18 @@ public sealed class CyclicTypeCheckVisitor : AstVisitor
         base.VisitVariableAccessSyntax(syntax);
     }
 
+    public override void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+    {
+        // If this reference is not nested within a type container, it would have been detected based on syntax alone in CyclicCheckVisitor.
+        // To avoid doubling up on diagnostics, skip recording cycles on top-level accesses
+        if (enteredTypeContainer)
+        {
+            declarationAccesses.Add(syntax);
+        }
+        
+        base.VisitTypeVariableAccessSyntax(syntax);
+    }
+
     public override void VisitArrayTypeSyntax(ArrayTypeSyntax syntax)
         => WithEnteredTypeContainerState(() => base.VisitArrayTypeSyntax(syntax), enteredTypeContainer: true);
 

--- a/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
+++ b/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
@@ -51,8 +51,8 @@ public static class OperationReturnTypeEvaluator
         // coalesce
         new CoalesceEvaluator());
 
-    public static TypeSymbol? TryFoldUnaryExpression(UnaryOperationSyntax expressionSyntax, TypeSymbol operandType, IDiagnosticWriter diagnosticWriter)
-        => unaryEvaluators.Where(e => e.IsMatch(expressionSyntax.Operator, operandType)).FirstOrDefault()?.Evaluate(expressionSyntax, operandType);
+    public static TypeSymbol? TryFoldUnaryExpression(UnaryOperator unaryOperator, TypeSymbol operandType, IDiagnosticWriter diagnosticWriter)
+        => unaryEvaluators.Where(e => e.IsMatch(unaryOperator, operandType)).FirstOrDefault()?.Evaluate(operandType);
 
     public static TypeSymbol? TryFoldBinaryExpression(BinaryOperationSyntax expressionSyntax, TypeSymbol leftOperandType, TypeSymbol rightOperandType, IDiagnosticWriter diagnosticWriter)
     {
@@ -70,7 +70,7 @@ public static class OperationReturnTypeEvaluator
 
         TypeSymbol OperandType { get; }
 
-        TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol operandType);
+        TypeSymbol Evaluate(TypeSymbol operandType);
 
         bool IsMatch(UnaryOperator @operator, TypeSymbol operandType)
             => Operator == @operator && TypeValidator.AreTypesAssignable(operandType, OperandType);
@@ -82,9 +82,9 @@ public static class OperationReturnTypeEvaluator
 
         public TypeSymbol OperandType => LanguageConstants.Bool;
 
-        public TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol operandType) => operandType switch
+        public TypeSymbol Evaluate(TypeSymbol operandType) => operandType switch
         {
-            UnionType union => TypeHelper.CreateTypeUnion(union.Members.Select(t => Evaluate(expressionSyntax, t.Type))),
+            UnionType union => TypeHelper.CreateTypeUnion(union.Members.Select(t => Evaluate(t.Type))),
             BooleanLiteralType booleanLiteral => TypeFactory.CreateBooleanLiteralType(!booleanLiteral.Value, booleanLiteral.ValidationFlags),
             BooleanType @bool => @bool,
             _ => TypeFactory.CreateBooleanType(operandType.ValidationFlags),
@@ -148,7 +148,7 @@ public static class OperationReturnTypeEvaluator
 
         public TypeSymbol OperandType => LanguageConstants.Int;
 
-        public TypeSymbol Evaluate(SyntaxBase expressionSyntax, TypeSymbol operandType) => Negate(operandType);
+        public TypeSymbol Evaluate(TypeSymbol operandType) => Negate(operandType);
     }
 
     private interface IBinaryEvaluator

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -667,7 +667,7 @@ namespace Bicep.Core.TypeSystem
 
         private bool MightBeArrayAny(SyntaxBase syntax) => binder.GetParent(syntax) switch
         {
-            ParenthesizedExpressionSyntax parenthesized => MightBeArrayAny(parenthesized),
+            ParenthesizedTypeSyntax parenthesized => MightBeArrayAny(parenthesized),
             ArrayTypeMemberSyntax arrayTypeMember => MightBeArrayAny(arrayTypeMember),
             ArrayTypeSyntax => true,
             _ => false,
@@ -780,6 +780,79 @@ namespace Bicep.Core.TypeSystem
                 var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
 
                 base.VisitTypeItemsAccessSyntax(syntax);
+
+                return declaredType;
+            });
+
+        public override void VisitTypeVariableAccessSyntax(TypeVariableAccessSyntax syntax)
+            => AssignType(syntax, () =>
+            {
+                var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
+
+                base.VisitTypeVariableAccessSyntax(syntax);
+
+                return declaredType;
+            });
+
+        public override void VisitStringTypeLiteralSyntax(StringTypeLiteralSyntax syntax)
+            => AssignType(syntax, () =>
+            {
+                var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
+
+                base.VisitStringTypeLiteralSyntax(syntax);
+
+                return declaredType;
+            });
+
+        public override void VisitIntegerTypeLiteralSyntax(IntegerTypeLiteralSyntax syntax)
+            => AssignType(syntax, () =>
+            {
+                var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
+
+                base.VisitIntegerTypeLiteralSyntax(syntax);
+
+                return declaredType;
+            });
+
+        public override void VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax)
+            => AssignType(syntax, () =>
+            {
+                var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
+
+                base.VisitBooleanTypeLiteralSyntax(syntax);
+
+                return declaredType;
+            });
+
+        public override void VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax)
+            => AssignType(syntax, () => LanguageConstants.Null);
+
+        public override void VisitUnaryTypeOperationSyntax(UnaryTypeOperationSyntax syntax)
+            => AssignType(syntax, () =>
+            {
+                var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
+
+                base.VisitUnaryTypeOperationSyntax(syntax);
+
+                return declaredType;
+            });
+
+        public override void VisitNonNullableTypeSyntax(NonNullableTypeSyntax syntax)
+            => AssignType(syntax, () =>
+            {
+                var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
+
+                base.VisitNonNullableTypeSyntax(syntax);
+
+                return declaredType;
+            });
+
+        public override void VisitParenthesizedTypeSyntax(ParenthesizedTypeSyntax syntax)
+            => AssignType(syntax, () =>
+            {
+                var declaredType = typeManager.GetDeclaredType(syntax) ?? ErrorType.Empty();
+
+                base.VisitParenthesizedTypeSyntax(syntax);
 
                 return declaredType;
             });
@@ -1380,7 +1453,7 @@ namespace Bicep.Core.TypeSystem
 
                 // operand doesn't appear to have errors
                 // let's fold the expression so that an operation with a literal typed operand will have a literal return type
-                if (OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax, operandType, diagnostics) is { } result)
+                if (OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax.Operator, operandType, diagnostics) is { } result)
                 {
                     return result;
                 }

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -118,7 +118,7 @@ namespace Bicep.LangServer.IntegrationTests
 
                     switch (symbol)
                     {
-                        case FunctionSymbol when symbolReference is VariableAccessSyntax:
+                        case FunctionSymbol when symbolReference is VariableAccessSyntax or TypeVariableAccessSyntax:
                             // variable got bound to a function
                             hover.Should().BeNull();
                             break;

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -345,24 +345,24 @@ namespace Bicep.LanguageServer.Completions
                 (output.Assignment is SkippedTriviaSyntax || (output.Assignment is Token assignment && offset <= assignment.GetPosition()));
 
             if (SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax>(matchingNodes, parameter => CheckTypeIsExpected(parameter.Name, parameter.Type)) ||
-                SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier))
+                SyntaxMatcher.IsTailMatch<ParameterDeclarationSyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier))
             {
                 // the most specific matching node is a parameter declaration
                 // the declaration syntax is "param <identifier> <type> ..."
                 // the cursor position is on the type if we have an identifier (non-zero length span) and the offset matches the type position
                 // OR
-                // we are in a token that is inside a VariableAccessSyntax node, which is inside a parameter node
+                // we are in a token that is inside a TypeVariableAccessSyntax node, which is inside a parameter node
                 return BicepCompletionContextKind.ParameterType;
             }
 
             if (SyntaxMatcher.IsTailMatch<TypeDeclarationSyntax>(matchingNodes, typeDeclaration => typeDeclaration.Assignment is not SkippedTriviaSyntax && offset > typeDeclaration.Assignment.GetEndPosition() && offset <= typeDeclaration.Value.Span.Position) ||
-                SyntaxMatcher.IsTailMatch<TypeDeclarationSyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier))
+                SyntaxMatcher.IsTailMatch<TypeDeclarationSyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier))
             {
                 // the most specific matching node is a type declaration
                 // the declaration syntax is "type <identifier> = <type>"
                 // the cursor position is on the type if we have an identifier (non-zero length span) and the offset matches the type position
                 // OR
-                // we are in a token that is inside a VariableAccessSyntax node, which is inside a type declaration node
+                // we are in a token that is inside a TypeVariableAccessSyntax node, which is inside a type declaration node
                 return BicepCompletionContextKind.TypeDeclarationValue;
             }
 
@@ -378,13 +378,13 @@ namespace Bicep.LanguageServer.Completions
             }
 
             if (SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax>(matchingNodes, output => CheckTypeIsExpected(output.Name, output.Type)) ||
-                SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier))
+                SyntaxMatcher.IsTailMatch<OutputDeclarationSyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier))
             {
                 // the most specific matching node is an output declaration
                 // the declaration syntax is "output <identifier> <type> ..."
                 // the cursor position is on the type if we have an identifier (non-zero length span) and the offset matches the type position
                 // OR
-                // we are in a token that is inside a VariableAccessSyntax node, which is inside an output node
+                // we are in a token that is inside a TypeVariableAccessSyntax node, which is inside an output node
                 return BicepCompletionContextKind.OutputType;
             }
 
@@ -895,12 +895,12 @@ namespace Bicep.LanguageServer.Completions
 
         private static bool IsObjectTypePropertyValueContext(List<SyntaxBase> matchingNodes, int offset) =>
             SyntaxMatcher.IsTailMatch<ObjectTypePropertySyntax>(matchingNodes, typePropertySyntax => typePropertySyntax.Colon is not SkippedTriviaSyntax && offset > typePropertySyntax.Colon.Span.Position) ||
-            SyntaxMatcher.IsTailMatch<ObjectTypePropertySyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier);
+            SyntaxMatcher.IsTailMatch<ObjectTypePropertySyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.Identifier);
 
         private static bool IsUnionTypeMemberContext(List<SyntaxBase> matchingNodes, int offset) =>
             SyntaxMatcher.IsTailMatch<UnionTypeSyntax, Token>(matchingNodes, (_, token) => token.Type == TokenType.Pipe) ||
             SyntaxMatcher.IsTailMatch<UnionTypeSyntax>(matchingNodes, union => union.Children.LastOrDefault() is SkippedTriviaSyntax) ||
-            SyntaxMatcher.IsTailMatch<UnionTypeSyntax, UnionTypeMemberSyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, _, token) => token.Type == TokenType.Identifier);
+            SyntaxMatcher.IsTailMatch<UnionTypeSyntax, UnionTypeMemberSyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, _, token) => token.Type == TokenType.Identifier);
 
         private static IndexedSyntaxContext<FunctionCallSyntaxBase>? TryGetFunctionArgumentContext(List<SyntaxBase> matchingNodes, int offset)
         {
@@ -983,7 +983,7 @@ namespace Bicep.LanguageServer.Completions
 
             // someType<x, 'a|bc'>
             // abc.someType<x, 'de|f'>
-            if (SyntaxMatcher.IsTailMatch<ParameterizedTypeInstantiationSyntaxBase, ParameterizedTypeArgumentSyntax, StringSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.StringComplete))
+            if (SyntaxMatcher.IsTailMatch<ParameterizedTypeInstantiationSyntaxBase, ParameterizedTypeArgumentSyntax, StringTypeLiteralSyntax, Token>(matchingNodes, (_, _, _, token) => token.Type == TokenType.StringComplete))
             {
                 var instantiation = (ParameterizedTypeInstantiationSyntaxBase)matchingNodes[^4];
                 var args = instantiation.Arguments;
@@ -993,7 +993,7 @@ namespace Bicep.LanguageServer.Completions
 
             // someType<x, ab|c>
             // abc.someType<x, de|f>
-            if (SyntaxMatcher.IsTailMatch<ParameterizedTypeInstantiationSyntaxBase, ParameterizedTypeArgumentSyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, _, token) => token.Type == TokenType.Identifier))
+            if (SyntaxMatcher.IsTailMatch<ParameterizedTypeInstantiationSyntaxBase, ParameterizedTypeArgumentSyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, _, _, _, token) => token.Type == TokenType.Identifier))
             {
                 var instantiation = (ParameterizedTypeInstantiationSyntaxBase)matchingNodes[^5];
                 var args = instantiation.Arguments;
@@ -1249,13 +1249,13 @@ namespace Bicep.LanguageServer.Completions
             // func foo() | => bar
             SyntaxMatcher.IsTailMatch<TypedLambdaSyntax>(matchingNodes, (lambda) => offset > lambda.VariableSection.GetEndPosition() && (lambda.Arrow.IsSkipped || offset < lambda.Arrow.GetPosition())) ||
             // func foo() a| => bar
-            SyntaxMatcher.IsTailMatch<TypedLambdaSyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (lambda, variable, _, _) => lambda.ReturnType == variable);
+            SyntaxMatcher.IsTailMatch<TypedLambdaSyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (lambda, variable, _, _) => lambda.ReturnType == variable);
 
         private static bool IsTypedLocalVariableTypeContext(List<SyntaxBase> matchingNodes, int offset) =>
             // func foo(a |) string => bar
             SyntaxMatcher.IsTailMatch<TypedVariableBlockSyntax, TypedLocalVariableSyntax>(matchingNodes, (_, variable) => offset > variable.Name.GetEndPosition()) ||
             // func foo(a b|) string => bar
-            SyntaxMatcher.IsTailMatch<TypedVariableBlockSyntax, TypedLocalVariableSyntax, VariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, variable, type, _, _) => variable.Type == type);
+            SyntaxMatcher.IsTailMatch<TypedVariableBlockSyntax, TypedLocalVariableSyntax, TypeVariableAccessSyntax, IdentifierSyntax, Token>(matchingNodes, (_, variable, type, _, _) => variable.Type == type);
 
         private static bool IsResourceDependsOnArrayItemContext(BicepCompletionContextKind kind, string? propertyName, SyntaxBase? topLevelDeclarationInfo)
         {

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -357,9 +357,9 @@ namespace Bicep.LanguageServer.Completions
                         .Select(exportMetadata => (wildcardImport, exportMetadata)))
                     .Select(t => CreateWildcardPropertyCompletion(t.Item1, t.Item2, context.ReplacementRange, CompletionPriority.High)));
 
-        private static bool IsTypeLiteralSyntax(SyntaxBase syntax) => syntax is BooleanLiteralSyntax
-            || syntax is IntegerLiteralSyntax
-            || (syntax is StringSyntax @string && @string.TryGetLiteralValue() is string literal)
+        private static bool IsTypeLiteralSyntax(SyntaxBase syntax) => syntax is BooleanTypeLiteralSyntax
+            || syntax is IntegerTypeLiteralSyntax
+            || (syntax is StringTypeLiteralSyntax @string && @string.SegmentValues.Length == 1)
             || syntax is UnionTypeSyntax
             || (syntax is ObjectTypeSyntax objectType && objectType.Properties.All(p => IsTypeLiteralSyntax(p.Value)))
             || (syntax is TupleTypeSyntax tupleType && tupleType.Items.All(i => IsTypeLiteralSyntax(i.Value)));
@@ -406,6 +406,7 @@ namespace Bicep.LanguageServer.Completions
         private static string? TryGetEnteredTextFromStringOrSkipped(SyntaxBase syntax)
             => syntax switch
             {
+                StringTypeLiteralSyntax s when s.SegmentValues.Length == 1 => s.SegmentValues[0],
                 StringSyntax s => s.TryGetLiteralValue(),
                 SkippedTriviaSyntax s => TryGetSkippedTokenText(s),
                 _ => null,

--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -287,8 +287,8 @@ namespace Bicep.LanguageServer.Handlers
                 break;
             }
 
-            if (syntax is VariableAccessSyntax ancestor
-                && semanticModel.GetSymbolInfo(ancestor) is DeclaredSymbol ancestorSymbol)
+            if (syntax is VariableAccessSyntax or TypeVariableAccessSyntax
+                && semanticModel.GetSymbolInfo(syntax) is DeclaredSymbol ancestorSymbol)
             {
                 // If the symbol is a module, we need to redirect the user to the module file
                 // note: module.name doesn't follow this: it should refer to the declaration of the module in the current file, like regular variable and resource property accesses


### PR DESCRIPTION
Resolves #13618

In order to make type determinations, the `DeclaredTypeManager` needs to know whether it is within type syntax or expression syntax. This distinction is meaningful for property access (e.g., `<array type>[*]` is legal within type syntax but not within expression syntax, whereas `<array value>[?0]` is legal within expression syntax but not within type syntax), variable access (variables within type syntax can refer to other types but not values, and variables within expression syntax can refer to values but not types), nullability control syntax, and literal value syntax. 

Prior to Bicep 0.26, the type manager was relying on internal state that assumed the AST would be visited in order. This resulted in unstable type assignments if the type of type syntax was requested out of order. In Bicep 0.26.54, this was replaced with a deterministic check that used the model's syntax hierarchy to determine whether a given syntax node was a descendant of the type declaration of an `output` or `parameter` statement or the assigned value of a `type` statement (indicating type syntax) or not (indicating expression syntax). However, querying the syntax hierarchy can throw an exception if a node was not part of the original model (e.g., if it was created by a `SyntaxRewriteVisitor`).

This PR moves the responsibility for making this distinction to the parser. The parser is already tracking whether it is within type syntax or expression syntax, as the grammar for each syntax class is distinct. This PR introduces some new descendent classes of `TypeSyntax` that are minimally changed copies of descendent classes of `ExpressionSyntax`: `VariableAccessSyntax` is a descendent of `ExpressionSyntax`, and `TypeVariableAccessSyntax` is a descendent of `TypeSyntax`, but the two classes are otherwise identical. This means that the compiler can determine whether an arbitrary syntax node was encountered in type syntax or expression syntax based solely on the C# type of the syntax node rather than having to rely on the syntax hierarchy or order of operations.

About 50% of the line count for this PR comes from baseline changes. These are all to the `main.syntax.bicep` artifacts and consist of the class name for specific nodes being changed (e.g., `VariableAccessSyntax` -> `TypeVariableAccessSyntax`, `StringSyntax` -> `StringTypeLiteralSyntax`, etc.).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13671)