### PR TITLE
Remove explict nuget.org feed reference in NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/src/Bicep.MSBuild.E2eTests/examples/NuGet.config
+++ b/src/Bicep.MSBuild.E2eTests/examples/NuGet.config
@@ -5,7 +5,6 @@
 -->
 <configuration>
   <packageSources>
-    <clear />
     <add key="Local" value="local-packages" />
   </packageSources>
 </configuration>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/NuGet.config
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/NuGet.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/NuGet.config
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/NuGet.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
TL;DR:

This is a weird workaround that allows us to use a central feed when running official builds in ADO and to avoid being flagged by S360. Ideally, we would use environment variables in NuGet.config, but unfortunately, Dependabot doesn't support this approach.

Be aware that this might cause issues with local builds due to environment-specific setups. If you encounter this problem, a solution is to place Bicep in a wrapper folder and include a dedicated NuGet.config file there.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14882)