### PR TITLE
[Secure Outputs] Bicep Side Implementations and Testing

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -6142,4 +6142,87 @@ resource addAppConfigValues 'Microsoft.AppConfiguration/configurationStores/keyV
 
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
+
+    [TestMethod]
+    public void Test_Issue2163_Deployments_Secure_Outputs_E2E()
+    {
+        // https://github.com/Azure/bicep/issues/2163
+        var result = CompilationHelper.Compile(
+            ("main.bicep", @"
+                @secure()
+                param myInput string
+ 
+                module foo 'foo.bicep' = {
+                  name: 'foo'
+                  params: {
+                    myInput : myInput
+                  }
+                }
+ 
+                output myOutput string = foo.outputs.myOutput
+            "),
+            ("foo.bicep", @"
+                @secure()
+                param myInput string
+ 
+                @secure()
+                output myOutput string = myInput
+            ")
+        );
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+  }
+
+    [TestMethod]
+    public void Test_Issue2163_Deployments_Secure_Outputs_Decorator_Translates_To_SecureString_And_SecureObject()
+    {
+        // https://github.com/Azure/bicep/issues/2163
+        var result = CompilationHelper.Compile(
+            ("main.bicep", @"
+                @secure()
+                output secureStringOutput string = 'intern project 2024'
+
+                @secure()
+                output secureObjectOutput object = {
+                  key1: 'value1'
+                  key2: 'value2'
+                }
+            ")
+        );
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveValueAtPath("$.outputs['secureStringOutput'].type", "securestring");
+        result.Template.Should().HaveValueAtPath("$.outputs['secureObjectOutput'].type", "secureObject");
+    }
+
+    [TestMethod]
+    public void Test_Issue2163_Deployments_Secure_Outputs_Call_Correct_API()
+    {
+        // https://github.com/Azure/bicep/issues/2163
+        var result = CompilationHelper.Compile(
+            ("main.bicep", @"
+                @secure()
+                param foo string
+ 
+                module mod 'module.bicep' = {
+                  name: 'mod'
+                  params: {
+                    foo: foo
+                  }
+                }
+ 
+                output bar string = mod.outputs.bar
+                "),
+            ("module.bicep", @"
+                @secure()
+                param foo string
+ 
+                @secure()
+                output bar string = foo
+            ")
+        );
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveValueAtPath("$.outputs['bar'].value", "[listOutputWithSecureValues(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').bar]");
+    }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1594,7 +1594,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 yield return new DecoratorBuilder(LanguageConstants.ParameterSecurePropertyName)
                     .WithDescription("Makes the parameter a secure parameter.")
-                    .WithFlags(FunctionFlags.ParameterOrTypeDecorator)
+                    .WithFlags(FunctionFlags.ParameterOutputOrTypeDecorator)
                     .WithAttachableType(TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Object))
                     .WithValidator(ValidateNotTargetingAlias)
                     .WithEvaluator((functionCall, decorated) =>


### PR DESCRIPTION
Enable Secure Decorator & Call Secure Outputs API in template if @secure

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
