### PR TITLE
Fix mirror build: Revert "Bump Microsoft.VisualStudio.Telemetry from 16.5.6 to 17.9.305…

### DIFF
--- a/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/packages.lock.json
@@ -1161,7 +1161,7 @@
           "Microsoft.VisualStudio.Shell.Interop": "[17.9.37000, )",
           "Microsoft.VisualStudio.Utilities": "[17.2.32505.113, )",
           "Microsoft.VisualStudio.Workspace.VSIntegration": "[17.1.11-preview-0002, )",
-          "Microsoft.Visualstudio.Telemetry": "[17.9.305, )",
+          "Microsoft.Visualstudio.Telemetry": "[16.5.6, )",
           "OmniSharp.Extensions.LanguageServer": "[0.19.7, )"
         }
       },

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/packages.lock.json
@@ -1036,7 +1036,7 @@
           "Microsoft.VisualStudio.Shell.Interop": "[17.9.37000, )",
           "Microsoft.VisualStudio.Utilities": "[17.2.32505.113, )",
           "Microsoft.VisualStudio.Workspace.VSIntegration": "[17.1.11-preview-0002, )",
-          "Microsoft.Visualstudio.Telemetry": "[17.9.305, )",
+          "Microsoft.Visualstudio.Telemetry": "[16.5.6, )",
           "OmniSharp.Extensions.LanguageServer": "[0.19.7, )"
         }
       }

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
@@ -480,10 +480,10 @@
       },
       "Microsoft.VisualStudio.RemoteControl": {
         "type": "Transitive",
-        "resolved": "16.3.52",
-        "contentHash": "+MgP1+Rtt1uJZyqhf7+H6KAQ57wc7v00ixuLhEgFggIbmW2/29YXfPK7gLvXw+vU7vimuM47cqAHrnB7RWYqtg==",
+        "resolved": "16.3.44",
+        "contentHash": "hbc2FxReEyotRXM1dtQSZxt2ccNMBgPbcX6MylKp9UDbHsTPJ0dk5CEuZAqoqOFKUzFtorZL6A7BcRAjP9HU1g==",
         "dependencies": {
-          "Microsoft.VisualStudio.Utilities.Internal": "16.3.42"
+          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36"
         }
       },
       "Microsoft.VisualStudio.RpcContracts": {
@@ -555,13 +555,14 @@
       },
       "Microsoft.VisualStudio.Telemetry": {
         "type": "Transitive",
-        "resolved": "17.9.305",
-        "contentHash": "dWQlTc3o1zvnr0dFD+ZpC04gZtP3pzAMEQBK2oqPZoMRm4n3cj5sSNSlSugDjWHAnVAKzses/ZTvR2SHTyCQNA==",
+        "resolved": "16.5.6",
+        "contentHash": "afyxTJBcntD92T9Ce8gZxOgEZBLZXFA7kxQLW1gnbnF5yGBkeF8vdwIlvJ/aw6+Of0cgfjgY9J/bLGZ976puAQ==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.VisualStudio.RemoteControl": "16.3.52",
-          "Microsoft.VisualStudio.Utilities.Internal": "16.3.56",
-          "Newtonsoft.Json": "13.0.1"
+          "Microsoft.VisualStudio.RemoteControl": "16.3.44",
+          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36",
+          "Newtonsoft.Json": "13.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
       "Microsoft.VisualStudio.Threading": {
@@ -578,8 +579,8 @@
       },
       "Microsoft.VisualStudio.Utilities.Internal": {
         "type": "Transitive",
-        "resolved": "16.3.56",
-        "contentHash": "QX5UVVk4+/rPu3Xy3QRAntNBy/3VMl2whwSlt73Ksp6MRf5ersUopgmHbkEnWSTX6e/SZf+mfqTmvdk67URH2Q=="
+        "resolved": "16.3.36",
+        "contentHash": "tVOE9DJbd4PETSgBW+9448jvRdhm/hNHJFaGyCq6Gtlg+ElELBmfMFxgp2rsrqzUkLjehwnrw6uX4Yj9krOfJQ=="
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",
@@ -992,7 +993,7 @@
           "Microsoft.VisualStudio.Shell.Interop": "[17.9.37000, )",
           "Microsoft.VisualStudio.Utilities": "[17.2.32505.113, )",
           "Microsoft.VisualStudio.Workspace.VSIntegration": "[17.1.11-preview-0002, )",
-          "Microsoft.Visualstudio.Telemetry": "[17.9.305, )",
+          "Microsoft.Visualstudio.Telemetry": "[16.5.6, )",
           "OmniSharp.Extensions.LanguageServer": "[0.19.7, )"
         }
       }

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/packages.lock.json
@@ -655,10 +655,10 @@
       },
       "Microsoft.VisualStudio.RemoteControl": {
         "type": "Transitive",
-        "resolved": "16.3.52",
-        "contentHash": "+MgP1+Rtt1uJZyqhf7+H6KAQ57wc7v00ixuLhEgFggIbmW2/29YXfPK7gLvXw+vU7vimuM47cqAHrnB7RWYqtg==",
+        "resolved": "16.3.44",
+        "contentHash": "hbc2FxReEyotRXM1dtQSZxt2ccNMBgPbcX6MylKp9UDbHsTPJ0dk5CEuZAqoqOFKUzFtorZL6A7BcRAjP9HU1g==",
         "dependencies": {
-          "Microsoft.VisualStudio.Utilities.Internal": "16.3.42"
+          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36"
         }
       },
       "Microsoft.VisualStudio.RpcContracts": {
@@ -786,13 +786,14 @@
       },
       "Microsoft.VisualStudio.Telemetry": {
         "type": "Transitive",
-        "resolved": "17.9.305",
-        "contentHash": "dWQlTc3o1zvnr0dFD+ZpC04gZtP3pzAMEQBK2oqPZoMRm4n3cj5sSNSlSugDjWHAnVAKzses/ZTvR2SHTyCQNA==",
+        "resolved": "16.5.6",
+        "contentHash": "afyxTJBcntD92T9Ce8gZxOgEZBLZXFA7kxQLW1gnbnF5yGBkeF8vdwIlvJ/aw6+Of0cgfjgY9J/bLGZ976puAQ==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.VisualStudio.RemoteControl": "16.3.52",
-          "Microsoft.VisualStudio.Utilities.Internal": "16.3.56",
-          "Newtonsoft.Json": "13.0.1"
+          "Microsoft.VisualStudio.RemoteControl": "16.3.44",
+          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36",
+          "Newtonsoft.Json": "13.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
       "Microsoft.VisualStudio.Text.Data": {
@@ -958,8 +959,8 @@
       },
       "Microsoft.VisualStudio.Utilities.Internal": {
         "type": "Transitive",
-        "resolved": "16.3.56",
-        "contentHash": "QX5UVVk4+/rPu3Xy3QRAntNBy/3VMl2whwSlt73Ksp6MRf5ersUopgmHbkEnWSTX6e/SZf+mfqTmvdk67URH2Q=="
+        "resolved": "16.3.36",
+        "contentHash": "tVOE9DJbd4PETSgBW+9448jvRdhm/hNHJFaGyCq6Gtlg+ElELBmfMFxgp2rsrqzUkLjehwnrw6uX4Yj9krOfJQ=="
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",
@@ -1468,7 +1469,7 @@
           "Microsoft.VisualStudio.Shell.Interop": "[17.9.37000, )",
           "Microsoft.VisualStudio.Utilities": "[17.2.32505.113, )",
           "Microsoft.VisualStudio.Workspace.VSIntegration": "[17.1.11-preview-0002, )",
-          "Microsoft.Visualstudio.Telemetry": "[17.9.305, )",
+          "Microsoft.Visualstudio.Telemetry": "[16.5.6, )",
           "OmniSharp.Extensions.LanguageServer": "[0.19.7, )"
         }
       }

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.9.2164" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="17.9.37000" />
-    <PackageReference Include="Microsoft.Visualstudio.Telemetry" Version="17.9.305" />
+    <PackageReference Include="Microsoft.Visualstudio.Telemetry" Version="16.5.6" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="17.2.32505.113" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="17.1.11-preview-0002" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.7" />

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/packages.lock.json
@@ -69,14 +69,15 @@
       },
       "Microsoft.VisualStudio.Telemetry": {
         "type": "Direct",
-        "requested": "[17.9.305, )",
-        "resolved": "17.9.305",
-        "contentHash": "dWQlTc3o1zvnr0dFD+ZpC04gZtP3pzAMEQBK2oqPZoMRm4n3cj5sSNSlSugDjWHAnVAKzses/ZTvR2SHTyCQNA==",
+        "requested": "[16.5.6, )",
+        "resolved": "16.5.6",
+        "contentHash": "afyxTJBcntD92T9Ce8gZxOgEZBLZXFA7kxQLW1gnbnF5yGBkeF8vdwIlvJ/aw6+Of0cgfjgY9J/bLGZ976puAQ==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
-          "Microsoft.VisualStudio.RemoteControl": "16.3.52",
-          "Microsoft.VisualStudio.Utilities.Internal": "16.3.56",
-          "Newtonsoft.Json": "13.0.1"
+          "Microsoft.VisualStudio.RemoteControl": "16.3.44",
+          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36",
+          "Newtonsoft.Json": "13.0.1",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0"
         }
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
@@ -432,10 +433,10 @@
       },
       "Microsoft.VisualStudio.RemoteControl": {
         "type": "Transitive",
-        "resolved": "16.3.52",
-        "contentHash": "+MgP1+Rtt1uJZyqhf7+H6KAQ57wc7v00ixuLhEgFggIbmW2/29YXfPK7gLvXw+vU7vimuM47cqAHrnB7RWYqtg==",
+        "resolved": "16.3.44",
+        "contentHash": "hbc2FxReEyotRXM1dtQSZxt2ccNMBgPbcX6MylKp9UDbHsTPJ0dk5CEuZAqoqOFKUzFtorZL6A7BcRAjP9HU1g==",
         "dependencies": {
-          "Microsoft.VisualStudio.Utilities.Internal": "16.3.42"
+          "Microsoft.VisualStudio.Utilities.Internal": "16.3.36"
         }
       },
       "Microsoft.VisualStudio.RpcContracts": {
@@ -506,8 +507,8 @@
       },
       "Microsoft.VisualStudio.Utilities.Internal": {
         "type": "Transitive",
-        "resolved": "16.3.56",
-        "contentHash": "QX5UVVk4+/rPu3Xy3QRAntNBy/3VMl2whwSlt73Ksp6MRf5ersUopgmHbkEnWSTX6e/SZf+mfqTmvdk67URH2Q=="
+        "resolved": "16.3.36",
+        "contentHash": "tVOE9DJbd4PETSgBW+9448jvRdhm/hNHJFaGyCq6Gtlg+ElELBmfMFxgp2rsrqzUkLjehwnrw6uX4Yj9krOfJQ=="
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",


### PR DESCRIPTION
… in /src/vs-bicep (#13683)"

This reverts commit e588d82d524461bc8ccf112a8eed7a35a0201e4c.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13780)