### PR TITLE
Convert `with` + `as` keywords into identifiers

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ProviderImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ProviderImportTests.cs
@@ -111,7 +111,7 @@ provider
             } something
             """);
             result.Should().HaveDiagnostics(new[] {
-                ("BCP012", DiagnosticLevel.Error, "Expected the \"as\" keyword at this location."),
+                ("BCP305", DiagnosticLevel.Error, """Expected the "with" keyword, "as" keyword, or a new line character at this location."""),
             });
         }
 

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.syntax.bicep
@@ -31,7 +31,7 @@ import * as mod2 from 'modules/mod2.bicep'
 //@[07:016) | ├─WildcardImportSyntax
 //@[07:008) | | ├─Token(Asterisk) |*|
 //@[09:016) | | └─AliasAsClauseSyntax
-//@[09:011) | |   ├─Token(AsKeyword) |as|
+//@[09:011) | |   ├─Token(Identifier) |as|
 //@[12:016) | |   └─IdentifierSyntax
 //@[12:016) | |     └─Token(Identifier) |mod2|
 //@[17:042) | └─CompileTimeImportFromClauseSyntax
@@ -50,7 +50,7 @@ import {
 //@[02:032) | | | ├─StringSyntax
 //@[02:032) | | | | └─Token(StringComplete) |'not-a-valid-bicep-identifier'|
 //@[33:057) | | | └─AliasAsClauseSyntax
-//@[33:035) | | |   ├─Token(AsKeyword) |as|
+//@[33:035) | | |   ├─Token(Identifier) |as|
 //@[36:057) | | |   └─IdentifierSyntax
 //@[36:057) | | |     └─Token(Identifier) |withInvalidIdentifier|
 //@[57:058) | | ├─Token(NewLine) |\n|

--- a/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Imports_LF/main.tokens.bicep
@@ -15,7 +15,7 @@ import {foo, fizz, pop, greet} from 'modules/mod.bicep'
 import * as mod2 from 'modules/mod2.bicep'
 //@[00:06) Identifier |import|
 //@[07:08) Asterisk |*|
-//@[09:11) AsKeyword |as|
+//@[09:11) Identifier |as|
 //@[12:16) Identifier |mod2|
 //@[17:21) Identifier |from|
 //@[22:42) StringComplete |'modules/mod2.bicep'|
@@ -26,7 +26,7 @@ import {
 //@[08:09) NewLine |\n|
   'not-a-valid-bicep-identifier' as withInvalidIdentifier
 //@[02:32) StringComplete |'not-a-valid-bicep-identifier'|
-//@[33:35) AsKeyword |as|
+//@[33:35) Identifier |as|
 //@[36:57) Identifier |withInvalidIdentifier|
 //@[57:58) NewLine |\n|
   refersToCopyVariable

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Imports/parameters.syntax.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Imports/parameters.syntax.bicepparam
@@ -11,7 +11,7 @@ import * as bicepconfig from 'bicepconfig.bicep'
 //@[007:023) | ├─WildcardImportSyntax
 //@[007:008) | | ├─Token(Asterisk) |*|
 //@[009:023) | | └─AliasAsClauseSyntax
-//@[009:011) | |   ├─Token(AsKeyword) |as|
+//@[009:011) | |   ├─Token(Identifier) |as|
 //@[012:023) | |   └─IdentifierSyntax
 //@[012:023) | |     └─Token(Identifier) |bicepconfig|
 //@[024:048) | └─CompileTimeImportFromClauseSyntax

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Imports/parameters.tokens.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Imports/parameters.tokens.bicepparam
@@ -5,7 +5,7 @@ using 'main.bicep'
 import * as bicepconfig from 'bicepconfig.bicep'
 //@[000:006) Identifier |import|
 //@[007:008) Asterisk |*|
-//@[009:011) AsKeyword |as|
+//@[009:011) Identifier |as|
 //@[012:023) Identifier |bicepconfig|
 //@[024:028) Identifier |from|
 //@[029:048) StringComplete |'bicepconfig.bicep'|

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Imports/parameters.syntax.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Imports/parameters.syntax.bicepparam
@@ -12,7 +12,7 @@ import * as foo from 'foo.bicep'
 //@[07:15) | ├─WildcardImportSyntax
 //@[07:08) | | ├─Token(Asterisk) |*|
 //@[09:15) | | └─AliasAsClauseSyntax
-//@[09:11) | |   ├─Token(AsKeyword) |as|
+//@[09:11) | |   ├─Token(Identifier) |as|
 //@[12:15) | |   └─IdentifierSyntax
 //@[12:15) | |     └─Token(Identifier) |foo|
 //@[16:32) | └─CompileTimeImportFromClauseSyntax

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Imports/parameters.tokens.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Imports/parameters.tokens.bicepparam
@@ -6,7 +6,7 @@ using 'main.bicep'
 import * as foo from 'foo.bicep'
 //@[00:06) Identifier |import|
 //@[07:08) Asterisk |*|
-//@[09:11) AsKeyword |as|
+//@[09:11) Identifier |as|
 //@[12:15) Identifier |foo|
 //@[16:20) Identifier |from|
 //@[21:32) StringComplete |'foo.bicep'|

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/PreferUnquotedPropertyNamesRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/PreferUnquotedPropertyNamesRuleTests.cs
@@ -7,144 +7,165 @@ using Bicep.Core.UnitTests.Assertions;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests;
+
+[TestClass]
+public class PreferUnquotedPropertyNamesRuleTests : LinterRuleTestsBase
 {
-    [TestClass]
-    public class PreferUnquotedPropertyNamesRuleTests : LinterRuleTestsBase
+    private void AssertNoDiagnostics(string inputFile)
+        => AssertLinterRuleDiagnostics(PreferUnquotedPropertyNamesRule.Code, inputFile, [], new(OnCompileErrors.Ignore, IncludePosition.None));
+
+    private void ExpectPass(string text)
     {
-        private void ExpectPass(string text)
-        {
-            AssertLinterRuleDiagnostics(PreferUnquotedPropertyNamesRule.Code, text, []);
-        }
-
-        private void ExpectDiagnosticWithFix(string text, string expectedFix)
-        {
-            AssertLinterRuleDiagnostics(PreferUnquotedPropertyNamesRule.Code, text, diags =>
-            {
-                diags.Should().HaveCount(1, $"expected one fix per testcase");
-
-                diags.First().As<IBicepAnalyerFixableDiagnostic>().Fixes.Should().HaveCount(1);
-                diags.First().As<IBicepAnalyerFixableDiagnostic>().Fixes.First().Replacements.Should().HaveCount(1);
-                diags.First().As<IBicepAnalyerFixableDiagnostic>().Fixes.First().Replacements.First().Text.Should().Be(expectedFix);
-            });
-        }
-
-        [DataRow(
-            @"
-                var v1 = {
-                    'myProp': {}
-                }",
-            "myProp"
-        )]
-        [DataRow(
-            @"
-                var v1 = {
-                    'my_property': {}
-                }",
-            "my_property"
-        )]
-        [DataRow(
-            @"
-                var v1 = {
-                    'myProp1': {}
-                }",
-            "myProp1"
-        )]
-        [DataTestMethod]
-        public void ObjectPropertyDeclaration(string text, string expectedFix)
-        {
-            ExpectDiagnosticWithFix(text, expectedFix);
-        }
-
-        [DataRow(
-            @"
-                var v1 = {
-                    '1': {}
-                }"
-        )]
-        [DataRow(
-            @"
-                var v1 = {
-                    'my-property': {}
-                }"
-        )]
-        [DataTestMethod]
-        public void ObjectPropertyDeclaration_NotValidIdentifier(string text)
-        {
-            ExpectPass(text);
-        }
-
-        [DataRow(
-            @"
-                var v1 = {
-                    v1: {}
-                }"
-        )]
-        [DataRow(
-            @"
-                var v1 = {
-                    myProperty: {}
-                }"
-        )]
-        [DataTestMethod]
-        public void ObjectPropertyDeclaration_AlreadyBare(string text)
-        {
-            ExpectPass(text);
-        }
-
-        [DataRow(
-            @"
-                param AnObject object
-                var v1 = AnObject['myProp']",
-            ".myProp"
-        )]
-        [DataRow(
-            @"
-                param AnObject object
-                var v1 = AnObject['my_property']",
-            ".my_property"
-        )]
-        [DataRow(
-            @"
-                param AnObject object
-                var v1 = AnObject['myProp1']",
-            ".myProp1"
-        )]
-        [DataTestMethod]
-        public void ObjectPropertyDereference(string text, string expectedFix)
-        {
-            ExpectDiagnosticWithFix(text, expectedFix);
-        }
-
-        [DataRow(
-            @"
-                param AnObject object
-                var v1 = AnObject['1']"
-        )]
-        [DataRow(
-            @"
-                param AnObject object
-                var v1 = AnObject['my-property']"
-        )]
-        [DataTestMethod]
-        public void ObjectPropertyDereference_NotValidIdentifier(string text)
-        {
-            ExpectPass(text);
-        }
-
-        [DataRow(
-            @"
-                param AutomationAccountName string
-                param AutomationAccountLocation string
-                resource AutomationAccount 'Microsoft.Automation/automationAccounts@2020-01-13-preview' = {
-                    name: AutomationAccountName
-                    location: AutomationAccountLocation
-                }"
-        )]
-        [DataTestMethod]
-        public void NoPropertyDeclarationOrDereference_Passes(string text)
-        {
-            ExpectPass(text);
-        }
+        AssertLinterRuleDiagnostics(PreferUnquotedPropertyNamesRule.Code, text, []);
     }
+
+    private void ExpectDiagnosticWithFix(string text, string expectedFix)
+    {
+        AssertLinterRuleDiagnostics(PreferUnquotedPropertyNamesRule.Code, text, diags =>
+        {
+            diags.Should().HaveCount(1, $"expected one fix per testcase");
+
+            diags.First().As<IBicepAnalyerFixableDiagnostic>().Fixes.Should().HaveCount(1);
+            diags.First().As<IBicepAnalyerFixableDiagnostic>().Fixes.First().Replacements.Should().HaveCount(1);
+            diags.First().As<IBicepAnalyerFixableDiagnostic>().Fixes.First().Replacements.First().Text.Should().Be(expectedFix);
+        });
+    }
+
+    [DataRow(
+        @"
+            var v1 = {
+                'myProp': {}
+            }",
+        "myProp"
+    )]
+    [DataRow(
+        @"
+            var v1 = {
+                'my_property': {}
+            }",
+        "my_property"
+    )]
+    [DataRow(
+        @"
+            var v1 = {
+                'myProp1': {}
+            }",
+        "myProp1"
+    )]
+    [DataTestMethod]
+    public void ObjectPropertyDeclaration(string text, string expectedFix)
+    {
+        ExpectDiagnosticWithFix(text, expectedFix);
+    }
+
+    [DataRow(
+        @"
+            var v1 = {
+                '1': {}
+            }"
+    )]
+    [DataRow(
+        @"
+            var v1 = {
+                'my-property': {}
+            }"
+    )]
+    [DataTestMethod]
+    public void ObjectPropertyDeclaration_NotValidIdentifier(string text)
+    {
+        ExpectPass(text);
+    }
+
+    [DataRow(
+        @"
+            var v1 = {
+                v1: {}
+            }"
+    )]
+    [DataRow(
+        @"
+            var v1 = {
+                myProperty: {}
+            }"
+    )]
+    [DataTestMethod]
+    public void ObjectPropertyDeclaration_AlreadyBare(string text)
+    {
+        ExpectPass(text);
+    }
+
+    [DataRow(
+        @"
+            param AnObject object
+            var v1 = AnObject['myProp']",
+        ".myProp"
+    )]
+    [DataRow(
+        @"
+            param AnObject object
+            var v1 = AnObject['my_property']",
+        ".my_property"
+    )]
+    [DataRow(
+        @"
+            param AnObject object
+            var v1 = AnObject['myProp1']",
+        ".myProp1"
+    )]
+    [DataTestMethod]
+    public void ObjectPropertyDereference(string text, string expectedFix)
+    {
+        ExpectDiagnosticWithFix(text, expectedFix);
+    }
+
+    [DataRow(
+        @"
+            param AnObject object
+            var v1 = AnObject['1']"
+    )]
+    [DataRow(
+        @"
+            param AnObject object
+            var v1 = AnObject['my-property']"
+    )]
+    [DataTestMethod]
+    public void ObjectPropertyDereference_NotValidIdentifier(string text)
+    {
+        ExpectPass(text);
+    }
+
+    [DataRow(
+        @"
+            param AutomationAccountName string
+            param AutomationAccountLocation string
+            resource AutomationAccount 'Microsoft.Automation/automationAccounts@2020-01-13-preview' = {
+                name: AutomationAccountName
+                location: AutomationAccountLocation
+            }"
+    )]
+    [DataTestMethod]
+    public void NoPropertyDeclarationOrDereference_Passes(string text)
+    {
+        ExpectPass(text);
+    }
+
+    [TestMethod]
+    public void Rule_ignores_non_contextual_keywords_in_object_keys() => AssertNoDiagnostics("""
+var test = {
+  'null': 'asdf'
+  'true': 'asdf'
+  'false': 'asdf'
+}
+""");
+
+    [TestMethod]
+    public void Rule_ignores_non_contextual_keywords_in_object_property_access() => AssertNoDiagnostics("""
+param test object
+var foo = [
+  test['null']
+  test['true']
+  test['false']
+]
+""");
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/PreferUnquotedPropertyNamesRule.cs
@@ -70,10 +70,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             private static bool TryGetValidIdentifierToken(SyntaxBase syntax, [NotNullWhen(true)] out string? validToken)
             {
-                if (syntax is StringSyntax @string)
+                if (syntax is StringSyntax stringSyntax &&
+                    stringSyntax.TryGetLiteralValue() is {} literalValue)
                 {
-                    string? literalValue = @string.TryGetLiteralValue();
-                    if (literalValue is not null && Lexer.IsValidIdentifier(literalValue))
+                    if (Lexer.IsValidIdentifier(literalValue) &&
+                        // exclude non-contextual keywords like 'nul and 'true' - see https://github.com/Azure/bicep/issues/13347.
+                        !LanguageConstants.NonContextualKeywords.ContainsKey(literalValue))
                     {
                         validToken = literalValue;
                         return true;

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -117,7 +117,9 @@ namespace Bicep.Core
             .Add(IfKeyword)
             .Add(ForKeyword)
             .Add(InKeyword)
-            .Add(FromKeyword);
+            .Add(FromKeyword)
+            .Add(WithKeyword)
+            .Add(AsKeyword);
 
         public const string TrueKeyword = "true";
         public const string FalseKeyword = "false";
@@ -128,7 +130,7 @@ namespace Bicep.Core
 
         public const string McrRepositoryPrefix = "bicep/";
 
-        public static readonly ImmutableDictionary<string, TokenType> Keywords = new Dictionary<string, TokenType>(StringComparer.Ordinal)
+        public static readonly ImmutableDictionary<string, TokenType> NonContextualKeywords = new Dictionary<string, TokenType>(StringComparer.Ordinal)
         {
             [TrueKeyword] = TokenType.TrueKeyword,
             [FalseKeyword] = TokenType.FalseKeyword,

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -133,8 +133,6 @@ namespace Bicep.Core
             [TrueKeyword] = TokenType.TrueKeyword,
             [FalseKeyword] = TokenType.FalseKeyword,
             [NullKeyword] = TokenType.NullKeyword,
-            [WithKeyword] = TokenType.WithKeyword,
-            [AsKeyword] = TokenType.AsKeyword,
         }.ToImmutableDictionary();
 
         // Decorators

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -304,10 +304,11 @@ namespace Bicep.Core.Parsing
             throw new ExpectedTokenException(this.reader.Peek(), errorFunc);
         }
 
-        protected Token ExpectKeyword(string expectedKeyword)
+        protected Token ExpectKeyword(string expectedKeyword, DiagnosticBuilder.ErrorBuilderDelegate? errorFunc = null)
         {
+            errorFunc ??= b => b.ExpectedKeyword(expectedKeyword);
             return GetOptionalKeyword(expectedKeyword) ??
-                throw new ExpectedTokenException(this.reader.Peek(), b => b.ExpectedKeyword(expectedKeyword));
+                throw new ExpectedTokenException(this.reader.Peek(), errorFunc);
         }
 
         private SyntaxBase ForBody(ExpressionFlags expressionFlags, bool isResourceOrModuleContext)
@@ -1712,13 +1713,13 @@ namespace Bicep.Core.Parsing
             return new ImportedSymbolsListItemSyntax(originalSymbolName, aliasAsClause);
         }
 
-        private AliasAsClauseSyntax? ImportedSymbolsListItemAsClause() => Check(reader.Peek(), TokenType.AsKeyword)
-            ? new(Expect(TokenType.AsKeyword, b => b.ExpectedKeyword(LanguageConstants.AsKeyword)),
+        private AliasAsClauseSyntax? ImportedSymbolsListItemAsClause() => CheckKeyword(reader.Peek(), LanguageConstants.AsKeyword)
+            ? new(ExpectKeyword(LanguageConstants.AsKeyword),
                 IdentifierWithRecovery(b => b.ExpectedTypeIdentifier(), RecoveryFlags.None, TokenType.Comma, TokenType.NewLine))
             : null;
 
         private WildcardImportSyntax WildcardImport() => new(Expect(TokenType.Asterisk, b => b.ExpectedCharacter("*")),
-            new AliasAsClauseSyntax(Expect(TokenType.AsKeyword, b => b.ExpectedKeyword(LanguageConstants.AsKeyword)),
+            new AliasAsClauseSyntax(ExpectKeyword(LanguageConstants.AsKeyword),
                 Identifier(b => b.ExpectedNamespaceIdentifier())));
 
         private CompileTimeImportFromClauseSyntax CompileTimeImportFromClause()

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -820,7 +820,7 @@ namespace Bicep.Core.Parsing
         {
             var identifier = textWindow.GetText().ToString();
 
-            if (LanguageConstants.Keywords.TryGetValue(identifier, out var tokenType))
+            if (LanguageConstants.NonContextualKeywords.TryGetValue(identifier, out var tokenType))
             {
                 return tokenType;
             }

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -292,16 +292,18 @@ namespace Bicep.Core.Parsing
                     TokenType.NewLine)
             };
 
-            var withClause = this.reader.Peek().Type switch
+            var current = this.reader.Peek();
+            var withClause = current.Type switch
             {
                 TokenType.EndOfFile or
-                TokenType.NewLine or
-                TokenType.AsKeyword => this.SkipEmpty(),
+                TokenType.NewLine or 
+                TokenType.Identifier when current.Text == LanguageConstants.IfKeyword => this.SkipEmpty(),
 
                 _ => this.WithRecovery(() => this.ProviderWithClause(), GetSuppressionFlag(providerSpecificationSyntax), TokenType.NewLine),
             };
 
-            var asClause = this.reader.Peek().Type switch
+            current = this.reader.Peek();
+            var asClause = current.Type switch
             {
                 TokenType.EndOfFile or
                 TokenType.NewLine => this.SkipEmpty(),
@@ -314,15 +316,15 @@ namespace Bicep.Core.Parsing
 
         private ProviderWithClauseSyntax ProviderWithClause()
         {
-            var keyword = this.Expect(TokenType.WithKeyword, b => b.ExpectedWithOrAsKeywordOrNewLine());
-            var config = this.WithRecovery(() => this.Object(ExpressionFlags.AllowComplexLiterals), RecoveryFlags.None, TokenType.AsKeyword, TokenType.NewLine);
+            var keyword = this.ExpectKeyword(LanguageConstants.WithKeyword, b => b.ExpectedWithOrAsKeywordOrNewLine());
+            var config = this.WithRecovery(() => this.Object(ExpressionFlags.AllowComplexLiterals), RecoveryFlags.None, TokenType.NewLine);
 
             return new(keyword, config);
         }
 
         private AliasAsClauseSyntax ProviderAsClause()
         {
-            var keyword = this.Expect(TokenType.AsKeyword, b => b.ExpectedKeyword(LanguageConstants.AsKeyword));
+            var keyword = this.ExpectKeyword(LanguageConstants.AsKeyword, b => b.ExpectedWithOrAsKeywordOrNewLine());
             var modifier = this.IdentifierWithRecovery(b => b.ExpectedProviderAliasName(), RecoveryFlags.None, TokenType.NewLine);
 
             return new(keyword, modifier);

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -296,8 +296,8 @@ namespace Bicep.Core.Parsing
             var withClause = current.Type switch
             {
                 TokenType.EndOfFile or
-                TokenType.NewLine or 
-                TokenType.Identifier when current.Text == LanguageConstants.IfKeyword => this.SkipEmpty(),
+                TokenType.NewLine => this.SkipEmpty(),
+                TokenType.Identifier when current.Text == LanguageConstants.AsKeyword => this.SkipEmpty(),
 
                 _ => this.WithRecovery(() => this.ProviderWithClause(), GetSuppressionFlag(providerSpecificationSyntax), TokenType.NewLine),
             };

--- a/src/Bicep.Core/Parsing/TokenType.cs
+++ b/src/Bicep.Core/Parsing/TokenType.cs
@@ -50,8 +50,6 @@ namespace Bicep.Core.Parsing
         DoubleColon,
         Arrow,
         Pipe,
-        WithKeyword,
-        AsKeyword,
         Ellipsis,
     }
 }

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -26,7 +26,7 @@ namespace Bicep.Core.PrettyPrint
 
         private static readonly ImmutableDictionary<string, TextDocument> CommonTextCache =
             LanguageConstants.ContextualKeywords
-            .Concat(LanguageConstants.Keywords.Keys)
+            .Concat(LanguageConstants.NonContextualKeywords.Keys)
             .Concat(["(", ")", "[", "]", "{", "}", "=", ":", "+", "-", "*", "/", "!"])
             .Concat(["name", "properties", "string", "bool", "int", "array", "object"])
             .ToImmutableDictionary(value => value, value => new TextDocument(value));

--- a/src/Bicep.Core/Syntax/AliasAsClauseSyntax.cs
+++ b/src/Bicep.Core/Syntax/AliasAsClauseSyntax.cs
@@ -9,7 +9,7 @@ public class AliasAsClauseSyntax : SyntaxBase
 {
     public AliasAsClauseSyntax(Token keyword, IdentifierSyntax alias)
     {
-        AssertTokenType(keyword, nameof(keyword), TokenType.AsKeyword);
+        AssertKeyword(keyword, nameof(keyword), LanguageConstants.AsKeyword);
         AssertSyntaxType(alias, nameof(alias), typeof(IdentifierSyntax), typeof(SkippedTriviaSyntax));
 
         this.Keyword = keyword;

--- a/src/Bicep.Core/Syntax/ProviderWithClauseSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProviderWithClauseSyntax.cs
@@ -9,7 +9,7 @@ namespace Bicep.Core.Syntax
     {
         public ProviderWithClauseSyntax(Token keyword, SyntaxBase config)
         {
-            AssertTokenType(keyword, nameof(keyword), TokenType.WithKeyword);
+            AssertKeyword(keyword, nameof(keyword), LanguageConstants.WithKeyword);
             AssertSyntaxType(config, nameof(config), typeof(ObjectSyntax), typeof(SkippedTriviaSyntax));
 
             this.Keyword = keyword;

--- a/src/Bicep.Core/Syntax/SyntaxFacts.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFacts.cs
@@ -61,8 +61,6 @@ namespace Bicep.Core.Syntax
             TokenType.DoubleColon => "::",
             TokenType.Arrow => "=>",
             TokenType.Pipe => "|",
-            TokenType.WithKeyword => "with",
-            TokenType.AsKeyword => "as",
             TokenType.Ellipsis => "...",
             _ => null,
         };

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -49,7 +49,7 @@ namespace Bicep.LanguageServer.Completions
             TokenType.Identifier,
             TokenType.Integer,
             TokenType.StringComplete,
-            .. LanguageConstants.Keywords.Values,
+            .. LanguageConstants.NonContextualKeywords.Values,
         ];
 
         private BicepCompletionContext(

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -2174,7 +2174,7 @@ namespace Bicep.LanguageServer.Completions
             };
 
         private static bool IsPropertyNameEscapingRequired(TypeProperty property) =>
-            !Lexer.IsValidIdentifier(property.Name) || LanguageConstants.Keywords.ContainsKey(property.Name);
+            !Lexer.IsValidIdentifier(property.Name) || LanguageConstants.NonContextualKeywords.ContainsKey(property.Name);
 
         private static string FormatPropertyDetail(TypeProperty property) =>
             TypeHelper.IsRequired(property)

--- a/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/ImportKubernetesManifestHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Text;
+using Bicep.Core;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.FileSystem;
@@ -64,7 +65,7 @@ namespace Bicep.LanguageServer.Handlers
                     SyntaxFactory.ProviderKeywordToken,
                     SyntaxFactory.CreateIdentifierWithTrailingSpace(K8sNamespaceType.BuiltInName),
                     new ProviderWithClauseSyntax(
-                        SyntaxFactory.CreateToken(TokenType.WithKeyword),
+                        SyntaxFactory.CreateIdentifierToken(LanguageConstants.WithKeyword),
                         SyntaxFactory.CreateObject(
                         [
                             SyntaxFactory.CreateObjectProperty("namespace", SyntaxFactory.CreateStringLiteral("default")),


### PR DESCRIPTION
Noticed when helping @polatengin on modular params that we have also implemented `with` and `as` as dedicated tokens, rather than identifiers.

This means that the following cannot be parsed as legitimate Bicep code:
```bicep
var with = 'with'
```

Also closes #13347

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14360)