### PR TITLE
Onboard microsoft graph extension with registry provided types

### DIFF
--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -164,6 +164,18 @@ public static class RegistryHelper
         await PublishExtensionToRegistryAsync(services, pathToIndexJson, $"br:{LanguageConstants.BicepPublicMcrRegistry}/{repository}:{version}");
     }
 
+    public static async Task PublishMsGraphExtension(IDependencyHelper services, string pathToIndexJson, string repoVersion, string extensionVersion)
+    {
+        var repository = "bicep/extensions/microsoftgraph/" + repoVersion;
+        await PublishExtensionToRegistryAsync(services, pathToIndexJson, $"br:{LanguageConstants.BicepPublicMcrRegistry}/{repository}:{extensionVersion}");
+    }
+
     public static IContainerRegistryClientFactory CreateOciClientForAzExtension()
         => CreateMockRegistryClients((LanguageConstants.BicepPublicMcrRegistry, $"bicep/extensions/az")).factoryMock;
+
+    public static IContainerRegistryClientFactory CreateOciClientForMsGraphExtension()
+        => CreateMockRegistryClients(
+            (LanguageConstants.BicepPublicMcrRegistry, $"bicep/extensions/microsoftgraph/beta"),
+            (LanguageConstants.BicepPublicMcrRegistry, $"bicep/extensions/microsoftgraph/v1")
+            ).factoryMock;
 }

--- a/src/Bicep.Core/Semantics/Namespaces/MicrosoftGraphNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/MicrosoftGraphNamespaceType.cs
@@ -1,24 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection;
+using Azure.Deployments.Core.Definitions.Identifiers;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Intermediate;
+using Bicep.Core.Registry;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Providers;
 using Bicep.Core.TypeSystem.Providers.MicrosoftGraph;
 using Bicep.Core.TypeSystem.Types;
+using Bicep.Core.Workspaces;
+using Microsoft.Graph.Bicep.Types;
+using static Bicep.Core.TypeSystem.Providers.ThirdParty.ThirdPartyResourceTypeLoader;
 
 namespace Bicep.Core.Semantics.Namespaces
 {
     public static class MicrosoftGraphNamespaceType
     {
         public const string BuiltInName = "microsoftGraph";
+        public const string TemplateExtensionName = "MicrosoftGraph";
+        public const string BicepExtensionBetaName = "MicrosoftGraphBeta";
+        public const string BicepExtensionV10Name = "MicrosoftGraphV1.0";
 
         private static readonly Lazy<IResourceTypeProvider> TypeProviderLazy
             = new(() => new MicrosoftGraphResourceTypeProvider(new MicrosoftGraphResourceTypeLoader()));
 
         public static NamespaceSettings Settings { get; } = new(
-            IsSingleton: true,
+            IsSingleton: false,
             BicepExtensionName: BuiltInName,
             ConfigurationType: null,
-            TemplateExtensionName: "MicrosoftGraph",
+            TemplateExtensionName: TemplateExtensionName,
             TemplateExtensionVersion: "1.0.0");
 
         public static NamespaceType Create(string aliasName)
@@ -31,6 +44,35 @@ namespace Bicep.Core.Semantics.Namespaces
                 ImmutableArray<BannedFunction>.Empty,
                 ImmutableArray<Decorator>.Empty,
                 TypeProviderLazy.Value);
+        }
+
+        public static NamespaceType Create(string? aliasName, IResourceTypeProvider resourceTypeProvider, ArtifactReference? artifact)
+        {
+            if (resourceTypeProvider is MicrosoftGraphResourceTypeProvider microsoftGraphProvider &&
+            microsoftGraphProvider.GetNamespaceConfiguration() is NamespaceConfiguration namespaceConfig)
+            {
+                return new NamespaceType(
+                    aliasName ?? namespaceConfig.Name,
+                    new NamespaceSettings(
+                        IsSingleton: namespaceConfig.IsSingleton,
+                        BicepExtensionName: namespaceConfig.Name,
+                        ConfigurationType: namespaceConfig.ConfigurationObject,
+                        TemplateExtensionName: TemplateExtensionName,
+                        TemplateExtensionVersion: namespaceConfig.Version),
+                    ImmutableArray<TypeProperty>.Empty,
+                    ImmutableArray<FunctionOverload>.Empty,
+                    ImmutableArray<BannedFunction>.Empty,
+                    ImmutableArray<Decorator>.Empty,
+                    resourceTypeProvider,
+                    artifact);
+            }
+
+            throw new ArgumentException("Invalid resource type provider or namespace config for Microsoft Graph resource.");
+        }
+
+        public static bool ShouldUseLoader(string? typeSettingName)
+        {
+            return typeSettingName == TemplateExtensionName || typeSettingName == BicepExtensionBetaName || typeSettingName == BicepExtensionV10Name;
         }
     }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
@@ -15,6 +15,7 @@ using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Providers;
 using Bicep.Core.TypeSystem.Providers.Az;
+using Bicep.Core.TypeSystem.Providers.MicrosoftGraph;
 using Bicep.Core.TypeSystem.Providers.ThirdParty;
 using Bicep.Core.TypeSystem.Types;
 using Bicep.Core.Workspaces;
@@ -199,6 +200,11 @@ public class NamespaceProvider : INamespaceProvider
         if (typeProvider is AzResourceTypeProvider)
         {
             return new(AzNamespaceType.Create(aliasName, targetScope, typeProvider, sourceFile.FileKind));
+        }
+
+        if (typeProvider is MicrosoftGraphResourceTypeProvider)
+        {
+            return new(MicrosoftGraphNamespaceType.Create(aliasName, typeProvider, artifact.Reference));
         }
 
         return new(ThirdPartyNamespaceType.Create(aliasName, typeProvider, artifact.Reference));

--- a/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeFactory.cs
@@ -23,6 +23,13 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
             return new ResourceTypeComponents(resourceTypeReference, ToResourceScope(resourceType.ScopeType), ToResourceScope(resourceType.ReadOnlyScopes), ToResourceFlags(resourceType.Flags), bodyType);
         }
 
+        public TypeSymbol GetObjectType(Azure.Bicep.Types.Concrete.ObjectType objectType)
+        {
+            var bodyType = GetTypeSymbol(objectType, false);
+
+            return bodyType;
+        }
+
         private TypeSymbol GetTypeSymbol(Azure.Bicep.Types.Concrete.TypeBase serializedType, bool isResourceBodyType)
             => typeCache.GetOrAdd(serializedType, serializedType => ToTypeSymbol(serializedType, isResourceBodyType));
 

--- a/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeLoader.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 using System.Collections.Immutable;
 using Azure.Bicep.Types;
+using Azure.Bicep.Types.Index;
 using Bicep.Core.Resources;
 using Bicep.Core.TypeSystem.Types;
 using Microsoft.Graph.Bicep.Types;
+using static Bicep.Core.TypeSystem.Providers.ThirdParty.ThirdPartyResourceTypeLoader;
 
 namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
 {
@@ -13,15 +15,24 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
         private readonly ITypeLoader typeLoader;
         private readonly MicrosoftGraphResourceTypeFactory resourceTypeFactory;
         private readonly ImmutableDictionary<ResourceTypeReference, CrossFileTypeReference> availableTypes;
+        private readonly TypeSettings? typeSettings;
+        private readonly CrossFileTypeReference? fallbackResourceType;
 
-        public MicrosoftGraphResourceTypeLoader()
+        public MicrosoftGraphResourceTypeLoader(ITypeLoader typeLoader)
         {
-            typeLoader = new MicrosoftGraphTypeLoader();
+            this.typeLoader = typeLoader;
             resourceTypeFactory = new MicrosoftGraphResourceTypeFactory();
             var indexedTypes = typeLoader.LoadTypeIndex();
             availableTypes = indexedTypes.Resources.ToImmutableDictionary(
                 kvp => ResourceTypeReference.Parse(kvp.Key),
                 kvp => kvp.Value);
+
+            typeSettings = indexedTypes.Settings;
+            fallbackResourceType = indexedTypes.FallbackResourceType;
+        }
+
+        public MicrosoftGraphResourceTypeLoader() : this(new MicrosoftGraphTypeLoader())
+        {
         }
 
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
@@ -33,6 +44,33 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
 
             var serializedResourceType = typeLoader.LoadResourceType(typeLocation);
             return resourceTypeFactory.GetResourceType(serializedResourceType);
+        }
+
+        public NamespaceConfiguration? LoadNamespaceConfiguration()
+        {
+            if (typeSettings == null)
+            {
+                throw new ArgumentException($"Please provide the following Settings properties: Name, Version, & IsSingleton.");
+            }
+
+            ObjectType? configurationType = null;
+            if (typeSettings.ConfigurationType is { } reference)
+            {
+
+                if (typeLoader.LoadType(reference) is not Azure.Bicep.Types.Concrete.ObjectType concreteObjectType ||
+                    resourceTypeFactory.GetObjectType(concreteObjectType) is not ObjectType objectType)
+                {
+                    throw new ArgumentException($"Unable to locate resource object type at index {reference.Index} in \"{reference.RelativePath}\" resource");
+                }
+
+                configurationType = objectType;
+            }
+
+            return new(
+                typeSettings.Name,
+                typeSettings.Version,
+                typeSettings.IsSingleton,
+                configurationType);
         }
     }
 }

--- a/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeProvider.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Immutable;
+using System.Reflection;
 using Bicep.Core.Resources;
+using Bicep.Core.TypeSystem.Providers.ThirdParty;
 using Bicep.Core.TypeSystem.Types;
 
 namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
@@ -179,6 +181,9 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableResourceTypes;
 
-        public string Version { get; } = "1.0.0";
+        public ThirdPartyResourceTypeLoader.NamespaceConfiguration? GetNamespaceConfiguration()
+        {
+            return resourceTypeLoader.LoadNamespaceConfiguration();
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/Providers/ResourceTypeProviderFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ResourceTypeProviderFactory.cs
@@ -10,6 +10,7 @@ using Bicep.Core.Modules;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Providers.Az;
+using Bicep.Core.TypeSystem.Providers.MicrosoftGraph;
 using Bicep.Core.TypeSystem.Providers.ThirdParty;
 using JetBrains.Annotations;
 
@@ -37,13 +38,18 @@ namespace Bicep.Core.TypeSystem.Providers
 
                     var typeIndex = typesLoader.LoadTypeIndex();
                     var useAzLoader = typeIndex.Settings?.Name == AzNamespaceType.Settings.TemplateExtensionName;
+                    var useMsGraphLoader = MicrosoftGraphNamespaceType.ShouldUseLoader(typeIndex.Settings?.Name);
 
                     if (useAzLoader)
                     {
                         return new(new AzResourceTypeProvider(new AzResourceTypeLoader(typesLoader, typeIndex)));
                     }
+                    else if (useMsGraphLoader)
+                    {
+                        return new(new MicrosoftGraphResourceTypeProvider(new MicrosoftGraphResourceTypeLoader(typesLoader)));
+                    }
 
-                    return new(new ThirdPartyResourceTypeProvider(new ThirdPartyResourceTypeLoader(typesLoader, typeIndex)));
+                    return new(new ThirdPartyResourceTypeProvider(new ThirdPartyResourceTypeLoader(typesLoader)));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Onboard Microsoft Graph extension to allow Graph Bicep types to be fetched from registry
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15038)