### PR TITLE
Support completions inside object spread

### DIFF
--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -1423,6 +1423,10 @@ namespace Bicep.Core.TypeSystem
                     return GetNonNullableTypeAssignment(parameterDeclaration)?.ReplaceDeclaringSyntax(syntax);
                 case ParameterAssignmentSyntax:
                     return GetNonNullableTypeAssignment(parent)?.ReplaceDeclaringSyntax(syntax);
+                case SpreadExpressionSyntax when binder.GetParent(parent) is {} grandParent &&
+                    GetDeclaredTypeAssignment(grandParent)?.Reference is ArrayType enclosingArrayType:
+
+                    return TryCreateAssignment(enclosingArrayType, syntax);
                 default:
                     return null;
             }
@@ -1743,6 +1747,13 @@ namespace Bicep.Core.TypeSystem
                     };
 
                     return TryCreateAssignment(parameterAssignmentTypeAssignment.Reference.Type, syntax);
+
+                case SpreadExpressionSyntax when binder.GetParent(parent) is {} grandParent &&
+                    GetDeclaredTypeAssignment(grandParent)?.Reference is ObjectType enclosingObjectType:
+
+                    var type = TypeHelper.MakeRequiredPropertiesOptional(enclosingObjectType);
+
+                    return TryCreateAssignment(type, syntax);
             }
 
             return null;

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -548,5 +548,19 @@ namespace Bicep.Core.TypeSystem
 
             return new(ResourceTypeReference.Combine(parentResourceType.TypeReference, typeReference));
         }
+
+        private static ObjectType TransformProperties(ObjectType input, Func<TypeProperty, TypeProperty> transformFunc)
+        {
+            return new ObjectType(
+                input.Name,
+                input.ValidationFlags,
+                input.Properties.Values.Select(transformFunc),
+                input.AdditionalPropertiesType,
+                input.AdditionalPropertiesFlags,
+                input.MethodResolver.functionOverloads);
+        }
+
+        public static ObjectType MakeRequiredPropertiesOptional(ObjectType input)
+            => TransformProperties(input, p => p.With(p.Flags & ~TypePropertyFlags.Required));
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1365,6 +1365,39 @@ resource testRes2 'Test.Rp/readWriteTests@2020-01-01' = {
         }
 
         [TestMethod]
+        public async Task Spread_operator_supports_outer_object_property_completions()
+        {
+            var fileWithCursors = @"
+type myType = {
+  foo: string
+  bar: string
+}
+
+output foo myType = {
+  ...{|}
+  bar: 'bar'
+}
+";
+
+            var (text, cursor) = ParserHelper.GetFileWithSingleCursor(fileWithCursors);
+            var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(text);
+
+            var completions = await file.RequestCompletion(cursor);
+            var updatedFile = file.ApplyCompletion(completions, "foo");
+            updatedFile.Should().HaveSourceText(@"
+type myType = {
+  foo: string
+  bar: string
+}
+
+output foo myType = {
+  ...{foo:|}
+  bar: 'bar'
+}
+");
+        }
+
+        [TestMethod]
         public async Task PropertyNameCompletionsShouldNotIncludeTrailingColonIfItIsPresent()
         {
             static void AssertPropertyNameCompletionsWithoutColons(CompletionList list)
@@ -1399,12 +1432,12 @@ resource testRes3 'Test.Rp/readWriteTests@2020-01-01' = {
         public async Task RequestCompletionsInResourceBodies_AtPositionsWhereNodeShouldNotBeInserted_ReturnsEmptyCompletions()
         {
             var fileWithCursors = @"
-resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {|
+resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {
  | name: 'myRes' |
   tags | : {
     a: 'A'   |
   }
-|}
+}
 ";
             await RunCompletionScenarioTest(this.TestContext, ServerWithBuiltInTypes, fileWithCursors, AssertAllCompletionsEmpty, '|');
         }


### PR DESCRIPTION
This would allow completions for an outer object type within a spread - e.g. `foo` and `bar` should be offered in the following cursor location:
```bicep
type myType = {
  foo: string
  bar: string
}
output foo myType = {
  ...{ | }
  bar: 'bar'
}
```

Raised by @slavizh on the community call.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14000)