### PR TITLE
Standardize error code format

### DIFF
--- a/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TestFrameworkTests.cs
@@ -50,7 +50,7 @@ test test1
 ");
             result.Should().HaveDiagnostics(new[] {
                 ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
-                ("BCP0347", DiagnosticLevel.Error,  "Expected a test path string at this location."),
+                ("BCP347", DiagnosticLevel.Error,  "Expected a test path string at this location."),
                 ("BCP358", DiagnosticLevel.Error, "This declaration is missing a template file path reference.")
             });
             result = CompilationHelper.Compile(@"
@@ -58,7 +58,7 @@ test
 ");
             result.Should().HaveDiagnostics(new[] {
                 ("BCP348", DiagnosticLevel.Error, "Using a test declaration statement requires enabling EXPERIMENTAL feature \"TestFramework\"."),
-                ("BCP0346", DiagnosticLevel.Error,  "Expected a test identifier at this location."),
+                ("BCP346", DiagnosticLevel.Error,  "Expected a test identifier at this location."),
                 ("BCP358", DiagnosticLevel.Error, "This declaration is missing a template file path reference.")
             });
         }
@@ -70,7 +70,7 @@ test
 test
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP0346", DiagnosticLevel.Error,  "Expected a test identifier at this location."),
+                ("BCP346", DiagnosticLevel.Error,  "Expected a test identifier at this location."),
                 ("BCP358", DiagnosticLevel.Error,  "This declaration is missing a template file path reference.")
 
             });
@@ -79,7 +79,7 @@ test
 test test1
 ");
             result.Should().HaveDiagnostics(new[] {
-                ("BCP0347", DiagnosticLevel.Error,  "Expected a test path string at this location."),
+                ("BCP347", DiagnosticLevel.Error,  "Expected a test path string at this location."),
                 ("BCP358", DiagnosticLevel.Error, "This declaration is missing a template file path reference.")
             });
 

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTestFramework_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTestFramework_CRLF/main.diagnostics.bicep
@@ -90,7 +90,7 @@ test sample 'samples/sample1.bicep'{
 
 test sample ={
 //@[05:11) [BCP028 (Error)] Identifier "sample" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |sample|
-//@[12:13) [BCP0347 (Error)] Expected a test path string at this location. (CodeDescription: none) |=|
+//@[12:13) [BCP347 (Error)] Expected a test path string at this location. (CodeDescription: none) |=|
 //@[12:14) [BCP358 (Error)] This declaration is missing a template file path reference. (CodeDescription: none) |={|
 //@[14:14) [BCP018 (Error)] Expected the "=" character at this location. (CodeDescription: none) ||
     params: {
@@ -113,7 +113,7 @@ test sample 'samples/sample1.bicep'{
 
 test sample{
 //@[05:11) [BCP028 (Error)] Identifier "sample" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |sample|
-//@[11:12) [BCP0347 (Error)] Expected a test path string at this location. (CodeDescription: none) |{|
+//@[11:12) [BCP347 (Error)] Expected a test path string at this location. (CodeDescription: none) |{|
 //@[11:12) [BCP358 (Error)] This declaration is missing a template file path reference. (CodeDescription: none) |{|
 //@[12:12) [BCP018 (Error)] Expected the "=" character at this location. (CodeDescription: none) ||
     params: {
@@ -127,7 +127,7 @@ test sample{
 
 test sample{
 //@[05:11) [BCP028 (Error)] Identifier "sample" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |sample|
-//@[11:12) [BCP0347 (Error)] Expected a test path string at this location. (CodeDescription: none) |{|
+//@[11:12) [BCP347 (Error)] Expected a test path string at this location. (CodeDescription: none) |{|
 //@[11:12) [BCP358 (Error)] This declaration is missing a template file path reference. (CodeDescription: none) |{|
 //@[12:12) [BCP018 (Error)] Expected the "=" character at this location. (CodeDescription: none) ||
     params: {
@@ -141,7 +141,7 @@ test sample{
 
 test sample{
 //@[05:11) [BCP028 (Error)] Identifier "sample" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |sample|
-//@[11:12) [BCP0347 (Error)] Expected a test path string at this location. (CodeDescription: none) |{|
+//@[11:12) [BCP347 (Error)] Expected a test path string at this location. (CodeDescription: none) |{|
 //@[11:12) [BCP358 (Error)] This declaration is missing a template file path reference. (CodeDescription: none) |{|
 //@[12:12) [BCP018 (Error)] Expected the "=" character at this location. (CodeDescription: none) ||
     params: {
@@ -156,7 +156,7 @@ test sample{
 //@[02:03) [BCP007 (Error)] This declaration type is not recognized. Specify a metadata, parameter, variable, resource, or output declaration. (CodeDescription: none) |}|
 
 test 'samples/sample1.bicep'{
-//@[05:28) [BCP0346 (Error)] Expected a test identifier at this location. (CodeDescription: none) |'samples/sample1.bicep'|
+//@[05:28) [BCP346 (Error)] Expected a test identifier at this location. (CodeDescription: none) |'samples/sample1.bicep'|
 //@[28:29) [BCP018 (Error)] Expected the "=" character at this location. (CodeDescription: none) |{|
     params: {
       location: 'westus',
@@ -167,12 +167,12 @@ test 'samples/sample1.bicep'{
   }
 
 test
-//@[04:04) [BCP0346 (Error)] Expected a test identifier at this location. (CodeDescription: none) ||
+//@[04:04) [BCP346 (Error)] Expected a test identifier at this location. (CodeDescription: none) ||
 //@[04:04) [BCP358 (Error)] This declaration is missing a template file path reference. (CodeDescription: none) ||
 
 test sample
 //@[05:11) [BCP028 (Error)] Identifier "sample" is declared multiple times. Remove or rename the duplicates. (CodeDescription: none) |sample|
-//@[11:11) [BCP0347 (Error)] Expected a test path string at this location. (CodeDescription: none) ||
+//@[11:11) [BCP347 (Error)] Expected a test path string at this location. (CodeDescription: none) ||
 //@[11:11) [BCP358 (Error)] This declaration is missing a template file path reference. (CodeDescription: none) ||
 
 test sample 'samples/sample1.bicep'

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1923,12 +1923,12 @@ namespace Bicep.Core.Diagnostics
 
             public ErrorDiagnostic ExpectedTestIdentifier() => new(
                 TextSpan,
-                "BCP0346",
+                "BCP346",
                 "Expected a test identifier at this location.");
 
             public ErrorDiagnostic ExpectedTestPathString() => new(
                 TextSpan,
-                "BCP0347",
+                "BCP347",
                 "Expected a test path string at this location.");
             public ErrorDiagnostic TestDeclarationStatementsUnsupported() => new(
                 TextSpan,


### PR DESCRIPTION
There are a couple of three-digit error codes that use a leading 0 (for a total of four digits). This PR updates them to follow the pattern of always using three digits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14778)