### PR TITLE
Support including imported types in user-defined tagged unions

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
@@ -510,24 +510,6 @@ type discriminatedUnion1 = typeA | typeB
 //@        }
 //@      }
 //@    },
-//@          "a": {
-//@            "$ref": "#/definitions/typeA"
-//@          },
-//@          "b": {
-//@            "$ref": "#/definitions/typeB"
-//@          },
-//@          "a": {
-//@            "$ref": "#/definitions/typeA"
-//@          },
-//@          "b": {
-//@            "$ref": "#/definitions/typeB"
-//@          },
-//@                    "a": {
-//@                      "$ref": "#/definitions/typeA"
-//@                    },
-//@                    "b": {
-//@                      "$ref": "#/definitions/typeB"
-//@                    },
 
 @discriminator('type')
 type discriminatedUnion2 = { type: 'c', value: string } | { type: 'd', value: bool }
@@ -659,6 +641,12 @@ type discriminatedUnion3 = discriminatedUnion1 | discriminatedUnion2 | { type: '
 //@      "discriminator": {
 //@        "propertyName": "type",
 //@        "mapping": {
+//@          "a": {
+//@            "$ref": "#/definitions/typeA"
+//@          },
+//@          "b": {
+//@            "$ref": "#/definitions/typeB"
+//@          },
 //@          "e": {
 //@            "type": "object",
 //@            "properties": {
@@ -684,6 +672,12 @@ type discriminatedUnion4 = discriminatedUnion1 | (discriminatedUnion2 | typeE)
 //@      "discriminator": {
 //@        "propertyName": "type",
 //@        "mapping": {
+//@          "a": {
+//@            "$ref": "#/definitions/typeA"
+//@          },
+//@          "b": {
+//@            "$ref": "#/definitions/typeB"
+//@          },
 //@          "e": {
 //@            "$ref": "#/definitions/typeE"
 //@          }
@@ -855,6 +849,12 @@ type inlineDiscriminatedUnion3 = {
 //@                "discriminator": {
 //@                  "propertyName": "type",
 //@                  "mapping": {
+//@                    "a": {
+//@                      "$ref": "#/definitions/typeA"
+//@                    },
+//@                    "b": {
+//@                      "$ref": "#/definitions/typeB"
+//@                    },
 //@                  }
 //@                }
 //@              }

--- a/src/Bicep.Core.UnitTests/TypeSystem/ResourceDerivedTypeResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/ResourceDerivedTypeResolverTests.cs
@@ -292,13 +292,28 @@ public class ResourceDerivedTypeResolverTests
                     ImmutableArray.Create<ITypeReference>(new ObjectType("dictionary",
                         TypeSymbolValidationFlags.Default,
                         ImmutableArray<TypeProperty>.Empty,
-                        TypeFactory.CreateArrayType(targetType))),
+                        TypeFactory.CreateArrayType(new DiscriminatedObjectType("taggedUnion",
+                            TypeSymbolValidationFlags.Default,
+                            "type",
+                            ImmutableArray.Create<ITypeReference>(
+                                new ObjectType("fooVariant",
+                                    TypeSymbolValidationFlags.Default,
+                                    ImmutableArray.Create(
+                                        new TypeProperty("type", TypeFactory.CreateStringLiteralType("foo")),
+                                        new TypeProperty("property", LanguageConstants.Int)),
+                                    null),
+                                new ObjectType("barVariant",
+                                    TypeSymbolValidationFlags.Default,
+                                    ImmutableArray.Create(
+                                        new TypeProperty("type", TypeFactory.CreateStringLiteralType("bar")),
+                                        new TypeProperty("property", targetType)),
+                                    null)))))),
                     TypeSymbolValidationFlags.Default))),
             null);
         var (sut, unhydratedTypeRef) = SetupResolver(hydrated);
 
         UnresolvedResourceDerivedType unresolved = new(unhydratedTypeRef,
-            ImmutableArray.Create("properties", "property", "prefixItems", "0", "additionalProperties", "items"),
+            ImmutableArray.Create("properties", "property", "prefixItems", "0", "additionalProperties", "items", "discriminator", "mapping", "bar", "properties", "property"),
             LanguageConstants.Any);
 
         var bound = sut.ResolveResourceDerivedTypes(unresolved);

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -839,7 +839,7 @@ namespace Bicep.Core.Emit
                     ITypeReferenceAccessExpression => ResolveTypeReferenceExpression(memberExpression) switch
                     {
                         ResolvedInternalReference udtRef => GetDiscriminatedUnionMappingEntries(discriminatorPropertyName, udtRef.Declaration, udtRef),
-                        ResourceDerivedTypeResolution rdtRef => GetDiscriminatedUnionMappingEntries(discriminatorPropertyName, rdtRef, memberExpression.SourceSyntax),
+                        ResourceDerivedTypeResolution rdtRef => GetDiscriminatedUnionMappingEntries(discriminatorPropertyName, rdtRef),
                         _ => throw new UnreachableException(),
                     },
                     _ => GetDiscriminatedUnionMappingEntries(discriminatorPropertyName, memberExpression, null),
@@ -861,9 +861,8 @@ namespace Bicep.Core.Emit
             {
                 yield return ExpressionFactory.CreateObjectProperty(
                     DiscriminatorValue(discriminatorPropertyName, objectUnionMemberExpr.ExpressedObjectType),
-                    memberResolution?.GetTypePropertiesForResolvedReferenceExpression(memberDeclaration.SourceSyntax)
-                        ?? GetTypePropertiesForObjectType(objectUnionMemberExpr),
-                    memberDeclaration.SourceSyntax);
+                    memberResolution?.GetTypePropertiesForResolvedReferenceExpression(sourceSyntax: null)
+                        ?? GetTypePropertiesForObjectType(objectUnionMemberExpr));
             }
             else if (memberDeclaration is DiscriminatedObjectTypeExpression nestedDiscriminatedMemberExpr)
             {
@@ -887,17 +886,15 @@ namespace Bicep.Core.Emit
             }
         }
 
-        private IEnumerable<ObjectPropertyExpression> GetDiscriminatedUnionMappingEntries(
+        private static IEnumerable<ObjectPropertyExpression> GetDiscriminatedUnionMappingEntries(
             string discriminatorPropertyName,
-            ResourceDerivedTypeResolution resolution,
-            SyntaxBase? sourceSyntax)
+            ResourceDerivedTypeResolution resolution)
         {
             if (resolution.DerivedType is ObjectType @object)
             {
                 yield return ExpressionFactory.CreateObjectProperty(
                     DiscriminatorValue(discriminatorPropertyName, @object),
-                    resolution.GetTypePropertiesForResolvedReferenceExpression(sourceSyntax),
-                    sourceSyntax);
+                    resolution.GetTypePropertiesForResolvedReferenceExpression(sourceSyntax: null));
             }
             else if (resolution.DerivedType is DiscriminatedObjectType discriminatedObject)
             {
@@ -911,8 +908,7 @@ namespace Bicep.Core.Emit
 
                     yield return ExpressionFactory.CreateObjectProperty(
                         discriminatorValue,
-                        variantResolution.GetTypePropertiesForResolvedReferenceExpression(sourceSyntax),
-                        sourceSyntax);
+                        variantResolution.GetTypePropertiesForResolvedReferenceExpression(sourceSyntax: null));
                 }
             }
             else

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -454,6 +454,9 @@ namespace Bicep.Core.Emit
 
             ImmutableArray<string> SegmentsForItems()
                 => PointerSegments.Add("items");
+
+            ImmutableArray<string> SegmentsForVariant(string discriminatorValue)
+                => PointerSegments.AddRange("discriminator", "mapping", discriminatorValue);
         }
 
         private record ResourceDerivedTypeResolution(ResourceTypeReference RootResourceTypeReference, ImmutableArray<string> PointerSegments, TypeSymbol DerivedType) : ITypeReferenceExpressionResolution
@@ -827,67 +830,108 @@ namespace Bicep.Core.Emit
 
             foreach (var memberExpression in discriminatedObjectTypeExpr.MemberExpressions)
             {
-                var resolvedMemberExpression = memberExpression;
-                TypeExpression? typeAliasReferenceExpr = null;
-                if (memberExpression is TypeAliasReferenceExpression memberTypeAliasExpr
-                    && declaredTypesByName.TryGetValue(memberTypeAliasExpr.Symbol.Name, out var declaredTypeExpression))
+                var mappingsEnumerable = memberExpression switch
                 {
-                    resolvedMemberExpression = declaredTypeExpression.Value;
-                    typeAliasReferenceExpr = memberTypeAliasExpr;
-                }
+                    TypeAliasReferenceExpression or
+                    SynthesizedTypeAliasReferenceExpression or
+                    ImportedTypeReferenceExpression or
+                    WildcardImportTypePropertyReferenceExpression or
+                    ITypeReferenceAccessExpression => ResolveTypeReferenceExpression(memberExpression) switch
+                    {
+                        ResolvedInternalReference udtRef => GetDiscriminatedUnionMappingEntries(discriminatorPropertyName, udtRef.Declaration, udtRef),
+                        ResourceDerivedTypeResolution rdtRef => GetDiscriminatedUnionMappingEntries(discriminatorPropertyName, rdtRef, memberExpression.SourceSyntax),
+                        _ => throw new UnreachableException(),
+                    },
+                    _ => GetDiscriminatedUnionMappingEntries(discriminatorPropertyName, memberExpression, null),
+                };
 
-                if (memberExpression is SynthesizedTypeAliasReferenceExpression memberSynthesizedTypeAliasExpr
-                    && declaredTypesByName.TryGetValue(memberSynthesizedTypeAliasExpr.Name, out declaredTypeExpression))
+                foreach (var mapping in mappingsEnumerable)
                 {
-                    resolvedMemberExpression = declaredTypeExpression.Value;
-                    typeAliasReferenceExpr = memberSynthesizedTypeAliasExpr;
+                    yield return mapping;
                 }
+            }
+        }
 
-                if (resolvedMemberExpression is ObjectTypeExpression objectUnionMemberExpr)
-                {
-                    var memberObjectType = objectUnionMemberExpr.ExpressedObjectType;
+        private IEnumerable<ObjectPropertyExpression> GetDiscriminatedUnionMappingEntries(
+            string discriminatorPropertyName,
+            TypeExpression memberDeclaration,
+            ITypeReferenceExpressionResolution? memberResolution)
+        {
+            if (memberDeclaration is ObjectTypeExpression objectUnionMemberExpr)
+            {
+                yield return ExpressionFactory.CreateObjectProperty(
+                    DiscriminatorValue(discriminatorPropertyName, objectUnionMemberExpr.ExpressedObjectType),
+                    memberResolution?.GetTypePropertiesForResolvedReferenceExpression(memberDeclaration.SourceSyntax)
+                        ?? GetTypePropertiesForObjectType(objectUnionMemberExpr),
+                    memberDeclaration.SourceSyntax);
+            }
+            else if (memberDeclaration is DiscriminatedObjectTypeExpression nestedDiscriminatedMemberExpr)
+            {
+                var nestedDiscriminatorPropertyName = nestedDiscriminatedMemberExpr.ExpressedDiscriminatedObjectType.DiscriminatorProperty.Name;
 
-                    if (!memberObjectType.Properties.TryGetValue(discriminatorPropertyName, out var discriminatorTypeProperty)
-                        || discriminatorTypeProperty.TypeReference.Type is not StringLiteralType discriminatorStringLiteral)
-                    {
-                        // This should have been caught during type checking
-                        throw new ArgumentException("Invalid discriminated union type encountered during serialization.");
-                    }
-
-                    ObjectExpression objectExpression;
-
-                    if (typeAliasReferenceExpr != null)
-                    {
-                        objectExpression = TypePropertiesForTypeExpression(typeAliasReferenceExpr);
-                    }
-                    else
-                    {
-                        objectExpression = GetTypePropertiesForObjectType(objectUnionMemberExpr);
-                    }
-
-                    yield return ExpressionFactory.CreateObjectProperty(discriminatorStringLiteral.RawStringValue, objectExpression);
-                }
-                else if (resolvedMemberExpression is DiscriminatedObjectTypeExpression nestedDiscriminatedMemberExpr)
-                {
-                    var nestedDiscriminatorPropertyName = nestedDiscriminatedMemberExpr.ExpressedDiscriminatedObjectType.DiscriminatorProperty.Name;
-
-                    if (nestedDiscriminatorPropertyName != discriminatorPropertyName)
-                    {
-                        // This should have been caught during type checking
-                        throw new ArgumentException("Invalid discriminated union type encountered during serialization.");
-                    }
-
-                    foreach (var nestedPropertyExpr in GetDiscriminatedUnionMappingEntries(nestedDiscriminatedMemberExpr))
-                    {
-                        yield return nestedPropertyExpr;
-                    }
-                }
-                else
+                if (nestedDiscriminatorPropertyName != discriminatorPropertyName)
                 {
                     // This should have been caught during type checking
                     throw new ArgumentException("Invalid discriminated union type encountered during serialization.");
                 }
+
+                foreach (var nestedPropertyExpr in GetDiscriminatedUnionMappingEntries(nestedDiscriminatedMemberExpr))
+                {
+                    yield return nestedPropertyExpr;
+                }
             }
+            else
+            {
+                // This should have been caught during type checking
+                throw new ArgumentException("Invalid discriminated union type encountered during serialization.");
+            }
+        }
+
+        private IEnumerable<ObjectPropertyExpression> GetDiscriminatedUnionMappingEntries(
+            string discriminatorPropertyName,
+            ResourceDerivedTypeResolution resolution,
+            SyntaxBase? sourceSyntax)
+        {
+            if (resolution.DerivedType is ObjectType @object)
+            {
+                yield return ExpressionFactory.CreateObjectProperty(
+                    DiscriminatorValue(discriminatorPropertyName, @object),
+                    resolution.GetTypePropertiesForResolvedReferenceExpression(sourceSyntax),
+                    sourceSyntax);
+            }
+            else if (resolution.DerivedType is DiscriminatedObjectType discriminatedObject)
+            {
+                foreach (var variant in discriminatedObject.UnionMembersByKey.Values)
+                {
+                    var discriminatorValue = DiscriminatorValue(discriminatorPropertyName, variant);
+                    var variantResolution = new ResourceDerivedTypeResolution(
+                        resolution.RootResourceTypeReference,
+                        (resolution as ITypeReferenceExpressionResolution).SegmentsForVariant(discriminatorValue),
+                        variant);
+
+                    yield return ExpressionFactory.CreateObjectProperty(
+                        discriminatorValue,
+                        variantResolution.GetTypePropertiesForResolvedReferenceExpression(sourceSyntax),
+                        sourceSyntax);
+                }
+            }
+            else
+            {
+                // This should have been caught during type checking
+                throw new ArgumentException("Invalid discriminated union type encountered during serialization.");
+            }
+        }
+
+        private static string DiscriminatorValue(string discriminatorPropertyName, ObjectType @object)
+        {
+            if (!@object.Properties.TryGetValue(discriminatorPropertyName, out var discriminatorTypeProperty)
+                || discriminatorTypeProperty.TypeReference.Type is not StringLiteralType discriminatorStringLiteral)
+            {
+                // This should have been caught during type checking
+                throw new ArgumentException("Invalid discriminated union type encountered during serialization.");
+            }
+
+            return discriminatorStringLiteral.RawStringValue;
         }
 
         private static Expression ToLiteralValue(ITypeReference literalType) => literalType.Type switch

--- a/src/Bicep.Core/TypeSystem/ResourceDerivedTypeResolver.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceDerivedTypeResolver.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Types;
@@ -76,6 +77,11 @@ public class ResourceDerivedTypeResolver
                     case "additionalproperties" when current is ObjectType @object &&
                         @object.AdditionalPropertiesType is not null:
                         current = @object.AdditionalPropertiesType.Type;
+                        continue;
+                    case "discriminator" when current is DiscriminatedObjectType discriminatedObject &&
+                        unresolved.PointerSegments[++i].Equals("mapping", StringComparison.OrdinalIgnoreCase) &&
+                        discriminatedObject.UnionMembersByKey.TryGetValue(StringUtils.EscapeBicepString(unresolved.PointerSegments[++i]), out var variant):
+                        current = variant;
                         continue;
                     case "prefixitems" when current is TupleType tuple &&
                         int.TryParse(unresolved.PointerSegments[++i], out int index) &&


### PR DESCRIPTION
Resolves #13661 

User-defined tagged unions currently allow template authors to use type references as members of the union, but authors will encounter an unhandled exception if the referent is an imported type. This PR updates the tagged union member resolution to support imported types, resource-defined types, and type property accesses.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13728)