### PR TITLE
adding none in the suggested completions list

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -242,7 +242,9 @@ using |
             updated.Should().HaveSourceText("""
                 using none|
                 """);
+        }
 
+        [TestMethod]
         public async Task Request_for_extends_declaration_path_completions_should_return_correct_paths_for_file_directories()
         {
             var fileTextsByUri = new Dictionary<Uri, string>

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -642,6 +642,17 @@ namespace Bicep.LanguageServer.Completions
                 var armTemplateFileItems = CreateFileCompletionItems(model.SourceFile.FileUri, replacementRange, fileCompletionInfo, IsArmTemplateFileLike, CompletionPriority.Medium);
                 var dirItems = CreateDirectoryCompletionItems(replacementRange, fileCompletionInfo);
 
+                if (model.Configuration.ExperimentalFeaturesEnabled.ExtendableParamFiles && context.Kind.HasFlag(BicepCompletionContextKind.UsingFilePath))
+                {
+                    var item = CompletionItemBuilder.Create(CompletionItemKind.Enum, LanguageConstants.NoneKeyword)
+                                                    .WithFilterText(LanguageConstants.NoneKeyword)
+                                                    .WithSortText(GetSortText(LanguageConstants.NoneKeyword, CompletionPriority.Medium))
+                                                    .WithPlainTextEdit(replacementRange, LanguageConstants.NoneKeyword)
+                                                    .Build();
+
+                    bicepFileItems = bicepFileItems.Prepend(item);
+                }
+
                 return bicepFileItems.Concat(armTemplateFileItems).Concat(dirItems);
             }
             catch (DirectoryNotFoundException)

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -642,7 +642,7 @@ namespace Bicep.LanguageServer.Completions
                 var armTemplateFileItems = CreateFileCompletionItems(model.SourceFile.FileUri, replacementRange, fileCompletionInfo, IsArmTemplateFileLike, CompletionPriority.Medium);
                 var dirItems = CreateDirectoryCompletionItems(replacementRange, fileCompletionInfo);
 
-                if (model.Configuration.ExperimentalFeaturesEnabled.ExtendableParamFiles && context.Kind.HasFlag(BicepCompletionContextKind.UsingFilePath))
+                if (model.Features.ExtendableParamFilesEnabled && context.Kind.HasFlag(BicepCompletionContextKind.UsingFilePath))
                 {
                     var item = CompletionItemBuilder.Create(CompletionItemKind.Enum, LanguageConstants.NoneKeyword)
                                                     .WithFilterText(LanguageConstants.NoneKeyword)


### PR DESCRIPTION
Closes #14987 

Adding `none` option to the code completion list for `using` keyword in .bicepparam files

Current behavior;

![image](https://github.com/user-attachments/assets/f27e9cc6-a7d3-4971-814c-b0933ae2346f)

Expected behavior;

![image](https://github.com/user-attachments/assets/e6e356fb-801b-4418-9678-3ee72cda5d86)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14988)