### PR TITLE
Fix importing tuples from JSON

### DIFF
--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
@@ -134,28 +134,28 @@ internal class ArmDeclarationToExpressionConverter
         Expression? Sealed);
 
     private TypeModifiers GetTypeModifiers(ITemplateSchemaNode schemaNode) => new(
-        GetDescription(schemaNode) is string description ? ExpressionFactory.CreateStringLiteral(description, sourceSyntax) : null,
-        schemaNode.Metadata?.Value is JToken md && ConvertToExpression(ImmutableDictionary<JToken, LanguageExpression>.Empty, md) is ObjectExpression @object
+        Description: GetDescription(schemaNode) is string description ? ExpressionFactory.CreateStringLiteral(description, sourceSyntax) : null,
+        Metadata: schemaNode.Metadata?.Value is JToken md && ConvertToExpression(ImmutableDictionary<JToken, LanguageExpression>.Empty, md) is ObjectExpression @object
             ? ExcludingPropertiesNamed(@object, LanguageConstants.MetadataDescriptionPropertyName, LanguageConstants.MetadataExportedPropertyName)
             : null,
-        schemaNode.Type?.Value switch
+        Secure: schemaNode.Type?.Value switch
         {
             TemplateParameterType.SecureString or TemplateParameterType.SecureObject => ExpressionFactory.CreateBooleanLiteral(true, sourceSyntax),
             _ => null,
         },
-        schemaNode.MinLength?.Value is long minLength
+        MinLength: schemaNode.MinLength?.Value is long minLength
             ? ExpressionFactory.CreateIntegerLiteral(minLength, sourceSyntax)
             : null,
-        schemaNode.MaxLength?.Value is long maxLength
+        MaxLength: schemaNode.MaxLength?.Value is long maxLength
             ? ExpressionFactory.CreateIntegerLiteral(maxLength, sourceSyntax)
             : null,
-        schemaNode.MinValue?.Value is long minValue
+        MinValue: schemaNode.MinValue?.Value is long minValue
             ? ExpressionFactory.CreateIntegerLiteral(minValue, sourceSyntax)
             : null,
-        schemaNode.MaxValue?.Value is long maxValue
+        MaxValue: schemaNode.MaxValue?.Value is long maxValue
             ? ExpressionFactory.CreateIntegerLiteral(maxValue, sourceSyntax)
             : null,
-        schemaNode.AdditionalProperties?.BooleanValue is false || schemaNode.Items?.BooleanValue is false
+        Sealed: schemaNode.AdditionalProperties?.BooleanValue is false
             ? ExpressionFactory.CreateBooleanLiteral(true, sourceSyntax)
             : null);
 


### PR DESCRIPTION
Resolves #13724 

This PR applies the `sealed` modifier to types loaded from ARM JSON only if `additionalProperties` was set to `false` in the source.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13736)