### PR TITLE
Enable type narrowing on assignment of non-variable symbols

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -1592,4 +1592,36 @@ param myParam string
 
         result.Should().NotHaveAnyDiagnostics();
     }
+
+    [TestMethod]
+    public void Issue_14869()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(TestContext, ResourceDerivedTypesEnabled: true)),
+            ("main.bicep", """
+                param container resource<'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15'>.properties.resource.indexingPolicy
+
+                resource sa 'Microsoft.Storage/storageAccounts@2023-05-01'  = {
+                  location: resourceGroup().location
+                  sku: { name: 'Standard_GRS' }
+                  kind: 'StorageV2'
+                  name: 'my-sa'
+                  properties: {
+                    accessTier: 'Hot'
+                    azureFilesIdentityBasedAuthentication: container
+                  }
+                }
+                """));
+
+        result.Should().HaveDiagnostics(new[]
+        {
+            ("BCP035", DiagnosticLevel.Warning, """The specified "object" declaration is missing the following required properties: "directoryServiceOptions". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
+            ("BCP037", DiagnosticLevel.Warning, """The property "automatic" is not allowed on objects of type "AzureFilesIdentityBasedAuthentication". Permissible properties include "activeDirectoryProperties", "defaultSharePermission", "directoryServiceOptions". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
+            ("BCP037", DiagnosticLevel.Warning, """The property "compositeIndexes" is not allowed on objects of type "AzureFilesIdentityBasedAuthentication". Permissible properties include "activeDirectoryProperties", "defaultSharePermission", "directoryServiceOptions". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
+            ("BCP037", DiagnosticLevel.Warning, """The property "excludedPaths" is not allowed on objects of type "AzureFilesIdentityBasedAuthentication". Permissible properties include "activeDirectoryProperties", "defaultSharePermission", "directoryServiceOptions". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
+            ("BCP037", DiagnosticLevel.Warning, """The property "includedPaths" is not allowed on objects of type "AzureFilesIdentityBasedAuthentication". Permissible properties include "activeDirectoryProperties", "defaultSharePermission", "directoryServiceOptions". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
+            ("BCP037", DiagnosticLevel.Warning, """The property "indexingMode" is not allowed on objects of type "AzureFilesIdentityBasedAuthentication". Permissible properties include "activeDirectoryProperties", "defaultSharePermission", "directoryServiceOptions". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
+            ("BCP037", DiagnosticLevel.Warning, """The property "spatialIndexes" is not allowed on objects of type "AzureFilesIdentityBasedAuthentication". Permissible properties include "activeDirectoryProperties", "defaultSharePermission", "directoryServiceOptions". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
+        });
+    }
 }

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -299,6 +299,11 @@ namespace Bicep.Core.TypeSystem
                 return targetType;
             }
 
+            if (targetType is ResourceParameterType)
+            {
+                return targetType;
+            }
+
             // integer assignability check
             if (targetType is IntegerType targetInteger)
             {
@@ -341,9 +346,10 @@ namespace Bicep.Core.TypeSystem
                 return narrowedArray;
             }
 
-            if (expression is VariableAccessSyntax variableAccess)
+            if (expression is VariableAccessSyntax variableAccess &&
+                NarrowVariableAccessType(config, variableAccess, targetType) is TypeSymbol narrowedVariableAccess)
             {
-                return NarrowVariableAccessType(config, variableAccess, targetType);
+                return narrowedVariableAccess;
             }
 
             if (targetType is UnionType targetUnionType)
@@ -744,7 +750,7 @@ namespace Bicep.Core.TypeSystem
             return new LambdaType([.. narrowedVariables], [], returnType);
         }
 
-        private TypeSymbol NarrowVariableAccessType(TypeValidatorConfig config, VariableAccessSyntax variableAccess, TypeSymbol targetType)
+        private TypeSymbol? NarrowVariableAccessType(TypeValidatorConfig config, VariableAccessSyntax variableAccess, TypeSymbol targetType)
         {
             if (DeclaringSyntax(variableAccess) is SyntaxBase declaringSyntax)
             {
@@ -752,7 +758,7 @@ namespace Bicep.Core.TypeSystem
                 return NarrowType(newConfig, declaringSyntax, targetType);
             }
 
-            return targetType;
+            return null;
         }
 
         // TODO: Implement for non-variable variable access (resource, module, param)


### PR DESCRIPTION
Resolves #14869 

This PR updates the TypeValidator to perform narrowing even when the assigned expression is a symbolic reference to something other than a variable. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14989)