### PR TITLE
Handle special characters in use-safe-access rule correctly

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSafeAccessRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSafeAccessRuleTests.cs
@@ -36,6 +36,24 @@ var test = foo[?target] ?? 'baz'
 """);
 
     [TestMethod]
+    public void Codefix_fixes_syntax_which_can_be_simplified_named_array_access() => AssertCodeFix("""
+param foo object
+var test = contai|ns(foo, 'bar') ? foo['bar'] : 'baz'
+""", """
+param foo object
+var test = foo.?bar ?? 'baz'
+""");
+
+    [TestMethod]
+    public void Codefix_escapes_special_chars_correctly() => AssertCodeFix("""
+param foo object
+var test = contai|ns(foo, 'oh-dear') ? foo['oh-dear'] : 'baz'
+""", """
+param foo object
+var test = foo[?'oh-dear'] ?? 'baz'
+""");
+
+    [TestMethod]
     public void Rule_ignores_syntax_which_cannot_be_simplified() => AssertNoDiagnostics("""
 param foo object
 var test = contains(foo, 'bar') ? foo.baz : 'baz'

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceSymbolReferenceRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceSymbolReferenceRule.cs
@@ -148,7 +148,7 @@ public sealed class UseResourceSymbolReferenceRule : LinterRuleBase
         SyntaxBase newSyntax = SyntaxFactory.CreateIdentifier(resource.Symbol.Name);
         if (!isFull)
         {
-            newSyntax = SyntaxFactory.CreatePropertyAccess(newSyntax, "properties");
+            newSyntax = SyntaxFactory.CreateAccessSyntax(newSyntax, "properties");
         }
 
         var codeReplacement = new CodeReplacement(functionCall.Span, newSyntax.ToString());

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.ComponentModel;
 using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
+using Json.Pointer;
 
 namespace Bicep.Core.Syntax
 {
@@ -357,18 +358,20 @@ namespace Bicep.Core.Syntax
             _ => new NonNullAssertionSyntax(@base, ExclamationToken),
         };
 
-        public static PropertyAccessSyntax CreatePropertyAccess(SyntaxBase @base, string propertyName)
-            => CreatePropertyAccess(@base, false, propertyName);
+        public static AccessExpressionSyntax CreateAccessSyntax(SyntaxBase @base, string propertyName)
+            => CreateAccessSyntax(@base, false, propertyName);
 
-        public static PropertyAccessSyntax CreatePropertyAccess(SyntaxBase @base, bool safe, string propertyName)
-            => new(@base, DotToken, safe ? QuestionToken : null, CreateIdentifier(propertyName));
+        public static AccessExpressionSyntax CreateAccessSyntax(SyntaxBase @base, bool safe, string propertyName)
+            => Lexer.IsValidIdentifier(propertyName) ? 
+                new PropertyAccessSyntax(@base, DotToken, safe ? QuestionToken : null, CreateIdentifier(propertyName)) :
+                CreateArrayAccess(@base, safe, CreateStringLiteral(propertyName));
 
-        public static ArrayAccessSyntax CreateArrayAccess(SyntaxBase @base, bool safe, SyntaxBase accessExpression)
+        private static ArrayAccessSyntax CreateArrayAccess(SyntaxBase @base, bool safe, SyntaxBase accessExpression)
             => new(@base, LeftSquareToken, safe ? QuestionToken : null, accessExpression, RightSquareToken);
 
-        public static SyntaxBase CreateSafeAccess(SyntaxBase @base, SyntaxBase accessExpression)
+        public static AccessExpressionSyntax CreateSafeAccess(SyntaxBase @base, SyntaxBase accessExpression)
             => (accessExpression is StringSyntax stringAccess && stringAccess.TryGetLiteralValue() is { } stringValue) ?
-                CreatePropertyAccess(@base, true, stringValue) :
+                CreateAccessSyntax(@base, true, stringValue) :
                 CreateArrayAccess(@base, true, accessExpression);
 
         public static ParameterAssignmentSyntax CreateParameterAssignmentSyntax(string name, SyntaxBase value)


### PR DESCRIPTION
I noticed that the safe access code fix is not suggesting the correct replacement for property access containing special characters. This PR fixes that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14593)