### PR TITLE
[Local extensibility] Expose new classes

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -1663,6 +1663,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -1535,6 +1535,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
+++ b/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Providers;
 using Bicep.Core.Utils;
 using Bicep.Decompiler;
+using Bicep.Local.Deploy.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using Environment = Bicep.Core.Utils.Environment;
 using IOFileSystem = System.IO.Abstractions.FileSystem;

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -1432,6 +1432,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -1567,6 +1567,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -1513,6 +1513,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -1519,6 +1519,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -1567,6 +1567,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -1567,6 +1567,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -1524,6 +1524,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -1587,6 +1587,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -1409,6 +1409,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
@@ -1577,6 +1577,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Local.Deploy/Extensibility/GrpcProxyLocalExtension.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/GrpcProxyLocalExtension.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Bicep.Local.Extension.Protocol;
+using Bicep.Local.Extension.Rpc;
+using Google.Protobuf.Collections;
+using Json.Pointer;
+using ExtensibilityV2 = Azure.Deployments.Extensibility.Core.V2.Models;
+using Rpc = Bicep.Local.Extension.Rpc;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public class GrpcProxyLocalExtension : ILocalExtension, IAsyncDisposable
+    {
+        private readonly BicepExtension.BicepExtensionClient client;
+        private readonly Process process;
+
+        private GrpcProxyLocalExtension(BicepExtension.BicepExtensionClient client, Process process)
+        {
+            this.client = client;
+            this.process = process;
+        }
+
+        public static async Task<ILocalExtension> CreateGrpcExtension(Uri pathToBinary)
+        {
+            var socketName = $"{Guid.NewGuid()}.tmp";
+            var socketPath = Path.Combine(Path.GetTempPath(), socketName);
+
+            if (File.Exists(socketPath))
+            {
+                File.Delete(socketPath);
+            }
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = pathToBinary.LocalPath,
+                    Arguments = $"--socket {socketPath}",
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                },
+            };
+
+            try
+            {
+                // 30s timeout for starting up the RPC connection
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+                process.EnableRaisingEvents = true;
+                process.Exited += (sender, e) => cts.Cancel();
+                process.OutputDataReceived += (sender, e) => Trace.WriteLine($"{pathToBinary} stdout: {e.Data}");
+                process.ErrorDataReceived += (sender, e) => Trace.WriteLine($"{pathToBinary} stderr: {e.Data}");
+
+                process.Start();
+
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+
+                var channel = GrpcChannelHelper.CreateChannel(socketPath);
+                var client = new BicepExtension.BicepExtensionClient(channel);
+
+                await GrpcChannelHelper.WaitForConnectionAsync(client, cts.Token);
+
+                return new GrpcProxyLocalExtension(client, process);
+            }
+            catch (Exception ex)
+            {
+                await TerminateProcess(process);
+                throw new InvalidOperationException($"Failed to connect to provider {pathToBinary.LocalPath}", ex);
+            }
+        }
+
+        public async Task<LocalExtensionOperationResponse> CreateOrUpdate(ExtensibilityV2.ResourceSpecification request, CancellationToken cancellationToken)
+            => Convert(await client.CreateOrUpdateAsync(Convert(request), cancellationToken: cancellationToken));
+
+        public async Task<LocalExtensionOperationResponse> Delete(ExtensibilityV2.ResourceReference request, CancellationToken cancellationToken)
+            => Convert(await client.DeleteAsync(Convert(request), cancellationToken: cancellationToken));
+
+        public async Task<LocalExtensionOperationResponse> Get(ExtensibilityV2.ResourceReference request, CancellationToken cancellationToken)
+            => Convert(await client.GetAsync(Convert(request), cancellationToken: cancellationToken));
+
+        public async Task<LocalExtensionOperationResponse> Preview(ExtensibilityV2.ResourceSpecification request, CancellationToken cancellationToken)
+            => Convert(await client.PreviewAsync(Convert(request), cancellationToken: cancellationToken));
+
+        private static Rpc.ResourceReference Convert(ExtensibilityV2.ResourceReference request)
+        {
+            Rpc.ResourceReference output = new()
+            {
+                Type = request.Type,
+                Identifiers = request.Identifiers.ToJsonString(),
+            };
+
+            if (request.ApiVersion is { })
+            {
+                output.ApiVersion = request.ApiVersion;
+            }
+            if (request.Config is { })
+            {
+                output.Config = request.Config.ToJsonString();
+            }
+
+            return output;
+        }
+
+        private static Rpc.ResourceSpecification Convert(ExtensibilityV2.ResourceSpecification request)
+        {
+            Rpc.ResourceSpecification output = new()
+            {
+                Type = request.Type,
+                Properties = request.Properties.ToJsonString(),
+            };
+
+            if (request.ApiVersion is { })
+            {
+                output.ApiVersion = request.ApiVersion;
+            }
+            if (request.Config is { })
+            {
+                output.Config = request.Config.ToJsonString();
+            }
+
+            return output;
+        }
+
+        private static ExtensibilityV2.ErrorData Convert(Rpc.ErrorData errorData)
+            => new(new ExtensibilityV2.Error(errorData.Error.Code, errorData.Error.Message, JsonPointer.Empty, Convert(errorData.Error.Details), ConvertInnerError(errorData.Error.InnerError)));
+
+        private static ExtensibilityV2.ErrorDetail[]? Convert(RepeatedField<Rpc.ErrorDetail>? details)
+            => details is not null ? details.Select(Convert).ToArray() : null;
+
+        private static ExtensibilityV2.ErrorDetail Convert(Rpc.ErrorDetail detail)
+            => new(detail.Code, detail.Message, JsonPointer.Empty);
+
+        private static LocalExtensionOperationResponse Convert(Rpc.LocalExtensibilityOperationResponse response)
+            => new(
+                response.Resource is { } ? new(response.Resource.Type, response.Resource.ApiVersion, ToJsonObject(response.Resource.Identifiers, "Parsing response identifiers failed. Please ensure is non-null or empty and is a valid JSON object."), ToJsonObject(response.Resource.Properties, "Parsing response properties failed. Please ensure is non-null or empty and is ensure is a valid JSON object."), response.Resource.Status) : null,
+                response.ErrorData is { } ? Convert(response.ErrorData) : null);
+
+        private static JsonObject? ConvertInnerError(string innerError)
+            => string.IsNullOrEmpty(innerError) ? null : ToJsonObject(innerError, "Parsing innerError failed. Please ensure is non-null or empty and is a valid JSON object.");
+
+        private static JsonObject ToJsonObject(string json, string errorMessage)
+            => JsonNode.Parse(json)?.AsObject() ?? throw new ArgumentNullException(errorMessage);
+
+        public async ValueTask DisposeAsync()
+        {
+            await TerminateProcess(process);
+        }
+
+        private static async Task TerminateProcess(Process process)
+        {
+            try
+            {
+                var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+                await process.WaitForExitAsync(cts.Token);
+            }
+            finally
+            {
+                process.Kill();
+            }
+        }
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionFactory.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionFactory.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bicep.Local.Extension.Protocol;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public interface ILocalExtensionFactory
+    {
+        Task<ILocalExtension> CreateLocalExtensionAsync(LocalExtensionKey extensionKey, Uri extensionBinaryUri);
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionFactoryManager.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionFactoryManager.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bicep.Local.Extension.Protocol;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public interface ILocalExtensionFactoryManager
+    {
+        void InitializeLocalExtensions(IReadOnlyList<BinaryExtensionReference> binaryExtensions);
+        Task<ILocalExtension> GetLocalExtensionAsync(string providerName, string providerVersion);
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionHost.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionHost.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public interface ILocalExtensionHost
+    {
+        Task<HttpResponseMessage> CallExtensibilityHost(LocalDeploymentEngineHost.ExtensionInfo extensionInfo, HttpContent content, CancellationToken cancellationToken);
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionLifecycle.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionLifecycle.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public interface ILocalExtensionLifecycle : IDisposable
+    {
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensionFactoryManager.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensionFactoryManager.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bicep.Core.TypeSystem.Types;
+using Bicep.Local.Extension.Protocol;
+using Google.Protobuf;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public record LocalExtensionKey(string ExtensionName, string ExtensionVersion);
+
+    public class LocalExtensionFactoryManager(ILocalExtensionFactory extensionFactory) : ILocalExtensionFactoryManager
+    {
+        private readonly Dictionary<LocalExtensionKey, Func<Task<ILocalExtension>>> RegisteredLocalExtensions = [];
+        private readonly Dictionary<LocalExtensionKey, ILocalExtension> InitializedLocalExtensions = [];
+
+        public void InitializeLocalExtensions(IReadOnlyList<BinaryExtensionReference> binaryExtensions)
+        {
+            foreach (var (namespaceType, binaryUri) in binaryExtensions)
+            {
+                LocalExtensionKey providerKey = new(namespaceType.Settings.ArmTemplateProviderName, namespaceType.Settings.ArmTemplateProviderVersion);
+                RegisteredLocalExtensions[providerKey] = () => extensionFactory.CreateLocalExtensionAsync(providerKey, binaryUri);
+            }
+
+            RegisterBuiltInExtensions();
+        }
+
+        private void RegisterBuiltInExtensions() { }
+
+        public async Task<ILocalExtension> GetLocalExtensionAsync(string providerName, string providerVersion)
+        {
+            LocalExtensionKey providerKey = new(providerName, providerVersion);
+            if (!RegisteredLocalExtensions.TryGetValue(providerKey, out var localExtension))
+            {
+                throw new ArgumentException($"Provider name: '{providerName}' and version: '{providerVersion}' was not found.");
+            }
+
+            // Ensure loading the extension once and on-demand.
+            if (!InitializedLocalExtensions.TryGetValue(providerKey, out var initializedLocalExtension))
+            {
+                initializedLocalExtension = await localExtension();
+                InitializedLocalExtensions[providerKey] = initializedLocalExtension;
+            }
+
+            return initializedLocalExtension;
+        }
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensionHost.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensionHost.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
+using Azure.Deployments.Extensibility.Core.V2.Json;
+using Bicep.Local.Extension.Protocol;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public class LocalExtensionHost : ILocalExtensionHost
+    {
+        private readonly ILocalExtensionFactoryManager extensionFactoryManager;
+
+        public LocalExtensionHost(ILocalExtensionFactoryManager extensionFactoryManager)
+        {
+            this.extensionFactoryManager = extensionFactoryManager;
+        }
+
+        public async Task<HttpResponseMessage> CallExtensibilityHost(LocalDeploymentEngineHost.ExtensionInfo extensionInfo, HttpContent content, CancellationToken cancellationToken)
+        {
+            var extension = await extensionFactoryManager.GetLocalExtensionAsync(extensionInfo.ExtensionName, extensionInfo.ExtensionVersion);
+            var response = await CallExtension(extensionInfo.Method, extension, content, cancellationToken);
+
+            // DeploymentEngine performs header validation and expects these two to always be set.
+            response.Headers.Add("Location", "local");
+            response.Headers.Add("Version", extensionInfo.ExtensionVersion);
+
+            return response;
+        }
+
+        private async Task<HttpResponseMessage> CallExtension(string method, ILocalExtension provider, HttpContent content, CancellationToken cancellationToken)
+        {
+            switch (method)
+            {
+                case "createOrUpdate":
+                    {
+                        var resourceSpecification = await GetResourceSpecificationAsync(await content.ReadAsStreamAsync(cancellationToken), cancellationToken);
+                        var extensionResponse = await provider.CreateOrUpdate(resourceSpecification, cancellationToken);
+
+                        return await GetHttpResponseMessageAsync(extensionResponse, cancellationToken);
+                    }
+                case "delete":
+                    {
+                        var resourceReference = await GetResourceReferenceAsync(await content.ReadAsStreamAsync(cancellationToken), cancellationToken);
+                        var extensionResponse = await provider.Delete(resourceReference, cancellationToken);
+
+                        return await GetHttpResponseMessageAsync(extensionResponse, cancellationToken);
+                    }
+                case "get":
+                    {
+                        var resourceReference = await GetResourceReferenceAsync(await content.ReadAsStreamAsync(cancellationToken), cancellationToken);
+                        var extensionResponse = await provider.Delete(resourceReference, cancellationToken);
+
+                        return await GetHttpResponseMessageAsync(extensionResponse, cancellationToken);
+                    }
+                case "preview":
+                    {
+                        var resourceSpecification = await GetResourceSpecificationAsync(await content.ReadAsStreamAsync(cancellationToken), cancellationToken);
+                        var extensionResponse = await provider.CreateOrUpdate(resourceSpecification, cancellationToken);
+
+                        return await GetHttpResponseMessageAsync(extensionResponse, cancellationToken);
+                    }
+                default:
+                    throw new NotImplementedException($"Unsupported method {method}");
+            }
+        }
+
+        private async Task<Azure.Deployments.Extensibility.Core.V2.Models.ResourceSpecification> GetResourceSpecificationAsync(Stream stream, CancellationToken cancellationToken)
+        => await DeserializeAsync(
+                    stream,
+                    JsonDefaults.SerializerContext.ResourceSpecification,
+                    $"Deserializing '{nameof(global::Azure.Deployments.Extensibility.Core.V2.Models.ResourceSpecification)}' failed. Please ensure the request body contains a valid JSON object.",
+                    cancellationToken);
+
+        private async Task<Azure.Deployments.Extensibility.Core.V2.Models.ResourceReference> GetResourceReferenceAsync(Stream stream, CancellationToken cancellationToken)
+            => await DeserializeAsync(
+                        stream,
+                        JsonDefaults.SerializerContext.ResourceReference,
+                        $"Deserializing '{nameof(Azure.Deployments.Extensibility.Core.V2.Models.ResourceReference)}' failed. Please ensure the request body contains a valid JSON object.",
+                        cancellationToken);
+
+        private async Task<TEntity> DeserializeAsync<TEntity>(Stream stream, JsonTypeInfo<TEntity> typeInfo, string errorMessage, CancellationToken cancellationToken)
+            => await JsonSerializer.DeserializeAsync(stream, typeInfo, cancellationToken) ?? throw new ArgumentNullException(errorMessage);
+
+        private async Task<HttpResponseMessage> GetHttpResponseMessageAsync(LocalExtensionOperationResponse extensionResponse, CancellationToken cancellationToken)
+        {
+            if (extensionResponse.Resource is { } && extensionResponse.ErrorData is { })
+            {
+                throw new ArgumentException($"Setting '{nameof(LocalExtensibilityOperationResponse.ErrorData)}' and '{nameof(LocalExtensibilityOperationResponse.Resource)}' is not valid. Please make sure to set one of these properties.");
+            }
+
+            if (extensionResponse.Resource is not { } && extensionResponse.ErrorData is not { })
+            {
+                throw new ArgumentException($"'{nameof(LocalExtensibilityOperationResponse.ErrorData)}' and '{nameof(LocalExtensibilityOperationResponse.Resource)}' cannot be both empty. Please make sure to set one of these properties.");
+            }
+
+            var memoryStream = new MemoryStream();
+            if (extensionResponse.ErrorData is { })
+            {
+                await JsonSerializer.SerializeAsync(memoryStream, extensionResponse.ErrorData, JsonDefaults.SerializerContext.ErrorData, cancellationToken);
+                memoryStream.Position = 0;
+                var streamContent = new StreamContent(memoryStream);
+                streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                return new HttpResponseMessage(System.Net.HttpStatusCode.BadRequest)
+                {
+                    Content = streamContent
+                };
+            }
+            else if (extensionResponse.Resource is { })
+            {
+                await JsonSerializer.SerializeAsync(memoryStream, extensionResponse.Resource, JsonDefaults.SerializerContext.Resource, cancellationToken);
+                memoryStream.Position = 0;
+                var streamContent = new StreamContent(memoryStream);
+                streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = streamContent
+                };
+            }
+
+            throw new UnreachableException($"Should not reach here, either '{nameof(LocalExtensibilityOperationResponse.ErrorData)}' or '{nameof(LocalExtensibilityOperationResponse.Resource)}' should have been set.");
+        }
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensionHostManager.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensionHostManager.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using System.Threading.Tasks;
+using Bicep.Core.TypeSystem.Types;
+using Google.Protobuf;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public record BinaryExtensionReference(NamespaceType NamespaceType, Uri BinaryExtensionUri);
+
+    public class LocalExtensionHostManager : IAsyncDisposable, ILocalExtensionHost
+    {
+        private readonly ILocalExtensionFactoryManager localExtensionFactoryManager;
+        private readonly ILocalExtensionHost localExtensionHost;
+        private bool LocalExtensionsInitialized;
+
+        public LocalExtensionHostManager(ILocalExtensionFactoryManager localExtensionFactoryManager, ILocalExtensionHost localExtensionHost)
+        {
+            this.localExtensionFactoryManager = localExtensionFactoryManager;
+            this.localExtensionHost = localExtensionHost;
+        }
+
+        public void InitializeLocalExtensions(IReadOnlyList<BinaryExtensionReference> binaryExtensions)
+        {
+            if (LocalExtensionsInitialized == false)
+            {
+                localExtensionFactoryManager.InitializeLocalExtensions(binaryExtensions);
+                LocalExtensionsInitialized = true;
+            }
+        }
+
+        public void InitializeLocalExtensionsLifecycleManagement() { }
+
+        public Task<HttpResponseMessage> CallExtensibilityHost(LocalDeploymentEngineHost.ExtensionInfo extensionInfo, HttpContent content, CancellationToken cancellationToken)
+        {
+            EnsureLocalExtensionsInitialized();
+            return localExtensionHost.CallExtensibilityHost(extensionInfo, content, cancellationToken);
+        }
+
+        private void EnsureLocalExtensionsInitialized()
+        {
+            if (LocalExtensionsInitialized == false)
+            {
+                throw new ArgumentNullException($"Local extensions not initialized. Make sure to invoke: '{nameof(InitializeLocalExtensions)}' first.");
+            }
+        }
+
+        ValueTask IAsyncDisposable.DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensionRegistry.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensionRegistry.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Local.Deploy.Extensibility
+{
+    public class LocalExtensionRegistry
+    {
+        public LocalExtensionRegistry(ILocalExtensionFactory factory)
+        {
+        }
+
+        public void InitializeLocalExtensions()
+        {
+            RetrieveLocalExtensions();
+            RegisterLocalExtensions();
+            LoadLocalExtensions();
+        }
+
+        private void RetrieveLocalExtensions()
+        {
+
+        }
+
+        private void RegisterLocalExtensions()
+        {
+
+        }
+
+        private void LoadLocalExtensions()
+        {
+
+        }
+    }
+}

--- a/src/Bicep.Local.Deploy/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Local.Deploy/IServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Linq;
+using System.Web.Services.Description;
 using Azure.Deployments.Core.EventSources;
 using Azure.Deployments.Core.Exceptions;
 using Azure.Deployments.Core.FeatureEnablement;
@@ -72,6 +73,100 @@ public static class IServiceCollectionExtensions
         services.AddSingleton(extensibilityHandler);
 
         services.AddSingleton<LocalDeploymentEngine>();
+        services.AddSingleton<LocalExtensionHostManager>();
+        services.AddSingleton<LocalDeploy>();
+
+        return services;
+    }
+
+    public static IServiceCollection RegisterLocalDeployServices(this IServiceCollection services)
+    {
+        var eventSource = new TraceEventSource();
+        services.AddSingleton<IGeneralEventSource>(eventSource);
+        services.AddSingleton<IDeploymentEventSource>(eventSource);
+
+        services.AddSingleton<IKeyVaultDataProvider, LocalKeyVaultDataProvider>();
+        services.AddSingleton<IAzureDeploymentSettings, LocalDeploymentSettings>();
+        services.AddSingleton<IEnablementConfigProvider, LocalEnablementConfigProvider>();
+        services.AddSingleton<IAzureDeploymentEngineHost, LocalDeploymentEngineHost>();
+        services.AddSingleton<IPreflightEngineHost, PreflightEngineHost>();
+        services.AddSingleton<IDeploymentDependency, DependencyProcessor>();
+        services.AddSingleton<ITemplateExceptionHandler, TemplateExceptionHandler>();
+
+        services.AddSingleton<AzureDeploymentValidation>();
+        services.AddSingleton<IAzureDeploymentConfiguration, LocalDeploymentConfiguration>();
+        services.AddSingleton<AzureDeploymentEngine>();
+        services.AddSingleton<IDeploymentEntityFactory, VolatileDeploymentEntityFactory>();
+        services.AddSingleton<IDeploymentJobsDataProvider, VolatileDeploymentJobDataProvider>();
+        services.AddSingleton<IDataProviderHolder, VolatileDataProviderHolder>();
+
+        var jobConfiguration = new JobConfigurationBase
+        {
+            Location = "local",
+            EventSource = eventSource,
+        };
+        services.AddSingleton(jobConfiguration);
+        RegisterJobsAsService(services);
+
+        services.AddSingleton<VolatileMemoryStorage>();
+        services.AddSingleton<IJobInstanceResolver, JobInstanceResolver>();
+        services.AddSingleton<JobCallbackFactory, DeploymentJobCallbackFactory>();
+        services.AddSingleton<WorkerJobDispatcherClient>();
+
+        services.AddSingleton<IDeploymentsRequestContext, LocalRequestContext>();
+        services.AddSingleton<LocalRequestContext>();
+
+        services.AddSingleton<LocalDeploymentEngine>();
+        services.AddSingleton<LocalExtensionHostManager>();
+        services.AddSingleton<ILocalExtensionFactoryManager, LocalExtensionFactoryManager>();
+        services.AddSingleton<ILocalExtensionHost, LocalExtensionHost>();
+        services.AddSingleton<LocalDeploy>();
+
+        return services;
+    }
+
+    public static IServiceCollection RegisterLocalDeployServices(this IServiceCollection services, LocalExtensionHostManager extensionHostManager)
+    {
+        var eventSource = new TraceEventSource();
+        services.AddSingleton<IGeneralEventSource>(eventSource);
+        services.AddSingleton<IDeploymentEventSource>(eventSource);
+
+        services.AddSingleton<IKeyVaultDataProvider, LocalKeyVaultDataProvider>();
+        services.AddSingleton<IAzureDeploymentSettings, LocalDeploymentSettings>();
+        services.AddSingleton<IEnablementConfigProvider, LocalEnablementConfigProvider>();
+        services.AddSingleton<IAzureDeploymentEngineHost, LocalDeploymentEngineHost>();
+        services.AddSingleton<IPreflightEngineHost, PreflightEngineHost>();
+        services.AddSingleton<IDeploymentDependency, DependencyProcessor>();
+        services.AddSingleton<ITemplateExceptionHandler, TemplateExceptionHandler>();
+
+        services.AddSingleton<AzureDeploymentValidation>();
+        services.AddSingleton<IAzureDeploymentConfiguration, LocalDeploymentConfiguration>();
+        services.AddSingleton<AzureDeploymentEngine>();
+        services.AddSingleton<IDeploymentEntityFactory, VolatileDeploymentEntityFactory>();
+        services.AddSingleton<IDeploymentJobsDataProvider, VolatileDeploymentJobDataProvider>();
+        services.AddSingleton<IDataProviderHolder, VolatileDataProviderHolder>();
+
+        var jobConfiguration = new JobConfigurationBase
+        {
+            Location = "local",
+            EventSource = eventSource,
+        };
+        services.AddSingleton(jobConfiguration);
+        RegisterJobsAsService(services);
+
+        services.AddSingleton<VolatileMemoryStorage>();
+        services.AddSingleton<IJobInstanceResolver, JobInstanceResolver>();
+        services.AddSingleton<JobCallbackFactory, DeploymentJobCallbackFactory>();
+        services.AddSingleton<WorkerJobDispatcherClient>();
+
+        services.AddSingleton<IDeploymentsRequestContext, LocalRequestContext>();
+        services.AddSingleton<LocalRequestContext>();
+
+        services.AddSingleton<LocalDeploymentEngine>();
+        services.AddSingleton<LocalExtensionHostManager>(extensionHostManager);
+
+        services.AddSingleton<ILocalExtensionFactoryManager, LocalExtensionFactoryManager>();
+        services.AddSingleton<ILocalExtensionHost, LocalExtensionHost>();
 
         return services;
     }

--- a/src/Bicep.Local.Deploy/LocalDeployment.cs
+++ b/src/Bicep.Local.Deploy/LocalDeployment.cs
@@ -11,6 +11,35 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Bicep.Local.Deploy;
 
+public class LocalDeploy
+{
+    public record Result(
+        DeploymentContent Deployment,
+        ImmutableArray<DeploymentOperationDefinition> Operations);
+
+    private readonly LocalDeploymentEngine deploymentEngine;
+    private readonly WorkerJobDispatcherClient dispatcherClient;
+
+    public LocalDeploy(LocalDeploymentEngine deploymentEngine, WorkerJobDispatcherClient dispatcherClient)
+    {
+        this.deploymentEngine = deploymentEngine;
+        this.dispatcherClient = dispatcherClient;
+    }
+
+    public async Task<Result> Deploy(string templateString, string parametersString, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await deploymentEngine.Deploy(templateString, parametersString, cancellationToken);
+            return new(result.Deployment, result.Operations);
+        }
+        finally
+        {
+            await dispatcherClient.StopAsync();
+        }
+    }
+}
+
 public static class LocalDeployment
 {
     public record Result(
@@ -21,6 +50,25 @@ public static class LocalDeployment
     {
         var services = new ServiceCollection()
             .RegisterLocalDeployServices(extensibilityHandler)
+            .BuildServiceProvider();
+
+        var engine = services.GetRequiredService<LocalDeploymentEngine>();
+        var dispatcher = services.GetRequiredService<WorkerJobDispatcherClient>();
+
+        try
+        {
+            return await engine.Deploy(templateString, parametersString, cancellationToken);
+        }
+        finally
+        {
+            await dispatcher.StopAsync();
+        }
+    }
+
+    public static async Task<Result> Deploy(LocalExtensionHostManager extensionHostManager, string templateString, string parametersString, CancellationToken cancellationToken)
+    {
+        var services = new ServiceCollection()
+            .RegisterLocalDeployServices(extensionHostManager)
             .BuildServiceProvider();
 
         var engine = services.GetRequiredService<LocalDeploymentEngine>();

--- a/src/Bicep.Local.Deploy/LocalDeploymentEngine.cs
+++ b/src/Bicep.Local.Deploy/LocalDeploymentEngine.cs
@@ -31,7 +31,7 @@ using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 
 namespace Bicep.Local.Deploy;
 
-internal class LocalDeploymentEngine
+public class LocalDeploymentEngine
 {
 
     public LocalDeploymentEngine(

--- a/src/Bicep.Local.Deploy/LocalDeploymentEngineHost.cs
+++ b/src/Bicep.Local.Deploy/LocalDeploymentEngineHost.cs
@@ -28,12 +28,12 @@ namespace Bicep.Local.Deploy;
 
 public class LocalDeploymentEngineHost : DeploymentEngineHostBase
 {
-    private readonly LocalExtensibilityHostManager extensibilityHandler;
+    private readonly LocalExtensionHostManager extensionHostManager;
 
     public readonly record struct ExtensionInfo(string ExtensionName, string ExtensionVersion, string Method);
 
     public LocalDeploymentEngineHost(
-        LocalExtensibilityHostManager extensibilityHandler,
+        LocalExtensionHostManager extensionHostManager,
         IDeploymentsRequestContext requestContext,
         IDeploymentEventSource deploymentEventSource,
         IKeyVaultDataProvider keyVaultDataProvider,
@@ -43,7 +43,7 @@ public class LocalDeploymentEngineHost : DeploymentEngineHostBase
         IEnablementConfigProvider enablementConfigProvider)
         : base(settings, deploymentEventSource, keyVaultDataProvider, requestContext, dataProviderHolder, exceptionHandler, enablementConfigProvider)
     {
-        this.extensibilityHandler = extensibilityHandler;
+        this.extensionHostManager = extensionHostManager;
     }
 
     public override Task<HttpResponseMessage> DownloadContent(Uri requestUri, CancellationToken cancellationToken)
@@ -138,7 +138,7 @@ public class LocalDeploymentEngineHost : DeploymentEngineHostBase
 
         var extensionInfo = new ExtensionInfo(extensionName, extensionVersion, method);
 
-        return await extensibilityHandler.CallExtensibilityHost(extensionInfo, content, cancellationToken);
+        return await extensionHostManager.CallExtensibilityHost(extensionInfo, content, cancellationToken);
     }
 
     protected override Task<JToken> GetEnvironmentKey()

--- a/src/Bicep.Local.Deploy/packages.lock.json
+++ b/src/Bicep.Local.Deploy/packages.lock.json
@@ -1280,6 +1280,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Local.Extension.Mock/packages.lock.json
+++ b/src/Bicep.Local.Extension.Mock/packages.lock.json
@@ -117,6 +117,17 @@
           "Newtonsoft.Json": "13.0.2"
         }
       },
+      "Azure.Deployments.Extensibility.Core": {
+        "type": "Transitive",
+        "resolved": "0.1.55",
+        "contentHash": "iMZhx89YLqHaPGA20LXlzDBty7ov/UgOdxLudJtYwBXkalfSRHLPNKRnJVeGM3EZc9897LeoPyfJ8NvyLeZcgQ==",
+        "dependencies": {
+          "JsonPatch.Net": "3.1.0",
+          "JsonPath.Net": "1.1.0",
+          "JsonPointer.Net": "5.0.0",
+          "JsonSchema.Net": "7.0.4"
+        }
+      },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
         "resolved": "1.71.0",
@@ -265,6 +276,14 @@
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Json.More.Net": "2.0.1.2"
+        }
+      },
+      "JsonSchema.Net": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "R0Hk2Tr/np4Q1NO8CBjyQsoiD1iFJyEQP20Sw7JnZCNGJoaSBe+g4b+nZqnBXPQhiqY5LGZ8JZwZkRh/eKZhEQ==",
+        "dependencies": {
+          "JsonPointer.Net": "5.0.0"
         }
       },
       "Microsoft.Automata.SRM": {
@@ -1068,6 +1087,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj
+++ b/src/Bicep.Local.Extension/Bicep.Local.Extension.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
+    <PackageReference Include="Azure.Deployments.Extensibility.Core" Version="0.1.55" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Local.Extension/BicepExtensionHostBase.cs
+++ b/src/Bicep.Local.Extension/BicepExtensionHostBase.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Bicep.Local.Extension.Protocol;
+using Bicep.Local.Extension.Rpc;
+using CommandLine;
+
+namespace Bicep.Local.Extension
+{
+    public abstract class BicepExtensionHostBase
+    {
+        internal class CommandLineOptions
+        {
+            [Option("socket", Required = false, HelpText = "The path to the domain socket to connect on")]
+            public string? Socket { get; set; }
+
+            [Option("wait-for-debugger", Required = false, HelpText = "If set, wait for a dotnet debugger to be attached before starting the server")]
+            public bool WaitForDebugger { get; set; }
+        }
+
+        public static async Task Run(BicepExtensionHostBase extension, Action<LocalExtensionDispatcherBuilder> registerHandlers, string[] args)
+            => await RunWithCancellationAsync(async cancellationToken =>
+            {
+                if (IsTracingEnabled)
+                {
+                    Trace.Listeners.Add(new TextWriterTraceListener(Console.Error));
+                }
+
+                await extension.RunAsync(args, registerHandlers, cancellationToken);
+            });
+
+        public async Task RunAsync(string[] args, Action<LocalExtensionDispatcherBuilder> registerHandlers, CancellationToken cancellationToken)
+        {
+            var parser = new Parser(settings =>
+            {
+                settings.IgnoreUnknownArguments = true;
+            });
+
+            await parser.ParseArguments<CommandLineOptions>(args)
+                .WithNotParsed((x) => System.Environment.Exit(1))
+                .WithParsedAsync(async options => await RunServer(registerHandlers, options, cancellationToken));
+        }
+
+        protected abstract Task RunServer(string socketPath, LocalExtensionDispatcher dispatcher, CancellationToken cancellationToken);
+
+        private async Task RunServer(Action<LocalExtensionDispatcherBuilder> registerHandlers, CommandLineOptions options, CancellationToken cancellationToken)
+        {
+            if (options.WaitForDebugger)
+            {
+                // exit if we don't have a debugger attached within 5 minutes
+                var debuggerTimeoutToken = CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    new CancellationTokenSource(TimeSpan.FromMinutes(5)).Token).Token;
+
+                while (!Debugger.IsAttached)
+                {
+                    await Task.Delay(100, debuggerTimeoutToken);
+                }
+
+                Debugger.Break();
+            }
+
+            var handlerBuilder = new LocalExtensionDispatcherBuilder();
+            registerHandlers(handlerBuilder);
+            var dispatcher = handlerBuilder.Build();
+
+            if (options.Socket is { } socketPath)
+            {
+                await Task.WhenAny(RunServer(socketPath, dispatcher, cancellationToken), WaitForCancellation(cancellationToken));
+                return;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        private static async Task WaitForCancellation(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await Task.Delay(-1, cancellationToken);
+            }
+            catch (TaskCanceledException ex) when (ex.CancellationToken == cancellationToken)
+            {
+                // don't throw - continue
+            }
+        }
+
+        private static async Task RunWithCancellationAsync(Func<CancellationToken, Task> runFunc)
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                cancellationTokenSource.Cancel();
+                e.Cancel = true;
+            };
+
+            AppDomain.CurrentDomain.ProcessExit += (sender, e) =>
+            {
+                cancellationTokenSource.Cancel();
+            };
+
+            try
+            {
+                await runFunc(cancellationTokenSource.Token);
+            }
+            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationTokenSource.Token)
+            {
+                // this is expected - no need to rethrow
+            }
+        }
+
+        private static bool IsTracingEnabled
+            => bool.TryParse(Environment.GetEnvironmentVariable("BICEP_TRACING_ENABLED"), out var value) && value;
+    }
+}

--- a/src/Bicep.Local.Extension/Protocol/ILocalExtension.cs
+++ b/src/Bicep.Local.Extension/Protocol/ILocalExtension.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Local.Extension.Protocol
+{
+    public abstract class LocalExtension : ILocalExtension
+    {
+        private bool initialized;
+        private ILocalExtension? InitializedExtension;
+
+        public abstract Task<ILocalExtension> InitializeAsync();
+
+        public async Task<ILocalExtension> EnsureInitializedAsync()
+        {
+            if (initialized == false || InitializedExtension is null)
+            {
+                InitializedExtension = await InitializeAsync();
+                initialized = true;
+            }
+            return InitializedExtension;
+        }
+
+        public abstract Task<LocalExtensionOperationResponse> CreateOrUpdate(Azure.Deployments.Extensibility.Core.V2.Models.ResourceSpecification request, CancellationToken cancellationToken);
+
+        public abstract Task<LocalExtensionOperationResponse> Delete(Azure.Deployments.Extensibility.Core.V2.Models.ResourceReference request, CancellationToken cancellationToken);
+
+        public abstract Task<LocalExtensionOperationResponse> Get(Azure.Deployments.Extensibility.Core.V2.Models.ResourceReference request, CancellationToken cancellationToken);
+
+        public abstract Task<LocalExtensionOperationResponse> Preview(Azure.Deployments.Extensibility.Core.V2.Models.ResourceSpecification request, CancellationToken cancellationToken);
+    }
+
+    public interface ILocalExtension
+    {
+        Task<LocalExtensionOperationResponse> CreateOrUpdate(
+            Azure.Deployments.Extensibility.Core.V2.Models.ResourceSpecification request,
+            CancellationToken cancellationToken);
+
+        Task<LocalExtensionOperationResponse> Delete(
+            Azure.Deployments.Extensibility.Core.V2.Models.ResourceReference request,
+            CancellationToken cancellationToken);
+
+        Task<LocalExtensionOperationResponse> Get(
+            Azure.Deployments.Extensibility.Core.V2.Models.ResourceReference request,
+            CancellationToken cancellationToken);
+
+        Task<LocalExtensionOperationResponse> Preview(
+            Azure.Deployments.Extensibility.Core.V2.Models.ResourceSpecification request,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Bicep.Local.Extension/Protocol/IResourceHandler.cs
+++ b/src/Bicep.Local.Extension/Protocol/IResourceHandler.cs
@@ -47,6 +47,10 @@ public record LocalExtensibilityOperationResponse(
     Resource? Resource,
     ErrorData? ErrorData);
 
+public record LocalExtensionOperationResponse(
+    Azure.Deployments.Extensibility.Core.V2.Models.Resource? Resource,
+    Azure.Deployments.Extensibility.Core.V2.Models.ErrorData? ErrorData);
+
 public interface IGenericResourceHandler
 {
     Task<LocalExtensibilityOperationResponse> CreateOrUpdate(
@@ -67,6 +71,11 @@ public interface IGenericResourceHandler
 }
 
 public interface IResourceHandler : IGenericResourceHandler
+{
+    string ResourceType { get; }
+}
+
+public interface ILocalExtensionHandler : ILocalExtension
 {
     string ResourceType { get; }
 }

--- a/src/Bicep.Local.Extension/Protocol/LocalExtensionDispatcher.cs
+++ b/src/Bicep.Local.Extension/Protocol/LocalExtensionDispatcher.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Local.Extension.Protocol
+{
+    public class LocalExtensionDispatcher
+    {
+        private readonly ILocalExtension? genericResourceHandler;
+        private readonly ImmutableDictionary<string, ILocalExtensionHandler> resourceHandlers;
+
+        public LocalExtensionDispatcher(
+            ILocalExtension? genericResourceHandler,
+            ImmutableDictionary<string, ILocalExtensionHandler> resourceHandlers)
+        {
+            this.genericResourceHandler = genericResourceHandler;
+            this.resourceHandlers = resourceHandlers;
+        }
+
+        public ILocalExtension GetHandler(string resourceType)
+        {
+            if (this.resourceHandlers.TryGetValue(resourceType, out var handler))
+            {
+                return handler;
+            }
+
+            if (this.genericResourceHandler is { })
+            {
+                return this.genericResourceHandler;
+            }
+
+            throw new ArgumentException($"Resource type '{resourceType}' is not supported.");
+        }
+    }
+}

--- a/src/Bicep.Local.Extension/Protocol/LocalExtensionDispatcherBuilder.cs
+++ b/src/Bicep.Local.Extension/Protocol/LocalExtensionDispatcherBuilder.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.Local.Extension.Protocol
+{
+    public class LocalExtensionDispatcherBuilder
+    {
+        private ILocalExtension? genericResourceHandler;
+        private readonly Dictionary<string, ILocalExtensionHandler> resourceHandlers = new(StringComparer.OrdinalIgnoreCase);
+
+        public LocalExtensionDispatcherBuilder AddHandler(ILocalExtensionHandler handler)
+        {
+            if (!this.resourceHandlers.TryAdd(handler.ResourceType, handler))
+            {
+                throw new ArgumentException($"Resource type '{handler.ResourceType}' has already been registered.");
+            }
+
+            this.resourceHandlers[handler.ResourceType] = handler;
+            return this;
+        }
+
+        public LocalExtensionDispatcherBuilder AddGenericHandler(ILocalExtension handler)
+        {
+            if (this.genericResourceHandler is not null)
+            {
+                throw new ArgumentException($"Generic resource handler has already been registered.");
+            }
+
+            this.genericResourceHandler = handler;
+            return this;
+        }
+
+        public LocalExtensionDispatcher Build()
+        {
+            return new(
+                this.genericResourceHandler,
+                this.resourceHandlers.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Bicep.Local.Extension/Rpc/BicepGrpcService.cs
+++ b/src/Bicep.Local.Extension/Rpc/BicepGrpcService.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Bicep.Local.Extension.Protocol;
+using Google.Protobuf.Collections;
+using Grpc.Core;
+using Json.More;
+using Microsoft.Extensions.Logging;
+
+namespace Bicep.Local.Extension.Rpc
+{
+    public class BicepGrpcService : BicepExtension.BicepExtensionBase
+    {
+        private readonly ILogger<BicepGrpcService> logger;
+        private readonly LocalExtensionDispatcher dispatcher;
+
+        public BicepGrpcService(ILogger<BicepGrpcService> logger, LocalExtensionDispatcher dispatcher)
+        {
+            this.logger = logger;
+            this.dispatcher = dispatcher;
+        }
+
+        public override Task<LocalExtensibilityOperationResponse> CreateOrUpdate(ResourceSpecification request, ServerCallContext context)
+            => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Type).CreateOrUpdate(Convert(request), context.CancellationToken)));
+
+        public override Task<LocalExtensibilityOperationResponse> Preview(ResourceSpecification request, ServerCallContext context)
+            => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Type).Preview(Convert(request), context.CancellationToken)));
+
+        public override Task<LocalExtensibilityOperationResponse> Get(ResourceReference request, ServerCallContext context)
+            => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Type).Get(Convert(request), context.CancellationToken)));
+
+        public override Task<LocalExtensibilityOperationResponse> Delete(ResourceReference request, ServerCallContext context)
+            => WrapExceptions(async () => Convert(await dispatcher.GetHandler(request.Type).Delete(Convert(request), context.CancellationToken)));
+
+        public override Task<Empty> Ping(Empty request, ServerCallContext context)
+            => Task.FromResult(new Empty());
+
+        private Azure.Deployments.Extensibility.Core.V2.Models.ResourceSpecification Convert(ResourceSpecification request)
+            => new(request.Type, request.ApiVersion, ToJsonObject(request.Properties, "Parsing extension properties failed. Please ensure is a valid JSON object."), GetExtensionConfig(request.Config));
+
+        private Azure.Deployments.Extensibility.Core.V2.Models.ResourceReference Convert(ResourceReference request)
+            => new(request.Type, request.ApiVersion, ToJsonObject(request.Identifiers, "Parsing extension identifiers failed. Please ensure is a valid JSON object."), GetExtensionConfig(request.Config));
+
+        private JsonObject? GetExtensionConfig(string extensionConfig)
+        {
+            JsonObject? config = null;
+            if (!string.IsNullOrEmpty(extensionConfig))
+            {
+                config = ToJsonObject(extensionConfig, "Parsing extension config failed. Please ensure is a valid JSON object.");
+            }
+            return config;
+        }
+
+        private JsonObject ToJsonObject(string json, string errorMessage)
+            => JsonNode.Parse(json)?.AsObject() ?? throw new ArgumentNullException(errorMessage);
+
+        private Resource? Convert(Azure.Deployments.Extensibility.Core.V2.Models.Resource? response)
+            => response is null ? null :
+                new()
+                {
+                    Identifiers = response.Identifiers.ToJsonString(),
+                    Properties = response.Properties.ToJsonString(),
+                    Status = response.Status,
+                    Type = response.Type,
+                    ApiVersion = response.ApiVersion,
+                };
+
+        private ErrorData? Convert(Azure.Deployments.Extensibility.Core.V2.Models.ErrorData? response)
+        {
+            if (response is null)
+            {
+                return null;
+            }
+
+            var errorData = new ErrorData()
+            {
+                Error = new Error()
+                {
+                    Code = response.Error.Code,
+                    Message = response.Error.Message,
+                    InnerError = response.Error.InnerError?.ToJsonString(),
+                    Target = response.Error.Target?.ToString() ?? string.Empty,
+                }
+            };
+
+            var errorDetails = Convert(response.Error.Details);
+            if (errorDetails is not null)
+            {
+                errorData.Error.Details.AddRange(errorDetails);
+            }
+            return errorData;
+        }
+
+        private RepeatedField<ErrorDetail>? Convert(IList<Azure.Deployments.Extensibility.Core.V2.Models.ErrorDetail>? response)
+        {
+            if (response is null)
+            {
+                return null;
+            }
+
+            var list = new RepeatedField<ErrorDetail>();
+            foreach (var item in response)
+            {
+                list.Add(Convert(item));
+            }
+            return list;
+        }
+
+        private ErrorDetail Convert(Azure.Deployments.Extensibility.Core.V2.Models.ErrorDetail response)
+            => new()
+            {
+                Code = response.Code,
+                Message = response.Message,
+                Target = response.Target?.ToString() ?? string.Empty,
+            };
+
+        private LocalExtensibilityOperationResponse Convert(LocalExtensionOperationResponse response)
+            => new()
+            {
+                ErrorData = Convert(response.ErrorData),
+                Resource = Convert(response.Resource)
+            };
+
+        private static async Task<LocalExtensibilityOperationResponse> WrapExceptions(Func<Task<LocalExtensibilityOperationResponse>> func)
+        {
+            try
+            {
+                return await func();
+            }
+            catch (Exception ex)
+            {
+                var response = new LocalExtensibilityOperationResponse
+                {
+                    Resource = null,
+                    ErrorData = new ErrorData
+                    {
+                        Error = new Error
+                        {
+                            Message = $"Rpc request failed: {ex}",
+                            Code = "RpcException",
+                            Target = ""
+                        }
+                    }
+                };
+
+                return response;
+            }
+        }
+    }
+}

--- a/src/Bicep.Local.Extension/packages.lock.json
+++ b/src/Bicep.Local.Extension/packages.lock.json
@@ -2,6 +2,18 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Azure.Deployments.Extensibility.Core": {
+        "type": "Direct",
+        "requested": "[0.1.55, )",
+        "resolved": "0.1.55",
+        "contentHash": "iMZhx89YLqHaPGA20LXlzDBty7ov/UgOdxLudJtYwBXkalfSRHLPNKRnJVeGM3EZc9897LeoPyfJ8NvyLeZcgQ==",
+        "dependencies": {
+          "JsonPatch.Net": "3.1.0",
+          "JsonPath.Net": "1.1.0",
+          "JsonPointer.Net": "5.0.0",
+          "JsonSchema.Net": "7.0.4"
+        }
+      },
       "Azure.Deployments.Internal.GenerateNotice": {
         "type": "Direct",
         "requested": "[0.1.38, )",
@@ -75,6 +87,49 @@
         "contentHash": "RLt6p31ZMsXRcHNeu1dQuIFLYZvnwP6LUzoDPlV3KoR4w9btmwrXIvz9Jbp1SOmxW7nXw9zShAeIt5LsqFAx5w==",
         "dependencies": {
           "Grpc.Core.Api": "2.63.0"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Json.More.Net": {
+        "type": "Transitive",
+        "resolved": "2.0.1.2",
+        "contentHash": "uF3QeiaXEfH92emz0/BWUiNtMSfxIIvgynuB0Bf1vF4s8eWTcZitBx9l+g/FDaJk5XxqBv9buQXizXKQcXFG1w=="
+      },
+      "JsonPatch.Net": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "BS/8aoXm5mEA/8f7SzhfXEitsEbqERME7xzuRbCDvBXtS2mcAoPAq11L324rhARJfRZ/nGso/KFfggIIdyytww==",
+        "dependencies": {
+          "JsonPointer.Net": "5.0.0"
+        }
+      },
+      "JsonPath.Net": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "Njbt3xuyiJ41zkut0nrKbHL7Hpxb39siV/KchPnXKVNGnhnYqIUmiWh653EfRK4lG8H+ds08bNrw5/3jl9ZC3A==",
+        "dependencies": {
+          "Json.More.Net": "2.0.1.2"
+        }
+      },
+      "JsonPointer.Net": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "fm4T5w20AY6C+p5/pJr0vrXRNGgtSfHl34I1LxC9zdPwS9S3j0GiR1Mz/CVPWKDXXGDpCt1APHpCq7kn5adCfA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Json.More.Net": "2.0.1.2"
+        }
+      },
+      "JsonSchema.Net": {
+        "type": "Transitive",
+        "resolved": "7.0.4",
+        "contentHash": "R0Hk2Tr/np4Q1NO8CBjyQsoiD1iFJyEQP20Sw7JnZCNGJoaSBe+g4b+nZqnBXPQhiqY5LGZ8JZwZkRh/eKZhEQ==",
+        "dependencies": {
+          "JsonPointer.Net": "5.0.0"
         }
       },
       "Microsoft.Build.Tasks.Git": {

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -1785,6 +1785,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -1725,6 +1725,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -1785,6 +1785,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -1611,6 +1611,7 @@
       "Azure.Bicep.Local.Extension": {
         "type": "Project",
         "dependencies": {
+          "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "CommandLineParser": "[2.9.1, )",
           "Google.Protobuf": "[3.27.1, )",
           "Grpc.Net.Client": "[2.63.0, )"


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
