### PR TITLE
Update Microsoft Graph Bicep types

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -493,8 +493,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2176,7 +2176,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -407,8 +407,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -1995,7 +1995,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -399,8 +399,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -1893,7 +1893,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -465,8 +465,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2105,7 +2105,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
@@ -65,3 +65,8 @@ resource group 'Microsoft.Graph/groups@beta' = {
   groupTypes: ['Unified']
   owners: [resourceSp.id]
 }
+
+resource appV1 'Microsoft.Graph/applications@v1.0' = {
+  displayName: 'TestAppV1'
+  uniqueName: 'testAppV1'
+}

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.json
@@ -11,7 +11,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2462067839436922243"
+      "templateHash": "9158608803224636845"
     }
   },
   "parameters": {
@@ -138,6 +138,14 @@
       "dependsOn": [
         "resourceSp"
       ]
+    },
+    "appV1": {
+      "import": "graph",
+      "type": "Microsoft.Graph/applications@v1.0",
+      "properties": {
+        "displayName": "TestAppV1",
+        "uniqueName": "testAppV1"
+      }
     }
   }
 }

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -452,8 +452,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2052,7 +2052,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -481,8 +481,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2057,7 +2057,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Graph.Bicep.Types" Version="0.1.3-preview" />
+    <PackageReference Include="Microsoft.Graph.Bicep.Types" Version="0.1.4-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
     <PackageReference Include="Azure.Deployments.Templates" Version="1.0.1229" />

--- a/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeProvider.cs
@@ -10,6 +10,7 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
     {
         public const string UniqueNamePropertyName = "uniqueName";
         public const string AppIdPropertyName = "appId";
+        public const string NamePropertyName = "name";
 
         public static readonly TypeSymbol Tags = new ObjectType(nameof(Tags), TypeSymbolValidationFlags.Default, Enumerable.Empty<TypeProperty>(), LanguageConstants.String, TypePropertyFlags.None);
 
@@ -21,6 +22,7 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
         {
             UniqueNamePropertyName,
             AppIdPropertyName,
+            NamePropertyName,
         }.ToImmutableHashSet();
 
         /*
@@ -93,11 +95,18 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
                 properties = properties.SetItem(LanguageConstants.ResourceDependsOnPropertyName, new TypeProperty(LanguageConstants.ResourceDependsOnPropertyName, LanguageConstants.ResourceOrResourceCollectionRefArray, TypePropertyFlags.WriteOnly | TypePropertyFlags.DisallowAny));
             }
 
-            // add the loop variant flag to the name property (if it exists)
-            if (properties.TryGetValue(UniqueNamePropertyName, out var nameProperty))
+            // add the loop variant flag to the uniqueName property (if it exists)
+            if (properties.TryGetValue(UniqueNamePropertyName, out var uniqueNameProperty))
             {
                 // TODO apply this to all unique properties
-                properties = properties.SetItem(UniqueNamePropertyName, UpdateFlags(nameProperty, nameProperty.Flags | TypePropertyFlags.LoopVariant));
+                properties = properties.SetItem(UniqueNamePropertyName, UpdateFlags(uniqueNameProperty, uniqueNameProperty.Flags | TypePropertyFlags.LoopVariant));
+            }
+
+            // add the loop variant flag to the name property (if it exists)
+            if (properties.TryGetValue(NamePropertyName, out var nameProperty))
+            {
+                // TODO apply this to all unique properties
+                properties = properties.SetItem(NamePropertyName, UpdateFlags(nameProperty, nameProperty.Flags | TypePropertyFlags.LoopVariant));
             }
 
             foreach (var identifier in ReadWriteDeployTimeConstantPropertyNames)
@@ -121,7 +130,7 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
         {
             foreach (var property in properties)
             {
-                // "uniqueName", "scope" & "parent" can be set for existing resources - everything else should be read-only
+                // "uniqueName", "name", "appId", "scope" & "parent" can be set for existing resources - everything else should be read-only
                 if (UniqueIdentifierProperties.Contains(property.Name))
                 {
                     yield return property;

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -163,9 +163,9 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Direct",
-        "requested": "[0.1.3-preview, )",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "requested": "[0.1.4-preview, )",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -465,8 +465,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2105,7 +2105,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -465,8 +465,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2105,7 +2105,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -309,8 +309,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -1761,7 +1761,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -486,8 +486,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2066,7 +2066,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -501,8 +501,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2133,7 +2133,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -416,8 +416,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -1945,7 +1945,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -631,8 +631,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2338,7 +2338,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -601,8 +601,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2279,7 +2279,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -631,8 +631,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2338,7 +2338,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -592,8 +592,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2046,7 +2046,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -515,8 +515,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -2153,7 +2153,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -408,8 +408,8 @@
       },
       "Microsoft.Graph.Bicep.Types": {
         "type": "Transitive",
-        "resolved": "0.1.3-preview",
-        "contentHash": "GoB1xptBXqiJl2/aoC8V0sk4D7Hbt0Tq4DgeKDQ7WUF2IQIhFybsvc5uyuyChudLD0z4kDtObbUNlp18U6c64Q==",
+        "resolved": "0.1.4-preview",
+        "contentHash": "xKFWkpFUmimbuWB/zQva1e/AFTLlUiirRprqOCp1gWOVMMbF1ciyOl7XZ3rumYHvunSt/O+X2XHczA5sDxYgMQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.6"
         }
@@ -1887,7 +1887,7 @@
           "Microsoft.Extensions.Configuration.Binder": "[8.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[8.0.0, )",
           "Microsoft.Extensions.DependencyInjection": "[8.0.0, )",
-          "Microsoft.Graph.Bicep.Types": "[0.1.3-preview, )",
+          "Microsoft.Graph.Bicep.Types": "[0.1.4-preview, )",
           "Microsoft.PowerPlatform.ResourceStack": "[6.0.0.1485, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "SharpYaml": "[2.1.1, )",


### PR DESCRIPTION
Update MicrosoftGraph Bicep typeloader version to enable existing resources in v1.0 API version and support new resource `applications/federatedIdentityCredentials@beta`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13719)