### PR TITLE
Try to fix 13333

### DIFF
--- a/src/vscode-bicep/src/commands/createConfigurationFile.ts
+++ b/src/vscode-bicep/src/commands/createConfigurationFile.ts
@@ -63,7 +63,6 @@ export class CreateBicepConfigurationFile implements Command {
       while (true) {
         const response = await window.showSaveDialog({
           defaultUri: Uri.file(selectedPath),
-          filters: { "Bicep configuration files": [bicepConfig] },
           title: "Where would you like to save the Bicep configuration file?",
           saveLabel: "Save configuration file",
         });


### PR DESCRIPTION
The behavior in WSL seems to be weird - I'm getting back a filename of "bicepconfig.json.bicepconfig.json", making it impossible to get past the save dialog (since it requires the filename to be "bicepconfig.json".

Removing the filter (which is kinda weird anyway being used as a filename and not an extension) doesn't have much effect on non-WSL, simply meaning the dialog has "All Files" in the filter:

![image](https://github.com/Azure/bicep/assets/6913354/fed496d4-a0ef-433f-8c3b-9ce1ea870d3e)
