### PR TITLE
Use public ADO feed to install packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="BicepPackages" value="https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Bicep.Cli.E2eTests/.npmrc
+++ b/src/Bicep.Cli.E2eTests/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/

--- a/src/Bicep.MSBuild.E2eTests/.npmrc
+++ b/src/Bicep.MSBuild.E2eTests/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/

--- a/src/Bicep.MSBuild.E2eTests/examples/NuGet.config
+++ b/src/Bicep.MSBuild.E2eTests/examples/NuGet.config
@@ -6,6 +6,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="BicepPackages" value="https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/nuget/v3/index.json" />
     <add key="Local" value="local-packages" />
   </packageSources>
 </configuration>

--- a/src/highlightjs/.npmrc
+++ b/src/highlightjs/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/

--- a/src/monarch/.npmrc
+++ b/src/monarch/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/

--- a/src/playground/.npmrc
+++ b/src/playground/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/

--- a/src/textmate/.npmrc
+++ b/src/textmate/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/NuGet.config
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/NuGet.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/NuGet.config
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/NuGet.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/vscode-bicep-ui/.npmrc
+++ b/src/vscode-bicep-ui/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/

--- a/src/vscode-bicep/.npmrc
+++ b/src/vscode-bicep/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azure-deployments/Bicep%20Public/_packaging/BicepPackages/npm/registry/


### PR DESCRIPTION
Updated Bicep to use a newly created public Azure Artifacts feed, ensuring that packages are restored from this feed instead of directly from nuget.org and the npm registry. This change aligns our official build pipeline with MSFT internal policies. As the feed is public, it should not impact OSS contributors
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14844)