### PR TITLE
Fix IPublicRegistryModuleMetadataProvider to be singleton again

### DIFF
--- a/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
+++ b/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
     /// See https://endjin.com/blog/2020/09/simple-pattern-for-using-system-commandline-with-dependency-injection for reference.
     /// </remarks>
     public static IServiceCollection AddCommands(this IServiceCollection services) =>
-        // this is harcoded to make the code trim-safe
+        // this is hardcoded to make the code trim-safe
         services
             .AddSingleton<BuildCommand>()
             .AddSingleton<TestCommand>()

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -4141,7 +4141,7 @@ var file = " + functionName + @"(templ|)
             settingsProvider.Setup(x => x.GetSetting(LangServerConstants.GetAllAzureContainerRegistriesForCompletionsSetting)).Returns(false);
 
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<PublicRegistryModule> { new("app/dapr-containerapp", "d1", "contoso.com/help1"), new("app/dapr-containerapp-env", "d2", "contoso.com/help2") });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<RegistryModule> { new("app/dapr-containerapp", "d1", "contoso.com/help1"), new("app/dapr-containerapp-env", "d2", "contoso.com/help2") });
 
             using var helper = await MultiFileLanguageServerHelper.StartLanguageServer(
                 TestContext,
@@ -4185,7 +4185,7 @@ var file = " + functionName + @"(templ|)
             settingsProvider.Setup(x => x.GetSetting(LangServerConstants.GetAllAzureContainerRegistriesForCompletionsSetting)).Returns(false);
 
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<PublicRegistryModuleVersion> { new("1.0.2", "d1", "contoso.com/help1"), new("1.0.1", null, null) });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<RegistryModuleVersion> { new("1.0.2", "d1", "contoso.com/help1"), new("1.0.1", null, null) });
 
             using var helper = await MultiFileLanguageServerHelper.StartLanguageServer(
                 TestContext,

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -38,6 +38,8 @@ namespace Bicep.LangServer.UnitTests
             var mockHttpMessageHandler = new MockHttpMessageHandler();
             mockHttpMessageHandler.When("*").Respond("application/json", "{}");
 
+            var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
+
             var helper = ServiceBuilder.Create(services => services
                 .AddSingleton<ILanguageServerFacade>(server)
                 .AddSingleton<IAzureContainerRegistriesProvider, AzureContainerRegistriesProvider>()
@@ -47,7 +49,9 @@ namespace Bicep.LangServer.UnitTests
                 .AddHttpClient<IPublicRegistryModuleMetadataProvider, PublicRegistryModuleMetadataProvider>()
                     .ConfigurePrimaryHttpMessageHandler(() => mockHttpMessageHandler).Services
                 .AddSingleton<ITelemetryProvider, TelemetryProvider>()
-                .AddSingleton<BicepCompletionProvider>());
+                .AddSingleton<BicepCompletionProvider>()
+                .AddSingleton(publicRegistryModuleMetadataProvider.Object)
+            );
 
             return helper.Construct<BicepCompletionProvider>();
         }

--- a/src/Bicep.LangServer.UnitTests/Completions/ModuleReferenceCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/ModuleReferenceCompletionProviderTests.cs
@@ -209,7 +209,7 @@ namespace Bicep.LangServer.UnitTests.Completions
         public async Task GetFilteredCompletions_WithInvalidCompletionContext_ReturnsEmptyList(string inputWithCursors)
         {
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<PublicRegistryModuleVersion> { new("1.0.1", null, null), new("1.0.2", null, null) });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<RegistryModuleVersion> { new("1.0.1", null, null), new("1.0.2", null, null) });
 
             var completionContext = GetBicepCompletionContext(inputWithCursors, null, out DocumentUri documentUri);
             var moduleReferenceCompletionProvider = new ModuleReferenceCompletionProvider(
@@ -477,7 +477,7 @@ namespace Bicep.LangServer.UnitTests.Completions
             int expectedEnd)
         {
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<PublicRegistryModule> { new("app/dapr-cntrapp1", null, null), new("app/dapr-cntrapp2", "description2", "contoso.com/help2") });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<RegistryModule> { new("app/dapr-cntrapp1", null, null), new("app/dapr-cntrapp2", "description2", "contoso.com/help2") });
 
             var completionContext = GetBicepCompletionContext(inputWithCursors, null, out DocumentUri documentUri);
             var moduleReferenceCompletionProvider = new ModuleReferenceCompletionProvider(
@@ -595,7 +595,7 @@ namespace Bicep.LangServer.UnitTests.Completions
   }
 }";
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<PublicRegistryModuleVersion> { new("1.0.2", null, null), new("1.0.1", "d2", "contoso.com/help%20page.html") });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerapp")).ReturnsAsync(new List<RegistryModuleVersion> { new("1.0.2", null, null), new("1.0.1", "d2", "contoso.com/help%20page.html") });
 
             var completionContext = GetBicepCompletionContext(inputWithCursors, bicepConfigFileContents, out DocumentUri documentUri);
             var moduleReferenceCompletionProvider = new ModuleReferenceCompletionProvider(
@@ -637,7 +637,7 @@ namespace Bicep.LangServer.UnitTests.Completions
         public async Task GetFilteredCompletions_WithMcrVersionCompletionContext_AndNoMatchingModuleName_ReturnsEmptyListOfCompletionItems()
         {
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerappapp")).ReturnsAsync(new List<PublicRegistryModuleVersion>());
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetVersions("app/dapr-containerappapp")).ReturnsAsync(new List<RegistryModuleVersion>());
 
             var completionContext = GetBicepCompletionContext("module test 'br/public:app/dapr-containerappapp:|'", null, out DocumentUri documentUri);
             var moduleReferenceCompletionProvider = new ModuleReferenceCompletionProvider(
@@ -724,7 +724,7 @@ namespace Bicep.LangServer.UnitTests.Completions
   }
 }";
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<PublicRegistryModule> { new("app/dapr-containerappapp", "dapr description", "contoso.com/help") });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<RegistryModule> { new("app/dapr-containerappapp", "dapr description", "contoso.com/help") });
 
             var completionContext = GetBicepCompletionContext(inputWithCursors, bicepConfigFileContents, out DocumentUri documentUri);
             var moduleReferenceCompletionProvider = new ModuleReferenceCompletionProvider(
@@ -783,7 +783,7 @@ namespace Bicep.LangServer.UnitTests.Completions
             var completionContext = GetBicepCompletionContext(inputWithCursors, bicepConfigFileContents, out DocumentUri documentUri);
 
             var publicRegistryModuleMetadataProvider = StrictMock.Of<IPublicRegistryModuleMetadataProvider>();
-            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<PublicRegistryModule> { new("app/dapr-cntrapp1", "description1", null), new("app/dapr-cntrapp2", null, "contoso.com/help2") });
+            publicRegistryModuleMetadataProvider.Setup(x => x.GetModules()).ReturnsAsync(new List<RegistryModule> { new("app/dapr-cntrapp1", "description1", null), new("app/dapr-cntrapp2", null, "contoso.com/help2") });
 
             var telemetryProvider = StrictMock.Of<ITelemetryProvider>();
             telemetryProvider.Setup(x => x.PostEvent(It.IsAny<BicepTelemetryEvent>()));

--- a/src/Bicep.LangServer/Completions/IPublicRegistryModuleMetadataClient.cs
+++ b/src/Bicep.LangServer/Completions/IPublicRegistryModuleMetadataClient.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Registry.Oci;
+using System.Collections.Immutable;
+
+namespace Bicep.LanguageServer.Providers;
+
+public record ModuleTagPropertiesEntry(string Description, string DocumentationUri);
+
+public record ModuleMetadata(
+    string ModuleName, // e.g. "avm/app/dapr-containerapp"
+    List<string> Tags, // e.g. "1.0.0.0" (not guaranteed in that format)
+    ImmutableDictionary<string, ModuleTagPropertiesEntry> Properties // Module properties per tag
+);
+
+public interface IPublicRegistryModuleMetadataClient
+{
+    Task<ImmutableArray<ModuleMetadata>> GetModuleMetadata();
+}

--- a/src/Bicep.LangServer/Completions/IPublicRegistryModuleMetadataProvider.cs
+++ b/src/Bicep.LangServer/Completions/IPublicRegistryModuleMetadataProvider.cs
@@ -1,15 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Bicep.LanguageServer.Providers
-{
-    public record PublicRegistryModule(string Name, string? Description, string? DocumentationUri);
-    public record PublicRegistryModuleVersion(string Version, string? Description, string? DocumentationUri);
+namespace Bicep.LanguageServer.Providers;
 
-    public interface IPublicRegistryModuleMetadataProvider
+public record RegistryModule(
+    string Name, // e.g. "avm/app/dapr-containerapp"
+    string? Description,
+    string? DocumentationUri);
+
+public record RegistryModuleVersion(
+    string Version,
+    string? Description,
+    string? DocumentationUri);
+
+public interface IPublicRegistryModuleMetadataProvider
     {
-        Task<IEnumerable<PublicRegistryModule>> GetModules();
+        Task<IEnumerable<RegistryModule>> GetModules();
 
-        Task<IEnumerable<PublicRegistryModuleVersion>> GetVersions(string modulePath);
+        Task<IEnumerable<RegistryModuleVersion>> GetVersions(string modulePath);
     }
-}

--- a/src/Bicep.LangServer/Completions/PublicRegistryModuleMetadataClient.cs
+++ b/src/Bicep.LangServer/Completions/PublicRegistryModuleMetadataClient.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Bicep.Core.Extensions;
+
+namespace Bicep.LanguageServer.Providers;
+
+/// <summary>
+/// Typed http client to get modules metadata that we store at a public endpoint (currently https://github.com/Azure/bicep-registry-modules)
+/// </summary>
+public class PublicRegistryModuleMetadataClient(HttpClient httpClient) : IPublicRegistryModuleMetadataClient
+{
+    private const string LiveDataEndpoint = "https://aka.ms/br-module-index-data";
+
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    [SuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code", Justification = "Relying on references to required properties of the generic type elsewhere in the codebase.")]
+    public async Task<ImmutableArray<ModuleMetadata>> GetModuleMetadata()
+    {
+        Trace.WriteLine($"{nameof(PublicRegistryModuleMetadataClient)}: Retrieving list of public registry modules...");
+
+        try
+        {
+            var metadata = await httpClient.GetFromJsonAsync<ModuleMetadata[]>(LiveDataEndpoint, JsonSerializerOptions);
+
+            if (metadata is not null)
+            {
+                Trace.WriteLine($"{nameof(PublicRegistryModuleMetadataProvider)}: Retrieved info on {metadata.Length} public registry modules.");
+                return metadata.ToImmutableArray();
+            }
+            else
+            {
+                throw new Exception($"Error: List of MCR modules at {LiveDataEndpoint} was empty");
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new Exception(string.Format($"Error retrieving MCR modules metadata: {0}", ex.Message), ex);
+        }
+    }
+}

--- a/src/Bicep.LangServer/Completions/PublicRegistryModuleMetadataProvider.cs
+++ b/src/Bicep.LangServer/Completions/PublicRegistryModuleMetadataProvider.cs
@@ -120,8 +120,15 @@ namespace Bicep.LanguageServer.Providers
 
         private async Task<ImmutableArray<ModuleMetadata>?> TryGetModulesLive()
         {
-            var client = serviceProvider.GetRequiredService<IPublicRegistryModuleMetadataClient>();
-            return await client.GetModuleMetadata();
+            try
+            {
+                var client = serviceProvider.GetRequiredService<IPublicRegistryModuleMetadataClient>();
+                return await client.GetModuleMetadata();
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         // Modules paths are, e.g. "app/dapr-containerapp"

--- a/src/Bicep.LangServer/IServiceCollectionExtensions.cs
+++ b/src/Bicep.LangServer/IServiceCollectionExtensions.cs
@@ -63,7 +63,7 @@ public static class IServiceCollectionExtensions
         .AddSingleton<IModuleRestoreScheduler, ModuleRestoreScheduler>()
         .AddSingleton<IAzResourceProvider, AzResourceProvider>()
         .AddSingleton<IBicepConfigChangeHandler, BicepConfigChangeHandler>()
-        .AddSingleton<IDeploymentCollectionProvider, DeploymentCollectionProvider>()
+        .AddSingleton<IDeploymentCollectionProvider, DeploymentCollectionProvider>()    
         .AddSingleton<IDeploymentOperationsCache, DeploymentOperationsCache>()
         .AddSingleton<IDeploymentFileCompilationCache, DeploymentFileCompilationCache>()
         .AddSingleton<IClientCapabilitiesProvider, ClientCapabilitiesProvider>()
@@ -72,5 +72,7 @@ public static class IServiceCollectionExtensions
         .AddSingleton<IArmClientProvider, ArmClientProvider>()
         .AddSingleton<IDeploymentHelper, DeploymentHelper>()
         .AddSingleton<ISettingsProvider, SettingsProvider>()
-        .AddSingleton<IAzureContainerRegistriesProvider, AzureContainerRegistriesProvider>();
+        .AddSingleton<IAzureContainerRegistriesProvider, AzureContainerRegistriesProvider>()
+        .AddSingleton<IPublicRegistryModuleMetadataProvider, PublicRegistryModuleMetadataProvider>()
+        ;
 }

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -96,12 +96,12 @@ namespace Bicep.LanguageServer
 
         private static void RegisterServices(IServiceCollection services)
         {
-            // using type based registration so dependencies can be injected automatically
-            // without manually constructing up the graph
+            // using type based registration for Http clients so dependencies can be injected automatically
+            // without manually constructing up the graph, see https://learn.microsoft.com/en-us/dotnet/core/extensions/httpclient-factory#typed-clients
             services.AddServerDependencies();
 
             services
-                .AddHttpClient<IPublicRegistryModuleMetadataProvider, PublicRegistryModuleMetadataProvider>()
+                .AddHttpClient<IPublicRegistryModuleMetadataClient, PublicRegistryModuleMetadataClient>()
                 .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
                 {
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate


### PR DESCRIPTION
This issue (IPublicRegistryModuleMetadataProvider not being singleton) doesn't come up in current code but does in other code I'm working on.  Fixed by extracting just the http client code into separate typed http client PublicRegistryModuleMetadataClient.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14144)