### PR TITLE
Fixed missed node version updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build All Projects
         run: |

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: npm ci
         run: npm ci

--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -47,14 +47,14 @@ jobs:
 
       - name: Publish Language Server
         run: dotnet publish --configuration Release ./src/Bicep.LangServer/Bicep.LangServer.csproj
-      
+
       # this command is not correct for releasing the binaries but is sufficient for the purposes of this job
       - name: Windows Installer prerequisites
         run: mkdir ./src/installer-win/bicep && copy ./src/Bicep.Cli/obj/project.assets.json ./src/installer-win/bicep/ && copy ./src/Bicep.Cli/bin/Release/net8.0/bicep.* ./src/installer-win/bicep/
 
       - name: Build Windows Installer
         run: dotnet build --configuration Release ./src/installer-win/installer.proj
-      
+
       - name: CLI Package prerequisites
         run:  mkdir ./src/Bicep.Cli.Nuget/tools && copy ./src/Bicep.Cli/obj/project.assets.json ./src/Bicep.Cli.Nuget/tools/ && copy ./src/Bicep.Cli/bin/Release/net8.0/bicep.* ./src/Bicep.Cli.Nuget/tools/
 


### PR DESCRIPTION
The TPN update workflow has been failing for a while. It appears to be related to the node version, so I updated the remaining occurrences of Node.js 18 to 20 to match the rest.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15099)