### PR TITLE
Add `deployer()` function to the Az namespace

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "deployer",
+    "description": "Returns information about the principal that initiated the current deployment operation.",
+    "fixedParameters": [],
+    "minimumArgumentCount": 0,
+    "maximumArgumentCount": 0,
+    "flags": "default",
+    "typeSignature": "(): deployer",
+    "parameterTypeSignatures": []
+  },
+  {
     "name": "deployment",
     "description": "Returns information about the current deployment operation.",
     "fixedParameters": [],

--- a/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "deployer",
-    "description": "Returns information about the principal that initiated the current deployment operation.",
+    "description": "Returns information about the current deployment principal.",
     "fixedParameters": [],
     "minimumArgumentCount": 0,
     "maximumArgumentCount": 0,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
@@ -4,7 +4,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
@@ -1,5 +1,22 @@
 [
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -683,6 +683,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -687,7 +687,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -547,7 +547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -543,6 +543,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -547,7 +547,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -543,6 +543,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -361,6 +361,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -365,7 +365,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -347,6 +347,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -351,7 +351,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -347,6 +347,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -351,7 +351,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -347,6 +347,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -351,7 +351,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -455,6 +455,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -459,7 +459,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -441,6 +441,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -445,7 +445,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -441,6 +441,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -445,7 +445,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -463,7 +463,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -459,6 +459,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -910,7 +910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -906,6 +906,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -879,7 +879,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -875,6 +875,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -938,7 +938,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -934,6 +934,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -1166,7 +1166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -1162,6 +1162,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -1166,7 +1166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -1162,6 +1162,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -1166,7 +1166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -1162,6 +1162,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -1166,7 +1166,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -1162,6 +1162,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -1396,6 +1396,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -1400,7 +1400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -1396,6 +1396,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -1400,7 +1400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -1396,6 +1396,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -1400,7 +1400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -1396,6 +1396,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -1400,7 +1400,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -924,7 +924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -920,6 +920,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -924,7 +924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -920,6 +920,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -924,7 +924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -920,6 +920,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -924,7 +924,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -920,6 +920,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -910,6 +910,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -914,7 +914,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -896,7 +896,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -892,6 +892,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -896,7 +896,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -892,6 +892,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -1018,6 +1018,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -1022,7 +1022,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -896,7 +896,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -892,6 +892,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -910,7 +910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -906,6 +906,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -910,7 +910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -906,6 +906,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -910,7 +910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -906,6 +906,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -910,7 +910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -906,6 +906,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -910,7 +910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -906,6 +906,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -910,7 +910,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -906,6 +906,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -477,7 +477,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -473,6 +473,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -477,7 +477,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -473,6 +473,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -491,6 +491,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -495,7 +495,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -708,7 +708,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the current deployment principal.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -704,6 +704,23 @@
     }
   },
   {
+    "label": "deployer",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ndeployer(): deployer\n\n```  \nReturns information about the principal that initiated the current deployment operation.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_deployer",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "deployer()$0"
+    }
+  },
+  {
     "label": "deployment",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
@@ -226,6 +226,17 @@ namespace Bicep.Core.Semantics.Namespaces
             return new ObjectType("deployment", TypeSymbolValidationFlags.Default, properties, null);
         }
 
+        private static ObjectType GetDeployerReturnType()
+        {
+            IEnumerable<TypeProperty> properties = new[]
+            {
+                new TypeProperty("objectId", LanguageConstants.String),
+                new TypeProperty("tenantId", LanguageConstants.String),
+            };
+
+            return new ObjectType("deployer", TypeSymbolValidationFlags.Default, properties, null);
+        }
+
         private static IEnumerable<(FunctionOverload functionOverload, ResourceScope allowedScopes)> GetScopeFunctions()
         {
             // Depending on the scope of the Bicep file, different sets of function overloads are invalid - for example, you can't use 'resourceGroup()' inside a tenant-level deployment
@@ -314,6 +325,13 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithGenericDescription("Returns information about the current deployment operation.")
                     .Build(),
                 ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription);
+
+            yield return (
+                new FunctionOverloadBuilder("deployer")
+                    .WithReturnType(GetDeployerReturnType())
+                    .WithGenericDescription("Returns information about the principal that initiated the current deployment operation.")
+                    .Build(),
+                ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup);
         }
 
         private static IEnumerable<NamespaceValue<FunctionOverload>> GetAzOverloads()

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
@@ -155,7 +155,7 @@ namespace Bicep.Core.Semantics.Namespaces
             {
                 new TypeProperty("namespace", LanguageConstants.String),
                 new TypeProperty("resourceTypes", new TypedArrayType(GetProvidersSingleResourceReturnType(), TypeSymbolValidationFlags.Default)),
-                }, null);
+            }, null);
         }
 
         private static ObjectType GetEnvironmentReturnType()
@@ -329,7 +329,7 @@ namespace Bicep.Core.Semantics.Namespaces
             yield return (
                 new FunctionOverloadBuilder("deployer")
                     .WithReturnType(GetDeployerReturnType())
-                    .WithGenericDescription("Returns information about the principal that initiated the current deployment operation.")
+                    .WithGenericDescription("Returns information about the current deployment principal.")
                     .Build(),
                 ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup);
         }

--- a/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
+++ b/src/Bicep.Decompiler/BicepHelpers/SyntaxHelpers.cs
@@ -74,6 +74,7 @@ namespace Bicep.Decompiler.BicepHelpers
             "subscription",
             "resourceGroup",
             "deployment",
+            "deployer",
             "environment",
             "managementGroupResourceId",
             "resourceId",


### PR DESCRIPTION
Add `deployer()` function to Az namespace to return information about the principal that initiated the current deployment operation.

Linked [discussion](https://github.com/Azure/bicep/discussions/9969).
Closes #4959

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15340)