### PR TITLE
do not merge: Sw/upload artifact 4 testfailure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,14 +53,14 @@ jobs:
         run: dotnet publish --configuration release --self-contained true -r ${{ matrix.rid }} ./src/Bicep.Cli/Bicep.Cli.csproj
 
       - name: Upload Bicep
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bicep-release-${{ matrix.rid }}
           path: ./src/Bicep.Cli/bin/release/net8.0/${{ matrix.rid }}/publish/*
           if-no-files-found: error
 
       - name: Upload Bicep project assets file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bicep-project-assets-${{ matrix.rid }}
           path: ./src/Bicep.Cli/obj/project.assets.json
@@ -83,7 +83,7 @@ jobs:
         run: dotnet pack --configuration release
 
       - name: Upload Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bicep-nupkg-any
           path: out/*
@@ -128,7 +128,7 @@ jobs:
         working-directory: ./src/vscode-bicep
 
       - name: Upload VSIX
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vscode-bicep.vsix
           path: ./src/vscode-bicep/vscode-bicep.vsix
@@ -249,14 +249,14 @@ jobs:
         run: msbuild src/vs-bicep/BicepInVisualStudio.sln /restore /p:Configuration=Release /v:m /bl:./src/binlog/bicep_in_visual_studio_build.binlog
 
       - name: Upload BicepInVisualStudio.sln build binlog
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-binlog-files
           path: ./src/binlog/bicep_in_visual_studio_build.binlog
           if-no-files-found: error
 
       - name: Upload BicepLanguageServerClient VSIX
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Bicep.VSLanguageServerClient.Vsix.vsix
           path: ./src/vs-bicep/Bicep.VSLanguageServerClient.Vsix/bin/Release/vs-bicep.vsix
@@ -314,7 +314,7 @@ jobs:
         run: dotnet build --configuration release ./src/installer-win/installer.proj
 
       - name: Upload Windows Installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bicep-setup-win-x64
           path: ./src/installer-win/bin/release/net8.0/bicep-setup-win-x64.exe
@@ -403,7 +403,7 @@ jobs:
         run: dotnet build --configuration Release /p:RuntimeSuffix=${{ matrix.rid }} ./src/Bicep.Cli.Nuget/nuget.proj
 
       - name: Upload CLI Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bicep-nupkg-${{ matrix.rid }}
           path: ./src/Bicep.Cli.Nuget/*.nupkg
@@ -452,7 +452,7 @@ jobs:
         working-directory: ./src/playground
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playground
           path: ./src/playground/dist/*
@@ -591,7 +591,7 @@ jobs:
         run: dotnet test --filter '${{ matrix.config.filter}}' --configuration release --settings ./.github/workflows/ci.runsettings --results-directory ./TestResults
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Bicep.TestResults

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,13 +299,13 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       - name: Download Bicep CLI
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-release-win-x64
           path: ./src/installer-win/bicep
 
       - name: Download Bicep CLI project assets file
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-project-assets-win-x64
           path: ./src/installer-win/bicep
@@ -382,19 +382,19 @@ jobs:
         working-directory: ./src/Bicep.MSBuild.E2eTests
 
       - name: Download Bicep CLI
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-release-${{ matrix.rid }}
           path: ./src/Bicep.Cli.Nuget/tools
 
       - name: Download Bicep CLI project assets file
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-project-assets-${{ matrix.rid }}
           path: ./src/Bicep.Cli.Nuget/tools
 
       - name: Download .Net Packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-nupkg-any
           path: ./src/Bicep.MSBuild.E2eTests/examples/local-packages
@@ -411,7 +411,7 @@ jobs:
 
       - name: Download CLI Package
         if: matrix.runTests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-nupkg-${{ matrix.rid }}
           path: ./src/Bicep.MSBuild.E2eTests/examples/local-packages
@@ -527,7 +527,7 @@ jobs:
           node-version: 18
 
       - name: Download Bicep CLI
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-release-${{ matrix.runtime.rid }}
           path: ./src/Bicep.Cli.E2eTests/src/temp/bicep-cli
@@ -594,7 +594,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Bicep.TestResults
+          name: TestResults-${{ matrix.config.name }}-${{ matrix.os }}
           path: ./TestResults/*.trx
           if-no-files-found: error
 
@@ -614,9 +614,9 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          pattern: Bicep.TestResults-*
+          pattern: TestResults-*
           path: TestResults
           merge-multiple: true
 
@@ -706,7 +706,7 @@ jobs:
           node-version: 18
 
       - name: Download Bicep CLI
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-release-${{ matrix.runtime.rid }}
           path: ./src/Bicep.Cli.E2eTests/src/temp/bicep-cli
@@ -753,7 +753,7 @@ jobs:
         run: apk add --update nodejs npm
 
       - name: Download Bicep CLI
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bicep-release-linux-musl-x64
           path: ./src/Bicep.Cli.E2eTests/src/temp/bicep-cli

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -616,8 +616,9 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: Bicep.TestResults
+          pattern: Bicep.TestResults-*
           path: TestResults
+          merge-multiple: true
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -613,7 +613,14 @@ jobs:
     if: always()
 
     steps:
-      - name: Download Artifacts
+      - name: Merge Test Results into Single Artifact (fewer artifacts to deal with in build)
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: TestResults
+          pattern: TestResults-*
+          delete-merged: true
+
+      - name: Download Test Results Artifact
         uses: actions/download-artifact@v4
         with:
           pattern: TestResults-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -604,7 +604,7 @@ jobs:
           flags: dotnet
 
   comment-test-summary:
-    name: "PR Comment: Tests Summary"
+    name: "PR Comment: Dotnet Tests Summary"
     needs: test-dotnet
     runs-on: ubuntu-latest
     permissions:
@@ -623,14 +623,13 @@ jobs:
       - name: Download Test Results Artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: TestResults-*
+          pattern: TestResults
           path: TestResults
           merge-multiple: true
-
-      - name: Publish Test Results
+      - name: Publish Dotnet Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name: Test Results
+          check_name: Dotnet Test Results
           files: "TestResults/**/*.trx"
   
   comment-preview-links:

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
         run: dotnet run --configuration Release --project src/Bicep.Tools.Benchmark -- --filter '*' --profiler EP
 
       - name: Upload Benchmarks
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: BenchmarkDotNet.Artifacts
           path: ./BenchmarkDotNet.Artifacts

--- a/.github/workflows/run-compile-samples.yml
+++ b/.github/workflows/run-compile-samples.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./scripts/compile_samples.sh /tmp/bicep-release-linux-x64/bicep > results.txt
 
       - name: Upload Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: results.txt
           path: ./results.txt

--- a/src/Bicep.Cli.E2eTests/src/build.test.ts
+++ b/src/Bicep.Cli.E2eTests/src/build.test.ts
@@ -26,7 +26,7 @@ describe("bicep build", () => {
     expectFileExists(jsonFilePath);
 
     const jsonContents = readFileSync(jsonFilePath);
-    expect(jsonContents.length).toBeGreaterThan(0);
+    expect(jsonContents.length).toBeLessThan(0);
 
     // Building with --stdout should emit consistent result.
     invokingBicepCommand("build", "--stdout", bicepFilePath)

--- a/src/Bicep.Core.IntegrationTests/RegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryTests.cs
@@ -69,7 +69,7 @@ namespace Bicep.Core.IntegrationTests
                 x =>
                 {
                     x.Level.Should().Be(DiagnosticLevel.Error);
-                    x.Code.Should().Be("BCP192");
+                    x.Code.Should().Be("BCP192asdfg");
                     x.Message.Should().StartWith(string.Format(expectedErrorMessage, "br:mock-registry-one.invalid/demo/plan:v2"));
                 },
                 x =>

--- a/src/Bicep.Core.UnitTests/SourceFiles/ResXFileTests.cs
+++ b/src/Bicep.Core.UnitTests/SourceFiles/ResXFileTests.cs
@@ -36,7 +36,7 @@ namespace Bicep.Core.UnitTests.SourceFiles
             string[] resxFiles = System.IO.Directory.GetFiles(BaselineHelper.GetAbsolutePathRelativeToRepoRoot("src"), "*.resx", SearchOption.AllDirectories)
                 .Where(path => !path.ContainsOrdinally("packages"))
                 .ToArray();
-            resxFiles.Should().HaveCountGreaterThan(2, "There should be at least 3 ResX files found in the project");
+            resxFiles.Should().HaveCountGreaterThan(2000, "There should be at least 3 ResX files found in the project");
 
             foreach (string resXRelativePath in resxFiles)
             {


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/13999)