### PR TITLE
Fix importing tagged unions from compiled JSON

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedDiscriminatedObjectUnionTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedDiscriminatedObjectUnionTests.cs
@@ -773,5 +773,93 @@ namespace Bicep.Core.IntegrationTests
                 }
                 """);
         }
+
+        [TestMethod]
+        public void Tagged_unions_can_be_imported_from_json_templates()
+        {
+            var test1Bicep = """
+                @export()
+                type testType = {
+                  subType: subType[]
+                }
+
+                @discriminator('type')
+                type subType = testSub1 | testSub2 | testSub3
+
+                type testSub1 = {
+                  type: '1'
+                  subOption1: string
+                }
+
+                type testSub2 = {
+                  type: '2'
+                  subOption2: int
+                }
+
+                type testSub3 = {
+                  type: '3'
+                  subOption3: bool
+                }
+                """;
+
+            static string expectedSubTypeSchema(string extension) => $$"""
+                {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                      "1": {
+                        "$ref": "#/definitions/_1.testSub1"
+                      },
+                      "2": {
+                        "$ref": "#/definitions/_1.testSub2"
+                      },
+                      "3": {
+                        "$ref": "#/definitions/_1.testSub3"
+                      }
+                    }
+                  },
+                  "metadata": {
+                    "__bicep_imported_from!": {
+                      "sourceTemplate": "test1.{{extension}}"
+                    }
+                  }
+                }
+                """;
+
+            static string mainTypesBicep(string extension) => $$"""
+                import { testType } from 'test1.{{extension}}'
+
+                @export()
+                type mainType = {
+                  name: string
+                  test: testType[]?
+                }
+                """;
+
+            var mainBicep = """
+                import { mainType } from 'main.types.bicep'
+
+                param main mainType
+
+                output mainOut object = main
+                """;
+
+            var resultFromBicep = CompilationHelper.Compile(
+                ("test1.bicep", test1Bicep),
+                ("main.types.bicep", mainTypesBicep("bicep")),
+                ("main.bicep", mainBicep));
+
+            resultFromBicep.Template.Should().NotBeNull();
+            resultFromBicep.Template.Should().HaveJsonAtPath("$.definitions['_1.subType']", expectedSubTypeSchema("bicep"));
+
+            var resultFromJson = CompilationHelper.Compile(
+                ("test1.json", CompilationHelper.Compile(test1Bicep).Template!.ToString()),
+                ("main.types.bicep", mainTypesBicep("json")),
+                ("main.bicep", mainBicep));
+
+            resultFromJson.Template.Should().NotBeNull();
+            resultFromJson.Template.Should().HaveJsonAtPath("$.definitions['_1.subType']", expectedSubTypeSchema("json"));
+        }
     }
 }

--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmReferenceCollector.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmReferenceCollector.cs
@@ -132,5 +132,13 @@ internal partial class ArmReferenceCollector
                 yield return nested;
             }
         }
+
+        if (schemaNode.Discriminator is { } discriminatorConstraint)
+        {
+            foreach (var nested in discriminatorConstraint.Mapping.Values.SelectMany(EnumerateReferencesUsedIn))
+            {
+                yield return nested;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #13726

This PR updates the import closure compiler to take account of ARM's `discriminator` constraint both for type declaration -> TypeExpression conversion and for reference collecting purposes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13733)