### PR TITLE
Add quickfix for microsoftGraph deprecation warning

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
@@ -44,7 +44,7 @@ namespace Bicep.Core.IntegrationTests
                     "microsoftGraph",
                     false,
                     new (string, DiagnosticLevel, string)[] {
-                     ("BCP407", DiagnosticLevel.Warning, "Extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes" ) } };
+                     ("BCP407", DiagnosticLevel.Warning, "Built-in extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes" ) } };
                 yield return new object[] {
                     "az",
                     true,

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1799,9 +1799,23 @@ namespace Bicep.Core.Diagnostics
                 "BCP406",
                 $"The \"{LanguageConstants.ExtendsKeyword}\" keyword is not supported");
 
-            public Diagnostic MicrosoftGraphBuiltinDeprecatedSoon() => CoreWarning(
+            public Diagnostic MicrosoftGraphBuiltinDeprecatedSoon(ExtensionDeclarationSyntax syntax)
+            {
+                var msGraphRegistryPath = "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview";
+                var codeFix = new CodeFix(
+                    $"Replace built-in extension \'microsoftGraph\' with dynamic types registry path",
+                    true,
+                    CodeFixKind.QuickFix,
+                    new CodeReplacement(syntax.SpecificationString.Span, $"\'{msGraphRegistryPath}\'"));
+
+                return CoreWarning(
                 "BCP407",
-                $"Extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes");
+                $"Built-in extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes")
+                with
+                {
+                    Fixes = [codeFix]
+                };
+            }
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -918,7 +918,7 @@ namespace Bicep.Core.TypeSystem
 
                 if (LanguageConstants.IdentifierComparer.Equals(namespaceType.Name, MicrosoftGraphNamespaceType.BuiltInName))
                 {
-                    diagnostics.Write(syntax, x => x.MicrosoftGraphBuiltinDeprecatedSoon());
+                    diagnostics.Write(syntax.SpecificationString, x => x.MicrosoftGraphBuiltinDeprecatedSoon(syntax));
                 }
 
                 return namespaceType;


### PR DESCRIPTION
Adding a quickfix option to make it easier to switch to dynamic types for Microsoft Graph Bicep types when the built-in extension is deprecated.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15185)