### PR TITLE
Ensure `\n` is used when emitting template

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IO.Abstractions;
+using System.Text.RegularExpressions;
 using Bicep.Cli.UnitTests;
 using Bicep.Core;
 using Bicep.Core.Configuration;
@@ -88,7 +89,10 @@ namespace Bicep.Cli.IntegrationTests
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);
             File.Exists(compiledFilePath).Should().BeTrue();
 
-            var actual = JToken.Parse(File.ReadAllText(compiledFilePath));
+            var compiledFileContent = File.ReadAllText(compiledFilePath);
+            compiledFileContent.Should().OnlyContainLFNewline();
+
+            var actual = JToken.Parse(compiledFileContent);
 
             actual.Should().EqualWithJsonDiffOutput(
                 TestContext,
@@ -219,6 +223,7 @@ namespace Bicep.Cli.IntegrationTests
             {
                 result.Should().Be(0);
                 output.Should().NotBeEmpty();
+                output.Should().OnlyContainLFNewline();
                 AssertNoErrors(error);
             }
 

--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -308,6 +308,7 @@ output foo string = foo
                 AssertNoErrors(error);
             }
 
+            data.Compiled!.ReadFromOutputFolder().Should().OnlyContainLFNewline();
             data.Compiled!.ShouldHaveExpectedJsonValue();
         }
 
@@ -328,6 +329,8 @@ output foo string = foo
             }
 
             var parametersStdout = output.FromJson<BuildParamsStdout>();
+            parametersStdout.parametersJson.Should().OnlyContainLFNewline();
+
             data.Compiled!.WriteToOutputFolder(parametersStdout.parametersJson);
             data.Compiled.ShouldHaveExpectedJsonValue();
         }

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -146,7 +146,7 @@ namespace Bicep.Core.IntegrationTests.Emit
             var sourceMap = emitResult.SourceMap!;
 
             using var streamReader = new StreamReader(new MemoryStream(memoryStream.ToArray()));
-            var jsonLines = (await streamReader.ReadToEndAsync()).Split(System.Environment.NewLine);
+            var jsonLines = (await streamReader.ReadToEndAsync()).Split("\n");
 
             var sourceTextWithSourceMap = OutputHelper.AddSourceMapToSourceText(
                 dataSet.Bicep, DataSet.TestFileMain, dataSet.HasCrLfNewlines() ? "\r\n" : "\n", sourceMap, jsonLines);

--- a/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
+++ b/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
@@ -38,6 +38,7 @@ namespace Bicep.Core.Emit
             public PositionTrackingTextWriter(TextWriter textWriter)
             {
                 this.internalWriter = textWriter;
+                this.NewLine = textWriter.NewLine;
             }
 
             public override Encoding Encoding => this.internalWriter.Encoding;

--- a/src/Bicep.Core/Emit/SourceAwareJsonTextWriter.cs
+++ b/src/Bicep.Core/Emit/SourceAwareJsonTextWriter.cs
@@ -29,7 +29,7 @@ namespace Bicep.Core.Emit
         public SourceAwareJsonTextWriter(TextWriter textWriter, BicepSourceFile? sourceFileToTrack = default) : base(textWriter)
         {
             this.sourceFile = sourceFileToTrack;
-            this.TrackingJsonWriter = new PositionTrackingJsonTextWriter(new StringWriter(), this.sourceFile);
+            this.TrackingJsonWriter = new PositionTrackingJsonTextWriter(new StringWriter() { NewLine = "\n" }, this.sourceFile);
         }
 
         public void ProcessSourceMap(JToken templateWithHash)

--- a/src/Bicep.Core/Emit/TemplateEmitter.cs
+++ b/src/Bicep.Core/Emit/TemplateEmitter.cs
@@ -88,7 +88,10 @@ public class TemplateEmitter
     /// <param name="stream">The stream to write the template</param>
     public EmitResult Emit(Stream stream)
     {
-        using var sw = new StreamWriter(stream, UTF8EncodingWithoutBom, 4096, leaveOpen: true);
+        using var sw = new StreamWriter(stream, UTF8EncodingWithoutBom, 4096, leaveOpen: true)
+        {
+            NewLine = "\n",
+        };
 
         return Emit(sw);
     }

--- a/src/Bicep.LangServer.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/BuildCommandTests.cs
@@ -53,6 +53,7 @@ namespace Bicep.LangServer.IntegrationTests
             });
 
             var buildCommandOutput = File.ReadAllText(Path.ChangeExtension(bicepFilePath, ".json"));
+            buildCommandOutput.Should().OnlyContainLFNewline();
             buildCommandOutput.Should().BeEquivalentToIgnoringNewlines(expectedJson);
         }
 
@@ -87,6 +88,7 @@ namespace Bicep.LangServer.IntegrationTests
             });
 
             var buildCommandOutput = File.ReadAllText(Path.ChangeExtension(bicepFilePath, ".json"));
+            buildCommandOutput.Should().OnlyContainLFNewline();
             buildCommandOutput.Should().BeEquivalentToIgnoringNewlines(expectedJson);
         }
     }

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -39,10 +39,10 @@ namespace Bicep.LanguageServer.Handlers
             }
 
             var documentUri = DocumentUri.FromFileSystemPath(bicepFilePath);
-            return await GenerateCompiledFileAndReturnBuildOutputMessage(bicepFilePath, documentUri);
+            return await GenerateCompiledFileAndReturnBuildOutputMessageAsync(bicepFilePath, documentUri);
         }
 
-        private async Task<string> GenerateCompiledFileAndReturnBuildOutputMessage(string bicepFilePath, DocumentUri documentUri)
+        private async Task<string> GenerateCompiledFileAndReturnBuildOutputMessageAsync(string bicepFilePath, DocumentUri documentUri)
         {
             string compiledFilePath = PathHelper.GetDefaultBuildOutputPath(bicepFilePath);
 


### PR DESCRIPTION
Currently, Bicep generates inconsistent newlines depending on whether the template is built using the Build command (and with or without the `--stdout` flag) or through the VS Code extension.

This PR updates the emission code to consistently use `\n` for newlines. This change should prevent issues like https://github.com/Azure/bicep/issues/14383 in the future.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14581)