### PR TITLE
Increase timeout for a flaky test

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -862,7 +862,7 @@ param myParam string
     }
 
     [TestMethod]
-    [Timeout(5_000)]
+    [Timeout(5_0000)]
     public void Parsing_incomplete_tuple_type_expressions_halts()
     {
         var result = CompilationHelper.Compile("""


### PR DESCRIPTION
Increased the timeout by 10x to reduce the likelihood of test flakiness in official build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14930)