### PR TITLE
Fix go to def for template spec modules

### DIFF
--- a/src/Bicep.LangServer/Handlers/BicepExternalSourceRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepExternalSourceRequestHandler.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Modules;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Oci;
 using Bicep.Core.SourceCode;
@@ -113,9 +114,19 @@ namespace Bicep.LanguageServer.Handlers
         /// <param name="reference">The module reference</param>
         /// <param name="sourceArchive">The source archive for the module, if sources are available</param>
         /// <returns>A bicep-extsrc: URI</returns>
-        public static Uri GetExternalSourceLinkUri(OciArtifactReference reference, SourceArchive? sourceArchive)
+        public static Uri GetRegistryModuleSourceLinkUri(OciArtifactReference reference, SourceArchive? sourceArchive)
         {
             return new ExternalSourceReference(reference, sourceArchive).ToUri();
+        }
+
+        public static Uri GetTemplateSpeckSourceLinkUri(TemplateSpecModuleReference reference)
+        {
+            var uriBuilder = new UriBuilder($"{LangServerConstants.ExternalSourceFileScheme}:{Uri.EscapeDataString(reference.FullyQualifiedReference)}")
+            {
+                Query = Uri.EscapeDataString(reference.FullyQualifiedReference),
+            };
+
+            return uriBuilder.Uri;
         }
 
         private BicepTelemetryEvent CreateSuccessTelemetry(SourceArchive? sourceArchive, string? requestedSourceFile)

--- a/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
@@ -22,6 +22,11 @@ namespace Bicep.LanguageServer.Handlers
 
             if (request.TextDocument.Uri.Scheme == LangServerConstants.ExternalSourceFileScheme)
             {
+                if (request.TextDocument.Uri.Query.StartsWith("ts:", StringComparison.Ordinal))
+                {
+                    yield break;
+                }
+
                 string? message = null;
                 ExternalSourceReference? externalReference = null;
 

--- a/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Modules;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Oci;
 using Bicep.Core.SourceCode;


### PR DESCRIPTION
The "Go to Definition" feature for template specs in VS Code is currently broken. When used, it opens the template spec JSON file in an editable state, though it should be read-only. This action then triggers the `documentDidOpen` event for the JSON file, which leads to a compilation update for the template spec module. As a result, the Bicep compiler mistakenly interprets the template spec JSON file as an ARM template, causing an `The reference ARM template has errors` message. This PR aims to fix that issue.

The problem was initially identified during the investigation of issue #14660. However, this PR might not fully resolve the issue, as according to the customer, the `The reference ARM template has errors` message can still appear randomly, even when "Go to Definition" is not used.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14871)