### PR TITLE
Change apk to tdnf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -592,7 +592,7 @@ jobs:
         uses: docker://mcr.microsoft.com/azure-cli:latest
         with:
           entrypoint: sh
-          args: -c "tdnf install nodejs -y && npm ci --prefix ./src/Bicep.Cli.E2eTests && npm test --prefix ./src/Bicep.Cli.E2eTests"
+          args: -c "cp -r /root/.gnupg ~/.gnupg && tdnf install nodejs -y && npm ci --prefix ./src/Bicep.Cli.E2eTests && npm test --prefix ./src/Bicep.Cli.E2eTests"
         env:
           BICEP_CLI_DOTNET_RID: ${{ matrix.runtime.rid }}
           BICEP_CLI_EXECUTABLE: ../../../Bicep.Cli.E2eTests/src/temp/bicep-cli/bicep

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -592,7 +592,7 @@ jobs:
         uses: docker://mcr.microsoft.com/azure-cli:latest
         with:
           entrypoint: sh
-          args: -c "apk add --update nodejs npm && npm ci --prefix ./src/Bicep.Cli.E2eTests && npm test --prefix ./src/Bicep.Cli.E2eTests"
+          args: -c "tdnf install nodejs -y && npm ci --prefix ./src/Bicep.Cli.E2eTests && npm test --prefix ./src/Bicep.Cli.E2eTests"
         env:
           BICEP_CLI_DOTNET_RID: ${{ matrix.runtime.rid }}
           BICEP_CLI_EXECUTABLE: ../../../Bicep.Cli.E2eTests/src/temp/bicep-cli/bicep


### PR DESCRIPTION
The Azure CLI docker image is now based on Mariner, which uses its own package manager [TDNF](https://microsoft.github.io/azurelinux/docs/).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14979)