### PR TITLE
Use an identifier instead of a keyword for 'none'

### DIFF
--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -135,7 +135,6 @@ namespace Bicep.Core
             [TrueKeyword] = TokenType.TrueKeyword,
             [FalseKeyword] = TokenType.FalseKeyword,
             [NullKeyword] = TokenType.NullKeyword,
-            [NoneKeyword] = TokenType.NoneKeyword,
             [WithKeyword] = TokenType.WithKeyword,
             [AsKeyword] = TokenType.AsKeyword,
         }.ToImmutableDictionary();

--- a/src/Bicep.Core/Parsing/ParamsParser.cs
+++ b/src/Bicep.Core/Parsing/ParamsParser.cs
@@ -78,16 +78,7 @@ namespace Bicep.Core.Parsing
 
             SyntaxBase expression = reader.Peek().Type switch
             {
-                TokenType.NoneKeyword => WithRecovery(
-                    () => new NoneLiteralSyntax(
-                        Expect(
-                            TokenType.NoneKeyword,
-                            e => e.ExpectedKeyword(LanguageConstants.NoneKeyword)
-                        )
-                    ),
-                    GetSuppressionFlag(keyword),
-                    TokenType.NewLine
-                ),
+                TokenType.Identifier => new NoneLiteralSyntax(ExpectKeyword(LanguageConstants.NoneKeyword)),
                 TokenType.StringComplete => ThrowIfSkipped(this.InterpolableString, b => b.ExpectedFilePathString()),
                 _ => Skip(reader.Read(), b => b.ExpectedSymbolListOrWildcard()),
             };

--- a/src/Bicep.Core/Parsing/TokenType.cs
+++ b/src/Bicep.Core/Parsing/TokenType.cs
@@ -44,7 +44,6 @@ namespace Bicep.Core.Parsing
         TrueKeyword,
         FalseKeyword,
         NullKeyword,
-        NoneKeyword,
         NewLine,
         EndOfFile,
         DoubleQuestion,

--- a/src/Bicep.Core/Syntax/NoneLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/NoneLiteralSyntax.cs
@@ -8,7 +8,7 @@ namespace Bicep.Core.Syntax
     {
         public NoneLiteralSyntax(Token noneKeyword)
         {
-            AssertTokenType(noneKeyword, nameof(noneKeyword), TokenType.NoneKeyword);
+            AssertKeyword(noneKeyword, nameof(noneKeyword), LanguageConstants.NoneKeyword);
 
             this.NoneKeyword = noneKeyword;
         }

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -86,7 +86,6 @@ namespace Bicep.Core.Syntax
         public static Token TrueKeywordToken => CreateToken(TokenType.TrueKeyword);
         public static Token FalseKeywordToken => CreateToken(TokenType.FalseKeyword);
         public static Token NullKeywordToken => CreateToken(TokenType.NullKeyword);
-        public static Token NoneKeywordToken => CreateToken(TokenType.NoneKeyword);
         public static Token ArrowToken => CreateToken(TokenType.Arrow);
         public static Token EndOfFileToken => CreateToken(TokenType.EndOfFile);
         public static Token EllipsisToken => CreateToken(TokenType.Ellipsis);

--- a/src/Bicep.Core/Syntax/SyntaxFacts.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFacts.cs
@@ -56,7 +56,6 @@ namespace Bicep.Core.Syntax
             TokenType.TrueKeyword => "true",
             TokenType.FalseKeyword => "false",
             TokenType.NullKeyword => "null",
-            TokenType.NoneKeyword => "none",
             TokenType.EndOfFile => "",
             TokenType.DoubleQuestion => "??",
             TokenType.DoubleColon => "::",


### PR DESCRIPTION
Convert `none` from a dedicated token, to an identifier token, as per the other keywords we have implemented in the language.

The problem with parsing as a dedicated token is that it results in `none` being unusable elsewhere in Bicep (e.g. `var none = 'none'` would fail compilation).

(unrelated) I think this explains #13347!
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14358)