### PR TITLE
Add 'localDeploy' experimental feature, base extension nuget library

### DIFF
--- a/Bicep.sln
+++ b/Bicep.sln
@@ -83,6 +83,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{C6CAFEE8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.Tools.Benchmark", "src\Bicep.Tools.Benchmark\Bicep.Tools.Benchmark.csproj", "{A4127F6F-A282-47F3-BAFE-6A154F994B4E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{8F8DCFBC-A0DC-4E40-93C8-B4FB99FBD757}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.Local.Extension", "src\Bicep.Local.Extension\Bicep.Local.Extension.csproj", "{E84C0368-0D02-4284-A3CB-110B14FA8314}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -169,6 +173,10 @@ Global
 		{A4127F6F-A282-47F3-BAFE-6A154F994B4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A4127F6F-A282-47F3-BAFE-6A154F994B4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A4127F6F-A282-47F3-BAFE-6A154F994B4E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E84C0368-0D02-4284-A3CB-110B14FA8314}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E84C0368-0D02-4284-A3CB-110B14FA8314}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E84C0368-0D02-4284-A3CB-110B14FA8314}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E84C0368-0D02-4284-A3CB-110B14FA8314}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -194,6 +202,7 @@ Global
 		{8C2280F2-1E08-4022-B26B-59622DD8B126} = {90126655-7A34-4F5B-A41A-50A468F4632D}
 		{9F596D8D-5CDB-4830-B73C-26C33C0227D7} = {90126655-7A34-4F5B-A41A-50A468F4632D}
 		{A4127F6F-A282-47F3-BAFE-6A154F994B4E} = {C6CAFEE8-7779-4F48-BEA1-D59D3CD91A56}
+		{E84C0368-0D02-4284-A3CB-110B14FA8314} = {8F8DCFBC-A0DC-4E40-93C8-B4FB99FBD757}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {21F77282-91E7-4304-B1EF-FADFA4F39E37}

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -21,6 +21,9 @@ Allows Bicep to use a provider model to deploy non-ARM resources. Currently, we 
 ### `legacyFormatter`
 Enables code formatting with the legacy formatter. This feature flag is introduced to ensure a safer transition to the v2 formatter that implements a pretty-printing algorithm. It is intended for temporary use and will be phased out soon.
 
+### `localDeploy`
+Enables local deployment capability. See [Bicep Local Providers](https://github.com/anthony-c-martin/bicep-local-providers) for more information.
+
 ### `optionalModuleNames`
 Enabling this feature makes the `name` property in the body of `module` declarations optional. When a `module` omits the `name` property with the feature enabled, the Bicep compiler will automatically generate an expression for the name of the resulting nested deployment in the JSON. If you specify the `name` property, the compiler will use the specified expression in the resulting JSON. For more information, see [Added optional module names as an experimental feature](https://github.com/Azure/bicep/pull/12600).
 

--- a/src/Bicep.Cli/Commands/PublishProviderCommand.cs
+++ b/src/Bicep.Cli/Commands/PublishProviderCommand.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using System.IO.Abstractions;
 using Bicep.Cli.Arguments;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Exceptions;
+using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Modules;
@@ -57,11 +59,13 @@ namespace Bicep.Cli.Commands
                 throw new BicepException($"Provider package creation failed: {exception.Message}");
             }
 
-            await this.PublishProviderAsync(providerReference, tarPayload, overwriteIfExists);
+            var package = new ProviderPackage(Types: tarPayload);
+
+            await this.PublishProviderAsync(providerReference, package, overwriteIfExists);
             return 0;
         }
 
-        private async Task PublishProviderAsync(ArtifactReference target, BinaryData tarPayload, bool overwriteIfExists)
+        private async Task PublishProviderAsync(ArtifactReference target, ProviderPackage package, bool overwriteIfExists)
         {
             try
             {
@@ -70,7 +74,7 @@ namespace Bicep.Cli.Commands
                 {
                     throw new BicepException($"The Provider \"{target.FullyQualifiedReference}\" already exists. Use --force to overwrite the existing provider.");
                 }
-                await this.moduleDispatcher.PublishProvider(target, tarPayload);
+                await this.moduleDispatcher.PublishProvider(target, package);
             }
             catch (ExternalArtifactException exception)
             {

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -116,6 +116,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "dynamicTypeLoading": false,
           "providerRegistry": false,
           "optionalModuleNames": false,
+          "localDeploy": false,
           "resourceDerivedTypes": false
         },
         "formatting": {
@@ -204,6 +205,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "dynamicTypeLoading": false,
           "providerRegistry": false,
           "optionalModuleNames": false,
+          "localDeploy": false,
           "resourceDerivedTypes": false
         },
         "formatting": {
@@ -317,6 +319,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "dynamicTypeLoading": false,
           "providerRegistry": false,
           "optionalModuleNames": false,
+          "localDeploy": false,
           "resourceDerivedTypes": false
         },
         "formatting": {
@@ -758,6 +761,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "dynamicTypeLoading": false,
           "providerRegistry": false,
           "optionalModuleNames": false,
+          "localDeploy": false,
           "resourceDerivedTypes": false
         },
         "formatting": {

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -20,6 +20,7 @@ public record FeatureProviderOverrides(
     bool? DynamicTypeLoadingEnabled = default,
     bool? ProviderRegistry = default,
     bool? OptionalModuleNamesEnabled = default,
+    bool? LocalDeployEnabled = default,
     bool? ResourceDerivedTypesEnabled = default,
     string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion)
 {
@@ -37,6 +38,7 @@ public record FeatureProviderOverrides(
         bool? DynamicTypeLoadingEnabled = default,
         bool? ProviderRegistry = default,
         bool? OptionalModuleNamesEnabled = default,
+        bool? LocalDeployEnabled = default,
         bool? ResourceDerivedTypesEnabled = default,
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion
     ) : this(
@@ -53,6 +55,7 @@ public record FeatureProviderOverrides(
         DynamicTypeLoadingEnabled,
         ProviderRegistry,
         OptionalModuleNamesEnabled,
+        LocalDeployEnabled,
         ResourceDerivedTypesEnabled,
         AssemblyVersion)
     { }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -40,5 +40,7 @@ public class OverriddenFeatureProvider : IFeatureProvider
 
     public bool OptionalModuleNamesEnabled => overrides.OptionalModuleNamesEnabled ?? features.OptionalModuleNamesEnabled;
 
+    public bool LocalDeployEnabled => overrides.LocalDeployEnabled ?? features.LocalDeployEnabled;
+
     public bool ResourceDerivedTypesEnabled => overrides.ResourceDerivedTypesEnabled ?? features.ResourceDerivedTypesEnabled;
 }

--- a/src/Bicep.Core.UnitTests/Modules/LocalModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/LocalModuleReferenceTests.cs
@@ -3,6 +3,7 @@
 
 using Bicep.Core.FileSystem;
 using Bicep.Core.Modules;
+using Bicep.Core.Registry;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -47,7 +48,7 @@ namespace Bicep.Core.UnitTests.Modules
 
         private static LocalModuleReference Parse(string package)
         {
-            LocalModuleReference.TryParse(package, PathHelper.FilePathToFileUrl(Path.GetTempFileName())).IsSuccess(out var parsed, out var failureBuilder);
+            LocalModuleReference.TryParse(ArtifactType.Module, package, PathHelper.FilePathToFileUrl(Path.GetTempFileName())).IsSuccess(out var parsed, out var failureBuilder);
             parsed.Should().NotBeNull();
             failureBuilder.Should().BeNull();
             return parsed!;

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -62,6 +62,11 @@ namespace Bicep.Core.UnitTests.Utils
 
             var (uriDictionary, entryUri) = CreateFileDictionary(filesToAppend, "main.bicep");
 
+            return await RestoreAndCompile(services, uriDictionary, entryUri);
+        }
+
+        public static async Task<CompilationResult> RestoreAndCompile(ServiceBuilder services, IReadOnlyDictionary<Uri, string> uriDictionary, Uri entryUri)
+        {
             var compiler = services.Build().GetCompiler();
             var compilation = await compiler.CreateCompilation(entryUri, CreateWorkspace(uriDictionary));
 

--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -153,7 +153,7 @@ public static class RegistryHelper
             throw new InvalidOperationException($"Failed to get reference '{errorBuilder(DiagnosticBuilder.ForDocumentStart()).Message}'.");
         }
 
-        await dispatcher.PublishProvider(targetReference, tgzData);
+        await dispatcher.PublishProvider(targetReference, new(tgzData));
     }
 
     private static Uri RandomFileUri() => PathHelper.FilePathToFileUrl(Path.GetTempFileName());

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -18,6 +18,7 @@ public record ExperimentalFeaturesEnabled(
     bool DynamicTypeLoading,
     bool ProviderRegistry,
     bool OptionalModuleNames,
+    bool LocalDeploy,
     bool ResourceDerivedTypes)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -998,7 +998,7 @@ namespace Bicep.Core.Emit
             {
                 foreach (var provider in providers)
                 {
-                    var settings = provider.NamespaceType.Settings;
+                    var settings = provider.Settings;
 
                     emitter.EmitObjectProperty(provider.Name, () =>
                     {

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -42,6 +42,8 @@ namespace Bicep.Core.Features
 
         public bool OptionalModuleNamesEnabled => configuration.ExperimentalFeaturesEnabled.OptionalModuleNames;
 
+        public bool LocalDeployEnabled => configuration.ExperimentalFeaturesEnabled.LocalDeploy;
+
         public bool ResourceDerivedTypesEnabled => configuration.ExperimentalFeaturesEnabled.ResourceDerivedTypes;
 
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -30,6 +30,8 @@ public interface IFeatureProvider
 
     bool OptionalModuleNamesEnabled { get; }
 
+    bool LocalDeployEnabled { get; }
+
     bool ResourceDerivedTypesEnabled { get; }
 
     IEnumerable<(string name, bool impactsCompilation, bool usesExperimentalArmEngineFeature)> EnabledFeatureMetadata
@@ -49,6 +51,7 @@ public interface IFeatureProvider
                 (TestFrameworkEnabled, CoreResources.ExperimentalFeatureNames_TestFramework, false, false),
                 (AssertsEnabled, CoreResources.ExperimentalFeatureNames_Asserts, true, true),
                 (OptionalModuleNamesEnabled, CoreResources.ExperimentalFeatureNames_OptionalModuleNames, true, false),
+                (LocalDeployEnabled, "Enable local deploy", false, false),
                 (ResourceDerivedTypesEnabled, CoreResources.ExperimentalFeatureNames_ResourceDerivedTypes, true, false),
             })
             {

--- a/src/Bicep.Core/FileSystem/PathHelper.cs
+++ b/src/Bicep.Core/FileSystem/PathHelper.cs
@@ -247,5 +247,8 @@ namespace Bicep.Core.FileSystem
 
             return relativeUri;
         }
+
+        public static Uri ResolveFilePath(Uri parentFileUri, string childFilePath)
+            => TryResolveFilePath(parentFileUri, childFilePath) ?? throw new InvalidOperationException($"Failed to resolve file path for URI {parentFileUri} and child path {childFilePath}");
     }
 }

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -391,7 +391,7 @@ public record DeclaredMetadataExpression(
 public record DeclaredProviderExpression(
     SyntaxBase? SourceSyntax,
     string Name,
-    NamespaceType NamespaceType,
+    NamespaceSettings Settings,
     Expression? Config,
     Expression? Description = null
 ) : DescribableExpression(SourceSyntax, Description)

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -174,7 +174,7 @@ public class ExpressionBuilder
                 return EvaluateDecorators(provider, new DeclaredProviderExpression(
                     provider,
                     symbol.Name,
-                    GetTypeInfo<NamespaceType>(provider),
+                    GetTypeInfo<NamespaceType>(provider).Settings,
                     provider.Config is not null ? ConvertWithoutLowering(provider.Config) : null));
 
             case ParameterDeclarationSyntax parameter:

--- a/src/Bicep.Core/Modules/LocalModuleReference.cs
+++ b/src/Bicep.Core/Modules/LocalModuleReference.cs
@@ -15,11 +15,14 @@ namespace Bicep.Core.Modules
     {
         private static readonly IEqualityComparer<string> PathComparer = StringComparer.Ordinal;
 
-        private LocalModuleReference(string path, Uri parentModuleUri)
+        private LocalModuleReference(ArtifactType artifactType, string path, Uri parentModuleUri)
             : base(ArtifactReferenceSchemes.Local, parentModuleUri)
         {
+            ArtifactType = artifactType;
             this.Path = path;
         }
+
+        public ArtifactType ArtifactType { get; }
 
         /// <summary>
         /// Gets the relative path to the module.
@@ -44,10 +47,10 @@ namespace Bicep.Core.Modules
 
         public override bool IsExternal => false;
 
-        public static ResultWithDiagnostic<LocalModuleReference> TryParse(string unqualifiedReference, Uri parentModuleUri)
+        public static ResultWithDiagnostic<LocalModuleReference> TryParse(ArtifactType artifactType, string unqualifiedReference, Uri parentModuleUri)
         {
             return Validate(unqualifiedReference)
-                .Transform(_ => new LocalModuleReference(unqualifiedReference, parentModuleUri));
+                .Transform(_ => new LocalModuleReference(artifactType, unqualifiedReference, parentModuleUri));
         }
 
         public static ResultWithDiagnostic<bool> Validate(string pathName)

--- a/src/Bicep.Core/Registry/ArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/ArtifactRegistry.cs
@@ -22,7 +22,7 @@ namespace Bicep.Core.Registry
 
         public abstract Task PublishModule(T reference, BinaryData compiled, BinaryData? bicepSources, string? documentationUri, string? description);
 
-        public abstract Task PublishProvider(T reference, BinaryData typesTgz);
+        public abstract Task PublishProvider(T reference, ProviderPackage provider);
 
         public abstract Task<IDictionary<ArtifactReference, DiagnosticBuilder.ErrorBuilderDelegate>> RestoreArtifacts(IEnumerable<T> references);
 
@@ -46,8 +46,8 @@ namespace Bicep.Core.Registry
         public Task PublishModule(ArtifactReference artifactReference, BinaryData compiled, BinaryData? bicepSources, string? documentationUri, string? description)
             => this.PublishModule(ConvertReference(artifactReference), compiled, bicepSources, documentationUri, description);
 
-        public Task PublishProvider(ArtifactReference reference, BinaryData typesTgz)
-            => this.PublishProvider(ConvertReference(reference), typesTgz);
+        public Task PublishProvider(ArtifactReference reference, ProviderPackage provider)
+            => this.PublishProvider(ConvertReference(reference), provider);
 
         public Task<IDictionary<ArtifactReference, DiagnosticBuilder.ErrorBuilderDelegate>> RestoreArtifacts(IEnumerable<ArtifactReference> references) =>
             this.RestoreArtifacts(references.Select(ConvertReference));

--- a/src/Bicep.Core/Registry/DefaultArtifactRegistryProvider.cs
+++ b/src/Bicep.Core/Registry/DefaultArtifactRegistryProvider.cs
@@ -44,8 +44,7 @@ namespace Bicep.Core.Registry
             var builder = ImmutableArray.CreateBuilder<IArtifactRegistry>();
 
             // Using IServiceProvider instead of constructor injection due to a dependency cycle
-            var compiler = this.serviceProvider.GetService<BicepCompiler>();
-            builder.Add(new LocalModuleRegistry(this.fileResolver, templateUri, compiler));
+            builder.Add(new LocalModuleRegistry(fileResolver, fileSystem, features, templateUri));
             builder.Add(new OciArtifactRegistry(this.fileResolver, this.fileSystem, this.clientFactory, features, configuration, templateUri));
             builder.Add(new TemplateSpecModuleRegistry(this.fileResolver, this.fileSystem, this.templateSpecRepositoryFactory, features, configuration, templateUri));
 

--- a/src/Bicep.Core/Registry/IArtifactDispatcher.cs
+++ b/src/Bicep.Core/Registry/IArtifactDispatcher.cs
@@ -1,12 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.SourceCode;
 using Bicep.Core.Utils;
 
 namespace Bicep.Core.Registry
 {
+    public record ProviderPackage(
+        BinaryData Types);
+
     public interface IModuleDispatcher : IArtifactReferenceFactory
     {
         RegistryCapabilities GetRegistryCapabilities(ArtifactType artifactType, ArtifactReference reference);
@@ -23,7 +27,7 @@ namespace Bicep.Core.Registry
 
         Task PublishModule(ArtifactReference reference, BinaryData compiledArmTemplate, BinaryData? bicepSources, string? documentationUri);
 
-        Task PublishProvider(ArtifactReference reference, BinaryData compiledArmTemplate);
+        Task PublishProvider(ArtifactReference reference, ProviderPackage provider);
 
         void PruneRestoreStatuses();
 

--- a/src/Bicep.Core/Registry/IArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/IArtifactRegistry.cs
@@ -77,8 +77,7 @@ namespace Bicep.Core.Registry
         /// Publishes a provider types package to the registry.
         /// </summary>
         /// <param name="reference">The provider reference</param>
-        /// <param name="typesTgz">A BinaryData object with the contents of the types.tgz</param>
-        Task PublishProvider(ArtifactReference reference, BinaryData typesTgz);
+        Task PublishProvider(ArtifactReference reference, ProviderPackage provider);
 
         /// <summary>
         /// Returns documentationUri for the module.

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -228,11 +228,11 @@ namespace Bicep.Core.Registry
             await registry.PublishModule(reference, compiledArmTemplate, bicepSources, documentationUri, description);
         }
 
-        public async Task PublishProvider(ArtifactReference reference, BinaryData typesTgz)
+        public async Task PublishProvider(ArtifactReference reference, ProviderPackage provider)
         {
             var registry = this.GetRegistry(reference);
 
-            await registry.PublishProvider(reference, typesTgz);
+            await registry.PublishProvider(reference, provider);
         }
 
         public async Task<bool> CheckModuleExists(ArtifactReference reference)

--- a/src/Bicep.Core/Registry/Oci/OciDescriptor.cs
+++ b/src/Bicep.Core/Registry/Oci/OciDescriptor.cs
@@ -42,12 +42,12 @@ namespace Bicep.Core.Registry.Oci
         public long Size { get; }
         public ImmutableDictionary<string, string> Annotations { get; }
 
-        public static string ComputeDigest(string algorithmIdentifier, BinaryData data)
+        public static string ComputeDigest(string algorithmIdentifier, BinaryData data, char separator = ':')
         {
             using var algorithm = CreateHashAlgorithm(algorithmIdentifier);
             var hashValue = algorithm.ComputeHash(data.ToArray());
             string hexString = BitConverter.ToString(hashValue).Replace("-", "");
-            return $"{algorithmIdentifier}:{hexString.ToLowerInvariant()}";
+            return $"{algorithmIdentifier}{separator}{hexString.ToLowerInvariant()}";
         }
 
         private static HashAlgorithm CreateHashAlgorithm(string algorithm) => algorithm switch

--- a/src/Bicep.Core/Registry/Oci/OciProviderArtifactResult.cs
+++ b/src/Bicep.Core/Registry/Oci/OciProviderArtifactResult.cs
@@ -20,7 +20,8 @@ namespace Bicep.Core.Registry.Oci
                 throw new InvalidArtifactException($"Unknown config.mediaType: '{manifest.Config.MediaType}'.", InvalidArtifactExceptionKind.WrongArtifactType);
             }
 
-            this.mainLayer = this.Layers.Single();
+            var expectedLayerMediaType = BicepMediaTypes.BicepProviderArtifactLayerV1TarGzip;
+            this.mainLayer = this.Layers.Where(l => l.MediaType.Equals(expectedLayerMediaType, MediaTypeComparison)).Single();
         }
 
         public override OciArtifactLayer GetMainLayer() => this.mainLayer;

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -290,14 +290,14 @@ namespace Bicep.Core.Registry
             }
         }
 
-        public override async Task PublishProvider(OciArtifactReference reference, BinaryData typesTgz)
+        public override async Task PublishProvider(OciArtifactReference reference, ProviderPackage provider)
         {
             // This needs to be valid JSON, otherwise there may be compatibility issues.
             var config = new Oci.OciDescriptor("{}", BicepMediaTypes.BicepProviderConfigV1);
 
             List<Oci.OciDescriptor> layers = new()
             {
-                new(typesTgz, BicepMediaTypes.BicepProviderArtifactLayerV1TarGzip, new OciManifestAnnotationsBuilder().WithTitle("types.tgz").Build())
+                new(provider.Types, BicepMediaTypes.BicepProviderArtifactLayerV1TarGzip, new OciManifestAnnotationsBuilder().WithTitle("types.tgz").Build())
             };
 
             var annotations = new OciManifestAnnotationsBuilder()

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -59,7 +59,7 @@ namespace Bicep.Core.Registry
         public override Task PublishModule(TemplateSpecModuleReference reference, BinaryData compiled, BinaryData? bicepSources, string? documentationUri, string? description)
             => throw new NotSupportedException("Template Spec modules cannot be published.");
 
-        public override Task PublishProvider(TemplateSpecModuleReference reference, BinaryData typesTgz)
+        public override Task PublishProvider(TemplateSpecModuleReference reference, ProviderPackage provider)
             => throw new NotSupportedException("Template Spec providers cannot be published.");
 
         public override Task<bool> CheckArtifactExists(ArtifactType artifactType, TemplateSpecModuleReference reference)

--- a/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
@@ -209,6 +209,6 @@ public class NamespaceProvider : INamespaceProvider
             return new(AzNamespaceType.Create(aliasName, targetScope, typeProvider, sourceFile.FileKind));
         }
 
-        return new(ThirdPartyNamespaceType.Create(aliasName, typeProvider));
+        return new(ThirdPartyNamespaceType.Create(aliasName, typeProvider, artifact.Reference));
     }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/ThirdPartyNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/ThirdPartyNamespaceType.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Immutable;
+using Bicep.Core.Registry;
 using Bicep.Core.TypeSystem.Providers;
 using Bicep.Core.TypeSystem.Providers.ThirdParty;
 using Bicep.Core.TypeSystem.Types;
@@ -17,7 +18,7 @@ namespace Bicep.Core.Semantics.Namespaces
             ArmTemplateProviderName: string.Empty,
             ArmTemplateProviderVersion: string.Empty);
 
-        public static NamespaceType Create(string? aliasName, IResourceTypeProvider resourceTypeProvider)
+        public static NamespaceType Create(string? aliasName, IResourceTypeProvider resourceTypeProvider, ArtifactReference? artifact)
         {
             // NamespaceConfig is not null
             if (resourceTypeProvider is ThirdPartyResourceTypeProvider thirdPartyProvider && thirdPartyProvider.GetNamespaceConfiguration() is NamespaceConfiguration namespaceConfig && namespaceConfig != null)
@@ -34,7 +35,8 @@ namespace Bicep.Core.Semantics.Namespaces
                     ImmutableArray<FunctionOverload>.Empty,
                     ImmutableArray<BannedFunction>.Empty,
                     ImmutableArray<Decorator>.Empty,
-                    resourceTypeProvider);
+                    resourceTypeProvider,
+                    artifact);
             }
 
             // NamespaceConfig is required to be set for 3PProviders

--- a/src/Bicep.Core/TypeSystem/OciTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/OciTypeLoader.cs
@@ -15,31 +15,9 @@ namespace Bicep.Core.TypeSystem
     public class OciTypeLoader : TypeLoader
     {
         private readonly ImmutableDictionary<string, byte[]> typesCache;
-        public const string TypesArtifactFilename = "types.tgz";
         private OciTypeLoader(ImmutableDictionary<string, byte[]> typesCache)
         {
             this.typesCache = typesCache;
-        }
-
-        public static OciTypeLoader FromFilesystemBundle(Stream stream)
-        {
-            using var gzipStream = new GZipStream(stream, CompressionMode.Decompress);
-            using var tarReader = new TarReader(gzipStream);
-
-            while (tarReader.GetNextEntry() is { } entry)
-            {
-                if (entry.Name == TypesArtifactFilename)
-                {
-                    if (entry.DataStream is null)
-                    {
-                        throw new InvalidOperationException($"Stream for {entry.Name} is null.");
-                    }
-
-                    return FromStream(entry.DataStream);
-                }
-            }
-
-            throw new InvalidOperationException($"Failed to find {TypesArtifactFilename} in the bundle.");
         }
 
         public static OciTypeLoader FromStream(Stream stream)

--- a/src/Bicep.Core/TypeSystem/Providers/ResourceTypeProviderFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ResourceTypeProviderFactory.cs
@@ -35,9 +35,7 @@ namespace Bicep.Core.TypeSystem.Providers
                 try
                 {
                     using var fileStream = fileSystem.File.OpenRead(typesTgzUri.LocalPath);
-                    var typesLoader = artifactReference is LocalModuleReference ?
-                        OciTypeLoader.FromFilesystemBundle(fileStream) :
-                        OciTypeLoader.FromStream(fileStream);
+                    var typesLoader = OciTypeLoader.FromStream(fileStream);
 
                     if (key.UseAzLoader)
                     {

--- a/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ThirdPartyResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ThirdPartyResourceTypeProvider.cs
@@ -29,8 +29,13 @@ namespace Bicep.Core.TypeSystem.Providers.ThirdParty
             switch (bodyType)
             {
                 case ObjectType bodyObjectType:
-                    bodyType = SetBicepResourceProperties(bodyObjectType, resourceType.ValidParentScopes, resourceType.TypeReference, flags);
+                    bodyType = SetBicepResourceProperties(bodyObjectType, flags);
                     break;
+
+                case DiscriminatedObjectType bodyDiscriminatedType:
+                    bodyType = SetBicepResourceProperties(bodyDiscriminatedType, flags);
+                    break;
+
                 default:
                     throw new ArgumentException($"Resource {resourceType.TypeReference.FormatName()} has unexpected body type {bodyType.GetType()}");
             }
@@ -38,7 +43,7 @@ namespace Bicep.Core.TypeSystem.Providers.ThirdParty
             return resourceType with { Body = bodyType };
         }
 
-        private static ObjectType SetBicepResourceProperties(ObjectType objectType, ResourceScope validParentScopes, ResourceTypeReference typeReference, ResourceTypeGenerationFlags flags)
+        private static ObjectType SetBicepResourceProperties(ObjectType objectType, ResourceTypeGenerationFlags flags)
         {
             var properties = objectType.Properties;
             var isExistingResource = flags.HasFlag(ResourceTypeGenerationFlags.ExistingResource);
@@ -56,6 +61,18 @@ namespace Bicep.Core.TypeSystem.Providers.ThirdParty
                 objectType.AdditionalPropertiesType,
                 isExistingResource ? ConvertToReadOnly(objectType.AdditionalPropertiesFlags) : objectType.AdditionalPropertiesFlags,
                 functions: objectType.MethodResolver.functionOverloads);
+        }
+
+        private static DiscriminatedObjectType SetBicepResourceProperties(DiscriminatedObjectType objectType, ResourceTypeGenerationFlags flags)
+        {
+            var unionMembersByKey = objectType.UnionMembersByKey
+                .ToDictionary(x => x.Key, x => SetBicepResourceProperties(x.Value, flags));
+
+            return new DiscriminatedObjectType(
+                objectType.Name,
+                objectType.ValidationFlags,
+                objectType.DiscriminatorKey,
+                unionMembersByKey.Values);
         }
 
         private static IEnumerable<TypeProperty> ConvertToReadOnly(IEnumerable<TypeProperty> properties)

--- a/src/Bicep.Core/TypeSystem/Types/NamespaceType.cs
+++ b/src/Bicep.Core/TypeSystem/Types/NamespaceType.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using Bicep.Core.Registry;
+using Bicep.Core.Registry.Oci;
 using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem.Providers;
 
@@ -21,11 +23,13 @@ namespace Bicep.Core.TypeSystem.Types
             IEnumerable<FunctionOverload> functionOverloads,
             IEnumerable<BannedFunction> bannedFunctions,
             IEnumerable<Decorator> decorators,
-            IResourceTypeProvider resourceTypeProvider)
+            IResourceTypeProvider resourceTypeProvider,
+            ArtifactReference? artifact = null)
             : base(aliasName, TypeSymbolValidationFlags.PreventAssignment, properties, null, TypePropertyFlags.None, obj => new FunctionResolver(obj, functionOverloads, bannedFunctions))
         {
             Settings = settings;
             ResourceTypeProvider = resourceTypeProvider;
+            Artifact = artifact;
             DecoratorResolver = new DecoratorResolver(this, decorators);
         }
 
@@ -36,6 +40,8 @@ namespace Bicep.Core.TypeSystem.Types
         public NamespaceSettings Settings { get; }
 
         public IResourceTypeProvider ResourceTypeProvider { get; }
+
+        public ArtifactReference? Artifact { get; }
 
         public string ProviderName => Settings.BicepProviderName;
 

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -172,7 +172,7 @@ namespace Bicep.LangServer.IntegrationTests.Registry
             public Task PublishModule(ArtifactReference _, BinaryData __, BinaryData? ___, string? ____, string? _____)
                 => throw new NotImplementedException();
 
-            public Task PublishProvider(ArtifactReference _, BinaryData __)
+            public Task PublishProvider(ArtifactReference _, ProviderPackage __)
                 => throw new NotImplementedException();
 
             public Task<bool> CheckArtifactExists(ArtifactType artifactType, ArtifactReference reference) => throw new NotImplementedException();

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -90,7 +90,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var telemetryProviderMock = new TelemetryProviderMock();
 
             const string ModuleRefStr = "./hello.bicep";
-            LocalModuleReference.TryParse(ModuleRefStr, new Uri("fake:///not/real.bicep")).IsSuccess(out var localRef).Should().BeTrue();
+            LocalModuleReference.TryParse(ArtifactType.Module, ModuleRefStr, new Uri("fake:///not/real.bicep")).IsSuccess(out var localRef).Should().BeTrue();
             localRef.Should().NotBeNull();
 
             ArtifactReference? outRef = localRef;

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepForceModulesRestoreCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepForceModulesRestoreCommandHandlerTests.cs
@@ -144,7 +144,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' = {
 
             string expected = StringUtils.ReplaceNewlines(await handler.Handle(bicepFilePath, CancellationToken.None), "|");
 
-            expected.Should().Be(@"Restore (force) summary: |  * ./localmodule1.bicep: Succeeded|  * ./localmodule2.bicep: Succeeded");
+            expected.Should().Be(@"Restore (force) summary: |  * ./localmodule1.bicep: Succeeded|  * ./localmodule2.bicep: Failed");
         }
 
 

--- a/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj
+++ b/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>Azure.Bicep.Local.Extension</AssemblyName>
+    <RootNamespace>Bicep.Local.Extension</RootNamespace>
+    <EnableNuget>true</EnableNuget>
+    <PackageTags>Azure;ResourceManager;ARM;Deployments;Templates;Bicep</PackageTags>
+    <Description>
+      Bicep compiler extension functionality.
+      The Bicep team has made this NuGet package publicly available on nuget.org. While it is public, it is not a supported package. Any dependency you take on this package will be done at your own risk and we reserve the right to push breaking changes to this package at any time.
+    </Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="extension.proto" GrpcServices="Both" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
+  </ItemGroup>
+</Project>

--- a/src/Bicep.Local.Extension/Protocol/IResourceHandler.cs
+++ b/src/Bicep.Local.Extension/Protocol/IResourceHandler.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Bicep.Local.Extension.Protocol;
+
+public record ExtensibilityOperationRequest(
+    ExtensibleImportData Import,
+    ExtensibleResourceData Resource);
+
+public record ExtensibilityOperationResponse(
+    ExtensibleResourceData? Resource,
+    ExtensibleResourceMetadata? ResourceMetadata,
+    ImmutableArray<ExtensibilityError>? Errors);
+
+public record ExtensibleImportData(
+    string Provider,
+    string Version,
+    JsonObject? Config);
+
+public record ExtensibleResourceData(
+    string Type,
+    JsonObject? Properties);
+
+public record ExtensibleResourceMetadata(
+    ImmutableArray<string>? ReadOnlyProperties,
+    ImmutableArray<string>? ImmutableProperties,
+    ImmutableArray<string>? DynamicProperties);
+
+public record ExtensibilityError(
+    string Code,
+    string Message,
+    string Target);
+
+public interface IGenericResourceHandler
+{
+    Task<ExtensibilityOperationResponse> Save(
+        ExtensibilityOperationRequest request,
+        CancellationToken cancellationToken);
+
+    Task<ExtensibilityOperationResponse> PreviewSave(
+        ExtensibilityOperationRequest request,
+        CancellationToken cancellationToken);
+
+    Task<ExtensibilityOperationResponse> Get(
+        ExtensibilityOperationRequest request,
+        CancellationToken cancellationToken);
+
+    Task<ExtensibilityOperationResponse> Delete(
+        ExtensibilityOperationRequest request,
+        CancellationToken cancellationToken);
+}
+
+public interface IResourceHandler : IGenericResourceHandler
+{
+    string ResourceType { get; }
+}

--- a/src/Bicep.Local.Extension/Protocol/ResourceDispatcher.cs
+++ b/src/Bicep.Local.Extension/Protocol/ResourceDispatcher.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace Bicep.Local.Extension.Protocol;
+
+public class ResourceDispatcher
+{
+    private readonly IGenericResourceHandler? genericResourceHandler;
+    private readonly ImmutableDictionary<string, IResourceHandler> resourceHandlers;
+
+    public ResourceDispatcher(
+        IGenericResourceHandler? genericResourceHandler,
+        ImmutableDictionary<string, IResourceHandler> resourceHandlers)
+    {
+        this.genericResourceHandler = genericResourceHandler;
+        this.resourceHandlers = resourceHandlers;
+    }
+
+    public IGenericResourceHandler GetHandler(string resourceType)
+    {
+        if (this.resourceHandlers.TryGetValue(resourceType, out var handler))
+        {
+            return handler;
+        }
+
+        if (this.genericResourceHandler is {})
+        {
+            return this.genericResourceHandler;
+        }
+
+        throw new ArgumentException($"Resource type '{resourceType}' is not supported.");
+    }
+}

--- a/src/Bicep.Local.Extension/Protocol/ResourceDispatcherBuilder.cs
+++ b/src/Bicep.Local.Extension/Protocol/ResourceDispatcherBuilder.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace Bicep.Local.Extension.Protocol;
+
+public class ResourceDispatcherBuilder
+{
+    private IGenericResourceHandler? genericResourceHandler;
+    private readonly Dictionary<string, IResourceHandler> resourceHandlers = new(StringComparer.OrdinalIgnoreCase);
+
+    public ResourceDispatcherBuilder AddHandler(IResourceHandler handler)
+    {
+        if (!this.resourceHandlers.TryAdd(handler.ResourceType, handler))
+        {
+            throw new ArgumentException($"Resource type '{handler.ResourceType}' has already been registered.");
+        }
+
+        this.resourceHandlers[handler.ResourceType] = handler;
+        return this;
+    }
+
+    public ResourceDispatcherBuilder AddGenericHandler(IGenericResourceHandler handler)
+    {
+        if (this.genericResourceHandler is not null)
+        {
+            throw new ArgumentException($"Generic resource handler has already been registered.");
+        }
+
+        this.genericResourceHandler = handler;
+        return this;
+    }
+
+    public ResourceDispatcher Build()
+    {
+        return new(
+            this.genericResourceHandler,
+            this.resourceHandlers.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/src/Bicep.Local.Extension/ProviderExtension.cs
+++ b/src/Bicep.Local.Extension/ProviderExtension.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime;
+using Microsoft.AspNetCore.Builder;
+using Bicep.Local.Extension.Rpc;
+using CommandLine;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Bicep.Local.Extension.Protocol;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+namespace Bicep.Local.Extension;
+
+public class ProviderExtension
+{
+    internal class CommandLineOptions
+    {
+        [Option("socket", Required = false, HelpText = "The path to the domain socket to connect on")]
+        public string? Socket { get; set; }
+
+        [Option("wait-for-debugger", Required = false, HelpText = "If set, wait for a dotnet debugger to be attached before starting the server")]
+        public bool WaitForDebugger { get; set; }
+    }
+
+    public static async Task Run(Action<ResourceDispatcherBuilder> registerHandlers, string[] args)
+        => await RunWithCancellationAsync(async cancellationToken =>
+        {
+            if (IsTracingEnabled)
+            {
+                Trace.Listeners.Add(new TextWriterTraceListener(Console.Error));
+            }
+
+            var extension = new ProviderExtension();
+
+            await extension.RunAsync(args, registerHandlers, cancellationToken);
+        });
+
+    public async Task RunAsync(string[] args, Action<ResourceDispatcherBuilder> registerHandlers, CancellationToken cancellationToken)
+    {
+        var parser = new Parser(settings =>
+        {
+            settings.IgnoreUnknownArguments = true;
+        });
+
+        await parser.ParseArguments<CommandLineOptions>(args)
+            .WithNotParsed((x) => System.Environment.Exit(1))
+            .WithParsedAsync(async options => await RunServer(registerHandlers, options, cancellationToken));
+    }
+
+    private static async Task RunServer(Action<ResourceDispatcherBuilder> registerHandlers, CommandLineOptions options, CancellationToken cancellationToken)
+    {
+        if (options.WaitForDebugger)
+        {
+            // exit if we don't have a debugger attached within 5 minutes
+            var debuggerTimeoutToken = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                new CancellationTokenSource(TimeSpan.FromMinutes(5)).Token).Token;
+
+            while (!Debugger.IsAttached)
+            {
+                await Task.Delay(100, debuggerTimeoutToken);
+            }
+
+            Debugger.Break();
+        }
+
+        var handlerBuilder = new ResourceDispatcherBuilder();
+        registerHandlers(handlerBuilder);
+        var dispatcher = handlerBuilder.Build();
+
+        if (options.Socket is { } socketPath)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.WebHost.ConfigureKestrel(options =>
+            {
+                options.ListenUnixSocket(socketPath, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                });
+            });
+    
+            builder.Services.AddGrpc();
+            builder.Services.AddSingleton(dispatcher);
+            var app = builder.Build();
+            app.MapGrpcService<BicepExtensionImpl>();
+
+            await Task.WhenAny(app.RunAsync(), WaitForCancellation(cancellationToken));
+            return;
+        }
+
+        throw new NotImplementedException();
+    }
+
+    private static async Task WaitForCancellation(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(-1, cancellationToken);
+        }
+        catch (TaskCanceledException ex) when (ex.CancellationToken == cancellationToken)
+        {
+            // don't throw - continue
+        }
+    }
+
+    private static async Task RunWithCancellationAsync(Func<CancellationToken, Task> runFunc)
+    {
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        Console.CancelKeyPress += (sender, e) =>
+        {
+            cancellationTokenSource.Cancel();
+            e.Cancel = true;
+        };
+
+        AppDomain.CurrentDomain.ProcessExit += (sender, e) =>
+        {
+            cancellationTokenSource.Cancel();
+        };
+
+        try
+        {
+            await runFunc(cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationTokenSource.Token)
+        {
+            // this is expected - no need to rethrow
+        }
+    }
+
+    private static bool IsTracingEnabled
+        => bool.TryParse(Environment.GetEnvironmentVariable("BICEP_TRACING_ENABLED"), out var value) && value;
+}

--- a/src/Bicep.Local.Extension/Rpc/BicepExtensionImpl.cs
+++ b/src/Bicep.Local.Extension/Rpc/BicepExtensionImpl.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using System.Text.Json.Nodes;
+using Bicep.Local.Extension.Protocol;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Bicep.Local.Extension.Rpc;
+
+public class BicepExtensionImpl : BicepExtension.BicepExtensionBase
+{
+    private readonly ILogger<BicepExtensionImpl> logger;
+    private readonly ResourceDispatcher dispatcher;
+
+    public BicepExtensionImpl(ILogger<BicepExtensionImpl> logger, ResourceDispatcher dispatcher)
+    {
+        this.logger = logger;
+        this.dispatcher = dispatcher;
+    }
+
+    public override Task<ExtensibilityOperationResponse> Save(ExtensibilityOperationRequest request, ServerCallContext context)
+        => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Resource.Type).Save(Convert(request), context.CancellationToken)));
+
+    public override Task<ExtensibilityOperationResponse> PreviewSave(ExtensibilityOperationRequest request, ServerCallContext context)
+        => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Resource.Type).PreviewSave(Convert(request), context.CancellationToken)));
+
+    public override Task<ExtensibilityOperationResponse> Get(ExtensibilityOperationRequest request, ServerCallContext context)
+        => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Resource.Type).Get(Convert(request), context.CancellationToken)));
+
+    public override Task<ExtensibilityOperationResponse> Delete(ExtensibilityOperationRequest request, ServerCallContext context)
+        => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Resource.Type).Delete(Convert(request), context.CancellationToken)));
+
+    public override Task<Empty> Ping(Empty request, ServerCallContext context)
+        => Task.FromResult(new Empty());
+
+    private static Protocol.ExtensibilityOperationRequest Convert(ExtensibilityOperationRequest request)
+    {
+        return new(
+            new(request.Import.Provider, request.Import.Version, request.Import.Config is {} ? JsonNode.Parse(request.Import.Config) as JsonObject : null),
+            new(request.Resource.Type, request.Resource.Properties is {} ? JsonNode.Parse(request.Resource.Properties) as JsonObject : null));
+    }
+
+    private static ExtensibilityOperationResponse Convert(Protocol.ExtensibilityOperationResponse response)
+    {
+        var output = new ExtensibilityOperationResponse();
+        if (response.Resource is {})
+        {
+            output.Resource = new ExtensibleResourceData
+            {
+                Type = response.Resource.Type,
+                Properties = response.Resource.Properties?.ToString()
+            };
+        }
+
+        if (response.ResourceMetadata is {} metadata)
+        {
+            output.ResourceMetadata.ReadOnlyProperties.AddRange(metadata.ReadOnlyProperties);
+            output.ResourceMetadata.ImmutableProperties.AddRange(metadata.ImmutableProperties);
+            output.ResourceMetadata.DynamicProperties.AddRange(metadata.DynamicProperties);
+        }
+
+        if (response.Errors is {} errors)
+        {
+            output.Errors.AddRange(errors.Select(error => new ExtensibilityError
+            {
+                Code = error.Code,
+                Message = error.Message,
+                Target = error.Target
+            }));
+        }
+
+        return output;
+    }
+
+    private static async Task<ExtensibilityOperationResponse> WrapExceptions(Func<Task<ExtensibilityOperationResponse>> func)
+    {
+        try 
+        {
+            return await func();
+        }
+        catch (Exception ex)
+        {
+            var response = new ExtensibilityOperationResponse();
+            response.Errors.Add(new ExtensibilityError
+            {
+                Code = "RpcException",
+                Message = $"Rpc request failed: {ex}",
+                Target = ""
+            });
+            
+            return response;
+        }
+    }
+}

--- a/src/Bicep.Local.Extension/Rpc/GrpcChannelHelper.cs
+++ b/src/Bicep.Local.Extension/Rpc/GrpcChannelHelper.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Net;
+using System.Net.Sockets;
+using Grpc.Core;
+using Grpc.Net.Client;
+
+namespace Bicep.Local.Extension.Rpc;
+
+public static class GrpcChannelHelper
+{
+    public class UnixDomainSocketsConnectionFactory
+    {
+        private readonly EndPoint endPoint;
+
+        public UnixDomainSocketsConnectionFactory(EndPoint endPoint)
+        {
+            this.endPoint = endPoint;
+        }
+
+        public async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext _,
+            CancellationToken cancellationToken = default)
+        {
+            var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+
+            try
+            {
+                await socket.ConnectAsync(this.endPoint, cancellationToken).ConfigureAwait(false);
+                return new NetworkStream(socket, true);
+            }
+            catch
+            {
+                socket.Dispose();
+                throw;
+            }
+        }
+    }
+
+    public static GrpcChannel CreateChannel(string socketPath)
+    {
+        var udsEndPoint = new UnixDomainSocketEndPoint(socketPath);
+        var connectionFactory = new UnixDomainSocketsConnectionFactory(udsEndPoint);
+        var socketsHttpHandler = new SocketsHttpHandler
+        {
+            ConnectCallback = connectionFactory.ConnectAsync
+        };
+
+        return GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        {
+            HttpHandler = socketsHttpHandler
+        });
+    }
+
+    public static async Task WaitForConnectionAsync(BicepExtension.BicepExtensionClient client, CancellationToken cancellationToken)
+    {
+        var connected = false;
+        while (!connected)
+        {
+            try {
+                await Task.Delay(50, cancellationToken);
+                await client.PingAsync(new(), cancellationToken: cancellationToken);
+                connected = true;
+            } catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable) {
+                // ignore
+            }
+        }
+    }
+}

--- a/src/Bicep.Local.Extension/Rpc/GrpcChannelHelper.cs
+++ b/src/Bicep.Local.Extension/Rpc/GrpcChannelHelper.cs
@@ -47,7 +47,8 @@ public static class GrpcChannelHelper
             ConnectCallback = connectionFactory.ConnectAsync
         };
 
-        return GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+        // The URL is not used, but it must be a valid URI.
+        return GrpcChannel.ForAddress("invalid://unused", new GrpcChannelOptions
         {
             HttpHandler = socketsHttpHandler
         });

--- a/src/Bicep.Local.Extension/TextWriterTraceListener.cs
+++ b/src/Bicep.Local.Extension/TextWriterTraceListener.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace Bicep.Local.Extension;
+
+public class TextWriterTraceListener : TraceListener
+{
+    private readonly TextWriter textWriter;
+
+    public TextWriterTraceListener(TextWriter textWriter)
+    {
+        this.textWriter = textWriter;
+    }
+
+    public override void Write(string? message)
+    {
+        textWriter.WriteLine($"TRACE: {message}");
+    }
+
+    public override void WriteLine(string? message)
+    {
+        textWriter.WriteLine($"TRACE: {message}");
+    }
+}

--- a/src/Bicep.Local.Extension/extension.proto
+++ b/src/Bicep.Local.Extension/extension.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+option csharp_namespace = "Bicep.Local.Extension.Rpc";
+
+package extension;
+
+service BicepExtension {
+  rpc Save (ExtensibilityOperationRequest) returns (ExtensibilityOperationResponse);
+  rpc PreviewSave (ExtensibilityOperationRequest) returns (ExtensibilityOperationResponse);
+  rpc Get (ExtensibilityOperationRequest) returns (ExtensibilityOperationResponse);
+  rpc Delete (ExtensibilityOperationRequest) returns (ExtensibilityOperationResponse);
+  rpc Ping(Empty) returns (Empty);
+}
+
+message Empty {}
+
+message ExtensibleImportData {
+  string provider = 1;
+  string version = 2;
+  optional string config = 3;
+}
+
+message ExtensibleResourceData {
+  string type = 1;
+  optional string properties = 2;
+}
+
+message ExtensibleResourceMetadata {
+  repeated string readOnlyProperties = 1;
+  repeated string immutableProperties = 2;
+  repeated string dynamicProperties = 3;
+}
+
+message ExtensibilityError {
+  string code = 1;
+  string message = 2;
+  string target = 3;
+}
+
+message ExtensibilityOperationRequest {
+  ExtensibleImportData import = 1;
+  ExtensibleResourceData resource = 2;
+}
+
+message ExtensibilityOperationResponse {
+  optional ExtensibleResourceData resource = 1;
+  optional ExtensibleResourceMetadata resourceMetadata = 2;
+  repeated ExtensibilityError errors = 3;
+}

--- a/src/Bicep.Local.Extension/packages.lock.json
+++ b/src/Bicep.Local.Extension/packages.lock.json
@@ -1,0 +1,205 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Azure.Deployments.Internal.GenerateNotice": {
+        "type": "Direct",
+        "requested": "[0.1.38, )",
+        "resolved": "0.1.38",
+        "contentHash": "BqTIqpSk+JoK4QYpkt5htsccgBM4IrMINlo4d/Z4Ii3qV91V20VUhDqON+0Zax4hpGTsz710iDk0V7ypteLM/g=="
+      },
+      "CommandLineParser": {
+        "type": "Direct",
+        "requested": "[2.9.1, )",
+        "resolved": "2.9.1",
+        "contentHash": "OE0sl1/sQ37bjVsPKKtwQlWDgqaxWgtme3xZz7JssWUzg5JpMIyHgCTY9MVMxOg48fJ1AgGT3tgdH5m/kQ5xhA=="
+      },
+      "Grpc.AspNetCore": {
+        "type": "Direct",
+        "requested": "[2.62.0, )",
+        "resolved": "2.62.0",
+        "contentHash": "DnfhwUepm1zlgIDuZkuvi7B7gugM2m8GOUlmyUxDaBviyfj/Of6+dIAR342QQwnBwPFeSboDZu9DJA/3TGVz0g==",
+        "dependencies": {
+          "Google.Protobuf": "3.24.0",
+          "Grpc.AspNetCore.Server.ClientFactory": "2.62.0",
+          "Grpc.Tools": "2.62.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.4, )",
+        "resolved": "3.3.4",
+        "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "Microsoft.VisualStudio.Threading.Analyzers": {
+        "type": "Direct",
+        "requested": "[17.10.48, )",
+        "resolved": "17.10.48",
+        "contentHash": "xwvwT91oqFjLgQykUp6y/JPYxz8LchbfJKrLVatfczWddXKng8DAo8RiiIodt+pRdsVXP9Ud02GtJoY7ifdXPQ=="
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.6.133, )",
+        "resolved": "3.6.133",
+        "contentHash": "VZWMd5YAeDxpjWjAP/X6bAxnRMiEf6tES/ITN0X5CHJgkWLLeHGmEALivmTAfYM6P+P/3Szy6VCITUAkqjcHVw=="
+      },
+      "Google.Protobuf": {
+        "type": "Transitive",
+        "resolved": "3.24.0",
+        "contentHash": "5j/OBUVWPTeRYlG3Dm4PSupyU6nJmbnnhPeqjePzCqtzrh5vErx8dToStuhTnG1ZYZ+dawGziC7DN1I6FEQH0g=="
+      },
+      "Grpc.AspNetCore.Server": {
+        "type": "Transitive",
+        "resolved": "2.62.0",
+        "contentHash": "0ZmdjQ3TxV2DT9tqldfWjVh3R51IdDjuc8vuUJRoJAU4M9sRGNJqJC72wxU81tQFeHLhe0ahq8FngFPuAvByrg==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.62.0"
+        }
+      },
+      "Grpc.AspNetCore.Server.ClientFactory": {
+        "type": "Transitive",
+        "resolved": "2.62.0",
+        "contentHash": "hJUzvFmfI4JgQEJMu+1IVaKg+zMlDiFNlmyW/2m2X/XUAKIaopx0hd3aaQ+hiWr6Ih5RHH5ZVx+1QgLqNPLdgw==",
+        "dependencies": {
+          "Grpc.AspNetCore.Server": "2.62.0",
+          "Grpc.Net.ClientFactory": "2.62.0"
+        }
+      },
+      "Grpc.Core.Api": {
+        "type": "Transitive",
+        "resolved": "2.62.0",
+        "contentHash": "q4Jj6bRZHNnE4CMLqgjiBUCKLit+tRr0simZsS2W6U++akd7CzXByeKy2tddqT68hFzP2XzceXA2YtBTfWtixA=="
+      },
+      "Grpc.Net.Client": {
+        "type": "Transitive",
+        "resolved": "2.62.0",
+        "contentHash": "C7HxLt+wWPTpPFORRHkxxtDLL+K/jXSmZBaPLhFM8AEkN0bYjklIfCwnzajn1gcbRcEETBb0WnRgHJdVzpwbCg==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.62.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+        }
+      },
+      "Grpc.Net.ClientFactory": {
+        "type": "Transitive",
+        "resolved": "2.62.0",
+        "contentHash": "t0EbT6QHFBpc2OWMi5WdT8fKvn8OD6JDDlsL6VDHUC8kwIu7ouuW3JEJvEkdqD/25EUhWeBk6EISitAPK8NaFQ==",
+        "dependencies": {
+          "Grpc.Net.Client": "2.62.0",
+          "Microsoft.Extensions.Http": "6.0.0"
+        }
+      },
+      "Grpc.Net.Common": {
+        "type": "Transitive",
+        "resolved": "2.62.0",
+        "contentHash": "eBv5I4RPWfdezGXqooU5hs3+XcfVMLk5XDlA4G/Nd9TMX78ZGrFl/lM1Ad187zgBLmH7WPAgfjKRWLBwaa1Wbw==",
+        "dependencies": {
+          "Grpc.Core.Api": "2.62.0"
+        }
+      },
+      "Grpc.Tools": {
+        "type": "Transitive",
+        "resolved": "2.62.0",
+        "contentHash": "tVU0hseOI3tYI9Z62++01EAUBNsKMQfZfeuZyW9Qa3z1D7IqtQKoU2u+3426uIPCTzVVi8qBgsszThyKam9NQA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "15+pa2G0bAMHbHewaQIdr/y6ag2H3yh4rd9hTXavtWDzQBkvpe2RMqFg8BxDpcQWssmjmBApGPcw93QRz6YcMg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "frQDfv0rl209cKm1lnwTgFPzNigy2EKk1BS3uAvHvlBVKe5cymGyHO+Sj+NLv5VF/AhHsqPIUUwya5oV4CHMUw==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      }
+    },
+    "net8.0/linux-arm64": {},
+    "net8.0/linux-musl-x64": {},
+    "net8.0/linux-x64": {},
+    "net8.0/osx-arm64": {},
+    "net8.0/osx-x64": {},
+    "net8.0/win-arm64": {},
+    "net8.0/win-x64": {}
+  }
+}

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -818,6 +818,10 @@
         "providerRegistry": {
           "type": "boolean"
         },
+        "localDeploy": {
+          "type": "boolean",
+          "description": "Enabling this feature turns on support for local Bicep deployments. See https://aka.ms/bicep/experimental-features#localdeploy"
+        },
         "optionalModuleNames": {
           "type": "boolean",
           "description": "Enabling this feature makes the name property in the body of module declarations optional. See https://aka.ms/bicep/experimental-features#optionalmodulenames"


### PR DESCRIPTION
* Add wiring for "localDeploy" experimental feature. The feature doesn't do anything yet as of this PR.
* Add "Bicep.Local.Extension" nuget package to contain logic for C# extension authoring.
* Add "extension.proto" to defined the contract between client (Bicep) and extension in gRPC.
* Support unpacking of provider packages to the local file system to the ~/.bicep cache folder.

The full spec is available [here](https://microsoft.sharepoint.com/:w:/t/UniZomb/EVjskctj231Ipua9EVu5e4oBV83O8WsxNpD3InQZevLe2g?e=1CoJeV) - unfortunately only available to Microsoft employees currently.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14231)