### PR TITLE
Be smart about newlines before/after extractions

### DIFF
--- a/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
+++ b/src/Bicep.Core/Navigation/SyntaxBaseExtensions.cs
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Diagnostics;
+using Bicep.Core.Extensions;
+using Bicep.Core.Parsing;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Navigation
@@ -18,6 +22,25 @@ namespace Bicep.Core.Navigation
             visitor.Visit(root);
 
             return visitor.Result;
+        }
+
+        public static TextSpan GetSpanIncludingTrivia(this SyntaxBase root)
+        {
+            if (root is not Token token)
+            {
+                return root.Span;
+            }
+
+            var first = token.LeadingTrivia.Where(t => !t.Span.IsNil).FirstOrDefault();
+            var start = first is { } ? first.Span.Position : token.Span.Position;
+
+            var last = token.TrailingTrivia.Where(t => !t.Span.IsNil).LastOrDefault();
+            var end = last is { } ? last.GetEndPosition() : token.GetEndPosition();
+
+            Debug.Assert(start >= 0 && end >= 0, "start and end shouldn't be nil");
+            Debug.Assert(start <= end, "start <= end");
+
+            return new TextSpan(start, end - start);
         }
 
         private sealed class NavigationSearchVisitor : CstVisitor

--- a/src/Bicep.Core/Parsing/Token.cs
+++ b/src/Bicep.Core/Parsing/Token.cs
@@ -15,6 +15,25 @@ namespace Bicep.Core.Parsing
             Span = span;
             LeadingTrivia = leadingTrivia.ToImmutableArray();
             TrailingTrivia = trailingTrivia.ToImmutableArray();
+
+#if DEBUG
+            var leadingNonNil = LeadingTrivia.Where(x => x.Span != TextSpan.Nil).ToArray();
+            var trailingNonNil = TrailingTrivia.Where(x => x.Span != TextSpan.Nil).ToArray();
+
+            Debug.Assert(leadingNonNil.Length == 0
+                || leadingNonNil.Zip(leadingNonNil.Skip(1), (a, b) => !TextSpan.AreOverlapping(a.Span, b.Span) && a.Span.Position < b.Span.Position)
+                    .All(x => x == true),
+                "Leading trivia should be in numeric non-overlapping order");
+            Debug.Assert(trailingNonNil.Length == 0
+                || trailingNonNil.Zip(trailingNonNil.Skip(1), (a, b) => !TextSpan.AreOverlapping(a.Span, b.Span) && a.Span.Position < b.Span.Position)
+                    .All(x => x == true),
+                "Trailing trivia should be in numeric order by end position");
+
+            Debug.Assert(leadingNonNil.All(x => x.Span.Position < span.Position && !TextSpan.AreOverlapping(x.Span, span)),
+                "Leading trivia should not overlap token span");
+            Debug.Assert(trailingNonNil.All(x => x.Span.Position > span.Position && !TextSpan.AreOverlapping(x.Span, span)),
+                "Trailing trivia should not overlap token span");
+#endif
         }
 
         public TokenType Type { get; }

--- a/src/Bicep.LangServer/Refactor/ExpressionAndTypeExtractor.cs
+++ b/src/Bicep.LangServer/Refactor/ExpressionAndTypeExtractor.cs
@@ -476,7 +476,7 @@ public class ExpressionAndTypeExtractor
 
         public override void VisitSyntaxTrivia(SyntaxTrivia syntaxTrivia)
         {
-            if (TextSpan.AreOverlapping(span, syntaxTrivia.Span))
+            if (!HasComments && TextSpan.AreOverlapping(span, syntaxTrivia.Span))
             {
                 if (syntaxTrivia.Type == SyntaxTriviaType.SingleLineComment || syntaxTrivia.Type == SyntaxTriviaType.MultiLineComment)
                 {
@@ -487,7 +487,12 @@ public class ExpressionAndTypeExtractor
 
         protected override void VisitInternal(SyntaxBase node)
         {
-            if (TextSpan.AreOverlapping(span, node.Span) && node is Token token && token.Text.Trim().Length > 0)
+            if ((HasComments && HasContent) || !TextSpan.AreOverlapping(span, node.GetSpanIncludingTrivia()))
+            {
+                return;
+            }
+
+            if (!HasContent && node is Token token && token.Text.Trim().Length > 0)
             {
                 HasContent = true;
             }


### PR DESCRIPTION
The new behavior is essentially that we try to match the newly-inserted declaration (whether it has blank lines before/after) with the existing declaration that it's being inserted after.  For example:
```bicep
var v1 = 1
var v2 = 2

var expression = v1 + v2   // << EXTRACT THIS
``
=>
```bicep
var v1 = 1
var v2 = 2
var newVariable = v1 + v2  // << NEW DECLARATION

var expression = newVariable
``
Since v2 had a newline after it but none before it, we do the same with newVariable.  If there were a blank line between v1 and v2, we'd insert a blank line before newVariable.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15194)