### PR TITLE
Add troubleshooting doc

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,11 @@
+## Tracing
+To collect troubleshooting information, it can be useful to enable detailed tracing. To do this, run one of the following commands in your console window before invoking Bicep:
+
+1. (Mac/Linux) Run the following:
+   ```sh
+   export BICEP_TRACING_ENABLED=true
+   ```
+1. (Windows) Run the following in a PowerShell window:
+   ```powershell
+   $env:BICEP_TRACING_ENABLED = $true
+   ```


### PR DESCRIPTION
Since I'm often re-explaining how to enable tracing, I thought it would be useful to have the instructions written in a GitHub doc. We can also use this doc to add other user-facing troubleshooting tips.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14565)