### PR TITLE
Fix `Get` and `Preview` calls for local extensions

### DIFF
--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensibilityHostManager.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensibilityHostManager.cs
@@ -80,14 +80,14 @@ public class LocalExtensibilityHostManager : IAsyncDisposable
             case "get":
                 {
                     var resourceReference = await GetResourceReferenceAsync(await content.ReadAsStreamAsync(cancellationToken), cancellationToken);
-                    var extensionResponse = await provider.Delete(resourceReference, cancellationToken);
+                    var extensionResponse = await provider.Get(resourceReference, cancellationToken);
 
                     return await GetHttpResponseMessageAsync(extensionResponse, cancellationToken);
                 }
             case "preview":
                 {
                     var resourceSpecification = await GetResourceSpecificationAsync(await content.ReadAsStreamAsync(cancellationToken), cancellationToken);
-                    var extensionResponse = await provider.CreateOrUpdate(resourceSpecification, cancellationToken);
+                    var extensionResponse = await provider.Preview(resourceSpecification, cancellationToken);
 
                     return await GetHttpResponseMessageAsync(extensionResponse, cancellationToken);
                 }


### PR DESCRIPTION
The PR corrects the issue where `Get` and `Preview` operations were incorrectly calling `Delete` and `CreateOrUpdate`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14841)