### PR TITLE
Extensibility v2 emitting

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -15,7 +15,7 @@ Should be enabled in tandem with `testFramework` experimental feature flag for e
 Enables the ability to extend bicepparam files from other bicepparam files. For more information, see [Extendable Bicep Params Files](./experimental/extendable-param-files.md).
 
 ### `extensibility`
-Allows Bicep to use an extensibility model to deploy non-ARM resources. Currently, we support Kubernetes extension ([Bicep Kubernetes extension](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-extensibility-kubernetes-provider)) and Microsoft Graph extension ([Bicep templates for Microsoft Graph](https://aka.ms/graphbicep)).
+Allows Bicep to use an extensibility model to deploy non-ARM resources. Currently, we support Kubernetes extension ([Bicep Kubernetes extension](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-kubernetes-extension)) and Microsoft Graph extension ([Bicep templates for Microsoft Graph](https://aka.ms/graphbicep)).
 
 ### `legacyFormatter`
 Enables code formatting with the legacy formatter. This feature flag is introduced to ensure a safer transition to the v2 formatter that implements a pretty-printing algorithm. It is intended for temporary use and will be phased out soon.

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -22,7 +22,8 @@ public record FeatureProviderOverrides(
     bool? ResourceDerivedTypesEnabled = default,
     bool? SecureOutputsEnabled = default,
     bool? ExtendableParamFilesEnabled = default,
-    string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion)
+    string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
+    bool? ExtensibilityV2EmittingEnabled = default)
 {
     public FeatureProviderOverrides(
         TestContext testContext,
@@ -40,7 +41,8 @@ public record FeatureProviderOverrides(
         bool? ResourceDerivedTypesEnabled = default,
         bool? SecureOutputsEnabled = default,
         bool? ExtendableParamFilesEnabled = default,
-        string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion
+        string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
+        bool? ExtensibilityV2EmittingEnabled = default
     ) : this(
         FileHelper.GetCacheRootPath(testContext),
         RegistryEnabled,
@@ -57,6 +59,7 @@ public record FeatureProviderOverrides(
         ResourceDerivedTypesEnabled,
         SecureOutputsEnabled,
         ExtendableParamFilesEnabled,
-        AssemblyVersion)
+        AssemblyVersion,
+        ExtensibilityV2EmittingEnabled)
     { }
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -43,4 +43,6 @@ public class OverriddenFeatureProvider : IFeatureProvider
     public bool SecureOutputsEnabled => overrides.SecureOutputsEnabled ?? features.SecureOutputsEnabled;
 
     public bool ExtendableParamFilesEnabled => overrides.ExtendableParamFilesEnabled ?? features.ExtendableParamFilesEnabled;
+
+    public bool ExtensibilityV2EmittingEnabled => overrides.ExtensibilityV2EmittingEnabled ?? features.ExtensibilityV2EmittingEnabled;
 }

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Configuration;
+using Bicep.Core.Intermediate;
 
 namespace Bicep.Core.Features
 {
@@ -45,6 +46,8 @@ namespace Bicep.Core.Features
         public bool ResourceDerivedTypesEnabled => configuration.ExperimentalFeaturesEnabled.ResourceDerivedTypes;
 
         public bool SecureOutputsEnabled => configuration.ExperimentalFeaturesEnabled.SecureOutputs;
+
+        public bool ExtensibilityV2EmittingEnabled => ReadBooleanEnvVar("BICEP_EXTENSIBILITY_V2_EMITTING_ENABLED", defaultValue: false);
 
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)
             => bool.TryParse(Environment.GetEnvironmentVariable(envVar), out var value) ? value : defaultValue;

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -33,6 +33,8 @@ public interface IFeatureProvider
 
     bool SecureOutputsEnabled { get; }
 
+    bool ExtensibilityV2EmittingEnabled { get; }
+
     IEnumerable<(string name, bool impactsCompilation, bool usesExperimentalArmEngineFeature)> EnabledFeatureMetadata
     {
         get


### PR DESCRIPTION
Updated the emitter to generate templates using the Extensibility V2 contract when the BICEP_EXTENSIBILITY_V2_EMITTING_ENABLED environment variable is set to true. This environment variable is used to conditionally enable the change because the backend support for extensibility V2 -> V1 conversion is still pending deployment. It also allows us to safely test the backend logic without impacting existing customers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/14990)