### PR TITLE
Fix index out of range for `bicep format` with `--insert-final-newline`

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
@@ -300,6 +300,46 @@ namespace Bicep.Cli.IntegrationTests
             formatted.Should().BeEquivalentToIgnoringNewlines(expected);
         }
 
+        [TestMethod]
+        public async Task Format_WithInsertFinalNewline_AddsFinalNewline()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                ["main.bicep"] = "output myOutput string = 'hello!'",
+            });
+
+            var result = await Bicep(services => services.WithFileSystem(fileSystem), "format", "main.bicep", "--insert-final-newline");
+
+            AssertSuccess(result);
+
+            var formatted = fileSystem.File.ReadAllText("main.bicep");
+            formatted.Should().BeEquivalentTo("output myOutput string = 'hello!'\n");
+
+            result = await Bicep(services => services.WithFileSystem(fileSystem), "format", "main.bicep", "--insert-final-newline", "true");
+
+            AssertSuccess(result);
+
+            formatted = fileSystem.File.ReadAllText("main.bicep");
+            formatted.Should().BeEquivalentTo("output myOutput string = 'hello!'\n");
+        }
+
+        [TestMethod]
+        public async Task Format_WithInsertFinalNewlineFalse_RemovesFinalNewline()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                ["main.bicep"] = "output myOutput string = 'hello!'\n",
+            });
+
+            var result = await Bicep(services => services.WithFileSystem(fileSystem), "format", "main.bicep", "--insert-final-newline", "false");
+
+            AssertSuccess(result);
+
+            var formatted = fileSystem.File.ReadAllText("main.bicep");
+            formatted.Should().BeEquivalentTo("output myOutput string = 'hello!'");
+        }
+
+
         private static IEnumerable<object[]> GetDataSets() => DataSets.AllDataSets
             .Where(x => !x.Name.Equals(DataSets.PrettyPrint_LF.Name, StringComparison.Ordinal))
             .ToDynamicTestData();

--- a/src/Bicep.Cli/Arguments/FormatArguments.cs
+++ b/src/Bicep.Cli/Arguments/FormatArguments.cs
@@ -164,6 +164,12 @@ namespace Bicep.Cli.Arguments
                             throw new CommandLineException($"The --insertFinalNewline parameter cannot be specified twice");
                         }
 
+                        if (args.Length == i + 1)
+                        {
+                            InsertFinalNewline = true;
+                            break;
+                        }
+
                         if (bool.TryParse(args[i + 1], out var insertFinalNewline))
                         {
                             InsertFinalNewline = insertFinalNewline;
@@ -181,6 +187,12 @@ namespace Bicep.Cli.Arguments
                         if (InsertFinalNewline is not null)
                         {
                             throw new CommandLineException($"The --insert-final-newline parameter cannot be specified twice");
+                        }
+
+                        if (args.Length == i + 1)
+                        {
+                            InsertFinalNewline = true;
+                            break;
                         }
 
                         if (bool.TryParse(args[i + 1], out insertFinalNewline))


### PR DESCRIPTION
Closes #14099.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14193)