### PR TITLE
Add deprecation warning for microsoftGraph builtin extension

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
@@ -42,8 +42,9 @@ namespace Bicep.Core.IntegrationTests
                     emptyDiagnostics };
                 yield return new object[] {
                     "microsoftGraph",
-                    true,
-                    emptyDiagnostics };
+                    false,
+                    new (string, DiagnosticLevel, string)[] {
+                     ("BCP407", DiagnosticLevel.Warning, "Extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes" ) } };
                 yield return new object[] {
                     "az",
                     true,

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/bicepconfig.json
@@ -1,5 +1,9 @@
 {
   "experimentalFeaturesEnabled": {
     "extensibility": true
+  },
+  "extensions": {
+    "microsoftGraphV1_0": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview",
+    "microsoftGraphBeta": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/beta:0.1.8-preview"
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.bicep
@@ -1,4 +1,5 @@
-extension microsoftGraph  as graph
+extension microsoftGraphV1_0
+extension microsoftGraphBeta
 
 param appRoleId string = 'bc76c90e-eb7f-4a29-943b-49e88762d09d'
 param scopeId string = 'f761933c-643b-424f-a169-f9313d23a913'

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.bicep
@@ -1,4 +1,4 @@
-extension microsoftGraph
+extension microsoftGraphBeta
 
 resource resourceApp 'Microsoft.Graph/applications@beta' existing = {
   uniqueName: 'resourceApp'

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.existing.json
@@ -10,19 +10,19 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10094365870369225747"
+      "templateHash": "14301681087671152959"
     }
   },
   "imports": {
-    "microsoftGraph": {
+    "MicrosoftGraphBeta": {
       "provider": "MicrosoftGraph",
-      "version": "1.0.0"
+      "version": "0.1.8-preview"
     }
   },
   "resources": {
     "resourceApp": {
       "existing": true,
-      "import": "microsoftGraph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/applications@beta",
       "properties": {
         "uniqueName": "resourceApp"
@@ -30,7 +30,7 @@
     },
     "group": {
       "existing": true,
-      "import": "microsoftGraph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/applications@beta",
       "properties": {
         "uniqueName": "myGroup"

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/microsoftGraph/main.json
@@ -10,7 +10,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13653571511506928892"
+      "templateHash": "15609368468620239727"
     }
   },
   "parameters": {
@@ -24,14 +24,18 @@
     }
   },
   "imports": {
-    "graph": {
+    "MicrosoftGraph": {
       "provider": "MicrosoftGraph",
-      "version": "1.0.0"
+      "version": "0.1.8-preview"
+    },
+    "MicrosoftGraphBeta": {
+      "provider": "MicrosoftGraph",
+      "version": "0.1.8-preview"
     }
   },
   "resources": {
     "appV1::myTestFIC": {
-      "import": "graph",
+      "import": "MicrosoftGraph",
       "type": "Microsoft.Graph/applications/federatedIdentityCredentials@v1.0",
       "properties": {
         "name": "[format('{0}/mytestfic', reference('appV1').uniqueName)]",
@@ -47,7 +51,7 @@
       ]
     },
     "resourceApp": {
-      "import": "graph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/applications@beta",
       "properties": {
         "uniqueName": "resourceApp",
@@ -80,7 +84,7 @@
       }
     },
     "resourceSp": {
-      "import": "graph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/servicePrincipals@beta",
       "properties": {
         "appId": "[reference('resourceApp').appId]"
@@ -90,7 +94,7 @@
       ]
     },
     "clientApp": {
-      "import": "graph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/applications@beta",
       "properties": {
         "uniqueName": "clientApp",
@@ -98,7 +102,7 @@
       }
     },
     "clientSp": {
-      "import": "graph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/servicePrincipals@beta",
       "properties": {
         "appId": "[reference('clientApp').appId]"
@@ -108,7 +112,7 @@
       ]
     },
     "permissionGrant": {
-      "import": "graph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/oauth2PermissionGrants@beta",
       "properties": {
         "clientId": "[reference('clientSp').id]",
@@ -122,7 +126,7 @@
       ]
     },
     "appRoleAssignedTo": {
-      "import": "graph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/appRoleAssignedTo@beta",
       "properties": {
         "appRoleId": "[parameters('appRoleId')]",
@@ -135,7 +139,7 @@
       ]
     },
     "group": {
-      "import": "graph",
+      "import": "MicrosoftGraphBeta",
       "type": "Microsoft.Graph/groups@beta",
       "properties": {
         "uniqueName": "myGroup",
@@ -155,7 +159,7 @@
       ]
     },
     "appV1": {
-      "import": "graph",
+      "import": "MicrosoftGraph",
       "type": "Microsoft.Graph/applications@v1.0",
       "properties": {
         "displayName": "TestAppV1",

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1798,6 +1798,10 @@ namespace Bicep.Core.Diagnostics
             public Diagnostic ExtendsNotSupported() => CoreError(
                 "BCP406",
                 $"The \"{LanguageConstants.ExtendsKeyword}\" keyword is not supported");
+
+            public Diagnostic MicrosoftGraphBuiltinDeprecatedSoon() => CoreWarning(
+                "BCP407",
+                $"Extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -916,6 +916,11 @@ namespace Bicep.Core.TypeSystem
                     }
                 }
 
+                if (LanguageConstants.IdentifierComparer.Equals(namespaceType.Name, MicrosoftGraphNamespaceType.BuiltInName))
+                {
+                    diagnostics.Write(syntax, x => x.MicrosoftGraphBuiltinDeprecatedSoon());
+                }
+
                 return namespaceType;
             });
 


### PR DESCRIPTION
Adding a deprecation warning for `microsoftGraph` builtin extension. Users should use dynamic types instead.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15149)