### PR TITLE
Remove the nuget.org feed from `Bicep.MSBuild.E2eTests/examples/NuGet.Config`

### DIFF
--- a/src/Bicep.MSBuild.E2eTests/examples/NuGet.config
+++ b/src/Bicep.MSBuild.E2eTests/examples/NuGet.config
@@ -6,7 +6,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Local" value="local-packages" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Removed the feed to mitigate an S360 item. We don't need the nuget.org feed to run the e2e tests. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14776)