### PR TITLE
Make some minor improvements to resource filter keywords and add filter keyword support for resource snippets

### DIFF
--- a/.github/workflows/update-baselines.yml
+++ b/.github/workflows/update-baselines.yml
@@ -9,6 +9,9 @@ jobs:
   main:
     name: Update Baselines
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
 
     env:
       # don't print dotnet logo

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/declarations.json
@@ -278,7 +278,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-aks-cluster",
-    "filterText": "res-aks-cluster,Kubernetes Service Cluster,aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters",
+    "filterText": "res-aks-cluster Kubernetes Service Cluster Microsoft.ContainerService/managedClusters aks kubernetes k8s cluster",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -309,7 +309,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-api-management-instance",
-    "filterText": "res-api-management-instance,Api Management Instance,Microsoft.ApiManagement/service",
+    "filterText": "res-api-management-instance Api Management Instance Microsoft.ApiManagement/service",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -340,7 +340,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-gateway",
-    "filterText": "res-app-gateway,Application Gateway,Microsoft.Network/applicationGateways",
+    "filterText": "res-app-gateway Application Gateway Microsoft.Network/applicationGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -371,7 +371,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-gateway-waf",
-    "filterText": "res-app-gateway-waf,Application Gateway with Web Application Firewall,Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies",
+    "filterText": "res-app-gateway-waf Application Gateway with Web Application Firewall Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -402,7 +402,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-insights",
-    "filterText": "res-app-insights,Application Insights for Web Apps,Microsoft.Insights/components",
+    "filterText": "res-app-insights Application Insights for Web Apps Microsoft.Insights/components",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -433,7 +433,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-insights-alert-rules",
-    "filterText": "res-app-insights-alert-rules,Application Insights Alert Rules,Microsoft.Insights/alertrules",
+    "filterText": "res-app-insights-alert-rules Application Insights Alert Rules Microsoft.Insights/alertrules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -464,7 +464,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-insights-auto-scale-settings",
-    "filterText": "res-app-insights-auto-scale-settings,Application Insights Auto Scale Settings,Microsoft.Insights/autoscalesettings",
+    "filterText": "res-app-insights-auto-scale-settings Application Insights Auto Scale Settings Microsoft.Insights/autoscalesettings",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -495,7 +495,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-plan",
-    "filterText": "res-app-plan,Application Service Plan (Server Farm),asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms",
+    "filterText": "res-app-plan Application Service Plan (Server Farm) Microsoft.Web/serverfarms asp appserviceplan hostingplan",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -526,7 +526,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-security-group",
-    "filterText": "res-app-security-group,Application Security Group,Microsoft.Network/applicationSecurityGroups",
+    "filterText": "res-app-security-group Application Security Group Microsoft.Network/applicationSecurityGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -557,7 +557,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-account",
-    "filterText": "res-automation-account,Automation Account,Microsoft.Automation/automationAccounts",
+    "filterText": "res-automation-account Automation Account Microsoft.Automation/automationAccounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -588,7 +588,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-cert",
-    "filterText": "res-automation-cert,Automation Certificate,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/certificates",
+    "filterText": "res-automation-cert Automation Certificate Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/certificates",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -619,7 +619,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-cred",
-    "filterText": "res-automation-cred,Automation Credential,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/credentials",
+    "filterText": "res-automation-cred Automation Credential Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/credentials",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -650,7 +650,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-job-schedule",
-    "filterText": "res-automation-job-schedule,Automation Job Schedule,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/jobSchedules",
+    "filterText": "res-automation-job-schedule Automation Job Schedule Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/jobSchedules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -681,7 +681,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-module",
-    "filterText": "res-automation-module,Automation Module,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/modules",
+    "filterText": "res-automation-module Automation Module Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/modules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -712,7 +712,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-runbook",
-    "filterText": "res-automation-runbook,Automation Runbook,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/runbooks",
+    "filterText": "res-automation-runbook Automation Runbook Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/runbooks",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -743,7 +743,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-schedule",
-    "filterText": "res-automation-schedule,Automation Schedule,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/schedules",
+    "filterText": "res-automation-schedule Automation Schedule Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/schedules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -774,7 +774,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-variable",
-    "filterText": "res-automation-variable,Automation Variable,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/variables",
+    "filterText": "res-automation-variable Automation Variable Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/variables",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -805,7 +805,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-availability-set",
-    "filterText": "res-availability-set,Availability Set,Microsoft.Compute/availabilitySets",
+    "filterText": "res-availability-set Availability Set Microsoft.Compute/availabilitySets",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -836,7 +836,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-container-group",
-    "filterText": "res-container-group,Container Group,Microsoft.ContainerInstance/containerGroups",
+    "filterText": "res-container-group Container Group Microsoft.ContainerInstance/containerGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -867,7 +867,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-container-registry",
-    "filterText": "res-container-registry,Container Registry,Microsoft.ContainerRegistry/registries",
+    "filterText": "res-container-registry Container Registry Microsoft.ContainerRegistry/registries",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -898,7 +898,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-account",
-    "filterText": "res-cosmos-account,Cosmos DB Database Account,Microsoft.DocumentDB/databaseAccounts",
+    "filterText": "res-cosmos-account Cosmos DB Database Account Microsoft.DocumentDB/databaseAccounts cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -929,7 +929,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-cassandra-keyspace",
-    "filterText": "res-cosmos-cassandra-keyspace,Cosmos DB Cassandra Namespace,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces",
+    "filterText": "res-cosmos-cassandra-keyspace Cosmos DB Cassandra Namespace Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -960,7 +960,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-cassandra-table",
-    "filterText": "res-cosmos-cassandra-table,Cosmos DB Cassandra Table,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables",
+    "filterText": "res-cosmos-cassandra-table Cosmos DB Cassandra Table Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces cosmosdb Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -991,7 +991,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-gremlin-database",
-    "filterText": "res-cosmos-gremlin-database,Cosmos DB Gremlin Database,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases",
+    "filterText": "res-cosmos-gremlin-database Cosmos DB Gremlin Database Microsoft.DocumentDB/databaseAccounts/gremlinDatabases cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1022,7 +1022,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-gremlin-graph",
-    "filterText": "res-cosmos-gremlin-graph,Cosmos DB Gremlin Graph,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs",
+    "filterText": "res-cosmos-gremlin-graph Cosmos DB Gremlin Graph Microsoft.DocumentDB/databaseAccounts/gremlinDatabases cosmosdb Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1053,7 +1053,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-mongo-database",
-    "filterText": "res-cosmos-mongo-database,Cosmos DB Mongo Database,Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
+    "filterText": "res-cosmos-mongo-database Cosmos DB Mongo Database Microsoft.DocumentDB/databaseAccounts/mongodbDatabases cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1084,7 +1084,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-sql-container",
-    "filterText": "res-cosmos-sql-container,Cosmos DB SQL Container,Microsoft.DocumentDB/databaseAccounts/sqlDatabases,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+    "filterText": "res-cosmos-sql-container Cosmos DB SQL Container Microsoft.DocumentDB/databaseAccounts/sqlDatabases cosmosdb Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1115,7 +1115,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-sql-database",
-    "filterText": "res-cosmos-sql-database,Cosmos DB SQL Database,Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+    "filterText": "res-cosmos-sql-database Cosmos DB SQL Database Microsoft.DocumentDB/databaseAccounts/sqlDatabases cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1146,7 +1146,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-tablestorage-table",
-    "filterText": "res-cosmos-tablestorage-table,Cosmos Table Storage,Microsoft.DocumentDB/databaseAccounts/tables",
+    "filterText": "res-cosmos-tablestorage-table Cosmos Table Storage Microsoft.DocumentDB/databaseAccounts/tables cosmosdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1177,7 +1177,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-data-lake",
-    "filterText": "res-data-lake,Data Lake Store Account,Microsoft.DataLakeStore/accounts",
+    "filterText": "res-data-lake Data Lake Store Account Microsoft.DataLakeStore/accounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1208,7 +1208,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-dns-record",
-    "filterText": "res-dns-record,DNS Record,Microsoft.Network/dnsZones",
+    "filterText": "res-dns-record DNS Record Microsoft.Network/dnsZones",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1239,7 +1239,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-dns-resolver",
-    "filterText": "res-dns-resolver,,Microsoft.Network/dnsResolvers",
+    "filterText": "res-dns-resolver  Microsoft.Network/dnsResolvers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1270,7 +1270,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-dns-zone",
-    "filterText": "res-dns-zone,DNS Zone,Microsoft.Network/dnsZones",
+    "filterText": "res-dns-zone DNS Zone Microsoft.Network/dnsZones",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1301,7 +1301,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-expressroute-circuit",
-    "filterText": "res-expressroute-circuit,ExpressRoute Circuit,Microsoft.Network/expressRouteCircuits",
+    "filterText": "res-expressroute-circuit ExpressRoute Circuit Microsoft.Network/expressRouteCircuits",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1332,7 +1332,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-expressroute-gateway",
-    "filterText": "res-expressroute-gateway,ExpressRoute Gateway,Microsoft.Network/expressRouteGateways",
+    "filterText": "res-expressroute-gateway ExpressRoute Gateway Microsoft.Network/expressRouteGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1363,7 +1363,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-classic-rules",
-    "filterText": "res-firewall-classic-rules,Azure Firewall using classic rules,Microsoft.Network/azureFirewalls",
+    "filterText": "res-firewall-classic-rules Azure Firewall using classic rules Microsoft.Network/azureFirewalls",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1394,7 +1394,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-policy-standard",
-    "filterText": "res-firewall-policy-standard,Azure Firewall Policy Standard SKU,Microsoft.Network/firewallPolicies",
+    "filterText": "res-firewall-policy-standard Azure Firewall Policy Standard SKU Microsoft.Network/firewallPolicies",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1425,7 +1425,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-standard",
-    "filterText": "res-firewall-standard,Azure Firewall Standard SKU,Microsoft.Network/azureFirewalls",
+    "filterText": "res-firewall-standard Azure Firewall Standard SKU Microsoft.Network/azureFirewalls",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1456,7 +1456,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-standard-vwan",
-    "filterText": "res-firewall-standard-vwan,Azure Firewall Standard SKU for Virtual WAN Hub,Microsoft.Network/azureFirewalls",
+    "filterText": "res-firewall-standard-vwan Azure Firewall Standard SKU for Virtual WAN Hub Microsoft.Network/azureFirewalls",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1487,7 +1487,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-function",
-    "filterText": "res-function,Azure Functions (v2),appservice,webapp,function,Microsoft.Web/sites",
+    "filterText": "res-function Azure Functions (v2) Microsoft.Web/sites appservice webapp function",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1518,7 +1518,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-ip",
-    "filterText": "res-ip,Public IP Address,Microsoft.Network/publicIPAddresses",
+    "filterText": "res-ip Public IP Address Microsoft.Network/publicIPAddresses",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1549,7 +1549,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-ip-prefix",
-    "filterText": "res-ip-prefix,Public IP Prefix,Microsoft.Network/publicIPPrefixes",
+    "filterText": "res-ip-prefix Public IP Prefix Microsoft.Network/publicIPPrefixes",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1580,7 +1580,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-keyvault",
-    "filterText": "res-keyvault,KeyVault,Microsoft.KeyVault/vaults",
+    "filterText": "res-keyvault KeyVault Microsoft.KeyVault/vaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1611,7 +1611,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-keyvault-secret",
-    "filterText": "res-keyvault-secret,Key Vault Secret,Microsoft.KeyVault/vaults/secrets",
+    "filterText": "res-keyvault-secret Key Vault Secret Microsoft.KeyVault/vaults/secrets",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1642,7 +1642,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-loadbalancer-external",
-    "filterText": "res-loadbalancer-external,External Load Balancer,Microsoft.Network/loadBalancers",
+    "filterText": "res-loadbalancer-external External Load Balancer Microsoft.Network/loadBalancers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1673,7 +1673,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-loadbalancer-internal",
-    "filterText": "res-loadbalancer-internal,Internal Load Balancer,Microsoft.Network/loadBalancers",
+    "filterText": "res-loadbalancer-internal Internal Load Balancer Microsoft.Network/loadBalancers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1704,7 +1704,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-lock",
-    "filterText": "res-lock,,rbac,Microsoft.Authorization/locks",
+    "filterText": "res-lock  Microsoft.Authorization/locks rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1735,7 +1735,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-log-analytics-solution",
-    "filterText": "res-log-analytics-solution,Log Analytics Solution,Microsoft.OperationsManagement/solutions",
+    "filterText": "res-log-analytics-solution Log Analytics Solution Microsoft.OperationsManagement/solutions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1766,7 +1766,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-log-analytics-workspace",
-    "filterText": "res-log-analytics-workspace,Log Analytics Workspace,loganalytics,Microsoft.OperationalInsights/workspaces",
+    "filterText": "res-log-analytics-workspace Log Analytics Workspace Microsoft.OperationalInsights/workspaces loganalytics",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1797,7 +1797,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app",
-    "filterText": "res-logic-app,Logic App,Microsoft.Logic/workflows",
+    "filterText": "res-logic-app Logic App Microsoft.Logic/workflows",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1828,7 +1828,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app-connector",
-    "filterText": "res-logic-app-connector,Logic App Connector,Microsoft.Web/connections",
+    "filterText": "res-logic-app-connector Logic App Connector Microsoft.Web/connections",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1859,7 +1859,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app-from-file",
-    "filterText": "res-logic-app-from-file,Logic App,Microsoft.Logic/workflows",
+    "filterText": "res-logic-app-from-file Logic App Microsoft.Logic/workflows",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1890,7 +1890,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app-integration",
-    "filterText": "res-logic-app-integration,Logic App Integration Account,Microsoft.Logic/integrationAccounts",
+    "filterText": "res-logic-app-integration Logic App Integration Account Microsoft.Logic/integrationAccounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1921,7 +1921,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-managed-identity",
-    "filterText": "res-managed-identity,Managed Identity (User Assigned),Microsoft.ManagedIdentity/userAssignedIdentities",
+    "filterText": "res-managed-identity Managed Identity (User Assigned) Microsoft.ManagedIdentity/userAssignedIdentities",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1952,7 +1952,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-media",
-    "filterText": "res-media,Media Services account,Microsoft.Media/mediaServices",
+    "filterText": "res-media Media Services account Microsoft.Media/mediaServices",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1983,7 +1983,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-mg",
-    "filterText": "res-mg,Management Group(for tenant scope),Microsoft.Management/managementGroups",
+    "filterText": "res-mg Management Group(for tenant scope) Microsoft.Management/managementGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2014,7 +2014,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-mysql",
-    "filterText": "res-mysql,MySQL Database,Microsoft.DBforMySQL/servers",
+    "filterText": "res-mysql MySQL Database Microsoft.DBforMySQL/servers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2045,7 +2045,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-nic",
-    "filterText": "res-nic,Network Interface,Microsoft.Network/networkInterfaces",
+    "filterText": "res-nic Network Interface Microsoft.Network/networkInterfaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2076,7 +2076,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-nsg",
-    "filterText": "res-nsg,Network Security Group,Microsoft.Network/networkSecurityGroups",
+    "filterText": "res-nsg Network Security Group Microsoft.Network/networkSecurityGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2107,7 +2107,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-nsgrule",
-    "filterText": "res-nsgrule,Network Security Group Rule,Microsoft.Network/networkSecurityGroups/securityRules",
+    "filterText": "res-nsgrule Network Security Group Rule Microsoft.Network/networkSecurityGroups/securityRules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2138,7 +2138,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-plan",
-    "filterText": "res-plan,Application Service Plan (Server Farm),asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms",
+    "filterText": "res-plan Application Service Plan (Server Farm) Microsoft.Web/serverfarms asp appserviceplan hostingplan",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2169,7 +2169,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-assignment",
-    "filterText": "res-policy-assignment,Policy Assignment,rbac,Microsoft.Authorization/policyAssignments",
+    "filterText": "res-policy-assignment Policy Assignment Microsoft.Authorization/policyAssignments rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2200,7 +2200,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-definition-audit-effect",
-    "filterText": "res-policy-definition-audit-effect,Policy Definition,rbac,Microsoft.Authorization/policyDefinitions",
+    "filterText": "res-policy-definition-audit-effect Policy Definition Microsoft.Authorization/policyDefinitions rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2231,7 +2231,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-definition-deploy-effect",
-    "filterText": "res-policy-definition-deploy-effect,Policy Definition,rbac,Microsoft.Authorization/policyDefinitions",
+    "filterText": "res-policy-definition-deploy-effect Policy Definition Microsoft.Authorization/policyDefinitions rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2262,7 +2262,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-definition-modify-effect",
-    "filterText": "res-policy-definition-modify-effect,Policy Definition,rbac,Microsoft.Authorization/policyDefinitions",
+    "filterText": "res-policy-definition-modify-effect Policy Definition Microsoft.Authorization/policyDefinitions rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2293,7 +2293,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-exemption",
-    "filterText": "res-policy-exemption,Policy Exemption,rbac,Microsoft.Authorization/policyExemptions",
+    "filterText": "res-policy-exemption Policy Exemption Microsoft.Authorization/policyExemptions rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2324,7 +2324,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-guestconfig",
-    "filterText": "res-policy-guestconfig,Guest configuration assignment for virtual machine,Microsoft.Compute/virtualMachines,Microsoft.GuestConfiguration/guestConfigurationAssignments",
+    "filterText": "res-policy-guestconfig Guest configuration assignment for virtual machine Microsoft.Compute/virtualMachines Microsoft.GuestConfiguration/guestConfigurationAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2355,7 +2355,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-guestconfig-hybrid",
-    "filterText": "res-policy-guestconfig-hybrid,Guest configuration assignment for virtual machine,Microsoft.HybridCompute/machines,Microsoft.GuestConfiguration/guestConfigurationAssignments",
+    "filterText": "res-policy-guestconfig-hybrid Guest configuration assignment for virtual machine Microsoft.HybridCompute/machines Microsoft.GuestConfiguration/guestConfigurationAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2386,7 +2386,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-guestconfig-params",
-    "filterText": "res-policy-guestconfig-params,Guest configuration assignment with parameters, for virtual machine,Microsoft.Compute/virtualMachines,Microsoft.GuestConfiguration/guestConfigurationAssignments",
+    "filterText": "res-policy-guestconfig-params Guest configuration assignment with parameters, for virtual machine Microsoft.Compute/virtualMachines Microsoft.GuestConfiguration/guestConfigurationAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2417,7 +2417,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-remediation",
-    "filterText": "res-policy-remediation,Policy Remediation,Microsoft.PolicyInsights/remediations",
+    "filterText": "res-policy-remediation Policy Remediation Microsoft.PolicyInsights/remediations",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2448,7 +2448,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policyset-definition",
-    "filterText": "res-policyset-definition,PolicySet Definition,rbac,Microsoft.Authorization/policySetDefinitions",
+    "filterText": "res-policyset-definition PolicySet Definition Microsoft.Authorization/policySetDefinitions rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2479,7 +2479,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-private-endpoint",
-    "filterText": "res-private-endpoint,,Microsoft.Network/privateEndpoints",
+    "filterText": "res-private-endpoint  Microsoft.Network/privateEndpoints",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2510,7 +2510,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-recovery-service-vault",
-    "filterText": "res-recovery-service-vault,Recovery Service Vault,Microsoft.RecoveryServices/vaults",
+    "filterText": "res-recovery-service-vault Recovery Service Vault Microsoft.RecoveryServices/vaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2541,7 +2541,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-redis",
-    "filterText": "res-redis,Redis Cache,Microsoft.Cache/Redis",
+    "filterText": "res-redis Redis Cache Microsoft.Cache/Redis",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2572,7 +2572,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-rg",
-    "filterText": "res-rg,Resource Group,Microsoft.Resources/resourceGroups",
+    "filterText": "res-rg Resource Group Microsoft.Resources/resourceGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2603,7 +2603,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-role-assignment",
-    "filterText": "res-role-assignment,,rbac,Microsoft.Authorization/roleAssignments",
+    "filterText": "res-role-assignment  Microsoft.Authorization/roleAssignments rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2634,7 +2634,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-route-server",
-    "filterText": "res-route-server,Route Server,Microsoft.Network/virtualHubs,Microsoft.Network/virtualHubs/ipConfigurations",
+    "filterText": "res-route-server Route Server Microsoft.Network/virtualHubs Microsoft.Network/virtualHubs/ipConfigurations",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2665,7 +2665,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-route-table",
-    "filterText": "res-route-table,Route Table,Microsoft.Network/routeTables",
+    "filterText": "res-route-table Route Table Microsoft.Network/routeTables",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2696,7 +2696,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-route-table-route",
-    "filterText": "res-route-table-route,Azure Route Table Route,Microsoft.Network/routeTables/routes",
+    "filterText": "res-route-table-route Azure Route Table Route Microsoft.Network/routeTables/routes",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2727,7 +2727,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-scoped-lock",
-    "filterText": "res-scoped-lock,,rbac,Microsoft.Authorization/locks",
+    "filterText": "res-scoped-lock  Microsoft.Authorization/locks rbac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2758,7 +2758,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-service-bus",
-    "filterText": "res-service-bus,Service Bus Namespace,Microsoft.ServiceBus/namespaces",
+    "filterText": "res-service-bus Service Bus Namespace Microsoft.ServiceBus/namespaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2789,7 +2789,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-shared-image-gallery",
-    "filterText": "res-shared-image-gallery,Create Image Gallery,Microsoft.Compute/galleries",
+    "filterText": "res-shared-image-gallery Create Image Gallery Microsoft.Compute/galleries",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2820,7 +2820,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-sql",
-    "filterText": "res-sql,SQL Database,Microsoft.Sql/servers,Microsoft.Sql/servers/databases",
+    "filterText": "res-sql SQL Database Microsoft.Sql/servers Microsoft.Sql/servers/databases",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2851,7 +2851,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-sql-db-import",
-    "filterText": "res-sql-db-import,SQL Database Import,Microsoft.Sql/servers/databases,Microsoft.Sql/servers/databases/extensions",
+    "filterText": "res-sql-db-import SQL Database Import Microsoft.Sql/servers/databases Microsoft.Sql/servers/databases/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2882,7 +2882,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-sql-server-firewall-rules",
-    "filterText": "res-sql-server-firewall-rules,SQL Server Firewall Rules,Microsoft.Sql/servers,Microsoft.Sql/servers/firewallRules",
+    "filterText": "res-sql-server-firewall-rules SQL Server Firewall Rules Microsoft.Sql/servers Microsoft.Sql/servers/firewallRules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2913,7 +2913,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-storage",
-    "filterText": "res-storage,Storage Account,Microsoft.Storage/storageAccounts",
+    "filterText": "res-storage Storage Account Microsoft.Storage/storageAccounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2944,7 +2944,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-template-spec",
-    "filterText": "res-template-spec,Template spec,Microsoft.Resources/templateSpecs",
+    "filterText": "res-template-spec Template spec Microsoft.Resources/templateSpecs",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2975,7 +2975,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-traffic-manager",
-    "filterText": "res-traffic-manager,Traffic Manager Profile,Microsoft.Network/trafficManagerProfiles",
+    "filterText": "res-traffic-manager Traffic Manager Profile Microsoft.Network/trafficManagerProfiles",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3006,7 +3006,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-virtual-wan",
-    "filterText": "res-virtual-wan,Virtual WAN,Microsoft.Network/virtualWans",
+    "filterText": "res-virtual-wan Virtual WAN Microsoft.Network/virtualWans",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3037,7 +3037,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-dsc",
-    "filterText": "res-vm-dsc,Desired State Configuration PowerShell script for a Windows Virtual Machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
+    "filterText": "res-vm-dsc Desired State Configuration PowerShell script for a Windows Virtual Machine Microsoft.Compute/virtualMachines Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3068,7 +3068,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-linux-guestconfig-ext",
-    "filterText": "res-vm-linux-guestconfig-ext,Guest configuration extension for Linux virtual machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
+    "filterText": "res-vm-linux-guestconfig-ext Guest configuration extension for Linux virtual machine Microsoft.Compute/virtualMachines Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3099,7 +3099,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-script-linux",
-    "filterText": "res-vm-script-linux,Custom script extension for Linux Virtual Machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
+    "filterText": "res-vm-script-linux Custom script extension for Linux Virtual Machine Microsoft.Compute/virtualMachines Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3130,7 +3130,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-script-windows",
-    "filterText": "res-vm-script-windows,Custom script extension for a Windows Virtual Machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
+    "filterText": "res-vm-script-windows Custom script extension for a Windows Virtual Machine Microsoft.Compute/virtualMachines Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3161,7 +3161,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-ubuntu",
-    "filterText": "res-vm-ubuntu,Ubuntu Virtual Machine,Microsoft.Compute/virtualMachines",
+    "filterText": "res-vm-ubuntu Ubuntu Virtual Machine Microsoft.Compute/virtualMachines",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3192,7 +3192,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-windows",
-    "filterText": "res-vm-windows,Windows Virtual Machine,Microsoft.Compute/virtualMachines",
+    "filterText": "res-vm-windows Windows Virtual Machine Microsoft.Compute/virtualMachines",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3223,7 +3223,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-windows-diagnostics",
-    "filterText": "res-vm-windows-diagnostics,Diagnostics Extension for a Windows Virtual Machine,Microsoft.Compute/virtualMachines/extensions",
+    "filterText": "res-vm-windows-diagnostics Diagnostics Extension for a Windows Virtual Machine Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3254,7 +3254,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-windows-guestconfig-ext",
-    "filterText": "res-vm-windows-guestconfig-ext,Guest configuration assignment for Windows virtual machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
+    "filterText": "res-vm-windows-guestconfig-ext Guest configuration assignment for Windows virtual machine Microsoft.Compute/virtualMachines Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3285,7 +3285,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vnet",
-    "filterText": "res-vnet,Virtual Network,Microsoft.Network/virtualNetworks",
+    "filterText": "res-vnet Virtual Network Microsoft.Network/virtualNetworks",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3316,7 +3316,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vnet-peering",
-    "filterText": "res-vnet-peering,Virtual Network Peering,Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+    "filterText": "res-vnet-peering Virtual Network Peering Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3347,7 +3347,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vpn-local-gateway",
-    "filterText": "res-vpn-local-gateway,VPN Local Network Gateway,Microsoft.Network/localNetworkGateways",
+    "filterText": "res-vpn-local-gateway VPN Local Network Gateway Microsoft.Network/localNetworkGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3378,7 +3378,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vpn-vnet-connection",
-    "filterText": "res-vpn-vnet-connection,VPN Virtual Network Connection,Microsoft.Network/connections",
+    "filterText": "res-vpn-vnet-connection VPN Virtual Network Connection Microsoft.Network/connections",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3409,7 +3409,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vpn-vnet-gateway",
-    "filterText": "res-vpn-vnet-gateway,VPN Virtual Network Gateway,Microsoft.Network/virtualNetworkGateways",
+    "filterText": "res-vpn-vnet-gateway VPN Virtual Network Gateway Microsoft.Network/virtualNetworkGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3440,7 +3440,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-web-app",
-    "filterText": "res-web-app,Web Application,appservice,webapp,function,Microsoft.Web/sites",
+    "filterText": "res-web-app Web Application Microsoft.Web/sites appservice webapp function",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3471,7 +3471,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-web-app-deploy",
-    "filterText": "res-web-app-deploy,Web Deploy for a Web Application,appservice,webapp,function,Microsoft.Web/sites,appservice,webapp,function,Microsoft.Web/sites/extensions",
+    "filterText": "res-web-app-deploy Web Deploy for a Web Application Microsoft.Web/sites appservice webapp function Microsoft.Web/sites/extensions appservice webapp function",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3502,7 +3502,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-wvd-appgroup",
-    "filterText": "res-wvd-appgroup,WVD AppGroup,Microsoft.DesktopVirtualization/applicationgroups",
+    "filterText": "res-wvd-appgroup WVD AppGroup Microsoft.DesktopVirtualization/applicationgroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3533,7 +3533,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-wvd-hostpool",
-    "filterText": "res-wvd-hostpool,WVD Host Pool,Microsoft.DesktopVirtualization/hostpools",
+    "filterText": "res-wvd-hostpool WVD Host Pool Microsoft.DesktopVirtualization/hostpools",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3564,7 +3564,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-wvd-workspace",
-    "filterText": "res-wvd-workspace,WVD Workspace,Microsoft.DesktopVirtualization/workspaces",
+    "filterText": "res-wvd-workspace WVD Workspace Microsoft.DesktopVirtualization/workspaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/declarations.json
@@ -278,6 +278,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-aks-cluster",
+    "filterText": "res-aks-cluster,Kubernetes Service Cluster,aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -308,6 +309,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-api-management-instance",
+    "filterText": "res-api-management-instance,Api Management Instance,Microsoft.ApiManagement/service",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -338,6 +340,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-gateway",
+    "filterText": "res-app-gateway,Application Gateway,Microsoft.Network/applicationGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -368,6 +371,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-gateway-waf",
+    "filterText": "res-app-gateway-waf,Application Gateway with Web Application Firewall,Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -398,6 +402,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-insights",
+    "filterText": "res-app-insights,Application Insights for Web Apps,Microsoft.Insights/components",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -428,6 +433,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-insights-alert-rules",
+    "filterText": "res-app-insights-alert-rules,Application Insights Alert Rules,Microsoft.Insights/alertrules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -458,6 +464,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-insights-auto-scale-settings",
+    "filterText": "res-app-insights-auto-scale-settings,Application Insights Auto Scale Settings,Microsoft.Insights/autoscalesettings",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -488,6 +495,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-plan",
+    "filterText": "res-app-plan,Application Service Plan (Server Farm),asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -518,6 +526,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-app-security-group",
+    "filterText": "res-app-security-group,Application Security Group,Microsoft.Network/applicationSecurityGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -548,6 +557,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-account",
+    "filterText": "res-automation-account,Automation Account,Microsoft.Automation/automationAccounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -578,6 +588,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-cert",
+    "filterText": "res-automation-cert,Automation Certificate,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/certificates",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -608,6 +619,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-cred",
+    "filterText": "res-automation-cred,Automation Credential,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/credentials",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -638,6 +650,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-job-schedule",
+    "filterText": "res-automation-job-schedule,Automation Job Schedule,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/jobSchedules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -668,6 +681,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-module",
+    "filterText": "res-automation-module,Automation Module,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/modules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -698,6 +712,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-runbook",
+    "filterText": "res-automation-runbook,Automation Runbook,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/runbooks",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -728,6 +743,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-schedule",
+    "filterText": "res-automation-schedule,Automation Schedule,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/schedules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -758,6 +774,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-automation-variable",
+    "filterText": "res-automation-variable,Automation Variable,Microsoft.Automation/automationAccounts,Microsoft.Automation/automationAccounts/variables",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -788,6 +805,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-availability-set",
+    "filterText": "res-availability-set,Availability Set,Microsoft.Compute/availabilitySets",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -818,6 +836,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-container-group",
+    "filterText": "res-container-group,Container Group,Microsoft.ContainerInstance/containerGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -848,6 +867,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-container-registry",
+    "filterText": "res-container-registry,Container Registry,Microsoft.ContainerRegistry/registries",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -878,6 +898,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-account",
+    "filterText": "res-cosmos-account,Cosmos DB Database Account,Microsoft.DocumentDB/databaseAccounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -908,6 +929,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-cassandra-keyspace",
+    "filterText": "res-cosmos-cassandra-keyspace,Cosmos DB Cassandra Namespace,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -938,6 +960,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-cassandra-table",
+    "filterText": "res-cosmos-cassandra-table,Cosmos DB Cassandra Table,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -968,6 +991,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-gremlin-database",
+    "filterText": "res-cosmos-gremlin-database,Cosmos DB Gremlin Database,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -998,6 +1022,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-gremlin-graph",
+    "filterText": "res-cosmos-gremlin-graph,Cosmos DB Gremlin Graph,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1028,6 +1053,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-mongo-database",
+    "filterText": "res-cosmos-mongo-database,Cosmos DB Mongo Database,Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1058,6 +1084,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-sql-container",
+    "filterText": "res-cosmos-sql-container,Cosmos DB SQL Container,Microsoft.DocumentDB/databaseAccounts/sqlDatabases,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1088,6 +1115,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-sql-database",
+    "filterText": "res-cosmos-sql-database,Cosmos DB SQL Database,Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1118,6 +1146,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-cosmos-tablestorage-table",
+    "filterText": "res-cosmos-tablestorage-table,Cosmos Table Storage,Microsoft.DocumentDB/databaseAccounts/tables",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1148,6 +1177,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-data-lake",
+    "filterText": "res-data-lake,Data Lake Store Account,Microsoft.DataLakeStore/accounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1178,6 +1208,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-dns-record",
+    "filterText": "res-dns-record,DNS Record,Microsoft.Network/dnsZones",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1208,6 +1239,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-dns-resolver",
+    "filterText": "res-dns-resolver,,Microsoft.Network/dnsResolvers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1238,6 +1270,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-dns-zone",
+    "filterText": "res-dns-zone,DNS Zone,Microsoft.Network/dnsZones",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1268,6 +1301,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-expressroute-circuit",
+    "filterText": "res-expressroute-circuit,ExpressRoute Circuit,Microsoft.Network/expressRouteCircuits",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1298,6 +1332,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-expressroute-gateway",
+    "filterText": "res-expressroute-gateway,ExpressRoute Gateway,Microsoft.Network/expressRouteGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1328,6 +1363,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-classic-rules",
+    "filterText": "res-firewall-classic-rules,Azure Firewall using classic rules,Microsoft.Network/azureFirewalls",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1358,6 +1394,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-policy-standard",
+    "filterText": "res-firewall-policy-standard,Azure Firewall Policy Standard SKU,Microsoft.Network/firewallPolicies",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1388,6 +1425,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-standard",
+    "filterText": "res-firewall-standard,Azure Firewall Standard SKU,Microsoft.Network/azureFirewalls",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1418,6 +1456,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-firewall-standard-vwan",
+    "filterText": "res-firewall-standard-vwan,Azure Firewall Standard SKU for Virtual WAN Hub,Microsoft.Network/azureFirewalls",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1448,6 +1487,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-function",
+    "filterText": "res-function,Azure Functions (v2),appservice,webapp,function,Microsoft.Web/sites",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1478,6 +1518,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-ip",
+    "filterText": "res-ip,Public IP Address,Microsoft.Network/publicIPAddresses",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1508,6 +1549,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-ip-prefix",
+    "filterText": "res-ip-prefix,Public IP Prefix,Microsoft.Network/publicIPPrefixes",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1538,6 +1580,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-keyvault",
+    "filterText": "res-keyvault,KeyVault,Microsoft.KeyVault/vaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1568,6 +1611,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-keyvault-secret",
+    "filterText": "res-keyvault-secret,Key Vault Secret,Microsoft.KeyVault/vaults/secrets",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1598,6 +1642,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-loadbalancer-external",
+    "filterText": "res-loadbalancer-external,External Load Balancer,Microsoft.Network/loadBalancers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1628,6 +1673,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-loadbalancer-internal",
+    "filterText": "res-loadbalancer-internal,Internal Load Balancer,Microsoft.Network/loadBalancers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1658,6 +1704,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-lock",
+    "filterText": "res-lock,,rbac,Microsoft.Authorization/locks",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1688,6 +1735,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-log-analytics-solution",
+    "filterText": "res-log-analytics-solution,Log Analytics Solution,Microsoft.OperationsManagement/solutions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1718,6 +1766,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-log-analytics-workspace",
+    "filterText": "res-log-analytics-workspace,Log Analytics Workspace,loganalytics,Microsoft.OperationalInsights/workspaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1748,6 +1797,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app",
+    "filterText": "res-logic-app,Logic App,Microsoft.Logic/workflows",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1778,6 +1828,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app-connector",
+    "filterText": "res-logic-app-connector,Logic App Connector,Microsoft.Web/connections",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1808,6 +1859,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app-from-file",
+    "filterText": "res-logic-app-from-file,Logic App,Microsoft.Logic/workflows",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1838,6 +1890,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-logic-app-integration",
+    "filterText": "res-logic-app-integration,Logic App Integration Account,Microsoft.Logic/integrationAccounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1868,6 +1921,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-managed-identity",
+    "filterText": "res-managed-identity,Managed Identity (User Assigned),Microsoft.ManagedIdentity/userAssignedIdentities",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1898,6 +1952,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-media",
+    "filterText": "res-media,Media Services account,Microsoft.Media/mediaServices",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1928,6 +1983,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-mg",
+    "filterText": "res-mg,Management Group(for tenant scope),Microsoft.Management/managementGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1958,6 +2014,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-mysql",
+    "filterText": "res-mysql,MySQL Database,Microsoft.DBforMySQL/servers",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1988,6 +2045,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-nic",
+    "filterText": "res-nic,Network Interface,Microsoft.Network/networkInterfaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2018,6 +2076,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-nsg",
+    "filterText": "res-nsg,Network Security Group,Microsoft.Network/networkSecurityGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2048,6 +2107,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-nsgrule",
+    "filterText": "res-nsgrule,Network Security Group Rule,Microsoft.Network/networkSecurityGroups/securityRules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2078,6 +2138,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-plan",
+    "filterText": "res-plan,Application Service Plan (Server Farm),asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2108,6 +2169,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-assignment",
+    "filterText": "res-policy-assignment,Policy Assignment,rbac,Microsoft.Authorization/policyAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2138,6 +2200,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-definition-audit-effect",
+    "filterText": "res-policy-definition-audit-effect,Policy Definition,rbac,Microsoft.Authorization/policyDefinitions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2168,6 +2231,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-definition-deploy-effect",
+    "filterText": "res-policy-definition-deploy-effect,Policy Definition,rbac,Microsoft.Authorization/policyDefinitions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2198,6 +2262,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-definition-modify-effect",
+    "filterText": "res-policy-definition-modify-effect,Policy Definition,rbac,Microsoft.Authorization/policyDefinitions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2228,6 +2293,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-exemption",
+    "filterText": "res-policy-exemption,Policy Exemption,rbac,Microsoft.Authorization/policyExemptions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2258,6 +2324,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-guestconfig",
+    "filterText": "res-policy-guestconfig,Guest configuration assignment for virtual machine,Microsoft.Compute/virtualMachines,Microsoft.GuestConfiguration/guestConfigurationAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2288,6 +2355,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-guestconfig-hybrid",
+    "filterText": "res-policy-guestconfig-hybrid,Guest configuration assignment for virtual machine,Microsoft.HybridCompute/machines,Microsoft.GuestConfiguration/guestConfigurationAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2318,6 +2386,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-guestconfig-params",
+    "filterText": "res-policy-guestconfig-params,Guest configuration assignment with parameters, for virtual machine,Microsoft.Compute/virtualMachines,Microsoft.GuestConfiguration/guestConfigurationAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2348,6 +2417,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policy-remediation",
+    "filterText": "res-policy-remediation,Policy Remediation,Microsoft.PolicyInsights/remediations",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2378,6 +2448,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-policyset-definition",
+    "filterText": "res-policyset-definition,PolicySet Definition,rbac,Microsoft.Authorization/policySetDefinitions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2408,6 +2479,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-private-endpoint",
+    "filterText": "res-private-endpoint,,Microsoft.Network/privateEndpoints",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2438,6 +2510,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-recovery-service-vault",
+    "filterText": "res-recovery-service-vault,Recovery Service Vault,Microsoft.RecoveryServices/vaults",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2468,6 +2541,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-redis",
+    "filterText": "res-redis,Redis Cache,Microsoft.Cache/Redis",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2498,6 +2572,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-rg",
+    "filterText": "res-rg,Resource Group,Microsoft.Resources/resourceGroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2528,6 +2603,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-role-assignment",
+    "filterText": "res-role-assignment,,rbac,Microsoft.Authorization/roleAssignments",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2558,6 +2634,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-route-server",
+    "filterText": "res-route-server,Route Server,Microsoft.Network/virtualHubs,Microsoft.Network/virtualHubs/ipConfigurations",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2588,6 +2665,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-route-table",
+    "filterText": "res-route-table,Route Table,Microsoft.Network/routeTables",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2618,6 +2696,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-route-table-route",
+    "filterText": "res-route-table-route,Azure Route Table Route,Microsoft.Network/routeTables/routes",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2648,6 +2727,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-scoped-lock",
+    "filterText": "res-scoped-lock,,rbac,Microsoft.Authorization/locks",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2678,6 +2758,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-service-bus",
+    "filterText": "res-service-bus,Service Bus Namespace,Microsoft.ServiceBus/namespaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2708,6 +2789,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-shared-image-gallery",
+    "filterText": "res-shared-image-gallery,Create Image Gallery,Microsoft.Compute/galleries",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2738,6 +2820,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-sql",
+    "filterText": "res-sql,SQL Database,Microsoft.Sql/servers,Microsoft.Sql/servers/databases",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2768,6 +2851,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-sql-db-import",
+    "filterText": "res-sql-db-import,SQL Database Import,Microsoft.Sql/servers/databases,Microsoft.Sql/servers/databases/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2798,6 +2882,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-sql-server-firewall-rules",
+    "filterText": "res-sql-server-firewall-rules,SQL Server Firewall Rules,Microsoft.Sql/servers,Microsoft.Sql/servers/firewallRules",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2828,6 +2913,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-storage",
+    "filterText": "res-storage,Storage Account,Microsoft.Storage/storageAccounts",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2858,6 +2944,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-template-spec",
+    "filterText": "res-template-spec,Template spec,Microsoft.Resources/templateSpecs",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2888,6 +2975,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-traffic-manager",
+    "filterText": "res-traffic-manager,Traffic Manager Profile,Microsoft.Network/trafficManagerProfiles",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2918,6 +3006,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-virtual-wan",
+    "filterText": "res-virtual-wan,Virtual WAN,Microsoft.Network/virtualWans",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2948,6 +3037,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-dsc",
+    "filterText": "res-vm-dsc,Desired State Configuration PowerShell script for a Windows Virtual Machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2978,6 +3068,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-linux-guestconfig-ext",
+    "filterText": "res-vm-linux-guestconfig-ext,Guest configuration extension for Linux virtual machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3008,6 +3099,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-script-linux",
+    "filterText": "res-vm-script-linux,Custom script extension for Linux Virtual Machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3038,6 +3130,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-script-windows",
+    "filterText": "res-vm-script-windows,Custom script extension for a Windows Virtual Machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3068,6 +3161,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-ubuntu",
+    "filterText": "res-vm-ubuntu,Ubuntu Virtual Machine,Microsoft.Compute/virtualMachines",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3098,6 +3192,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-windows",
+    "filterText": "res-vm-windows,Windows Virtual Machine,Microsoft.Compute/virtualMachines",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3128,6 +3223,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-windows-diagnostics",
+    "filterText": "res-vm-windows-diagnostics,Diagnostics Extension for a Windows Virtual Machine,Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3158,6 +3254,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vm-windows-guestconfig-ext",
+    "filterText": "res-vm-windows-guestconfig-ext,Guest configuration assignment for Windows virtual machine,Microsoft.Compute/virtualMachines,Microsoft.Compute/virtualMachines/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3188,6 +3285,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vnet",
+    "filterText": "res-vnet,Virtual Network,Microsoft.Network/virtualNetworks",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3218,6 +3316,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vnet-peering",
+    "filterText": "res-vnet-peering,Virtual Network Peering,Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3248,6 +3347,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vpn-local-gateway",
+    "filterText": "res-vpn-local-gateway,VPN Local Network Gateway,Microsoft.Network/localNetworkGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3278,6 +3378,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vpn-vnet-connection",
+    "filterText": "res-vpn-vnet-connection,VPN Virtual Network Connection,Microsoft.Network/connections",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3308,6 +3409,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-vpn-vnet-gateway",
+    "filterText": "res-vpn-vnet-gateway,VPN Virtual Network Gateway,Microsoft.Network/virtualNetworkGateways",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3338,6 +3440,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-web-app",
+    "filterText": "res-web-app,Web Application,appservice,webapp,function,Microsoft.Web/sites",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3368,6 +3471,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-web-app-deploy",
+    "filterText": "res-web-app-deploy,Web Deploy for a Web Application,appservice,webapp,function,Microsoft.Web/sites,appservice,webapp,function,Microsoft.Web/sites/extensions",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3398,6 +3502,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-wvd-appgroup",
+    "filterText": "res-wvd-appgroup,WVD AppGroup,Microsoft.DesktopVirtualization/applicationgroups",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3428,6 +3533,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-wvd-hostpool",
+    "filterText": "res-wvd-hostpool,WVD Host Pool,Microsoft.DesktopVirtualization/hostpools",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3458,6 +3564,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "2_res-wvd-workspace",
+    "filterText": "res-wvd-workspace,WVD Workspace,Microsoft.DesktopVirtualization/workspaces",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
@@ -3327,7 +3327,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000008d",
-    "filterText": "'containerapp,Microsoft.App/builders'",
+    "filterText": "'Microsoft.App/builders containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3349,7 +3349,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000008e",
-    "filterText": "'containerapp,Microsoft.App/builders/builds'",
+    "filterText": "'Microsoft.App/builders/builds containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3371,7 +3371,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000008f",
-    "filterText": "'containerapp,Microsoft.App/connectedEnvironments'",
+    "filterText": "'Microsoft.App/connectedEnvironments containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3393,7 +3393,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000090",
-    "filterText": "'containerapp,Microsoft.App/connectedEnvironments/certificates'",
+    "filterText": "'Microsoft.App/connectedEnvironments/certificates containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3415,7 +3415,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000091",
-    "filterText": "'containerapp,Microsoft.App/connectedEnvironments/daprComponents'",
+    "filterText": "'Microsoft.App/connectedEnvironments/daprComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3437,7 +3437,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000092",
-    "filterText": "'containerapp,Microsoft.App/connectedEnvironments/storages'",
+    "filterText": "'Microsoft.App/connectedEnvironments/storages containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3459,7 +3459,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000093",
-    "filterText": "'containerapp,Microsoft.App/containerApps'",
+    "filterText": "'Microsoft.App/containerApps containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3481,7 +3481,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000094",
-    "filterText": "'containerapp,Microsoft.App/containerApps/authConfigs'",
+    "filterText": "'Microsoft.App/containerApps/authConfigs containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3503,7 +3503,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000095",
-    "filterText": "'containerapp,Microsoft.App/containerApps/detectorProperties'",
+    "filterText": "'Microsoft.App/containerApps/detectorProperties containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3525,7 +3525,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000096",
-    "filterText": "'containerapp,Microsoft.App/containerApps/detectorProperties/revisions'",
+    "filterText": "'Microsoft.App/containerApps/detectorProperties/revisions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3547,7 +3547,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000097",
-    "filterText": "'containerapp,Microsoft.App/containerApps/detectors'",
+    "filterText": "'Microsoft.App/containerApps/detectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3569,7 +3569,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000098",
-    "filterText": "'containerapp,Microsoft.App/containerApps/resiliencyPolicies'",
+    "filterText": "'Microsoft.App/containerApps/resiliencyPolicies containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3591,7 +3591,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000099",
-    "filterText": "'containerapp,Microsoft.App/containerApps/revisions'",
+    "filterText": "'Microsoft.App/containerApps/revisions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3613,7 +3613,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000009a",
-    "filterText": "'containerapp,Microsoft.App/containerApps/revisions/replicas'",
+    "filterText": "'Microsoft.App/containerApps/revisions/replicas containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3635,7 +3635,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000009b",
-    "filterText": "'containerapp,Microsoft.App/containerApps/sourcecontrols'",
+    "filterText": "'Microsoft.App/containerApps/sourcecontrols containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3657,7 +3657,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000009c",
-    "filterText": "'containerapp,Microsoft.App/jobs'",
+    "filterText": "'Microsoft.App/jobs containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3679,7 +3679,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000009d",
-    "filterText": "'containerapp,Microsoft.App/jobs/detectorProperties'",
+    "filterText": "'Microsoft.App/jobs/detectorProperties containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3701,7 +3701,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000009e",
-    "filterText": "'containerapp,Microsoft.App/jobs/detectors'",
+    "filterText": "'Microsoft.App/jobs/detectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3723,7 +3723,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000009f",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments'",
+    "filterText": "'Microsoft.App/managedEnvironments containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3745,7 +3745,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a0",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/certificates'",
+    "filterText": "'Microsoft.App/managedEnvironments/certificates containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3767,7 +3767,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a1",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/daprComponents'",
+    "filterText": "'Microsoft.App/managedEnvironments/daprComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3789,7 +3789,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a2",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies'",
+    "filterText": "'Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3811,7 +3811,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a3",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/daprSubscriptions'",
+    "filterText": "'Microsoft.App/managedEnvironments/daprSubscriptions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3833,7 +3833,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a4",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/detectorProperties'",
+    "filterText": "'Microsoft.App/managedEnvironments/detectorProperties containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3855,7 +3855,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a5",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/detectors'",
+    "filterText": "'Microsoft.App/managedEnvironments/detectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3877,7 +3877,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a6",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/dotNetComponents'",
+    "filterText": "'Microsoft.App/managedEnvironments/dotNetComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3899,7 +3899,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a7",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/javaComponents'",
+    "filterText": "'Microsoft.App/managedEnvironments/javaComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3921,7 +3921,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a8",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/managedCertificates'",
+    "filterText": "'Microsoft.App/managedEnvironments/managedCertificates containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3943,7 +3943,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000a9",
-    "filterText": "'containerapp,Microsoft.App/managedEnvironments/storages'",
+    "filterText": "'Microsoft.App/managedEnvironments/storages containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4826,7 +4826,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d3",
-    "filterText": "'rbac,Microsoft.Authorization/accessReviewHistoryDefinitions'",
+    "filterText": "'Microsoft.Authorization/accessReviewHistoryDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4848,7 +4848,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d4",
-    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleDefinitions'",
+    "filterText": "'Microsoft.Authorization/accessReviewScheduleDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4870,7 +4870,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d5",
-    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleDefinitions/instances'",
+    "filterText": "'Microsoft.Authorization/accessReviewScheduleDefinitions/instances rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4892,7 +4892,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d6",
-    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions'",
+    "filterText": "'Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4914,7 +4914,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d7",
-    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleSettings'",
+    "filterText": "'Microsoft.Authorization/accessReviewScheduleSettings rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4936,7 +4936,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d8",
-    "filterText": "'rbac,Microsoft.Authorization/dataPolicyManifests'",
+    "filterText": "'Microsoft.Authorization/dataPolicyManifests rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4958,7 +4958,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d9",
-    "filterText": "'rbac,Microsoft.Authorization/locks'",
+    "filterText": "'Microsoft.Authorization/locks rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4980,7 +4980,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000da",
-    "filterText": "'rbac,Microsoft.Authorization/policyAssignments'",
+    "filterText": "'Microsoft.Authorization/policyAssignments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5002,7 +5002,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000db",
-    "filterText": "'rbac,Microsoft.Authorization/policyDefinitions'",
+    "filterText": "'Microsoft.Authorization/policyDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5024,7 +5024,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000dc",
-    "filterText": "'rbac,Microsoft.Authorization/policyDefinitions/versions'",
+    "filterText": "'Microsoft.Authorization/policyDefinitions/versions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5046,7 +5046,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000dd",
-    "filterText": "'rbac,Microsoft.Authorization/policyExemptions'",
+    "filterText": "'Microsoft.Authorization/policyExemptions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5068,7 +5068,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000de",
-    "filterText": "'rbac,Microsoft.Authorization/policySetDefinitions'",
+    "filterText": "'Microsoft.Authorization/policySetDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5090,7 +5090,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000df",
-    "filterText": "'rbac,Microsoft.Authorization/policySetDefinitions/versions'",
+    "filterText": "'Microsoft.Authorization/policySetDefinitions/versions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5112,7 +5112,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e0",
-    "filterText": "'rbac,Microsoft.Authorization/privateLinkAssociations'",
+    "filterText": "'Microsoft.Authorization/privateLinkAssociations rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5134,7 +5134,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e1",
-    "filterText": "'rbac,Microsoft.Authorization/resourceManagementPrivateLinks'",
+    "filterText": "'Microsoft.Authorization/resourceManagementPrivateLinks rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5156,7 +5156,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e2",
-    "filterText": "'rbac,Microsoft.Authorization/roleAssignmentApprovals'",
+    "filterText": "'Microsoft.Authorization/roleAssignmentApprovals rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5178,7 +5178,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e3",
-    "filterText": "'rbac,Microsoft.Authorization/roleAssignmentApprovals/stages'",
+    "filterText": "'Microsoft.Authorization/roleAssignmentApprovals/stages rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5200,7 +5200,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e5",
-    "filterText": "'rbac,Microsoft.Authorization/roleAssignmentScheduleRequests'",
+    "filterText": "'Microsoft.Authorization/roleAssignmentScheduleRequests rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5222,7 +5222,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e4",
-    "filterText": "'rbac,Microsoft.Authorization/roleAssignments'",
+    "filterText": "'Microsoft.Authorization/roleAssignments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5244,7 +5244,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e6",
-    "filterText": "'rbac,Microsoft.Authorization/roleDefinitions'",
+    "filterText": "'Microsoft.Authorization/roleDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5266,7 +5266,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e7",
-    "filterText": "'rbac,Microsoft.Authorization/roleEligibilityScheduleRequests'",
+    "filterText": "'Microsoft.Authorization/roleEligibilityScheduleRequests rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5288,7 +5288,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e8",
-    "filterText": "'rbac,Microsoft.Authorization/roleManagementPolicyAssignments'",
+    "filterText": "'Microsoft.Authorization/roleManagementPolicyAssignments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5310,7 +5310,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e9",
-    "filterText": "'rbac,Microsoft.Authorization/variables'",
+    "filterText": "'Microsoft.Authorization/variables rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5332,7 +5332,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000ea",
-    "filterText": "'rbac,Microsoft.Authorization/variables/values'",
+    "filterText": "'Microsoft.Authorization/variables/values rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12200,7 +12200,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000024a",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/containerServices'",
+    "filterText": "'Microsoft.ContainerService/containerServices aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12222,7 +12222,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000024b",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/fleets'",
+    "filterText": "'Microsoft.ContainerService/fleets aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12244,7 +12244,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000024c",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/fleets/members'",
+    "filterText": "'Microsoft.ContainerService/fleets/members aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12266,7 +12266,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000024d",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/fleets/updateRuns'",
+    "filterText": "'Microsoft.ContainerService/fleets/updateRuns aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12288,7 +12288,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000024e",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/fleets/updateStrategies'",
+    "filterText": "'Microsoft.ContainerService/fleets/updateStrategies aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12310,7 +12310,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000024f",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/locations/guardrailsVersions'",
+    "filterText": "'Microsoft.ContainerService/locations/guardrailsVersions aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12332,7 +12332,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000250",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/locations/meshRevisionProfiles'",
+    "filterText": "'Microsoft.ContainerService/locations/meshRevisionProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12354,7 +12354,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000251",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/locations/safeguardsVersions'",
+    "filterText": "'Microsoft.ContainerService/locations/safeguardsVersions aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12376,7 +12376,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000252",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters'",
+    "filterText": "'Microsoft.ContainerService/managedClusters aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12398,7 +12398,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000253",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters/accessProfiles'",
+    "filterText": "'Microsoft.ContainerService/managedClusters/accessProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12420,7 +12420,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000254",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters/agentPools'",
+    "filterText": "'Microsoft.ContainerService/managedClusters/agentPools aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12442,7 +12442,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000255",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters/agentPools/machines'",
+    "filterText": "'Microsoft.ContainerService/managedClusters/agentPools/machines aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12464,7 +12464,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000256",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters/maintenanceConfigurations'",
+    "filterText": "'Microsoft.ContainerService/managedClusters/maintenanceConfigurations aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12486,7 +12486,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000257",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters/meshUpgradeProfiles'",
+    "filterText": "'Microsoft.ContainerService/managedClusters/meshUpgradeProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12508,7 +12508,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000258",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters/privateEndpointConnections'",
+    "filterText": "'Microsoft.ContainerService/managedClusters/privateEndpointConnections aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12530,7 +12530,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000259",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings'",
+    "filterText": "'Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12552,7 +12552,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000025a",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedclustersnapshots'",
+    "filterText": "'Microsoft.ContainerService/managedclustersnapshots aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12574,7 +12574,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000025b",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/openShiftManagedClusters'",
+    "filterText": "'Microsoft.ContainerService/openShiftManagedClusters aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12596,7 +12596,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000025c",
-    "filterText": "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/snapshots'",
+    "filterText": "'Microsoft.ContainerService/snapshots aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18939,7 +18939,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000038a",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/cassandraClusters'",
+    "filterText": "'Microsoft.DocumentDB/cassandraClusters cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18961,7 +18961,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000038b",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/cassandraClusters/backups'",
+    "filterText": "'Microsoft.DocumentDB/cassandraClusters/backups cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18983,7 +18983,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000038c",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/cassandraClusters/dataCenters'",
+    "filterText": "'Microsoft.DocumentDB/cassandraClusters/dataCenters cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19005,7 +19005,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000038d",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19027,7 +19027,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000038e",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19049,7 +19049,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000038f",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases/collections'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/collections cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19071,7 +19071,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000390",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases/collections/settings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/collections/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19093,7 +19093,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000391",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases/containers'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/containers cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19115,7 +19115,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000392",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases/containers/settings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/containers/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19137,7 +19137,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000393",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19159,7 +19159,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000394",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs/settings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19181,7 +19181,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000395",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/databases/settings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19203,7 +19203,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000396",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/keyspaces'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19225,7 +19225,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000397",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/settings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19247,7 +19247,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000398",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19269,7 +19269,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000399",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables/settings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19291,7 +19291,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000039a",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/tables'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19313,7 +19313,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000039b",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/apis/tables/settings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/tables/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19335,7 +19335,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000039c",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19357,7 +19357,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000039d",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19379,7 +19379,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000039e",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19401,7 +19401,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000039f",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19423,7 +19423,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a0",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19445,7 +19445,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a1",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19467,7 +19467,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a2",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/dataTransferJobs'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/dataTransferJobs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19489,7 +19489,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a3",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/graphs'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/graphs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19511,7 +19511,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a4",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19533,7 +19533,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a5",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19555,7 +19555,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a6",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19577,7 +19577,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a7",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19599,7 +19599,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a8",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/mongodbDatabases'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19621,7 +19621,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003a9",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19643,7 +19643,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003aa",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19665,7 +19665,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003ab",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19687,7 +19687,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003ac",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19709,7 +19709,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003ad",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19731,7 +19731,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003ae",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/notebookWorkspaces'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/notebookWorkspaces cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19753,7 +19753,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003af",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19775,7 +19775,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b0",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/privateLinkResources'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/privateLinkResources cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19797,7 +19797,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b1",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/services'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/services cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19819,7 +19819,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b2",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19841,7 +19841,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b3",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19863,7 +19863,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b4",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19885,7 +19885,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b5",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19907,7 +19907,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b6",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19929,7 +19929,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b7",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19951,7 +19951,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b8",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19973,7 +19973,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003b9",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19995,7 +19995,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003ba",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20017,7 +20017,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003bb",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20039,7 +20039,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003bc",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/tables'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20061,7 +20061,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003bd",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings'",
+    "filterText": "'Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20083,7 +20083,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003be",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/locations'",
+    "filterText": "'Microsoft.DocumentDB/locations cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20105,7 +20105,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003bf",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/mongoClusters'",
+    "filterText": "'Microsoft.DocumentDB/mongoClusters cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20127,7 +20127,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003c0",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/mongoClusters/firewallRules'",
+    "filterText": "'Microsoft.DocumentDB/mongoClusters/firewallRules cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20149,7 +20149,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003c1",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/throughputPools'",
+    "filterText": "'Microsoft.DocumentDB/throughputPools cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20171,7 +20171,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000003c2",
-    "filterText": "'cosmosdb,Microsoft.DocumentDB/throughputPools/throughputPoolAccounts'",
+    "filterText": "'Microsoft.DocumentDB/throughputPools/throughputPoolAccounts cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37980,7 +37980,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071a",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38002,7 +38002,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071b",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/dataCollectorLogs'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/dataCollectorLogs loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38024,7 +38024,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071c",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/dataExports'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/dataExports loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38046,7 +38046,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071d",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/dataSources'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/dataSources loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38068,7 +38068,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071e",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/clientGroups'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/features/clientGroups loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38090,7 +38090,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071f",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machineGroups'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/features/machineGroups loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38112,7 +38112,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000720",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machines'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/features/machines loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38134,7 +38134,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000721",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machines/ports'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/features/machines/ports loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38156,7 +38156,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000722",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machines/processes'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/features/machines/processes loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38178,7 +38178,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000723",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/summaries'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/features/summaries loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38200,7 +38200,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000724",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/linkedServices'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/linkedServices loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38222,7 +38222,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000725",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/linkedStorageAccounts'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/linkedStorageAccounts loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38244,7 +38244,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000726",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/savedSearches'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/savedSearches loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38266,7 +38266,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000727",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/storageInsightConfigs'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/storageInsightConfigs loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38288,7 +38288,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000728",
-    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/tables'",
+    "filterText": "'Microsoft.OperationalInsights/workspaces/tables loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52821,7 +52821,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009df",
-    "filterText": "'asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms'",
+    "filterText": "'Microsoft.Web/serverfarms asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52843,7 +52843,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e0",
-    "filterText": "'asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms/hybridConnectionNamespaces/relays'",
+    "filterText": "'Microsoft.Web/serverfarms/hybridConnectionNamespaces/relays asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52865,7 +52865,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e1",
-    "filterText": "'asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms/hybridConnectionPlanLimits'",
+    "filterText": "'Microsoft.Web/serverfarms/hybridConnectionPlanLimits asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52887,7 +52887,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e2",
-    "filterText": "'asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms/operationresults'",
+    "filterText": "'Microsoft.Web/serverfarms/operationresults asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52909,7 +52909,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e3",
-    "filterText": "'asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms/virtualNetworkConnections'",
+    "filterText": "'Microsoft.Web/serverfarms/virtualNetworkConnections asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52931,7 +52931,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e4",
-    "filterText": "'asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms/virtualNetworkConnections/gateways'",
+    "filterText": "'Microsoft.Web/serverfarms/virtualNetworkConnections/gateways asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52953,7 +52953,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e5",
-    "filterText": "'asp,appserviceplan,hostingplan,Microsoft.Web/serverfarms/virtualNetworkConnections/routes'",
+    "filterText": "'Microsoft.Web/serverfarms/virtualNetworkConnections/routes asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52975,7 +52975,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e6",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites'",
+    "filterText": "'Microsoft.Web/sites appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52997,7 +52997,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e7",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/backups'",
+    "filterText": "'Microsoft.Web/sites/backups appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53019,7 +53019,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e8",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/basicPublishingCredentialsPolicies'",
+    "filterText": "'Microsoft.Web/sites/basicPublishingCredentialsPolicies appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53041,7 +53041,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009e9",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/config'",
+    "filterText": "'Microsoft.Web/sites/config appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53063,7 +53063,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009ea",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/config/appsettings'",
+    "filterText": "'Microsoft.Web/sites/config/appsettings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53085,7 +53085,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009eb",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/config/connectionstrings'",
+    "filterText": "'Microsoft.Web/sites/config/connectionstrings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53107,7 +53107,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009ec",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/config/snapshots'",
+    "filterText": "'Microsoft.Web/sites/config/snapshots appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53129,7 +53129,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009ed",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/continuouswebjobs'",
+    "filterText": "'Microsoft.Web/sites/continuouswebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53151,7 +53151,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009ef",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/deploymentStatus'",
+    "filterText": "'Microsoft.Web/sites/deploymentStatus appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53173,7 +53173,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009ee",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/deployments'",
+    "filterText": "'Microsoft.Web/sites/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53195,7 +53195,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f0",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/detectors'",
+    "filterText": "'Microsoft.Web/sites/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53217,7 +53217,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f1",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/diagnostics'",
+    "filterText": "'Microsoft.Web/sites/diagnostics appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53239,7 +53239,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f2",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/diagnostics/analyses'",
+    "filterText": "'Microsoft.Web/sites/diagnostics/analyses appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53261,7 +53261,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f3",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/diagnostics/detectors'",
+    "filterText": "'Microsoft.Web/sites/diagnostics/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53283,7 +53283,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f4",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/domainOwnershipIdentifiers'",
+    "filterText": "'Microsoft.Web/sites/domainOwnershipIdentifiers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53305,7 +53305,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f5",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/extensions'",
+    "filterText": "'Microsoft.Web/sites/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53327,7 +53327,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f6",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/functions'",
+    "filterText": "'Microsoft.Web/sites/functions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53349,7 +53349,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f7",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/functions/keys'",
+    "filterText": "'Microsoft.Web/sites/functions/keys appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53371,7 +53371,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f8",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostNameBindings'",
+    "filterText": "'Microsoft.Web/sites/hostNameBindings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53393,7 +53393,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009f9",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53415,7 +53415,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009fa",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53437,7 +53437,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009fb",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53459,7 +53459,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009fc",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions/requestHistories'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions/requestHistories appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53481,7 +53481,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009fd",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/scopeRepetitions'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/scopeRepetitions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53503,7 +53503,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009fe",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53525,7 +53525,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000009ff",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers/histories'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers/histories appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53547,7 +53547,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a00",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hostruntime/webhooks/api/workflows/versions'",
+    "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/versions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53569,7 +53569,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a02",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hybridConnectionNamespaces/relays'",
+    "filterText": "'Microsoft.Web/sites/hybridConnectionNamespaces/relays appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53591,7 +53591,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a01",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/hybridconnection'",
+    "filterText": "'Microsoft.Web/sites/hybridconnection appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53613,7 +53613,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a03",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/instances'",
+    "filterText": "'Microsoft.Web/sites/instances appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53635,7 +53635,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a04",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/instances/deployments'",
+    "filterText": "'Microsoft.Web/sites/instances/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53657,7 +53657,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a05",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/instances/extensions'",
+    "filterText": "'Microsoft.Web/sites/instances/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53679,7 +53679,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a06",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/instances/processes'",
+    "filterText": "'Microsoft.Web/sites/instances/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53701,7 +53701,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a07",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/instances/processes/modules'",
+    "filterText": "'Microsoft.Web/sites/instances/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53723,7 +53723,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a08",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/instances/processes/threads'",
+    "filterText": "'Microsoft.Web/sites/instances/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53745,7 +53745,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a09",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/migratemysql'",
+    "filterText": "'Microsoft.Web/sites/migratemysql appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53767,7 +53767,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a0a",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/networkConfig'",
+    "filterText": "'Microsoft.Web/sites/networkConfig appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53789,7 +53789,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a0b",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/networkFeatures'",
+    "filterText": "'Microsoft.Web/sites/networkFeatures appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53811,7 +53811,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a0c",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/premieraddons'",
+    "filterText": "'Microsoft.Web/sites/premieraddons appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53833,7 +53833,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a0d",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/privateAccess'",
+    "filterText": "'Microsoft.Web/sites/privateAccess appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53855,7 +53855,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a0e",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/privateEndpointConnections'",
+    "filterText": "'Microsoft.Web/sites/privateEndpointConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53877,7 +53877,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a0f",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/processes'",
+    "filterText": "'Microsoft.Web/sites/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53899,7 +53899,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a10",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/processes/modules'",
+    "filterText": "'Microsoft.Web/sites/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53921,7 +53921,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a11",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/processes/threads'",
+    "filterText": "'Microsoft.Web/sites/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53943,7 +53943,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a12",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/publicCertificates'",
+    "filterText": "'Microsoft.Web/sites/publicCertificates appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53965,7 +53965,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a13",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/recommendations'",
+    "filterText": "'Microsoft.Web/sites/recommendations appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53987,7 +53987,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a14",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/resourceHealthMetadata'",
+    "filterText": "'Microsoft.Web/sites/resourceHealthMetadata appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54009,7 +54009,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a15",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/siteextensions'",
+    "filterText": "'Microsoft.Web/sites/siteextensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54031,7 +54031,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a16",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots'",
+    "filterText": "'Microsoft.Web/sites/slots appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54053,7 +54053,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a17",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/backups'",
+    "filterText": "'Microsoft.Web/sites/slots/backups appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54075,7 +54075,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a18",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies'",
+    "filterText": "'Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54097,7 +54097,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a19",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/config'",
+    "filterText": "'Microsoft.Web/sites/slots/config appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54119,7 +54119,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a1a",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/config/appsettings'",
+    "filterText": "'Microsoft.Web/sites/slots/config/appsettings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54141,7 +54141,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a1b",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/config/connectionstrings'",
+    "filterText": "'Microsoft.Web/sites/slots/config/connectionstrings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54163,7 +54163,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a1c",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/config/snapshots'",
+    "filterText": "'Microsoft.Web/sites/slots/config/snapshots appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54185,7 +54185,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a1d",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/continuouswebjobs'",
+    "filterText": "'Microsoft.Web/sites/slots/continuouswebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54207,7 +54207,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a1f",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/deploymentStatus'",
+    "filterText": "'Microsoft.Web/sites/slots/deploymentStatus appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54229,7 +54229,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a1e",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/deployments'",
+    "filterText": "'Microsoft.Web/sites/slots/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54251,7 +54251,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a20",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/detectors'",
+    "filterText": "'Microsoft.Web/sites/slots/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54273,7 +54273,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a21",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/diagnostics'",
+    "filterText": "'Microsoft.Web/sites/slots/diagnostics appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54295,7 +54295,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a22",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/diagnostics/analyses'",
+    "filterText": "'Microsoft.Web/sites/slots/diagnostics/analyses appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54317,7 +54317,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a23",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/diagnostics/detectors'",
+    "filterText": "'Microsoft.Web/sites/slots/diagnostics/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54339,7 +54339,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a24",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/domainOwnershipIdentifiers'",
+    "filterText": "'Microsoft.Web/sites/slots/domainOwnershipIdentifiers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54361,7 +54361,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a25",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/extensions'",
+    "filterText": "'Microsoft.Web/sites/slots/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54383,7 +54383,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a26",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/functions'",
+    "filterText": "'Microsoft.Web/sites/slots/functions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54405,7 +54405,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a27",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/functions/keys'",
+    "filterText": "'Microsoft.Web/sites/slots/functions/keys appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54427,7 +54427,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a28",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/hostNameBindings'",
+    "filterText": "'Microsoft.Web/sites/slots/hostNameBindings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54449,7 +54449,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a2a",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays'",
+    "filterText": "'Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54471,7 +54471,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a29",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/hybridconnection'",
+    "filterText": "'Microsoft.Web/sites/slots/hybridconnection appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54493,7 +54493,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a2b",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/instances'",
+    "filterText": "'Microsoft.Web/sites/slots/instances appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54515,7 +54515,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a2c",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/instances/deployments'",
+    "filterText": "'Microsoft.Web/sites/slots/instances/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54537,7 +54537,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a2d",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/instances/extensions'",
+    "filterText": "'Microsoft.Web/sites/slots/instances/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54559,7 +54559,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a2e",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/instances/processes'",
+    "filterText": "'Microsoft.Web/sites/slots/instances/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54581,7 +54581,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a2f",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/instances/processes/modules'",
+    "filterText": "'Microsoft.Web/sites/slots/instances/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54603,7 +54603,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a30",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/instances/processes/threads'",
+    "filterText": "'Microsoft.Web/sites/slots/instances/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54625,7 +54625,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a31",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/migratemysql'",
+    "filterText": "'Microsoft.Web/sites/slots/migratemysql appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54647,7 +54647,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a32",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/networkConfig'",
+    "filterText": "'Microsoft.Web/sites/slots/networkConfig appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54669,7 +54669,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a33",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/networkFeatures'",
+    "filterText": "'Microsoft.Web/sites/slots/networkFeatures appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54691,7 +54691,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a34",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/premieraddons'",
+    "filterText": "'Microsoft.Web/sites/slots/premieraddons appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54713,7 +54713,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a35",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/privateAccess'",
+    "filterText": "'Microsoft.Web/sites/slots/privateAccess appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54735,7 +54735,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a36",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/privateEndpointConnections'",
+    "filterText": "'Microsoft.Web/sites/slots/privateEndpointConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54757,7 +54757,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a37",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/processes'",
+    "filterText": "'Microsoft.Web/sites/slots/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54779,7 +54779,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a38",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/processes/modules'",
+    "filterText": "'Microsoft.Web/sites/slots/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54801,7 +54801,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a39",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/processes/threads'",
+    "filterText": "'Microsoft.Web/sites/slots/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54823,7 +54823,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a3a",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/publicCertificates'",
+    "filterText": "'Microsoft.Web/sites/slots/publicCertificates appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54845,7 +54845,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a3b",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/resourceHealthMetadata'",
+    "filterText": "'Microsoft.Web/sites/slots/resourceHealthMetadata appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54867,7 +54867,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a3c",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/siteextensions'",
+    "filterText": "'Microsoft.Web/sites/slots/siteextensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54889,7 +54889,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a3d",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/sourcecontrols'",
+    "filterText": "'Microsoft.Web/sites/slots/sourcecontrols appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54911,7 +54911,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a3e",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/triggeredwebjobs'",
+    "filterText": "'Microsoft.Web/sites/slots/triggeredwebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54933,7 +54933,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a3f",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/triggeredwebjobs/history'",
+    "filterText": "'Microsoft.Web/sites/slots/triggeredwebjobs/history appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54955,7 +54955,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a40",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/virtualNetworkConnections'",
+    "filterText": "'Microsoft.Web/sites/slots/virtualNetworkConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54977,7 +54977,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a41",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/virtualNetworkConnections/gateways'",
+    "filterText": "'Microsoft.Web/sites/slots/virtualNetworkConnections/gateways appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54999,7 +54999,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a42",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/slots/webjobs'",
+    "filterText": "'Microsoft.Web/sites/slots/webjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55021,7 +55021,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a43",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/sourcecontrols'",
+    "filterText": "'Microsoft.Web/sites/sourcecontrols appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55043,7 +55043,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a44",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/triggeredwebjobs'",
+    "filterText": "'Microsoft.Web/sites/triggeredwebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55065,7 +55065,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a45",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/triggeredwebjobs/history'",
+    "filterText": "'Microsoft.Web/sites/triggeredwebjobs/history appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55087,7 +55087,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a46",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/virtualNetworkConnections'",
+    "filterText": "'Microsoft.Web/sites/virtualNetworkConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55109,7 +55109,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a47",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/virtualNetworkConnections/gateways'",
+    "filterText": "'Microsoft.Web/sites/virtualNetworkConnections/gateways appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55131,7 +55131,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000a48",
-    "filterText": "'appservice,webapp,function,Microsoft.Web/sites/webjobs'",
+    "filterText": "'Microsoft.Web/sites/webjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
@@ -4826,6 +4826,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d3",
+    "filterText": "'rbac,Microsoft.Authorization/accessReviewHistoryDefinitions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4847,6 +4848,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d4",
+    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleDefinitions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4868,6 +4870,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d5",
+    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleDefinitions/instances'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4889,6 +4892,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d6",
+    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4910,6 +4914,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d7",
+    "filterText": "'rbac,Microsoft.Authorization/accessReviewScheduleSettings'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4931,6 +4936,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d8",
+    "filterText": "'rbac,Microsoft.Authorization/dataPolicyManifests'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4952,6 +4958,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000d9",
+    "filterText": "'rbac,Microsoft.Authorization/locks'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4973,6 +4980,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000da",
+    "filterText": "'rbac,Microsoft.Authorization/policyAssignments'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4994,6 +5002,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000db",
+    "filterText": "'rbac,Microsoft.Authorization/policyDefinitions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5015,6 +5024,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000dc",
+    "filterText": "'rbac,Microsoft.Authorization/policyDefinitions/versions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5036,6 +5046,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000dd",
+    "filterText": "'rbac,Microsoft.Authorization/policyExemptions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5057,6 +5068,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000de",
+    "filterText": "'rbac,Microsoft.Authorization/policySetDefinitions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5078,6 +5090,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000df",
+    "filterText": "'rbac,Microsoft.Authorization/policySetDefinitions/versions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5099,6 +5112,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e0",
+    "filterText": "'rbac,Microsoft.Authorization/privateLinkAssociations'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5120,6 +5134,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e1",
+    "filterText": "'rbac,Microsoft.Authorization/resourceManagementPrivateLinks'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5141,6 +5156,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e2",
+    "filterText": "'rbac,Microsoft.Authorization/roleAssignmentApprovals'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5162,6 +5178,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e3",
+    "filterText": "'rbac,Microsoft.Authorization/roleAssignmentApprovals/stages'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5183,6 +5200,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e5",
+    "filterText": "'rbac,Microsoft.Authorization/roleAssignmentScheduleRequests'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5226,6 +5244,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e6",
+    "filterText": "'rbac,Microsoft.Authorization/roleDefinitions'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5247,6 +5266,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e7",
+    "filterText": "'rbac,Microsoft.Authorization/roleEligibilityScheduleRequests'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5268,6 +5288,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e8",
+    "filterText": "'rbac,Microsoft.Authorization/roleManagementPolicyAssignments'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5289,6 +5310,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000e9",
+    "filterText": "'rbac,Microsoft.Authorization/variables'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5310,6 +5332,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "000000ea",
+    "filterText": "'rbac,Microsoft.Authorization/variables/values'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37957,6 +37980,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071a",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37978,6 +38002,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071b",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/dataCollectorLogs'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37999,6 +38024,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071c",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/dataExports'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38020,6 +38046,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071d",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/dataSources'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38041,6 +38068,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071e",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/clientGroups'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38062,6 +38090,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "0000071f",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machineGroups'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38083,6 +38112,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000720",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machines'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38104,6 +38134,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000721",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machines/ports'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38125,6 +38156,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000722",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/machines/processes'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38146,6 +38178,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000723",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/features/summaries'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38167,6 +38200,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000724",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/linkedServices'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38188,6 +38222,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000725",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/linkedStorageAccounts'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38209,6 +38244,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000726",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/savedSearches'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38230,6 +38266,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000727",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/storageInsightConfigs'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38251,6 +38288,7 @@
     "deprecated": false,
     "preselect": false,
     "sortText": "00000728",
+    "filterText": "'loganalytics,Microsoft.OperationalInsights/workspaces/tables'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -2152,8 +2152,7 @@ resource abc 'Test.Rp/basic|'
                 foreach (var completion in microsoftApp)
                 {
                     completion.FilterText.Should().NotBeNull();
-                    completion.FilterText.Should().NotBeUpperCased();
-                    var filters = completion.FilterText!.Trim('\'').Split(',');
+                    var filters = completion.FilterText!.Trim('\'').Split(' ');
 
                     filters.Where(x => x.StartsWith("microsoft.app", StringComparison.OrdinalIgnoreCase)).Should().HaveCount(1);
                     filters.Should().Contain("containerapp");
@@ -2163,8 +2162,7 @@ resource abc 'Test.Rp/basic|'
                 {
                     if (completion.FilterText is string filterText)
                     {
-                        filterText.Should().NotBeUpperCased();
-                        var filters = filterText.Trim('\'').Split(',');
+                        var filters = filterText.Trim('\'').Split(' ');
 
                         filters.Where(x => x.StartsWith("microsoft.app", StringComparison.OrdinalIgnoreCase)).Should().HaveCount(0);
                         filters.Should().NotContain("containerapp");
@@ -2189,8 +2187,7 @@ resource abc 'Test.Rp/basic|'
                 foreach (var completion in serverFarms)
                 {
                     completion.FilterText.Should().NotBeNull();
-                    completion.FilterText.Should().NotBeUpperCased();
-                    var filters = completion.FilterText!.Trim('\'').Split(',');
+                    var filters = completion.FilterText!.Trim('\'').Split(' ');
 
                     filters.Where(x => x.StartsWith("microsoft.web/serverfarms", StringComparison.OrdinalIgnoreCase)).Should().HaveCount(1);
                     filters.Should().Contain("appserviceplan");
@@ -2205,8 +2202,7 @@ resource abc 'Test.Rp/basic|'
                 {
                     if (completion.FilterText is string filterText)
                     {
-                        filterText.Should().NotBeUpperCased();
-                        var filters = filterText.Trim('\'').Split(',');
+                        var filters = filterText.Trim('\'').Split(' ');
 
                         filters.Where(x => x.StartsWith("microsoft.web/serverfarms", StringComparison.OrdinalIgnoreCase)).Should().HaveCount(0);
                         filters.Should().NotContain("appserviceplan");
@@ -2220,8 +2216,7 @@ resource abc 'Test.Rp/basic|'
                 {
                     if (completion.FilterText is string filterText)
                     {
-                        filterText.Should().NotBeUpperCased();
-                        var filters = filterText.Trim('\'').Split(',');
+                        var filters = filterText.Trim('\'').Split(' ');
 
                         filters.Where(x => x.StartsWith("microsoft.web/serverfarms", StringComparison.OrdinalIgnoreCase)).Should().HaveCount(0);
                         filters.Should().NotContain("appserviceplan");

--- a/src/Bicep.LangServer.UnitTests/Completions/ResourceTypeSearchKeywordsTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/ResourceTypeSearchKeywordsTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Bicep.Core.Resources;
 using Bicep.LanguageServer.Completions;
+using Bicep.LanguageServer.Snippets;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -18,20 +19,19 @@ namespace Bicep.LangServer.UnitTests.Completions
     [TestClass]
     public class ResourceTypeSearchKeywordsTests
     {
-        [DataRow("Microsoft.Web/sites", "'appservice,webapp,function,Microsoft.Web/sites'")]
-        [DataRow("microsoft.web/sites", "'appservice,webapp,function,microsoft.web/sites'")]
-        [DataRow("microsoft.app/abc", "'containerapp,microsoft.app/abc'")]
-        [DataRow("Microsoft.ContainerService/managedClusters", "'aks,kubernetes,k8s,cluster,Microsoft.ContainerService/managedClusters'")]
-        [DataRow("toplevel1", "'top level keyword,toplevel1'")]
-        [DataRow("toplevel1/secondlevel1", "'top level keyword,toplevel1/secondlevel1'")]
-        [DataRow("toplevel1/secondlevel2", "'top level keyword,toplevel1/secondlevel2'")]
-        [DataRow("toplevel1/secondlevel1/thirdlevel", "'top level keyword,toplevel1/secondlevel1/thirdlevel'")]
+        [DataRow("Microsoft.Web/sites", "'Microsoft.Web/sites appservice webapp function'")]
+        [DataRow("microsoft.web/sites", "'microsoft.web/sites appservice webapp function'")]
+        [DataRow("microsoft.app/abc", "'microsoft.app/abc containerapp'")]
+        [DataRow("Microsoft.ContainerService/managedClusters", "'Microsoft.ContainerService/managedClusters aks kubernetes k8s cluster'")]
+        [DataRow("toplevel1", "'toplevel1 top level keyword'")]
+        [DataRow("toplevel1/secondlevel1", "'toplevel1/secondlevel1 top level keyword'")]
+        [DataRow("toplevel1/secondlevel2", "'toplevel1/secondlevel2 top level keyword'")]
+        [DataRow("toplevel1/secondlevel1/thirdlevel", "'toplevel1/secondlevel1/thirdlevel top level keyword'")]
         [DataRow("toplevel2", null)]
-        [DataRow("toplevel2/secondlevel1", "'second level keyword,toplevel2/secondlevel1'")]
+        [DataRow("toplevel2/secondlevel1", "'toplevel2/secondlevel1 second level keyword'")]
         [DataRow("toplevel2/secondlevel2", null)]
         [DataRow("toplevel2/secondlevel2/thirdlevel", null)]
-        [DataRow("toplevel2/secondlevel1/thirdlevel", "'second level keyword,toplevel2/secondlevel1/thirdlevel'")]
-
+        [DataRow("toplevel2/secondlevel1/thirdlevel", "'toplevel2/secondlevel1/thirdlevel second level keyword'")]
         [DataTestMethod]
         public void TryGetResourceTypeFilterText(string resourceType, string? expectedFilter)
         {
@@ -46,7 +46,100 @@ namespace Bicep.LangServer.UnitTests.Completions
                 ["toplevel2/secondlevel1"] = ["second level keyword"],
             });
 
-            var result = sut.TryGetResourceTypeFilterText(new ResourceTypeReference(resourceType, "2020-06-01"));
+            var result = sut.TryGetResourceTypeFilterText(new ResourceTypeReference(resourceType, "2020-06-01"), surroundWithSingleQuotes: true);
+
+            result.Should().Be(expectedFilter);
+        }
+
+        [DataRow(
+            "res-app-plan",
+            "Application Service Plan (Server Farm)",
+            """
+                no resources          
+                """,
+            null)]
+        [DataRow(
+            "res-app-plan",
+            "Application Service Plan (Server Farm)",
+            """
+                resource /*${1:appServicePlan}*/appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
+                  name: /*${2:'name'}*/'name'
+                  location: /*${3:location}*/'location'
+                  sku: {
+                    name: 'F1'
+                    capacity: 1
+                  }
+                }            
+                """,
+            "res-app-plan Application Service Plan (Server Farm) Microsoft.Web/serverfarms asp appserviceplan hostingplan")]
+        [DataRow(
+            "res-app-plan",
+            "Application Service Plan (Server Farm)",
+            """
+                resource /*${1:appServicePlan}*/appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
+                  name: /*${2:'name'}*/'name'
+                  location: /*${3:location}*/'location'
+                  sku: {
+                    name: 'F1'
+                    capacity: 1
+                  }
+                }            
+                resource /*${1:appServicePlan}*/appServicePlan 'Microsoft.Web/serverfarms@3333-12-01' = {
+                  name: /*${2:'name'}*/'name'
+                  location: /*${3:location}*/'location'
+                  sku: {
+                    name: 'F1'
+                    capacity: 1
+                  }
+                }            
+                resource /*${1:appServicePlan}*/appServicePlan 'Microsoft.Web/unknown@2020-12-01-beta' = {
+                  name: /*${2:'name'}*/'name'
+                  location: /*${3:location}*/'location'
+                  sku: {
+                    name: reference
+                    capacity: 1
+                  }
+                }            
+                """,
+            "res-app-plan Application Service Plan (Server Farm) Microsoft.Web/serverfarms asp appserviceplan hostingplan Microsoft.Web/unknown")]
+        [DataRow(
+            "res-automation-job-schedule",
+            "Automation Job Schedule",
+            """
+            resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' = {
+              name: /*${1:'name'}*/'name'
+            }
+
+            resource /*${2:automationJobSchedule}*/automationJobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2019-06-01' = {
+              parent: automationAccount
+              name: /*${3:'name'}*/'name'
+              properties: {
+                schedule: {
+                  name: /*${4:'name'}*/'name'
+                }
+                runbook: {
+                  name: /*${5:'name'}*/'name'
+                }
+              }
+            }            
+            """,
+            "res-automation-job-schedule Automation Job Schedule Microsoft.Automation/automationAccounts Microsoft.Automation/automationAccounts/jobSchedules")]
+        [DataTestMethod]
+        public void TryGetSnippetFilterText(string prefix, string detail, string text, string? expectedFilter)
+        {
+            var sut = new ResourceTypeSearchKeywords(new Dictionary<string, string[]>
+            {
+                ["Microsoft.Web/sites"] = ["appservice", "webapp", "function"],
+                ["Microsoft.Web/serverFarms"] = ["asp", "appserviceplan", "hostingplan"],
+                ["MICROSOFT.APP"] = ["containerapp"],
+                ["Microsoft.ContainerService"] = ["aks", "kubernetes", "k8s", "cluster"],
+                ["Microsoft.Authorization/roleAssignments"] = ["rbac"],
+                ["toplevel1"] = ["top level keyword"],
+                ["toplevel2/secondlevel1"] = ["second level keyword"],
+            });
+
+            var snippet = new Snippet(text, prefix: prefix, detail: detail);
+            var result = sut.TryGetSnippetFilterText(snippet);
 
             result.Should().Be(expectedFilter);
         }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -185,7 +185,8 @@ namespace Bicep.LanguageServer.Completions
                                                                            resourceSnippet.Text,
                                                                            context.ReplacementRange,
                                                                            command,
-                                                                           resourceSnippet.CompletionPriority);
+                                                                           resourceSnippet.CompletionPriority,
+                                                                           filterText: ResourceTypeSearchKeywords.TryGetSnippetFilterText(resourceSnippet));
                         }
 
                         break;
@@ -1886,7 +1887,7 @@ namespace Bicep.LanguageServer.Completions
                         MarkdownHelper.AppendNewline($"Type: `{resourceType.Type}`"))
                     .WithFollowupCompletion("resource type completion")
                     .WithSortText(index.ToString("x8"))
-                    .WithFilterText(ResourceTypeSearchKeywords.TryGetResourceTypeFilterText(resourceType))
+                    .WithFilterText(ResourceTypeSearchKeywords.TryGetResourceTypeFilterText(resourceType, surroundWithSingleQuotes: true))
                     .Build();
             }
         }
@@ -1943,13 +1944,14 @@ namespace Bicep.LanguageServer.Completions
         /// <summary>
         /// Creates a completion with a contextual snippet with command option. This will look like a snippet to the user.
         /// </summary>
-        private static CompletionItem CreateContextualSnippetCompletion(string label, string detail, string snippet, Range replacementRange, Command command, CompletionPriority priority = CompletionPriority.Medium, bool preselect = false) =>
+        private static CompletionItem CreateContextualSnippetCompletion(string label, string detail, string snippet, Range replacementRange, Command command, CompletionPriority priority = CompletionPriority.Medium, bool preselect = false, string? filterText = null) =>
             CompletionItemBuilder.Create(CompletionItemKind.Snippet, label)
                 .WithSnippetEdit(replacementRange, snippet)
                 .WithCommand(command)
                 .WithDetail(detail)
                 .WithDocumentation(MarkdownHelper.CodeBlock(new Snippet(snippet).FormatDocumentation()))
                 .WithSortText(GetSortText(label, priority))
+                .WithFilterText(filterText)
                 .Preselect(preselect)
                 .Build();
 

--- a/src/Bicep.LangServer/Completions/ResourceTypeSearchKeywords.cs
+++ b/src/Bicep.LangServer/Completions/ResourceTypeSearchKeywords.cs
@@ -6,13 +6,15 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Bicep.Core.Parsing;
 using Bicep.Core.Resources;
+using Bicep.LanguageServer.Snippets;
 
 namespace Bicep.LanguageServer.Completions
 {
-    public class ResourceTypeSearchKeywords
+    public partial class ResourceTypeSearchKeywords
     {
         private readonly ImmutableDictionary<string, ImmutableArray<string>> keywordsMap;
 
@@ -27,6 +29,8 @@ namespace Bicep.LanguageServer.Completions
                 ["Microsoft.ContainerService"] = ["aks", "kubernetes", "k8s", "cluster"],
                 ["Microsoft.Authorization/roleAssignments"] = ["rbac"],
                 ["Microsoft.DocumentDb"] = ["cosmosdb"],
+                ["Microsoft.Authorization"] = ["rbac"],
+                ["Microsoft.OperationalInsights/workspaces"] = ["loganalytics"],
             })
         {
         }
@@ -45,30 +49,58 @@ namespace Bicep.LanguageServer.Completions
             this.keywordsMap = keywordsMap.ToImmutableDictionary(x => x.Key.ToLowerInvariant(), x => x.Value.ToImmutableArray(), StringComparer.InvariantCultureIgnoreCase);
         }
 
-        public string? TryGetResourceTypeFilterText(ResourceTypeReference resourceType)
+        public string? TryGetResourceTypeFilterText(ResourceTypeReference resourceType, bool surroundWithSingleQuotes = false)
         {
-            var filter = resourceType.Type;
+            var typeName = resourceType.Type;
             ImmutableArray<string> keywords;
 
             // We want to search using the top-level resource type, including subtypes
             // Microsoft.web/serverFarms/xxx -> top-level key is Microsoft.web
             // Microsoft.web/serverFarms/xxx -> second-level key is Microsoft.web/serverFarms
-            var indexFirstSlash = filter.IndexOf('/');
-            var topLevelKey = indexFirstSlash > 0 ? filter[0..indexFirstSlash] : filter;
+            var indexFirstSlash = typeName.IndexOf('/');
+            var topLevelKey = indexFirstSlash > 0 ? typeName[0..indexFirstSlash] : typeName;
             if (!keywordsMap.TryGetValue(topLevelKey, out keywords))
             {
                 if (indexFirstSlash > 0)
                 {
-                    var indexSecondSlash = filter.IndexOf('/', indexFirstSlash + 1);
-                    var secondLevelKey = indexSecondSlash > 0 ? filter[0..indexSecondSlash] : filter;
+                    var indexSecondSlash = typeName.IndexOf('/', indexFirstSlash + 1);
+                    var secondLevelKey = indexSecondSlash > 0 ? typeName[0..indexSecondSlash] : typeName;
                     keywordsMap.TryGetValue(secondLevelKey, out keywords);
                 }
             }
 
-            // The filter text, like the insertText, must include the single quotes that surround the resource type in the resource declaration
-            return !keywords.IsDefaultOrEmpty ?
-                StringUtils.EscapeBicepString($"{string.Join(',', keywords)},{filter}") :
-                null; // null - let vscode use the default (label)
+            var result = keywords.IsDefaultOrEmpty ?
+                null : // null - let vscode use the default (label)
+                string.Join(' ', keywords.Prepend(typeName));
+
+            return result is string && surroundWithSingleQuotes ? StringUtils.EscapeBicepString(result) : result;
+        }
+
+        public string? TryGetSnippetFilterText(Snippet snippet)
+        {
+            var resourceTypesUsed = GetResourceTypesFromBicepText(snippet.Text);
+            if (resourceTypesUsed.Length == 0)
+            {
+                // Don't provide filter text for non-resource snippets (e.g. param, var, output), just let vscode use label
+                return null;
+            }
+
+            // Add the resource type and its keywords for all resourced used in the snippet
+            var resourceTypeFilters = resourceTypesUsed.Select(rt => TryGetResourceTypeFilterText(new ResourceTypeReference(rt, null)) ?? rt).ToArray();
+            return $"{snippet.Prefix} {snippet.Detail} {string.Join(' ', resourceTypeFilters)}";
+        }
+
+        // Example match: resource /*${1:appServicePlan}*/appServicePlan 'Microsoft.Web/serverfarms@2020-12-01' = {
+        //   => "Microsoft.Web/serverfarms"
+        [GeneratedRegex("""'(?<resourceType>[a-z][a-z0-9.]+/[a-z0-9./]+)@[a-z0-9-]+'""", RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace)]
+        private static partial Regex RegexResourceType();
+
+        private string[] GetResourceTypesFromBicepText(string snippetText)
+        {
+            var matches = RegexResourceType().Matches(snippetText);
+            return matches.Select(m => m.Groups[1].Value)
+                .Distinct()
+                .ToArray();
         }
     }
 }


### PR DESCRIPTION
Another part of https://github.com/Azure/bicep/issues/6387

1) Hopefully fix update baselines script (unrelated)
2) vscode handles spaces between than commas
3) prioritize the actual resource name over the keywords by placing them first
4) Added a couple more aliases
5) Implement filtering for snippets:
  a) add snippet description to filter
  b) add resource types and keywords for all resources used in the snippet


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13731)