### PR TITLE
Replace the `provider` keyword with the `extension` keyword

### DIFF
--- a/src/Bicep.Cli.E2eTests/src/examples/local-deploy/main.bicep
+++ b/src/Bicep.Cli.E2eTests/src/examples/local-deploy/main.bicep
@@ -1,4 +1,4 @@
-provider '../../temp/local-deploy/provider.tgz'
+extension '../../temp/local-deploy/provider.tgz'
 
 param payload string
 

--- a/src/Bicep.Cli.E2eTests/src/examples/providers.ff/main.bicep
+++ b/src/Bicep.Cli.E2eTests/src/examples/providers.ff/main.bicep
@@ -1,4 +1,4 @@
-provider '$TARGET_REFERENCE'
+extension '$TARGET_REFERENCE'
 
 resource dadJoke 'request@v1' = {
   uri: 'https://icanhazdadjoke.com'

--- a/src/Bicep.Cli.E2eTests/src/examples/providers.prod/main.bicep
+++ b/src/Bicep.Cli.E2eTests/src/examples/providers.prod/main.bicep
@@ -1,4 +1,4 @@
-provider '$TARGET_REFERENCE'
+extension '$TARGET_REFERENCE'
 
 resource dadJoke 'request@v1' = {
   uri: 'https://icanhazdadjoke.com'

--- a/src/Bicep.Cli.IntegrationTests/PublishProviderCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishProviderCommandTests.cs
@@ -103,7 +103,7 @@ public class PublishProviderCommandTests : TestBase
 
         var services = new ServiceBuilder().WithFileSystem(fs).WithFeatureOverrides(new(ExtensibilityEnabled: true, ProviderRegistry: true));
         var compileResult = await CompilationHelper.RestoreAndCompile(services, """
-provider '../../target/provider.tgz'
+extension '../../target/provider.tgz'
 
 resource fooRes 'fooType@v1' = {
   identifier: 'foo'

--- a/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
@@ -23,7 +23,7 @@ namespace Bicep.Core.IntegrationTests
         public void ProvidersConfig_SupportForConfigManagedProviderDeclarationSyntax_When_ProviderIsBuiltIn(string providerIdentifier, bool shouldSucceed, (string code, DiagnosticLevel level, string message)[] expectedDiagnostics)
         {
             var result = CompilationHelper.Compile(Services, @$"
-                provider {providerIdentifier}
+                extension {providerIdentifier}
             ");
 
             if (shouldSucceed)
@@ -55,7 +55,7 @@ namespace Bicep.Core.IntegrationTests
                     "kubernetes",
                     false,
                     new (string, DiagnosticLevel, string)[] {
-                     ("BCP206", DiagnosticLevel.Error, "Provider namespace \"kubernetes\" requires configuration, but none was provided.") } };
+                     ("BCP206", DiagnosticLevel.Error, "Extension \"kubernetes\" requires configuration, but none was provided.") } };
             }
         }
     }

--- a/src/Bicep.Core.IntegrationTests/DynamicAzTypesTests.cs
+++ b/src/Bicep.Core.IntegrationTests/DynamicAzTypesTests.cs
@@ -64,7 +64,7 @@ namespace Bicep.Core.IntegrationTests
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, ("main.bicep", @$"
-            provider 'br/public:az:{BicepTestConstants.BuiltinAzProviderVersion}'
+            extension 'br/public:az:{BicepTestConstants.BuiltinAzProviderVersion}'
             "));
 
             result.Should().GenerateATemplate();
@@ -76,12 +76,12 @@ namespace Bicep.Core.IntegrationTests
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, @$"
-            provider 'br/public:az:{BicepTestConstants.BuiltinAzProviderVersion}' with {{}}
+            extension 'br/public:az:{BicepTestConstants.BuiltinAzProviderVersion}' with {{}}
             ");
 
             result.Should().NotGenerateATemplate();
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
-                ("BCP205", DiagnosticLevel.Error, "Provider namespace \"az\" does not support configuration."),
+                ("BCP205", DiagnosticLevel.Error, "Extension \"az\" does not support configuration."),
             });
         }
 
@@ -90,7 +90,7 @@ namespace Bicep.Core.IntegrationTests
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, @$"
-            provider 'br/public:az:{BicepTestConstants.BuiltinAzProviderVersion}' as testAlias
+            extension 'br/public:az:{BicepTestConstants.BuiltinAzProviderVersion}' as testAlias
             ");
 
             result.Should().GenerateATemplate();
@@ -114,7 +114,7 @@ namespace Bicep.Core.IntegrationTests
             """));
 
             var result = await CompilationHelper.RestoreAndCompile(services, @$"
-            provider 'br/customAlias:az:{BicepTestConstants.BuiltinAzProviderVersion}'
+            extension 'br/customAlias:az:{BicepTestConstants.BuiltinAzProviderVersion}'
             ");
 
             result.Should().GenerateATemplate();
@@ -128,7 +128,7 @@ namespace Bicep.Core.IntegrationTests
                .WithFeatureOverrides(new(ExtensibilityEnabled: true, DynamicTypeLoadingEnabled: true));
 
             var result = await CompilationHelper.RestoreAndCompile(services, @"
-            provider 'br/notFound:az:0.2.661'
+            extension 'br/notFound:az:0.2.661'
             ");
 
             result.Should().NotGenerateATemplate();
@@ -160,7 +160,7 @@ namespace Bicep.Core.IntegrationTests
 
             // ACT
             var result = await CompilationHelper.RestoreAndCompile(services, @$"
-            provider '{testArtifact.ToSpecificationString(':')}'
+            extension '{testArtifact.ToSpecificationString(':')}'
             ");
 
             // ASSERT
@@ -184,7 +184,7 @@ namespace Bicep.Core.IntegrationTests
 
             // ACT
             var result = await CompilationHelper.RestoreAndCompile(services, @$"
-            provider '{testArtifactAddress.ToSpecificationString(':')}'
+            extension '{testArtifactAddress.ToSpecificationString(':')}'
             ");
 
             // ASSERT
@@ -226,7 +226,7 @@ namespace Bicep.Core.IntegrationTests
 
             // ACT
             var result = await CompilationHelper.RestoreAndCompile(services, @$"
-            provider '{artifactRegistryAddress.ToSpecificationString(':')}'
+            extension '{artifactRegistryAddress.ToSpecificationString(':')}'
             ");
 
             // ASSERT
@@ -315,7 +315,7 @@ namespace Bicep.Core.IntegrationTests
             }
             """));
             var result = await CompilationHelper.RestoreAndCompile(services, ("main.bicep", @$"
-            provider az
+            extension az
             "));
 
             result.Should().GenerateATemplate();
@@ -333,7 +333,7 @@ namespace Bicep.Core.IntegrationTests
             //   "implicitProviders": ["az"]
             // }
             var result = await CompilationHelper.RestoreAndCompile(services, ("main.bicep", @$"
-            provider az
+            extension az
             "));
 
             result.Should().GenerateATemplate();
@@ -357,7 +357,7 @@ namespace Bicep.Core.IntegrationTests
             """));
             //ACT
             var result = await CompilationHelper.RestoreAndCompile(services, ("main.bicep", @$"
-            provider az
+            extension az
             "));
             //ASSERT
             result.Should().GenerateATemplate();

--- a/src/Bicep.Core.IntegrationTests/Extensibility/RadiusCompatibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Extensibility/RadiusCompatibilityTests.cs
@@ -43,7 +43,7 @@ public class RadiusCompatibilityTests
         var services = await GetServicesWithPrepublishedTypes();
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/test/radius:1.0.0'
+extension 'br:example.azurecr.io/test/radius:1.0.0'
 
 @description('The base name of the test, used to qualify resources and namespaces')
 param basename string
@@ -81,7 +81,7 @@ resource extender 'Applications.Core/extenders@2023-10-01-preview' = {
         var services = await GetServicesWithPrepublishedTypes();
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/test/radius:1.0.0'
+extension 'br:example.azurecr.io/test/radius:1.0.0'
 
 param bucketName string
 

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -34,7 +34,7 @@ namespace Bicep.Core.IntegrationTests
         public void Bar_import_bad_config_is_blocked()
         {
             var result = CompilationHelper.Compile(Services, @"
-provider bar with {
+extension bar with {
   madeUpProperty: 'asdf'
 } as stg
 ");
@@ -48,11 +48,11 @@ provider bar with {
         public void Bar_import_can_be_duplicated()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider bar with {
+            extension bar with {
                 connectionString: 'connectionString1'
             } as stg
 
-            provider bar with {
+            extension bar with {
                 connectionString: 'connectionString2'
             } as stg2
             """);
@@ -63,7 +63,7 @@ provider bar with {
         public void Bar_import_basic_test()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider bar with {
+            extension bar with {
                connectionString: 'asdf'
             } as stg
 
@@ -84,11 +84,11 @@ provider bar with {
         public void Ambiguous_type_references_return_errors()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider bar with {
+            extension bar with {
             connectionString: 'asdf'
             } as stg
 
-            provider bar with {
+            extension bar with {
             connectionString: 'asdf'
             } as stg2
 
@@ -101,11 +101,11 @@ provider bar with {
             });
 
             result = CompilationHelper.Compile(Services, """
-            provider bar with {
+            extension bar with {
             connectionString: 'asdf'
             } as stg
 
-            provider bar with {
+            extension bar with {
             connectionString: 'asdf'
             } as stg2
 
@@ -120,7 +120,7 @@ provider bar with {
         public void Bar_import_basic_test_loops_and_referencing()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider bar with {
+            extension bar with {
                 connectionString: 'asdf'
             } as stg
 
@@ -160,7 +160,7 @@ provider bar with {
         public void Foo_import_basic_test_loops_and_referencing()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider foo as foo
+            extension foo as foo
             param numApps int
 
             resource myApp 'application' = {
@@ -190,7 +190,7 @@ provider bar with {
         {
             // we've accidentally used 'name' even though this resource type doesn't support it
             var result = CompilationHelper.Compile(Services, """
-            provider foo
+            extension foo
 
             resource myApp 'application' existing = {
             name: 'foo'
@@ -206,7 +206,7 @@ provider bar with {
 
             // oops! let's change it to 'uniqueName'
             result = CompilationHelper.Compile(Services, """
-            provider foo as foo
+            extension foo as foo
 
             resource myApp 'application' existing = {
                 uniqueName: 'foo'
@@ -223,7 +223,7 @@ provider bar with {
         public void Kubernetes_import_existing_warns_with_readonly_fields()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider kubernetes with {
+            extension kubernetes with {
             namespace: 'default'
             kubeConfig: ''
             }
@@ -253,12 +253,12 @@ provider bar with {
         public void Kubernetes_competing_imports_are_blocked()
         {
             var result = CompilationHelper.Compile(Services, @"
-provider kubernetes with {
+extension kubernetes with {
   namespace: 'default'
   kubeConfig: ''
 }
 
-provider kubernetes with {
+extension kubernetes with {
   namespace: 'default'
   kubeConfig: ''
 }
@@ -277,7 +277,7 @@ provider kubernetes with {
         public void Kubernetes_import_existing_resources()
         {
             var result = CompilationHelper.Compile(Services, @"
-provider kubernetes with {
+extension kubernetes with {
   namespace: 'default'
   kubeConfig: ''
 }
@@ -313,7 +313,7 @@ resource configmap 'core/ConfigMap@v1' existing = {
         public void Kubernetes_import_existing_connectionstring_test()
         {
             var result = CompilationHelper.Compile(Services, @"
-provider kubernetes with {
+extension kubernetes with {
   namespace: 'default'
   kubeConfig: ''
 }
@@ -351,7 +351,7 @@ resource secret 'core/Secret@v1' = {
         public void Kubernetes_CustomResourceType_EmitWarning()
         {
             var result = CompilationHelper.Compile(Services, """
-                provider kubernetes with {
+                extension kubernetes with {
                   namespace: 'default'
                   kubeConfig: ''
                 }
@@ -372,7 +372,7 @@ resource secret 'core/Secret@v1' = {
         public void Kubernetes_AmbiguousFallbackType_MustFullyQualify()
         {
             var result = CompilationHelper.Compile(Services, """
-                provider kubernetes with {
+                extension kubernetes with {
                   namespace: 'default'
                   kubeConfig: ''
                 }
@@ -406,7 +406,7 @@ resource secret 'core/Secret@v1' = {
         public void Bar_import_basic_test_with_qualified_type()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider bar with {
+            extension bar with {
             connectionString: 'asdf'
             } as stg
 
@@ -427,7 +427,7 @@ resource secret 'core/Secret@v1' = {
         public void Invalid_namespace_qualifier_returns_error()
         {
             var result = CompilationHelper.Compile(Services, """
-            provider bar with {
+            extension bar with {
             connectionString: 'asdf'
             } as stg
 
@@ -452,7 +452,7 @@ resource secret 'core/Secret@v1' = {
         public void Child_resource_with_parent_namespace_mismatch_returns_error()
         {
             var result = CompilationHelper.Compile(Services, @"
-provider bar with {
+extension bar with {
   connectionString: 'asdf'
 } as stg
 
@@ -500,7 +500,7 @@ module website './website.bicep' = {
 @secure()
 param connectionString string
 
-provider bar with {
+extension bar with {
   connectionString: connectionString
 } as stg
 

--- a/src/Bicep.Core.IntegrationTests/OutputsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/OutputsTests.cs
@@ -235,7 +235,7 @@ output out resource = resource
         {
             var result = CompilationHelper.Compile(ServicesWithExtensibility,
             """
-            provider bar with {
+            extension bar with {
                 connectionString: 'asdf'
             } as stg
 

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -177,7 +177,7 @@ output id string = p.id
         public void Parameter_cannot_use_extensibility_resource_type()
         {
             var result = CompilationHelper.Compile(ServicesWithExtensibility, """
-            provider bar with {
+            extension bar with {
             connectionString: 'asdf'
             } as stg
 

--- a/src/Bicep.Core.IntegrationTests/ProviderImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ProviderImportTests.cs
@@ -53,10 +53,10 @@ namespace Bicep.Core.IntegrationTests
         {
             var services = new ServiceBuilder();
             var result = await CompilationHelper.RestoreAndCompile(services, """
-            provider az
+            extension az
             """);
             result.Should().HaveDiagnostics(new[] {
-                ("BCP203", DiagnosticLevel.Error, "Using provider statements requires enabling EXPERIMENTAL feature \"Extensibility\"."),
+                ("BCP203", DiagnosticLevel.Error, "Using extension declaration requires enabling EXPERIMENTAL feature \"Extensibility\"."),
             });
         }
 
@@ -65,13 +65,13 @@ namespace Bicep.Core.IntegrationTests
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, @"
-provider
+extension
 ");
             result.Should().HaveDiagnostics([
                 ("BCP201", DiagnosticLevel.Error, """
-                Expected a provider specification string with a valid format at this location. Valid formats:
-                * "br:<providerRegistryHost>/<providerRepositoryPath>:<providerVersion>"
-                * "br/<providerAlias>:<providerName>:<providerVersion>"
+                Expected an extension specification string with a valid format at this location. Valid formats:
+                * "br:<extensionRegistryHost>/<extensionRepositoryPath>:<extensionVersion>"
+                * "br/<extensionAlias>:<extensionName>:<extensionVersion>"
                 """)
             ]);
         }
@@ -81,7 +81,7 @@ provider
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, """
-            provider sys blahblah
+            extension sys blahblah
             """);
             result.Should().HaveDiagnostics(new[] {
                 ("BCP305", DiagnosticLevel.Error, "Expected the \"with\" keyword, \"as\" keyword, or a new line character at this location."),
@@ -93,7 +93,7 @@ provider
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, """
-            provider kubernetes with
+            extension kubernetes with
             """);
             result.Should().HaveDiagnostics(new[] {
                 ("BCP018", DiagnosticLevel.Error, "Expected the \"{\" character at this location."),
@@ -105,7 +105,7 @@ provider
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, """
-            provider kubernetes with {
+            extension kubernetes with {
                 kubeConfig: 'foo'
                 namespace: 'bar'
             } something
@@ -120,13 +120,13 @@ provider
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, """
-            provider kubernetes with {
+            extension kubernetes with {
                 kubeConfig: 'foo'
                 namespace: 'bar'
             } as
             """);
             result.Should().HaveDiagnostics(new[] {
-                ("BCP202", DiagnosticLevel.Error, "Expected a provider alias name at this location."),
+                ("BCP202", DiagnosticLevel.Error, "Expected an extension alias name at this location."),
             });
         }
 
@@ -135,10 +135,10 @@ provider
         {
             var services = await GetServices();
             var result = await CompilationHelper.RestoreAndCompile(services, """
-            provider sys as
+            extension sys as
             """);
             result.Should().HaveDiagnostics(new[] {
-                ("BCP202", DiagnosticLevel.Error, "Expected a provider alias name at this location."),
+                ("BCP202", DiagnosticLevel.Error, "Expected an extension alias name at this location."),
             });
         }
 
@@ -146,12 +146,12 @@ provider
         public async Task Import_configuration_is_blocked_by_default()
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), """
-            provider az with {
+            extension az with {
               foo: 'bar'
             }
             """);
             result.Should().HaveDiagnostics(new[] {
-                ("BCP205", DiagnosticLevel.Error, "Provider namespace \"az\" does not support configuration."),
+                ("BCP205", DiagnosticLevel.Error, "Extension \"az\" does not support configuration."),
             });
         }
 
@@ -159,10 +159,10 @@ provider
         public async Task Imports_return_error_with_unrecognized_namespace()
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), @"
-provider madeUpNamespace
+extension madeUpNamespace
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP204", DiagnosticLevel.Error, "Provider namespace \"madeUpNamespace\" is not recognized."),
+                ("BCP204", DiagnosticLevel.Error, "Extension \"madeUpNamespace\" is not recognized."),
             });
         }
 
@@ -170,7 +170,7 @@ provider madeUpNamespace
         public async Task Using_import_statements_frees_up_the_namespace_symbol()
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), """
-            provider az as newAz
+            extension az as newAz
 
             var az = 'Fake AZ!'
             var myRg = newAz.resourceGroup()
@@ -186,8 +186,8 @@ provider madeUpNamespace
         public async Task You_can_swap_imported_namespaces_if_you_really_really_want_to()
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), """
-            provider az as sys
-            provider sys as az
+            extension az as sys
+            extension sys as az
 
             var myRg = sys.resourceGroup()
 
@@ -204,7 +204,7 @@ provider madeUpNamespace
         public async Task Overwriting_single_built_in_namespace_with_import_is_prohibited()
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), """
-            provider az as sys
+            extension az as sys
 
             var myRg = sys.resourceGroup()
 
@@ -218,11 +218,11 @@ provider madeUpNamespace
         public async Task Singleton_imports_cannot_be_used_multiple_times()
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), """
-            provider az as az1
-            provider az as az2
+            extension az as az1
+            extension az as az2
 
-            provider sys as sys1
-            provider sys as sys2
+            extension sys as sys1
+            extension sys as sys2
             """);
 
             result.Should().HaveDiagnostics(new[] {
@@ -237,8 +237,8 @@ provider madeUpNamespace
         public async Task Import_names_must_not_conflict_with_other_symbols()
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), """
-            provider az
-            provider kubernetes with {
+            extension az
+            extension kubernetes with {
             kubeConfig: ''
             namespace: ''
             } as az
@@ -305,8 +305,8 @@ provider madeUpNamespace
                 """));
 
             var result = await CompilationHelper.RestoreAndCompile(services, @"
-            provider ns1
-            provider ns2
+            extension ns1
+            extension ns2
 
             output ambiguousResult string = dupeFunc()
             output ns1Result string = ns1Func()
@@ -319,8 +319,8 @@ provider madeUpNamespace
 
             // fix by fully-qualifying
             result = await CompilationHelper.RestoreAndCompile(services, @"
-            provider ns1
-            provider ns2
+            extension ns1
+            extension ns2
 
             output ambiguousResult string = ns1.dupeFunc()
             output ns1Result string = ns1Func()
@@ -370,10 +370,10 @@ provider madeUpNamespace
                 """));
 
             var result = await CompilationHelper.RestoreAndCompile(services, """
-            provider mockNs with {
+            extension mockNs with {
               optionalConfig: 'blah blah'
             } as ns1
-            provider mockNs
+            extension mockNs
             """);
 
             result.Should().NotHaveAnyDiagnostics();
@@ -382,7 +382,7 @@ provider madeUpNamespace
         [TestMethod]
         public async Task MicrosoftGraph_imports_succeed_default()
         {
-            var result = await CompilationHelper.RestoreAndCompile(await GetServices(), @"provider microsoftGraph as graph");
+            var result = await CompilationHelper.RestoreAndCompile(await GetServices(), @"extension microsoftGraph as graph");
 
             result.Should().NotHaveAnyDiagnostics();
         }

--- a/src/Bicep.Core.IntegrationTests/RegistryProviderTests.cs
+++ b/src/Bicep.Core.IntegrationTests/RegistryProviderTests.cs
@@ -57,7 +57,7 @@ public class RegistryProviderTests : TestBase
         await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), "/types/index.json", $"br:{registry}/{repository}:1.2.3");
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/test/provider/http:1.2.3'
+extension 'br:example.azurecr.io/test/provider/http:1.2.3'
 
 resource dadJoke 'request@v1' = {
   uri: 'https://icanhazdadjoke.com'
@@ -88,7 +88,7 @@ output joke string = dadJoke.body.joke
 
         var bicepPath = Path.Combine(tempDirectory, "main.bicep");
         await File.WriteAllTextAsync(bicepPath, """
-provider './provider.tgz'
+extension './provider.tgz'
 
 resource fooRes 'fooType@v1' = {
   identifier: 'foo'
@@ -115,7 +115,7 @@ resource fooRes 'fooType@v1' = {
         var services = await ProviderTestHelper.GetServiceBuilderWithPublishedProvider(ThirdPartyTypeHelper.GetTestTypesTgz(), AllFeaturesEnabled);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3'
+extension 'br:example.azurecr.io/providers/foo:1.2.3'
 
 resource fooRes 'fooType@v1' existing = {
 }
@@ -127,7 +127,7 @@ resource fooRes 'fooType@v1' existing = {
         });
 
         result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3'
+extension 'br:example.azurecr.io/providers/foo:1.2.3'
 
 resource fooRes 'fooType@v1' existing = {
   identifier: 'foo'
@@ -153,7 +153,7 @@ resource fooRes 'fooType@v1' existing = {
         await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), "/types/index.json", $"br:{registry}/{repository}:1.2.3");
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/test/provider/http:1.2.3' with {}
+extension 'br:example.azurecr.io/test/provider/http:1.2.3' with {}
 
 resource dadJoke 'request@v1' = {
   uri: 'https://icanhazdadjoke.com'
@@ -166,7 +166,7 @@ output joke string = dadJoke.body.joke
 
         result.Should().NotGenerateATemplate();
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
-            ("BCP205", DiagnosticLevel.Error, "Provider namespace \"http\" does not support configuration.")
+            ("BCP205", DiagnosticLevel.Error, "Extension \"http\" does not support configuration.")
         });
     }
 
@@ -176,7 +176,7 @@ output joke string = dadJoke.body.joke
         var services = await ProviderTestHelper.GetServiceBuilderWithPublishedProvider(ThirdPartyTypeHelper.GetTestTypesTgz(), AllFeaturesEnabled);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3'
+extension 'br:example.azurecr.io/providers/foo:1.2.3'
 
 resource fooRes 'fooType@v1' existing = {
   identifier: 'foo'
@@ -235,7 +235,7 @@ output baz string = fooRes.convertBarToBaz('bar')
         await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), "/types/index.json", $"br:{registry}/{repository}:1.2.3");
 
         var result = await CompilationHelper.RestoreAndCompile(services, @$"
-provider 'br:example.azurecr.io/test/provider/http:1.2.3'
+extension 'br:example.azurecr.io/test/provider/http:1.2.3'
 ");
         result.Should().NotHaveAnyDiagnostics();
         result.Template.Should().NotBeNull();
@@ -281,17 +281,17 @@ provider 'br:example.azurecr.io/test/provider/http:1.2.3'
         await RegistryHelper.PublishProviderToRegistryAsync(services.Build(), "/types/index.json", $"br:{registry}/{repository}:1.2.3");
 
         var result = await CompilationHelper.RestoreAndCompile(services, @$"
-provider 'br:example.azurecr.io/test/provider/http:1.2.3'
+extension 'br:example.azurecr.io/test/provider/http:1.2.3'
 ");
         result.Should().HaveDiagnostics([
-            ("BCP203", DiagnosticLevel.Error, "Using provider statements requires enabling EXPERIMENTAL feature \"Extensibility\"."),
+            ("BCP203", DiagnosticLevel.Error, "Using extension declaration requires enabling EXPERIMENTAL feature \"Extensibility\"."),
         ]);
 
         services = ProviderTestHelper.GetServiceBuilder(fileSystem, registry, repository, new(ExtensibilityEnabled: true));
 
 
         var result2 = await CompilationHelper.RestoreAndCompile(services, @$"
-provider 'br:example.azurecr.io/test/provider/http:1.2.3'
+extension 'br:example.azurecr.io/test/provider/http:1.2.3'
 ");
         result2.Should().HaveDiagnostics([
             ("BCP400", DiagnosticLevel.Error, """Fetching types from the registry requires enabling EXPERIMENTAL feature "ProviderRegistry"."""),
@@ -306,7 +306,7 @@ provider 'br:example.azurecr.io/test/provider/http:1.2.3'
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
 var registryHost = 'example.azurecr.io'
-provider 'br:${registryHost}/test/provider/http:1.2.3'
+extension 'br:${registryHost}/test/provider/http:1.2.3'
 """);
         result.Should().NotGenerateATemplate();
         result.Should().ContainDiagnostic("BCP303", DiagnosticLevel.Error, "String interpolation is unsupported for specifying the provider.");
@@ -319,7 +319,7 @@ provider 'br:${registryHost}/test/provider/http:1.2.3'
         services = services.WithFeatureOverrides(new(ExtensibilityEnabled: true, DynamicTypeLoadingEnabled: false));
 
         var result = await CompilationHelper.RestoreAndCompile(services, @"
-provider 'br:mcr.microsoft.com/bicep/provider/az:1.2.3'
+extension 'br:mcr.microsoft.com/bicep/provider/az:1.2.3'
 ");
         result.Should().NotGenerateATemplate();
         result.Should().HaveDiagnostics([
@@ -333,7 +333,7 @@ provider 'br:mcr.microsoft.com/bicep/provider/az:1.2.3'
         var services = await ProviderTestHelper.GetServiceBuilderWithPublishedProvider(ThirdPartyTypeHelper.GetTestTypesTgzWithFallbackAndConfiguration(), AllFeaturesEnabled);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3'
+extension 'br:example.azurecr.io/providers/foo:1.2.3'
 
 resource dadJoke 'fooType@v1' = {
   identifier: 'foo'
@@ -345,7 +345,7 @@ output joke string = dadJoke.joke
 
         result.Should().NotGenerateATemplate();
         result.Should().HaveDiagnostics(new[]{
-            ("BCP206", DiagnosticLevel.Error, "Provider namespace \"ThirdPartyProvider\" requires configuration, but none was provided.")
+            ("BCP206", DiagnosticLevel.Error, "Extension \"ThirdPartyProvider\" requires configuration, but none was provided.")
         });
     }
 
@@ -356,7 +356,7 @@ output joke string = dadJoke.joke
         var services = await ProviderTestHelper.GetServiceBuilderWithPublishedProvider(ThirdPartyTypeHelper.GetTestTypesTgzWithFallbackAndConfiguration(), AllFeaturesEnabled);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3' with {
+extension 'br:example.azurecr.io/providers/foo:1.2.3' with {
   namespace: 'ThirdPartyNamespace'
   config: 'Some path to config file'
   context: 'Some ThirdParty context'
@@ -389,7 +389,7 @@ output joke string = dadJoke.joke
 
         // Missing the required configuration property: namespace
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3' with {
+extension 'br:example.azurecr.io/providers/foo:1.2.3' with {
   config: 'Some path to config file'
   context: 'Some ThirdParty context'
 }
@@ -415,7 +415,7 @@ output joke string = dadJoke.joke
 
         // Mispelled the required configuration property: namespace
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3' with {
+extension 'br:example.azurecr.io/providers/foo:1.2.3' with {
   namespac: 'ThirdPartyNamespace'
   config: 'Some path to config file'
   context: 'Some ThirdParty context'
@@ -443,7 +443,7 @@ output joke string = dadJoke.joke
 
         // Mispelled the optional configuration property: context
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3' with {
+extension 'br:example.azurecr.io/providers/foo:1.2.3' with {
   namespace: 'ThirdPartyNamespace'
   config: 'Some path to config file'
   contex: 'Some ThirdParty context'
@@ -469,7 +469,7 @@ output joke string = dadJoke.joke
         var services = await ProviderTestHelper.GetServiceBuilderWithPublishedProvider(ThirdPartyTypeHelper.GetTestTypesTgzWithFallbackAndConfiguration(), AllFeaturesEnabled);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3' with {
+extension 'br:example.azurecr.io/providers/foo:1.2.3' with {
   namespace: 'ThirdPartyNamespace'
   config: 'Some path to config file'
 }
@@ -495,7 +495,7 @@ resource test 'test@v1' = {
         var services = await ProviderTestHelper.GetServiceBuilderWithPublishedProvider(ThirdPartyTypeHelper.GetTestTypesTgz(), AllFeaturesEnabled);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider 'br:example.azurecr.io/providers/foo:1.2.3'
+extension 'br:example.azurecr.io/providers/foo:1.2.3'
 
 resource test 'test@v1' = {
   bodyProp: 'fallback body'
@@ -514,7 +514,7 @@ resource test 'test@v1' = {
         var fileSystem = new MockFileSystem();
         var services = await ProviderTestHelper.GetServiceBuilderWithPublishedProvider(ThirdPartyTypeHelper.GetTestTypesTgz(), AllFeaturesEnabled, fileSystem);
 
-        // incorrect provider version - verify it returns an error
+        // incorrect extension version - verify it returns an error
         fileSystem.File.WriteAllText("/bicepconfig.json", """
  {
    "providers": {
@@ -527,7 +527,7 @@ resource test 'test@v1' = {
 }
 """);
         var result = await CompilationHelper.RestoreAndCompile(services, """
-provider foo
+extension foo
 """);
 
         result.Should().NotGenerateATemplate();
@@ -535,7 +535,7 @@ provider foo
             ("BCP192", DiagnosticLevel.Error, """Unable to restore the artifact with reference "br:example.azurecr.io/providers/foo:1.2.4": The artifact does not exist in the registry.""")
         });
 
-        // correct provider version
+        // correct extension version
         fileSystem.File.WriteAllText("/bicepconfig.json", """
  {
    "providers": {
@@ -548,7 +548,7 @@ provider foo
 }
 """);
         result = await CompilationHelper.RestoreAndCompile(services, """
-provider foo
+extension foo
 
 resource fooRes 'fooType@v1' = {
   identifier: 'foo'
@@ -560,7 +560,7 @@ resource fooRes 'fooType@v1' = {
 
         result.Should().GenerateATemplate();
 
-        // correct provider version, defined implicitly
+        // correct extension version, defined implicitly
         fileSystem.File.WriteAllText("/bicepconfig.json", """
  {
   "providers": {

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -5738,7 +5738,7 @@ param foo2 string[]
                 .WithFeatureOverrides(new(TestContext, ExtensibilityEnabled: true))
                 .WithConfigurationPatch(x => x.WithAnalyzersConfiguration(x.Analyzers.SetValue("core.rules.use-recent-api-versions.level", "error"))),
             ("main.bicep", """
-                provider kubernetes with {
+                extension kubernetes with {
                   kubeConfig: 'config'
                   namespace: ''
                 } as k8s

--- a/src/Bicep.Core.IntegrationTests/TypeSystem/Providers/ResourceTypeProviderFactoryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/Providers/ResourceTypeProviderFactoryTests.cs
@@ -45,7 +45,7 @@ public class ResourceTypeProviderFactoryTests
             (
                 "main.bicep",
                 @$"
-                provider 'br:example.azurecr.io/test/provider/foo:1.2.3' as foo
+                extension 'br:example.azurecr.io/test/provider/foo:1.2.3' as foo
 
                 module mod './mod.bicep' = {{
                     name: 'mod'
@@ -56,7 +56,7 @@ public class ResourceTypeProviderFactoryTests
             (
                 "mod.bicep",
                 @$"
-                provider 'br:example.azurecr.io/test/provider/bar:1.2.3' as foo
+                extension 'br:example.azurecr.io/test/provider/bar:1.2.3' as foo
                 "
             ));
 

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/kubernetes.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/kubernetes.bicep
@@ -1,7 +1,7 @@
 @secure()
 param kubeConfig string
 
-provider kubernetes with {
+extension kubernetes with {
   kubeConfig: kubeConfig
   namespace: 'default'
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
@@ -1,4 +1,4 @@
-provider microsoftGraph  as graph
+extension microsoftGraph  as graph
 
 param appRoleId string = 'bc76c90e-eb7f-4a29-943b-49e88762d09d'
 param scopeId string = 'f761933c-643b-424f-a169-f9313d23a913'

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.bicep
@@ -1,4 +1,4 @@
-provider microsoftGraph
+extension microsoftGraph
 
 resource resourceApp 'Microsoft.Graph/applications@beta' existing = {
   uniqueName: 'resourceApp'

--- a/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
@@ -40,7 +40,7 @@ public class ProvidersConfigurationTests
         provider.Should().BeNull();
         errorBuilder!.Should().NotBeNull();
         errorBuilder!.Should().HaveCode("BCP204");
-        errorBuilder!.Should().HaveMessage($"Provider namespace \"unspecified\" is not recognized.");
+        errorBuilder!.Should().HaveMessage($"Extension \"unspecified\" is not recognized.");
     }
 
     [TestMethod]
@@ -98,6 +98,6 @@ public class ProvidersConfigurationTests
         provider.Should().BeNull();
         errorBuilder!.Should().NotBeNull();
         errorBuilder!.Should().HaveCode("BCP204");
-        errorBuilder!.Should().HaveMessage($"Provider namespace \"sys\" is not recognized.");
+        errorBuilder!.Should().HaveMessage($"Extension \"sys\" is not recognized.");
     }
 }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1219,9 +1219,9 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic ExpectedProviderSpecification()
             {
                 var message = """
-                Expected a provider specification string with a valid format at this location. Valid formats:
-                * "br:<providerRegistryHost>/<providerRepositoryPath>:<providerVersion>"
-                * "br/<providerAlias>:<providerName>:<providerVersion>"
+                Expected an extension specification string with a valid format at this location. Valid formats:
+                * "br:<extensionRegistryHost>/<extensionRepositoryPath>:<extensionVersion>"
+                * "br/<extensionAlias>:<extensionName>:<extensionVersion>"
                 """;
                 return new(TextSpan, "BCP201", message);
             }
@@ -1229,27 +1229,27 @@ namespace Bicep.Core.Diagnostics
             public ErrorDiagnostic ExpectedProviderAliasName() => new(
                 TextSpan,
                 "BCP202",
-                "Expected a provider alias name at this location.");
+                "Expected an extension alias name at this location.");
 
             public ErrorDiagnostic ProvidersAreDisabled() => new(
                 TextSpan,
                 "BCP203",
-                $@"Using provider statements requires enabling EXPERIMENTAL feature ""{nameof(ExperimentalFeaturesEnabled.Extensibility)}"".");
+                $@"Using extension declaration requires enabling EXPERIMENTAL feature ""{nameof(ExperimentalFeaturesEnabled.Extensibility)}"".");
 
             public ErrorDiagnostic UnrecognizedProvider(string identifier) => new(
                 TextSpan,
                 "BCP204",
-                $"Provider namespace \"{identifier}\" is not recognized.");
+                $"Extension \"{identifier}\" is not recognized.");
 
             public ErrorDiagnostic ProviderDoesNotSupportConfiguration(string identifier) => new(
                 TextSpan,
                 "BCP205",
-                $"Provider namespace \"{identifier}\" does not support configuration.");
+                $"Extension \"{identifier}\" does not support configuration.");
 
             public ErrorDiagnostic ProviderRequiresConfiguration(string identifier) => new(
                 TextSpan,
                 "BCP206",
-                $"Provider namespace \"{identifier}\" requires configuration, but none was provided.");
+                $"Extension \"{identifier}\" requires configuration, but none was provided.");
 
             public ErrorDiagnostic NamespaceMultipleDeclarations(string identifier) => new(
                 TextSpan,
@@ -2076,19 +2076,19 @@ namespace Bicep.Core.Diagnostics
                 $"Artifacts of type: \"{artifactType}\" are not supported."
             );
 
-            public FixableDiagnostic ProviderDeclarationViaImportKeywordIsDeprecated(ProviderDeclarationSyntax syntax)
+            public FixableDiagnostic ExtensionDeclarationKeywordIsDeprecated(ProviderDeclarationSyntax syntax)
             {
                 var codeFix = new CodeFix(
-                    "Replace the import with the provider keyword",
+                    $"Replace the {syntax.Keyword.Text} keyword with the extension keyword",
                     true,
                     CodeFixKind.QuickFix,
-                    new CodeReplacement(syntax.Keyword.Span, LanguageConstants.ProviderKeyword));
+                    new CodeReplacement(syntax.Keyword.Span, LanguageConstants.ExtensionKeyword));
 
                 return new FixableDiagnostic(
                     TextSpan,
                     DiagnosticLevel.Warning,
                     "BCP381",
-                    $"Declaring provider namespaces with the \"import\" keyword has been deprecated. Please use the \"provider\" keyword instead.",
+                    @$"Declaring extension with the ""{syntax.Keyword.Text}"" keyword has been deprecated. Please use the ""extension"" keyword instead. Please see https://github.com/Azure/bicep/issues/14374 for more information.",
                     documentationUri: null,
                     DiagnosticStyling.Default,
                     codeFix);

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -72,6 +72,7 @@ namespace Bicep.Core
         public const string ExistingKeyword = "existing";
         public const string ImportKeyword = "import";
         public const string ProviderKeyword = "provider";
+        public const string ExtensionKeyword = "extension";
         public const string AssertKeyword = "assert";
         public const string WithKeyword = "with";
         public const string AsKeyword = "as";

--- a/src/Bicep.Core/Syntax/ProviderDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProviderDeclarationSyntax.cs
@@ -13,7 +13,7 @@ namespace Bicep.Core.Syntax
         public ProviderDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, SyntaxBase specificationString, SyntaxBase withClause, SyntaxBase asClause)
             : base(leadingNodes)
         {
-            AssertKeyword(keyword, nameof(keyword), LanguageConstants.ImportKeyword, LanguageConstants.ProviderKeyword);
+            AssertKeyword(keyword, nameof(keyword), LanguageConstants.ImportKeyword, LanguageConstants.ProviderKeyword, LanguageConstants.ExtensionKeyword);
             AssertSyntaxType(specificationString, nameof(specificationString), typeof(StringSyntax), typeof(SkippedTriviaSyntax), typeof(IdentifierSyntax));
 
             this.Keyword = keyword;

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -880,9 +880,10 @@ namespace Bicep.Core.TypeSystem
                     return ErrorType.Empty();
                 }
 
-                if (syntax.Keyword.Text.Equals(LanguageConstants.ImportKeyword))
+                if (syntax.Keyword.IsKeyword(LanguageConstants.ImportKeyword) ||
+                    syntax.Keyword.IsKeyword(LanguageConstants.ProviderKeyword))
                 {
-                    diagnostics.Write(syntax.Keyword, x => x.ProviderDeclarationViaImportKeywordIsDeprecated(syntax));
+                    diagnostics.Write(syntax.Keyword, x => x.ExtensionDeclarationKeywordIsDeprecated(syntax));
                 }
 
                 if (namespaceSymbol.DeclaredType is not NamespaceType namespaceType)

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -555,10 +555,19 @@ param foo2 string", "param foo2 string")]
 imp|ort 'br:example.azurecr.io/test/radius:1.0.0'
 ", server: server);
 
-            var updatedFile = ApplyCodeAction(bicepFile, codeActions.Single(x => x.Title.StartsWith("Replace the import with the provider keyword")));
+            var updatedFile = ApplyCodeAction(bicepFile, codeActions.Single(x => x.Title.StartsWith("Replace the import keyword with the extension keyword")));
             updatedFile.Should().HaveSourceText(@"
-provider 'br:example.azurecr.io/test/radius:1.0.0'
+extension 'br:example.azurecr.io/test/radius:1.0.0'
 ");
+
+//            (codeActions, bicepFile) = await RunSyntaxTest(@"
+//pro|vider 'br:example.azurecr.io/test/radius:1.0.0'
+//", server: server);
+
+//            updatedFile = ApplyCodeAction(bicepFile, codeActions.Single(x => x.Title.StartsWith("Replace the provider keyword with the extension keyword")));
+//            updatedFile.Should().HaveSourceText(@"
+//extension 'br:example.azurecr.io/test/radius:1.0.0'
+//");
         }
 
         [DataRow("var|")]

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -560,14 +560,14 @@ imp|ort 'br:example.azurecr.io/test/radius:1.0.0'
 extension 'br:example.azurecr.io/test/radius:1.0.0'
 ");
 
-//            (codeActions, bicepFile) = await RunSyntaxTest(@"
-//pro|vider 'br:example.azurecr.io/test/radius:1.0.0'
-//", server: server);
+            (codeActions, bicepFile) = await RunSyntaxTest(@"
+pro|vider 'br:example.azurecr.io/test/radius:1.0.0'
+", server: server);
 
-//            updatedFile = ApplyCodeAction(bicepFile, codeActions.Single(x => x.Title.StartsWith("Replace the provider keyword with the extension keyword")));
-//            updatedFile.Should().HaveSourceText(@"
-//extension 'br:example.azurecr.io/test/radius:1.0.0'
-//");
+            updatedFile = ApplyCodeAction(bicepFile, codeActions.Single(x => x.Title.StartsWith("Replace the provider keyword with the extension keyword")));
+            updatedFile.Should().HaveSourceText(@"
+extension 'br:example.azurecr.io/test/radius:1.0.0'
+");
         }
 
         [DataRow("var|")]


### PR DESCRIPTION
As the first step of addressing https://github.com/Azure/bicep/issues/14374, this PR replaces the provider keyword with the extension keyword. Using the provider keyword will now trigger a warning diagnostic with a code fix to assist users in migrating to the new keyword.

To reduce the scope of this PR, the use of `provider` within the Bicep CLI, Bicep configuration, and the codebase will be replaced separately in subsequent PRs.

Closes #14378.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14379)