### PR TITLE
Updated SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.202",
+    "version": "8.0.204",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
I updated the SDK version to work around errors like the following that I found when testing the official build:
```
##[error]bicep/src/Bicep.Core/Bicep.Core.csproj(0,0): Error NU1004: The package reference Microsoft.NET.ILLink.Tasks version has changed from [8.0.4, ) to [8.0.3, ).The packages lock file is inconsistent with the project dependencies so restore can't be run in locked mode. Disable the RestoreLockedMode MSBuild property or pass an explicit --force-evaluate option to run restore to update the lock file.
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14008)