### PR TITLE
Fix `reduce()` return type signature

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
@@ -1280,7 +1280,7 @@
     "minimumArgumentCount": 3,
     "maximumArgumentCount": 3,
     "flags": "default",
-    "typeSignature": "(array: array, initialValue: any, predicate: (any, any[, int]) => any): array",
+    "typeSignature": "(array: array, initialValue: any, predicate: (any, any[, int]) => any): any",
     "parameterTypeSignatures": [
       "array: array",
       "initialValue: any",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -2332,7 +2332,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
@@ -1050,7 +1050,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -2579,7 +2579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -2579,7 +2579,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -1201,7 +1201,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -1165,7 +1165,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -1151,7 +1151,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -1151,7 +1151,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -1871,7 +1871,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -1871,7 +1871,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -1857,7 +1857,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -1857,7 +1857,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -4823,7 +4823,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -4787,7 +4787,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -4815,7 +4815,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -5046,7 +5046,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -5046,7 +5046,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -5046,7 +5046,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -5046,7 +5046,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -5280,7 +5280,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -5280,7 +5280,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -5280,7 +5280,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -5280,7 +5280,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -4801,7 +4801,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -4801,7 +4801,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -4801,7 +4801,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -4801,7 +4801,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -4794,7 +4794,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -4773,7 +4773,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -4773,7 +4773,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -4899,7 +4899,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -4790,7 +4790,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -4787,7 +4787,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -4787,7 +4787,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -4804,7 +4804,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -4854,7 +4854,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -4818,7 +4818,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -4804,7 +4804,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -1879,7 +1879,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -1915,7 +1915,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -1897,7 +1897,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -2665,7 +2665,7 @@
     "kind": "function",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): array\n\n```  \nReduces an array with a custom reduce function.  \n"
+      "value": "```bicep\nreduce(array: array, initialValue: any, predicate: (any, any[, int]) => any): any\n\n```  \nReduces an array with a custom reduce function.  \n"
     },
     "deprecated": false,
     "preselect": false,

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1001,7 +1001,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     {
                         LambdaType lambdaType => new(lambdaType.ReturnType.Type),
                         _ => new(LanguageConstants.Any),
-                    }, LanguageConstants.Array)
+                    }, LanguageConstants.Any)
                     .Build();
 
                 yield return new FunctionOverloadBuilder("toObject")


### PR DESCRIPTION
Fix `reduce()` return type signature. 
Note: The [documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-lambda#reduce) indicates the correct return type of `any`.

Before:
<img width="966" alt="reduce_before" src="https://github.com/user-attachments/assets/50c810d2-6e8e-4607-b559-338e72a450e3">

After:
<img width="728" alt="reduce_after" src="https://github.com/user-attachments/assets/415ecaaa-30bd-49cb-8a87-ad830a71d122">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15386)