### PR TITLE
Support --outdir param with build-params

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -296,6 +296,24 @@ output foo string = foo
         [DataTestMethod]
         [BaselineData_Bicepparam.TestData(Filter = BaselineData_Bicepparam.TestDataFilterType.ValidOnly)]
         [TestCategory(BaselineHelper.BaselineTestCategory)]
+        public async Task Build_Valid_Params_File_To_Outdir_Should_Succeed(BaselineData_Bicepparam baselineData)
+        {
+            var data = baselineData.GetData(TestContext);
+            var (output, error, result) = await Bicep(Settings, "build-params", data.Parameters.OutputFilePath, "--bicep-file", data.Bicep.OutputFilePath, "--outdir", Path.GetDirectoryName(data.Compiled!.OutputFilePath));
+
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                AssertNoErrors(error);
+            }
+
+            data.Compiled!.ShouldHaveExpectedJsonValue();
+        }
+
+        [DataTestMethod]
+        [BaselineData_Bicepparam.TestData(Filter = BaselineData_Bicepparam.TestDataFilterType.ValidOnly)]
+        [TestCategory(BaselineHelper.BaselineTestCategory)]
         public async Task Build_Valid_Params_File_ToStdOut_Should_Succeed(BaselineData_Bicepparam baselineData)
         {
             var data = baselineData.GetData(TestContext);

--- a/src/Bicep.Cli/Arguments/BuildParamsArguments.cs
+++ b/src/Bicep.Cli/Arguments/BuildParamsArguments.cs
@@ -26,6 +26,19 @@ namespace Bicep.Cli.Arguments
                         i++;
                         break;
 
+                    case "--outdir":
+                        if (args.Length == i + 1)
+                        {
+                            throw new CommandLineException($"The --outdir parameter expects an argument");
+                        }
+                        if (OutputDir is not null)
+                        {
+                            throw new CommandLineException($"The --outdir parameter cannot be specified twice");
+                        }
+                        OutputDir = args[i + 1];
+                        i++;
+                        break;
+
                     case "--outfile":
                         if (args.Length == i + 1)
                         {
@@ -79,9 +92,19 @@ namespace Bicep.Cli.Arguments
                 throw new CommandLineException($"The parameters file path was not specified");
             }
 
-            if (OutputFile is not null && OutputToStdOut)
+            if (OutputToStdOut && OutputDir is not null)
             {
-                throw new CommandLineException($"The --stdout can not be used when --outfile is specified");
+                throw new CommandLineException($"The --outdir and --stdout parameters cannot both be used");
+            }
+
+            if (OutputToStdOut && OutputFile is not null)
+            {
+                throw new CommandLineException($"The --outfile and --stdout parameters cannot both be used");
+            }
+
+            if (OutputDir is not null && OutputFile is not null)
+            {
+                throw new CommandLineException($"The --outdir and --outfile parameters cannot both be used");
             }
 
             if (DiagnosticsFormat is null)
@@ -95,6 +118,8 @@ namespace Bicep.Cli.Arguments
         public string ParamsFile { get; }
 
         public string? BicepFile { get; }
+
+        public string? OutputDir { get; }
 
         public string? OutputFile { get; }
 

--- a/src/Bicep.Cli/Commands/BuildParamsCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildParamsCommand.cs
@@ -92,9 +92,9 @@ namespace Bicep.Cli.Commands
                 }
                 else
                 {
-                    var paramsOutputPath = PathHelper.ResolveDefaultOutputPath(paramsFileUri.LocalPath, null, args.OutputFile, PathHelper.GetDefaultBuildOutputPath);
+                    var outputPath = PathHelper.ResolveDefaultOutputPath(paramsFileUri.LocalPath, args.OutputDir, args.OutputFile, PathHelper.GetDefaultBuildOutputPath);
 
-                    writer.ParametersToFile(compilation, PathHelper.FilePathToFileUrl(paramsOutputPath));
+                    writer.ParametersToFile(compilation, PathHelper.FilePathToFileUrl(outputPath));
                 }
             }
 


### PR DESCRIPTION
This was implemented in AzureCLI, but never implemented in Bicep.

This PR addresses https://github.com/Azure/azure-cli/issues/27704.