### PR TITLE
Improve readability of CLI E2E test logging

### DIFF
--- a/src/Bicep.Cli.E2eTests/src/examples/101/aks.prod/main.json
+++ b/src/Bicep.Cli.E2eTests/src/examples/101/aks.prod/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.28.8.24706",
-      "templateHash": "13279681427225276221"
+      "version": "0.28.62.60134",
+      "templateHash": "13925749452283959897"
     }
   },
   "parameters": {

--- a/src/Bicep.Cli.E2eTests/src/utils/command.ts
+++ b/src/Bicep.Cli.E2eTests/src/utils/command.ts
@@ -6,6 +6,7 @@ import spawn from "cross-spawn";
 
 import { bicepCli } from "./fs";
 import { EnvironmentOverrides } from "./types";
+import { logStdErr } from "./log";
 
 class StdoutAssertionBuilder {
   constructor(private readonly stdout: string) {}
@@ -57,16 +58,13 @@ class BicepCommandTestRunner {
 
   shouldSucceed(): StdoutAssertionBuilder {
     const result = this.runCommand();
-
-    if (result.stderr.length > 0) {
-      console.error(result.stderr);
-    }
+    logStdErr(result.stderr);
 
     expect(result.status).toBe(0);
 
     return new StdoutAssertionBuilder(result.stdout);
   }
-
+  
   shouldFail(): StderrAssertionBuilder {
     const result = this.runCommand();
     expect(result.status).toBe(1);

--- a/src/Bicep.Cli.E2eTests/src/utils/jsonrpc.ts
+++ b/src/Bicep.Cli.E2eTests/src/utils/jsonrpc.ts
@@ -10,8 +10,9 @@ import {
   createClientPipeTransport,
 } from "vscode-jsonrpc/node";
 import { bicepCli } from "./fs";
+import { logStdErr } from "./log";
 
-interface VersionRequest {}
+interface VersionRequest { }
 
 interface VersionResponse {
   version: string;
@@ -174,7 +175,7 @@ export async function openConnection() {
 
   const child = spawn(bicepCli, ["jsonrpc", "--pipe", pipePath]);
   child.stdout.on("data", (x) => console.log(x.toString()));
-  child.stderr.on("data", (x) => console.error(x.toString()));
+  child.stderr.on("data", (x) => logStdErr(x.toString()));
 
   const [reader, writer] = await transport.onConnected();
   const connection = createMessageConnection(reader, writer, console);

--- a/src/Bicep.Cli.E2eTests/src/utils/log.ts
+++ b/src/Bicep.Cli.E2eTests/src/utils/log.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export function logStdErr(data: string): void {
+    for (const line of data.split("\n").filter((s: string) => !!s)) {
+        (line.toLowerCase().startsWith("warning") ? console.log : console.error)(line)
+    }
+}

--- a/src/Bicep.Cli.IntegrationTests/JsonRpcCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/JsonRpcCommandTests.cs
@@ -32,7 +32,7 @@ public class JsonRpcCommandTests : TestBase
             {
                 var result = await Bicep(registerAction, cts.Token, "jsonrpc", "--pipe", pipeName);
                 result.ExitCode.Should().Be(0);
-                result.Stderr.Should().EqualIgnoringNewlines("The 'jsonrpc' CLI command group is an experimental feature. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.\n");
+                result.Stderr.Should().EqualIgnoringNewlines("WARNING: The 'jsonrpc' CLI command group is an experimental feature. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.\n");
                 result.Stdout.Should().Be("");
             }),
             Task.Run(async () =>

--- a/src/Bicep.Cli.IntegrationTests/PublishProviderCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishProviderCommandTests.cs
@@ -45,7 +45,7 @@ public class PublishProviderCommandTests : TestBase
         result.Should().Succeed().And.NotHaveStdout();
 
         // this command should output an experimental warning
-        result.Stderr.Should().Match("The 'publish-provider' CLI command group is an experimental feature.*");
+        result.Stderr.Should().Match("WARNING: The 'publish-provider' CLI command group is an experimental feature.*");
 
         // verify the provider was published
         mockBlobClient.Should().HaveProvider(version, out var tgzStream);

--- a/src/Bicep.Cli/Commands/JsonRpcCommand.cs
+++ b/src/Bicep.Cli/Commands/JsonRpcCommand.cs
@@ -26,7 +26,7 @@ public class JsonRpcCommand : ICommand
 
     public async Task<int> RunAsync(JsonRpcArguments args, CancellationToken cancellationToken)
     {
-        await io.Error.WriteLineAsync("The 'jsonrpc' CLI command group is an experimental feature. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.");
+        await io.Error.WriteLineAsync("WARNING: The 'jsonrpc' CLI command group is an experimental feature. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.");
 
         if (args.Pipe is { } pipeName)
         {

--- a/src/Bicep.Cli/Commands/PublishProviderCommand.cs
+++ b/src/Bicep.Cli/Commands/PublishProviderCommand.cs
@@ -46,7 +46,7 @@ namespace Bicep.Cli.Commands
                 return new(architecture, BinaryData.FromStream(binaryStream));
             }
 
-            await ioContext.Error.WriteLineAsync("The 'publish-provider' CLI command group is an experimental feature. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.");
+            await ioContext.Error.WriteLineAsync("WARNING: The 'publish-provider' CLI command group is an experimental feature. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.");
 
             var indexPath = PathHelper.ResolvePath(args.IndexFile);
             var indexUri = PathHelper.FilePathToFileUrl(indexPath);


### PR DESCRIPTION
Even when passing these tests look like they're failing:

![image](https://github.com/Azure/bicep/assets/6913354/82b6017f-c7da-4de0-b5b0-6608db0fc35a)

Changed so that warnings (at least experimental feature warnings) go to console.log instead of console.error.