### PR TITLE
Fix vscode e2e tests

### DIFF
--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -736,6 +736,7 @@
     "watch": "webpack --watch --mode development --stats=minimal",
     "lint": "eslint src --ext ts",
     "lint:fix": "eslint src --ext ts --fix",
+    "$test:e2e.comment": "use testlocal:e2e to run on a local Mac/Linux/Windows (not PowerShell) machine",
     "test:e2e": "node ./out/test/e2e/runTests.js",
     "test:unit": "jest --config jest.config.unit.js",
     "test:snapshot": "jest --config jest.config.snapshot.js",

--- a/src/vscode-bicep/src/test/e2e/commands.ts
+++ b/src/vscode-bicep/src/test/e2e/commands.ts
@@ -83,7 +83,9 @@ export async function executeShowDeployPaneToSideCommand(
 export async function executeShowSourceCommand(): Promise<
   vscode.TextEditor | undefined
 > {
-  return await vscode.commands.executeCommand(ShowSourceFromVisualizerCommand.CommandId);
+  return await vscode.commands.executeCommand(
+    ShowSourceFromVisualizerCommand.CommandId,
+  );
 }
 
 export async function executeBuildCommand(

--- a/src/vscode-bicep/src/test/e2e/runTests.ts
+++ b/src/vscode-bicep/src/test/e2e/runTests.ts
@@ -49,12 +49,30 @@ async function go() {
         "ms-dotnettools.vscode-dotnet-runtime",
         ...userDataArguments,
       ];
+      const extensionListArguments = [
+        ...cliArguments,
+        "--list-extensions",
+        ...userDataArguments,
+      ];
 
-      // Install .NET Install Tool as a dependency.
-      cp.spawnSync(cliPath, extensionInstallArguments, {
+      // Install .NET Install Tool extension as a dependency.
+      console.log(
+        `Installing dotnet extension: ${cliPath} ${extensionInstallArguments.join(" ")}`,
+      );
+      let result = cp.spawnSync(cliPath, extensionInstallArguments, {
         encoding: "utf-8",
         stdio: "inherit",
+        shell: true,
       });
+      console.log(result.error ?? result.output?.filter((o) => !!o).join("\n"));
+
+      console.log("Installed extensions:");
+      result = cp.spawnSync(cliPath, extensionListArguments, {
+        encoding: "utf-8",
+        stdio: "inherit",
+        shell: true,
+      });
+      console.log(result.error ?? result.output?.filter((o) => !!o).join("\n"));
 
       await runTests({
         vscodeExecutablePath,


### PR DESCRIPTION
Caused by a bug in node 18 and 20 which were caused by recent security fixes, see https://github.com/node-red/node-red/pull/4652.  Short version, it's no longer valid to use spawnSync without"shell:true".
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13906)