### PR TITLE
Fixed UDT syntax highlighting

### DIFF
--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -73,6 +73,12 @@ namespace Bicep.LanguageServer
             base.VisitBooleanLiteralSyntax(syntax);
         }
 
+        public override void VisitBooleanTypeLiteralSyntax(BooleanTypeLiteralSyntax syntax)
+        {
+            AddTokenType(syntax.Literal, SemanticTokenType.Keyword);
+            base.VisitBooleanTypeLiteralSyntax(syntax);
+        }
+
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             // We need to set token types for OpenParen and CloseParen in case the function call
@@ -97,6 +103,12 @@ namespace Bicep.LanguageServer
         {
             AddTokenType(syntax.NullKeyword, SemanticTokenType.Keyword);
             base.VisitNullLiteralSyntax(syntax);
+        }
+
+        public override void VisitNullTypeLiteralSyntax(NullTypeLiteralSyntax syntax)
+        {
+            AddTokenType(syntax.NullKeyword, SemanticTokenType.Keyword);
+            base.VisitNullTypeLiteralSyntax(syntax);
         }
 
         public override void VisitIntegerLiteralSyntax(IntegerLiteralSyntax syntax)
@@ -349,7 +361,7 @@ namespace Bicep.LanguageServer
         public override void VisitAliasAsClauseSyntax(AliasAsClauseSyntax syntax)
         {
             AddTokenType(syntax.Keyword, SemanticTokenType.Keyword);
-            AddTokenType(syntax.Alias, SemanticTokenType.Variable);
+            AddTokenType(syntax.Alias, SemanticTokenType.Namespace);
         }
 
         public override void VisitCompileTimeImportDeclarationSyntax(CompileTimeImportDeclarationSyntax syntax)


### PR DESCRIPTION
Fixed the recent regression in syntax highlighting for user defined types:
* Now emitting `SemanticTokenType.Namespace` for namespace symbols.
* Now emitting `SemanticTokenType.Type` for `TypeVariableAccessSyntax` that resolves to a valid type symbol.
* Now emitting `SemanticTokenType.Keyword` for `null`, `true` and `false` type keywords.

Examples of changes:
<img width="458" alt="image" src="https://github.com/Azure/bicep/assets/22460039/42e65336-4885-43d6-8308-ea06b762d789">

I will look into adding tests separately since we don't currently have baselines or meaningful unit tests for syntax highlighting. (I recall we had some issues with that in the past, but will need to confirm.)

This fixes #14147
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14372)