### PR TITLE
Improve ternary type inference

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.symbols.bicep
@@ -95,7 +95,7 @@ var toObject7 = toObject(range(0, 10), i => '${i}', () => null)
 var ternary = map([123], true ? i => '${i}' : i => 'hello!')
 //@[32:33) Local i. Type: any. Declaration start char: 32, length: 1
 //@[46:47) Local i. Type: any. Declaration start char: 46, length: 1
-//@[04:11) Variable ternary. Type: any. Declaration start char: 0, length: 60
+//@[04:11) Variable ternary. Type: string[]. Declaration start char: 0, length: 60
 
 var outsideArgs = i => 123
 //@[18:19) Local i. Type: any. Declaration start char: 18, length: 1

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/main.diagnostics.bicep
@@ -179,7 +179,6 @@ output o object = 'str'
 output exp string = 2 + 3
 //@[20:25) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "5". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |2 + 3|
 output union string = true ? 's' : 1
-//@[22:36) [BCP033 (Error)] Expected a value of type "string" but the provided value is of type "'s' | 1". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |true ? 's' : 1|
 output bad int = true && !4
 //@[25:27) [BCP044 (Error)] Cannot apply operator "!" to operand of type "4". (bicep https://aka.ms/bicep/core-diagnostics#BCP044) |!4|
 output deeper bool = true ? -true : (14 && 's') + 10

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.diagnostics.bicep
@@ -2241,7 +2241,7 @@ resource dataCollectionRuleRes2 'Microsoft.Insights/dataCollectionRules@2021-04-
   properties: {
     description: dataCollectionRule.description
     destinations: empty([]) ? [for x in []: {}] : [for x in []: {}]
-//@[018:067) [BCP036 (Warning)] The property "destinations" expected a value of type "DataCollectionRuleDestinations | null" but the provided value is of type "object[] | object[]". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues. (bicep https://aka.ms/bicep/core-diagnostics#BCP036) |empty([]) ? [for x in []: {}] : [for x in []: {}]|
+//@[018:067) [BCP036 (Warning)] The property "destinations" expected a value of type "DataCollectionRuleDestinations | null" but the provided value is of type "object[]". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues. (bicep https://aka.ms/bicep/core-diagnostics#BCP036) |empty([]) ? [for x in []: {}] : [for x in []: {}]|
 //@[031:034) [BCP138 (Error)] For-expressions are not supported in this context. For-expressions may be used as values of resource, module, variable, and output declarations, or values of resource and module properties. (bicep https://aka.ms/bicep/core-diagnostics#BCP138) |for|
 //@[051:054) [BCP138 (Error)] For-expressions are not supported in this context. For-expressions may be used as values of resource, module, variable, and output declarations, or values of resource and module properties. (bicep https://aka.ms/bicep/core-diagnostics#BCP138) |for|
     dataSources: dataCollectionRule.dataSources

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbols.bicep
@@ -107,7 +107,7 @@ var reduceStringConcatEven = reduce(['abc', 'def', 'ghi'], '', (cur, next, i) =>
 //@[064:067) Local cur. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 64, length: 3
 //@[069:073) Local next. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 69, length: 4
 //@[075:076) Local i. Type: int. Declaration start char: 75, length: 1
-//@[004:026) Variable reduceStringConcatEven. Type: 'abc' | 'def' | 'ghi' | string. Declaration start char: 0, length: 117
+//@[004:026) Variable reduceStringConcatEven. Type: string. Declaration start char: 0, length: 117
 var reduceFactorial = reduce(range(1, 5), 1, (cur, next) => cur * next)
 //@[046:049) Local cur. Type: int. Declaration start char: 46, length: 3
 //@[051:055) Local next. Type: int. Declaration start char: 51, length: 4

--- a/src/Bicep.Core.Samples/Files/baselines/PrettyPrint_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/PrettyPrint_LF/main.symbols.bicep
@@ -43,16 +43,16 @@ var w42__ = concat('xxxxx', 'xxxxxxxxxxx')
 //@[04:09) Variable w42__. Type: string. Declaration start char: 0, length: 42
 
 var w38___ = true? 'xxxxx' : 'xxxxxx'
-//@[04:10) Variable w38___. Type: 'xxxxx' | 'xxxxxx'. Declaration start char: 0, length: 37
+//@[04:10) Variable w38___. Type: 'xxxxx'. Declaration start char: 0, length: 37
 var w39___ = true
 //@[04:10) Variable w39___. Type: 'xxxxxx'. Declaration start char: 0, length: 39
 ? 'xxxxxx' : 'xxxxxx' // suffix
 var w40___ = true ?'xxxxxx' : 'xxxxxxx'
-//@[04:10) Variable w40___. Type: 'xxxxxx' | 'xxxxxxx'. Declaration start char: 0, length: 39
+//@[04:10) Variable w40___. Type: 'xxxxxx'. Declaration start char: 0, length: 39
 var w41___ = true ? 'xxxxxxx' :         'xxxxxxx'
 //@[04:10) Variable w41___. Type: 'xxxxxxx'. Declaration start char: 0, length: 49
 var w42___ = true ? 'xxxxxxx':'xxxxxxxx'
-//@[04:10) Variable w42___. Type: 'xxxxxxx' | 'xxxxxxxx'. Declaration start char: 0, length: 40
+//@[04:10) Variable w42___. Type: 'xxxxxxx'. Declaration start char: 0, length: 40
 
 ////////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Baselines for width 80 ////////////////////////////
@@ -103,9 +103,9 @@ var w78___ = /* xxxxxxxxxxxxxxxxxxxxxxxxxxxx */ true
 ? 1234567890
 : 1234567890
 var w79___ = /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxx */ true ? { foo: 1 } : [12345678]
-//@[04:10) Variable w79___. Type: [12345678] | object. Declaration start char: 0, length: 79
+//@[04:10) Variable w79___. Type: object. Declaration start char: 0, length: 79
 var w80___ = true ? { foo: true, bar: false } : [123, 234, 456, { xyz: 'xxxx' }]
-//@[04:10) Variable w80___. Type: [123, 234, 456, object] | object. Declaration start char: 0, length: 80
+//@[04:10) Variable w80___. Type: object. Declaration start char: 0, length: 80
 var w81___ = /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */ true ? 1234567890 : 1234567890
 //@[04:10) Variable w81___. Type: 1234567890. Declaration start char: 0, length: 81
 var w82___ = /* xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx */ true ? 1234567890 : 1234567890
@@ -185,22 +185,22 @@ var forceBreak10 = [1, 2, intersection({ foo: true, bar: false }, {
   foo: true})]
 
 var forceBreak11 = true // comment
-//@[04:16) Variable forceBreak11. Type: bool. Declaration start char: 0, length: 57
+//@[04:16) Variable forceBreak11. Type: true. Declaration start char: 0, length: 57
     ? true
     : false
 var forceBreak12 = true ? true // comment
-//@[04:16) Variable forceBreak12. Type: bool. Declaration start char: 0, length: 53
+//@[04:16) Variable forceBreak12. Type: true. Declaration start char: 0, length: 53
     : false
 var forceBreak13 = true
-//@[04:16) Variable forceBreak13. Type: bool. Declaration start char: 0, length: 57
+//@[04:16) Variable forceBreak13. Type: true. Declaration start char: 0, length: 57
     ? true // comment
     : false
 var forceBreak14 = true ? {
-//@[04:16) Variable forceBreak14. Type: false | object. Declaration start char: 0, length: 49
+//@[04:16) Variable forceBreak14. Type: object. Declaration start char: 0, length: 49
     foo: 42
 } : false
 var forceBreak15 = true ? { foo: 0 } : {
-//@[04:16) Variable forceBreak15. Type: { bar: 1 | null, foo: 0 | null }. Declaration start char: 0, length: 52
+//@[04:16) Variable forceBreak15. Type: object. Declaration start char: 0, length: 52
     bar: 1}
 
 var forceBreak16 = union({ foo: 0 }, {

--- a/src/Bicep.Core.Samples/Files/baselines/PrettyPrint_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/PrettyPrint_LF/main.symbols.bicep
@@ -185,14 +185,14 @@ var forceBreak10 = [1, 2, intersection({ foo: true, bar: false }, {
   foo: true})]
 
 var forceBreak11 = true // comment
-//@[04:16) Variable forceBreak11. Type: false | true. Declaration start char: 0, length: 57
+//@[04:16) Variable forceBreak11. Type: bool. Declaration start char: 0, length: 57
     ? true
     : false
 var forceBreak12 = true ? true // comment
-//@[04:16) Variable forceBreak12. Type: false | true. Declaration start char: 0, length: 53
+//@[04:16) Variable forceBreak12. Type: bool. Declaration start char: 0, length: 53
     : false
 var forceBreak13 = true
-//@[04:16) Variable forceBreak13. Type: false | true. Declaration start char: 0, length: 57
+//@[04:16) Variable forceBreak13. Type: bool. Declaration start char: 0, length: 57
     ? true // comment
     : false
 var forceBreak14 = true ? {
@@ -200,7 +200,7 @@ var forceBreak14 = true ? {
     foo: 42
 } : false
 var forceBreak15 = true ? { foo: 0 } : {
-//@[04:16) Variable forceBreak15. Type: object | object. Declaration start char: 0, length: 52
+//@[04:16) Variable forceBreak15. Type: { bar: 1 | null, foo: 0 | null }. Declaration start char: 0, length: 52
     bar: 1}
 
 var forceBreak16 = union({ foo: 0 }, {

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
@@ -45,7 +45,6 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
   properties: {
     supportsHttpsTrafficOnly: !false
     accessTier: true ? 'Hot' : 'Cold'
-//@[16:37) [BCP036 (Warning)] The property "accessTier" expected a value of type "'Cool' | 'Hot' | null" but the provided value is of type "'Cold' | 'Hot'". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues. (bicep https://aka.ms/bicep/core-diagnostics#BCP036) |true ? 'Hot' : 'Cold'|
     encryption: {
       keySource: 'Microsoft.Storage'
       services: {

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbols.bicep
@@ -300,7 +300,7 @@ var isTrue = sys.max(1, 2) == 3
 var isFalse = !isTrue
 //@[04:11) Variable isFalse. Type: true. Declaration start char: 0, length: 21
 var someText = isTrue ? sys.concat('a', sys.concat('b', 'c')) : 'someText'
-//@[04:12) Variable someText. Type: string. Declaration start char: 0, length: 74
+//@[04:12) Variable someText. Type: 'someText'. Declaration start char: 0, length: 74
 
 // Bicep functions that cannot be converted into ARM functions
 var scopesWithoutArmRepresentation = {
@@ -320,7 +320,7 @@ var scopesWithArmRepresentation = {
 var issue1332_propname = 'ptest'
 //@[04:22) Variable issue1332_propname. Type: 'ptest'. Declaration start char: 0, length: 32
 var issue1332 = true ? {
-//@[04:13) Variable issue1332. Type: { prop1: null | object }. Declaration start char: 0, length: 86
+//@[04:13) Variable issue1332. Type: object. Declaration start char: 0, length: 86
     prop1: {
         '${issue1332_propname}': {}
     }

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.symbols.bicep
@@ -300,7 +300,7 @@ var isTrue = sys.max(1, 2) == 3
 var isFalse = !isTrue
 //@[04:11) Variable isFalse. Type: true. Declaration start char: 0, length: 21
 var someText = isTrue ? sys.concat('a', sys.concat('b', 'c')) : 'someText'
-//@[04:12) Variable someText. Type: 'someText' | string. Declaration start char: 0, length: 74
+//@[04:12) Variable someText. Type: string. Declaration start char: 0, length: 74
 
 // Bicep functions that cannot be converted into ARM functions
 var scopesWithoutArmRepresentation = {
@@ -320,7 +320,7 @@ var scopesWithArmRepresentation = {
 var issue1332_propname = 'ptest'
 //@[04:22) Variable issue1332_propname. Type: 'ptest'. Declaration start char: 0, length: 32
 var issue1332 = true ? {
-//@[04:13) Variable issue1332. Type: object | object. Declaration start char: 0, length: 86
+//@[04:13) Variable issue1332. Type: { prop1: null | object }. Declaration start char: 0, length: 86
     prop1: {
         '${issue1332_propname}': {}
     }

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Expressions/parameters.symbols.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Expressions/parameters.symbols.bicepparam
@@ -61,7 +61,7 @@ param myInt = sys.int(myBool ? 123 : 456)
 //@[6:11) ParameterAssignment myInt. Type: int. Declaration start char: 0, length: 41
 
 param myArray = [
-//@[6:13) ParameterAssignment myArray. Type: ['a' | 'b', false, 579, 333, 6, 5, true, false, false, true]. Declaration start char: 0, length: 123
+//@[6:13) ParameterAssignment myArray. Type: ['a', false, 579, 333, 6, 5, true, false, false, true]. Declaration start char: 0, length: 123
   (true ? 'a' : 'b')
   !true
   123 + 456

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.bicep
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.bicep
@@ -221,7 +221,7 @@ var applicationGroupReferencesArr = (('' == allApplicationGroupReferences)
 var hostpoolRequiredProps = {
   friendlyName: hostpoolFriendlyName
   description: hostpoolDescription
-  hostpoolType: hostpoolType
+  hostPoolType: hostpoolType
   personalDesktopAssignmentType: personalDesktopAssignmentType
   maxSessionLimit: maxSessionLimit
   loadBalancerType: loadBalancerType

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.json
@@ -526,7 +526,7 @@
     "hostpoolRequiredProps": {
       "friendlyName": "[parameters('hostpoolFriendlyName')]",
       "description": "[parameters('hostpoolDescription')]",
-      "hostpoolType": "[parameters('hostpoolType')]",
+      "hostPoolType": "[parameters('hostpoolType')]",
       "personalDesktopAssignmentType": "[parameters('personalDesktopAssignmentType')]",
       "maxSessionLimit": "[parameters('maxSessionLimit')]",
       "loadBalancerType": "[parameters('loadBalancerType')]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/wvd-create-hostpool/main.symbolicnames.json
@@ -527,7 +527,7 @@
     "hostpoolRequiredProps": {
       "friendlyName": "[parameters('hostpoolFriendlyName')]",
       "description": "[parameters('hostpoolDescription')]",
-      "hostpoolType": "[parameters('hostpoolType')]",
+      "hostPoolType": "[parameters('hostpoolType')]",
       "personalDesktopAssignmentType": "[parameters('personalDesktopAssignmentType')]",
       "maxSessionLimit": "[parameters('maxSessionLimit')]",
       "loadBalancerType": "[parameters('loadBalancerType')]",

--- a/src/Bicep.Core/TypeSystem/ArmTemplateTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/ArmTemplateTypeLoader.cs
@@ -289,7 +289,7 @@ public static class ArmTemplateTypeLoader
             {
                 var (type, typeName) = GetDeferrableTypeInfo(context, additionalPropertiesSchema);
                 additionalPropertiesType = type;
-                nameBuilder.AppendPropertyMatcher("*", typeName);
+                nameBuilder.AppendPropertyMatcher(typeName);
             }
             else if (additionalProperties.BooleanValue == false)
             {

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -671,7 +671,7 @@ namespace Bicep.Core.TypeSystem
 
             if (additionalPropertiesType is not null && !additionalPropertiesFlags.HasFlag(TypePropertyFlags.FallbackProperty))
             {
-                nameBuilder.AppendPropertyMatcher("*", GetPropertyTypeName(additionalPropertiesDeclarations[0].Value, additionalPropertiesType));
+                nameBuilder.AppendPropertyMatcher(GetPropertyTypeName(additionalPropertiesDeclarations[0].Value, additionalPropertiesType));
             }
 
             if (diagnostics.Any())

--- a/src/Bicep.Core/TypeSystem/DiscriminatedObjectTypeBuilder.cs
+++ b/src/Bicep.Core/TypeSystem/DiscriminatedObjectTypeBuilder.cs
@@ -19,12 +19,12 @@ public class DiscriminatedObjectTypeBuilder
 
     public bool TryInclude(ObjectType @object)
     {
-        if (members.Contains(@object))
+        if (!members.Add(@object))
         {
             return true;
         }
 
-        if (members.Count == 0)
+        if (members.Count == 1)
         {
             var foundViableDiscriminator = false;
 
@@ -49,7 +49,7 @@ public class DiscriminatedObjectTypeBuilder
         }
         else
         {
-            var noLongerViableDiscriminators = ImmutableHashSet.CreateBuilder<string>();
+            HashSet<string> noLongerViableDiscriminators = new();
             Dictionary<string, string> stillViableDiscriminators = new();
 
             foreach (var candidate in discriminatorCandidates.Keys)
@@ -68,13 +68,7 @@ public class DiscriminatedObjectTypeBuilder
                 }
             }
 
-            // If adding @object would eliminate all possible discriminators, reject it
-            if (noLongerViableDiscriminators.SetEquals(discriminatorCandidates.Keys))
-            {
-                return false;
-            }
-
-            // otherwise, narrow the list of discriminator candidates
+            // narrow the list of discriminator candidates
             foreach (var toEliminate in noLongerViableDiscriminators)
             {
                 discriminatorCandidates.Remove(toEliminate);
@@ -85,8 +79,7 @@ public class DiscriminatedObjectTypeBuilder
             }
         }
 
-        members.Add(@object);
-        return true;
+        return discriminatorCandidates.Count > 0;
     }
 
     public (ImmutableHashSet<ObjectType> Members, ImmutableHashSet<string> ViableDiscriminators) Build()

--- a/src/Bicep.Core/TypeSystem/ObjectTypeNameBuilder.cs
+++ b/src/Bicep.Core/TypeSystem/ObjectTypeNameBuilder.cs
@@ -18,6 +18,9 @@ internal class ObjectTypeNameBuilder
     internal void AppendPropertyMatcher(string matchNotation, string value)
         => DoAppendProperty(matchNotation, value);
 
+    internal void AppendPropertyMatcher(string value)
+        => AppendPropertyMatcher("*", value);
+
     private void DoAppendProperty(string propertyName, string propertyValue)
     {
         if (finalized)

--- a/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
+++ b/src/Bicep.Core/TypeSystem/OperationReturnTypeEvaluator.cs
@@ -107,8 +107,7 @@ public static class OperationReturnTypeEvaluator
                     return ErrorType.Create(errors.SelectMany(e => e.GetDiagnostics()));
                 }
 
-                var unionOfTransformed = TypeHelper.CreateTypeUnion(transformed);
-                return TypeCollapser.TryCollapse(unionOfTransformed) ?? unionOfTransformed;
+                return TypeHelper.CollapseOrCreateTypeUnion(transformed);
             case IntegerLiteralType integerLiteral when Negate(integerLiteral.Value) is long negated:
                 return TypeFactory.CreateIntegerLiteralType(negated, integerLiteral.ValidationFlags);
             case IntegerType @int:

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1686,7 +1686,8 @@ namespace Bicep.Core.TypeSystem
                                 return TypeHelper.GetNamedPropertyType(baseObject,
                                     syntax.IndexExpression,
                                     literalIndex.RawStringValue,
-                                    syntax.IsSafeAccess || TypeValidator.ShouldWarnForPropertyMismatch(baseObject),
+                                    syntax.IsSafeAccess,
+                                    shouldWarn: syntax.IsSafeAccess || TypeValidator.ShouldWarnForPropertyMismatch(baseObject),
                                     diagnostics);
                             }
 
@@ -1800,12 +1801,14 @@ namespace Bicep.Core.TypeSystem
             ObjectType objectType => TypeHelper.GetNamedPropertyType(objectType,
                 syntax.PropertyName,
                 syntax.PropertyName.IdentifierName,
+                syntax.IsSafeAccess,
                 syntax.IsSafeAccess || TypeValidator.ShouldWarnForPropertyMismatch(objectType),
                 diagnostics),
 
             UnionType unionType when syntax.PropertyName.IsValid => TypeHelper.GetNamedPropertyType(unionType,
                 syntax.PropertyName,
                 syntax.PropertyName.IdentifierName,
+                syntax.IsSafeAccess,
                 syntax.IsSafeAccess || TypeValidator.ShouldWarnForPropertyMismatch(unionType),
                 diagnostics),
 

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1493,7 +1493,7 @@ namespace Bicep.Core.TypeSystem
                 // TODO if the condition is of a boolean literal type, return either `trueType` or `falseType`, not the union of both
 
                 // the return type is the union of true and false expression types
-                return TypeHelper.CreateTypeUnion(trueType, falseType);
+                return TypeHelper.CollapseOrCreateTypeUnion(trueType, falseType);
             });
 
         public override void VisitBinaryOperationSyntax(BinaryOperationSyntax syntax)

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1490,10 +1490,13 @@ namespace Bicep.Core.TypeSystem
                     return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.ConditionExpression).ValueTypeMismatch(expectedConditionType));
                 }
 
-                // TODO if the condition is of a boolean literal type, return either `trueType` or `falseType`, not the union of both
-
-                // the return type is the union of true and false expression types
-                return TypeHelper.CollapseOrCreateTypeUnion(trueType, falseType);
+                return conditionType switch
+                {
+                    BooleanLiteralType { Value: true } => trueType,
+                    BooleanLiteralType => falseType,
+                    // the return type is the union of true and false expression types
+                    _ => TypeHelper.CollapseOrCreateTypeUnion(trueType, falseType),
+                };
             });
 
         public override void VisitBinaryOperationSyntax(BinaryOperationSyntax syntax)

--- a/src/Bicep.Core/TypeSystem/TypeCollapser.cs
+++ b/src/Bicep.Core/TypeSystem/TypeCollapser.cs
@@ -25,19 +25,25 @@ internal static class TypeCollapser
     private static TypeSymbol? TryCollapse(UnionType unionType)
     {
         var collapseState = UnionCollapseState.Initialize();
-        foreach (var member in unionType.Members)
+        foreach (var member in Flatten(unionType))
         {
             collapseState = collapseState.Push(member);
         }
 
-        return collapseState.Collapse();
+        return collapseState.TryCollapse();
     }
+
+    private static IEnumerable<TypeSymbol> Flatten(ITypeReference type) => type.Type switch
+    {
+        UnionType union => union.Members.SelectMany(Flatten),
+        TypeSymbol otherwise => otherwise.AsEnumerable(),
+    };
 
     private interface UnionCollapseState
     {
         UnionCollapseState Push(ITypeReference memberType);
 
-        TypeSymbol? Collapse();
+        TypeSymbol? TryCollapse();
 
         public static UnionCollapseState Initialize() => new InitialState();
 
@@ -48,7 +54,7 @@ internal static class TypeCollapser
         {
             private bool nullable = false;
 
-            public TypeSymbol? Collapse() => LanguageConstants.Never;
+            public TypeSymbol? TryCollapse() => LanguageConstants.Never;
 
             public UnionCollapseState Push(ITypeReference memberType) => memberType.Type switch
             {
@@ -92,7 +98,7 @@ internal static class TypeCollapser
                 this.nullable = nullable;
             }
 
-            public TypeSymbol? Collapse() => CreateTypeUnion(
+            public TypeSymbol? TryCollapse() => CreateTypeUnion(
                 // only keep string literals that are not valid in any of the discrete spans
                 stringLiterals.Where(literal => !spanCollapser.Spans.Any(s => s.Contains(literal.RawStringValue.Length)))
                     // create a refined string type for each span
@@ -148,7 +154,7 @@ internal static class TypeCollapser
                 this.nullable = nullable;
             }
 
-            public TypeSymbol? Collapse() => CreateTypeUnion(
+            public TypeSymbol? TryCollapse() => CreateTypeUnion(
                 spanCollapser.Spans.Select(span => span.Min == span.Max
                     ? TypeFactory.CreateIntegerLiteralType(span.Min, span.Flags)
                     : TypeFactory.CreateIntegerType(
@@ -208,7 +214,7 @@ internal static class TypeCollapser
                 this.nullable = nullable;
             }
 
-            public TypeSymbol? Collapse()
+            public TypeSymbol? TryCollapse()
             {
                 TypeSymbol collapsed = includesTrue ^ includesFalse
                     ? TypeFactory.CreateBooleanLiteralType(includesTrue, flags)
@@ -266,7 +272,7 @@ internal static class TypeCollapser
                 this.nullable = nullable;
             }
 
-            public TypeSymbol? Collapse()
+            public TypeSymbol? TryCollapse()
             {
                 foreach (var tuple in tuples.ToArray())
                 {
@@ -340,7 +346,7 @@ internal static class TypeCollapser
                 this.nullable = nullable;
             }
 
-            public TypeSymbol? Collapse()
+            public TypeSymbol? TryCollapse()
             {
                 var (members, viableDiscriminators) = discriminatedObjectTypeBuilder.Build();
 
@@ -365,18 +371,98 @@ internal static class TypeCollapser
                     return nullable ? TypeHelper.CreateTypeUnion(baseType, LanguageConstants.Null) : baseType;
                 }
 
-                return null;
+                ObjectTypeNameBuilder structuralNameBuilder = new();
+                List<TypeProperty> properties = new();
+                foreach (var declaredPropertyName in members.SelectMany(m => m.Properties.Keys).Distinct()
+                    .OrderBy(x => x, LanguageConstants.IdentifierComparer))
+                {
+                    List<TypeSymbol> possibleTypes = new();
+                    TypePropertyFlags propertyFlags = ~TypePropertyFlags.None;
+                    foreach (var member in members)
+                    {
+                        if (member.Properties.TryGetValue(declaredPropertyName, out var property))
+                        {
+                            possibleTypes.Add(property.TypeReference.Type);
+                            propertyFlags &= property.Flags;
+                        }
+                        else
+                        {
+                            possibleTypes.Add(member.AdditionalPropertiesType?.Type ?? LanguageConstants.Null);
+                            propertyFlags &= member.AdditionalPropertiesType is not null
+                                ? member.AdditionalPropertiesFlags
+                                : TypePropertyFlags.FallbackProperty;
+                        }
+                    }
+
+                    var propertyTypeUnion = TypeHelper.CreateTypeUnion(possibleTypes);
+
+                    properties.Add(new(
+                        declaredPropertyName,
+                        TypeCollapser.TryCollapse(propertyTypeUnion) is { } collapsed ? collapsed : propertyTypeUnion,
+                        propertyFlags));
+                    structuralNameBuilder.AppendProperty(declaredPropertyName, properties[^1].TypeReference.Type.Name);
+                }
+
+                var (additionalPropertiesType, additionalPropertiesFlags) = GetAdditionalPropertiesType(members);
+                if (additionalPropertiesType is not null &&
+                    !additionalPropertiesFlags.HasFlag(TypePropertyFlags.FallbackProperty))
+                {
+                    structuralNameBuilder.AppendPropertyMatcher(additionalPropertiesType.Name);
+                }
+
+                return new ObjectType(
+                    structuralNameBuilder.ToString(),
+                    flags,
+                    properties,
+                    additionalPropertiesType,
+                    additionalPropertiesFlags);
+            }
+
+            private static (TypeSymbol? type, TypePropertyFlags flags) GetAdditionalPropertiesType(
+                IEnumerable<ObjectType> objects)
+            {
+                var noneHaveAdditionalPropertiesType = true;
+                var allHaveImplicitAnyAdditionalPropertiesType = true;
+
+                List<TypeSymbol> possibleTypes = new();
+                TypePropertyFlags propertyFlags = ~TypePropertyFlags.None;
+                foreach (var @object in objects)
+                {
+                    noneHaveAdditionalPropertiesType &= @object.AdditionalPropertiesType is null;
+                    allHaveImplicitAnyAdditionalPropertiesType &= @object.AdditionalPropertiesType is not null &&
+                        @object.HasExplicitAdditionalPropertiesType;
+
+                    possibleTypes.Add(@object.AdditionalPropertiesType?.Type ?? LanguageConstants.Null);
+                    propertyFlags &= @object.AdditionalPropertiesFlags;
+                }
+
+                if (noneHaveAdditionalPropertiesType)
+                {
+                    return (null, TypePropertyFlags.None);
+                }
+
+                if (allHaveImplicitAnyAdditionalPropertiesType)
+                {
+                    return (LanguageConstants.Any, TypePropertyFlags.FallbackProperty);
+                }
+
+                return (TypeHelper.CollapseOrCreateTypeUnion(possibleTypes), propertyFlags);
             }
 
             public UnionCollapseState Push(ITypeReference memberType)
             {
                 switch (memberType.Type)
                 {
-                    case ObjectType @object when discriminatedObjectTypeBuilder.TryInclude(@object):
+                    case ObjectType @object:
                         flags |= @object.ValidationFlags;
+                        discriminatedObjectTypeBuilder.TryInclude(@object);
                         return this;
-                    case DiscriminatedObjectType @union when @union.UnionMembersByKey.Values.All(discriminatedObjectTypeBuilder.TryInclude):
+                    case DiscriminatedObjectType @union:
                         flags |= @union.ValidationFlags;
+                        foreach (var member in union.UnionMembersByKey.Values)
+                        {
+                            Push(member);
+                        }
                         return this;
                     case NullType:
                         nullable = true;
@@ -395,7 +481,7 @@ internal static class TypeCollapser
 
             internal static readonly CollapsesToAny Instance = new();
 
-            public TypeSymbol? Collapse() => LanguageConstants.Any;
+            public TypeSymbol? TryCollapse() => LanguageConstants.Any;
 
             public UnionCollapseState Push(ITypeReference _) => this;
         }
@@ -406,7 +492,7 @@ internal static class TypeCollapser
 
             internal static readonly Uncollapsable Instance = new();
 
-            public TypeSymbol? Collapse() => null;
+            public TypeSymbol? TryCollapse() => null;
 
             public UnionCollapseState Push(ITypeReference _) => this;
         }

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -55,95 +55,10 @@ namespace Bicep.Core.TypeSystem
         public static TypeSymbol CollapseOrCreateTypeUnion(params ITypeReference[] itemTypes)
             => CollapseOrCreateTypeUnion((IEnumerable<ITypeReference>)itemTypes);
 
-        private static TypeProperty GetCombinedTypeProperty(IEnumerable<ObjectType> objectTypes, string propertyName)
-        {
-            var flags = TypePropertyFlags.None;
-            var types = new List<TypeSymbol>();
-
-            foreach (var objectType in objectTypes)
-            {
-                if (objectType.Properties.TryGetValue(propertyName) is {} namedProperty)
-                {
-                    flags |= namedProperty.Flags;
-                    types.Add(namedProperty.TypeReference.Type);
-                }
-                else if (objectType.AdditionalPropertiesType is {} additionalPropertyType)
-                {
-                    flags |= objectType.AdditionalPropertiesFlags;
-                    types.Add(additionalPropertyType.Type);
-                }
-                else
-                {
-                    flags |= TypePropertyFlags.None;
-                    types.Add(LanguageConstants.Null);
-                }
-            }
-
-            // descriptions are not combined here
-            return new TypeProperty(propertyName, CreateTypeUnion(types), flags);
-        }
-
-        private static (TypeSymbol type, TypePropertyFlags flags)? TryGetCombinedAdditionalProperties(IReadOnlyList<ObjectType> objectTypes)
-        {
-            if (!objectTypes.Any(x => x.AdditionalPropertiesType is {}))
-            {
-                return null;
-            }
-
-            var flags = TypePropertyFlags.None;
-            var types = new List<TypeSymbol>();
-
-            foreach (var objectType in objectTypes)
-            {
-                if (objectType.AdditionalPropertiesType is {} additionalPropertyType)
-                {
-                    flags |= objectType.AdditionalPropertiesFlags;
-                    types.Add(additionalPropertyType.Type);
-                }
-                else
-                {
-                    flags |= TypePropertyFlags.None;
-                    types.Add(LanguageConstants.Null);
-                }
-            }
-
-            return (CreateTypeUnion(types), flags);
-        }
-
         /// <summary>
         /// Makes a type nullable by unioning it with null
         /// </summary>
         public static TypeSymbol MakeNullable(ITypeReference typeReference) => CreateTypeUnion(typeReference, LanguageConstants.Null);
-
-        /// <summary>
-        /// Converts a set of object types into a single object type with unioned properties
-        /// e.g. { foo: 'abc', bar: 'def' } | { foo: 'ghi', baz: 'jkl' }
-        /// would become { foo: ('abc' | 'ghi'), bar: ('def' | null), baz: ('jkl' | null) }
-        /// </summary>
-        public static ObjectType CreateObjectTypeFromObjectUnion(IReadOnlyList<ObjectType> objectTypes)
-        {
-            var propertyNames = objectTypes
-                .SelectMany(obj => obj.Properties.Select(x => x.Key))
-                .Distinct(LanguageConstants.IdentifierComparer);
-
-            var newProperties = new List<TypeProperty>();
-            foreach (var propertyName in propertyNames)
-            {
-                var newPropertyType = GetCombinedTypeProperty(objectTypes, propertyName);
-                newProperties.Add(newPropertyType);
-            }
-
-            var additionalProperties = TryGetCombinedAdditionalProperties(objectTypes);
-            var validationFlags = objectTypes.Select(x => x.ValidationFlags).Aggregate((a, b) => a | b);
-
-            return new ObjectType(
-                // TODO: Add better naming?
-                LanguageConstants.Object.Name,
-                validationFlags,
-                newProperties,
-                additionalProperties?.type,
-                additionalProperties?.flags ?? TypePropertyFlags.None);
-        }
 
         public static LambdaType CreateLambdaType(IEnumerable<ITypeReference> argumentTypes, IEnumerable<ITypeReference> optionalArgumentTypes, TypeSymbol returnType)
             => new(argumentTypes.ToImmutableArray(), optionalArgumentTypes.ToImmutableArray(), returnType);
@@ -246,17 +161,111 @@ namespace Bicep.Core.TypeSystem
             return new TupleType(nameBuilder.ToString(), [.. convertedItems], TypeSymbolValidationFlags.Default);
         }
 
-        public static TypeSymbol GetNamedPropertyType(UnionType unionType, IPositionable propertyExpressionPositionable, string propertyName, bool shouldWarn, IDiagnosticWriter diagnostics)
-        {
-            if (unionType.Members.IsEmpty ||
-                unionType.Members.Any(x => x is not ObjectType))
+        public static TypeSymbol GetNamedPropertyType(
+            UnionType unionType,
+            IPositionable propertyExpressionPositionable,
+            string propertyName,
+            bool isSafeAccess,
+            bool shouldWarn,
+            IDiagnosticWriter diagnostics) => TryCollapseTypes(unionType.Members) switch
             {
+                ObjectType @object => GetNamedPropertyType(
+                    @object,
+                    propertyExpressionPositionable,
+                    propertyName,
+                    isSafeAccess,
+                    shouldWarn,
+                    diagnostics),
+                DiscriminatedObjectType taggedUnion => GetNamedPropertyType(
+                    taggedUnion,
+                    propertyExpressionPositionable,
+                    propertyName,
+                    isSafeAccess,
+                    shouldWarn,
+                    diagnostics),
                 // TODO improve later here if necessary - we should be able to block stuff that is obviously wrong
-                return LanguageConstants.Any;
+                _ => LanguageConstants.Any,
+            };
+
+        public static TypeSymbol GetNamedPropertyType(
+            DiscriminatedObjectType discriminatedObjectType,
+            IPositionable propertyExpressionPositionable,
+            string propertyName,
+            bool isSafeAccess,
+            bool shouldWarn,
+            IDiagnosticWriter diagnostics)
+        {
+            if (propertyName.Equals(discriminatedObjectType.DiscriminatorProperty.Name))
+            {
+                return discriminatedObjectType.DiscriminatorProperty.TypeReference.Type;
             }
 
-            var objectType = CreateObjectTypeFromObjectUnion(unionType.Members.OfType<ObjectType>().ToArray());
-            return GetNamedPropertyType(objectType, propertyExpressionPositionable, propertyName, shouldWarn, diagnostics);
+            TypePropertyFlags flags = TypePropertyFlags.None;
+            List<TypeSymbol> propertyTypes = new();
+            var declaredOnAny = false;
+
+            foreach (var member in discriminatedObjectType.UnionMembersByKey.Values)
+            {
+                if (member.Properties.TryGetValue(propertyName, out var memberProperty))
+                {
+                    declaredOnAny = true;
+                    propertyTypes.Add(memberProperty.TypeReference.Type);
+                    flags |= memberProperty.Flags;
+                }
+                else if (member.AdditionalPropertiesType is not null)
+                {
+                    declaredOnAny = true;
+                    propertyTypes.Add(member.AdditionalPropertiesType.Type);
+                    flags |= member.AdditionalPropertiesFlags;
+                }
+                else
+                {
+                    propertyTypes.Add(LanguageConstants.Null);
+                    flags |= TypePropertyFlags.FallbackProperty;
+                }
+            }
+
+            if (declaredOnAny)
+            {
+                return GenerateAccessError(flags, discriminatedObjectType, propertyExpressionPositionable, propertyName, isSafeAccess, shouldWarn, diagnostics)
+                    ?? TypeHelper.CollapseOrCreateTypeUnion(propertyTypes);
+            }
+
+            return GetUnknownPropertyType(
+                discriminatedObjectType,
+                discriminatedObjectType.UnionMembersByKey.Values.SelectMany(obj => obj.Properties.Values),
+                propertyExpressionPositionable,
+                propertyName,
+                shouldWarn,
+                diagnostics);
+        }
+
+        private static ErrorType? GenerateAccessError(
+            TypePropertyFlags flags,
+            TypeSymbol baseType,
+            IPositionable propertyExpressionPositionable,
+            string propertyName,
+            bool isSafeAccess,
+            bool shouldWarn,
+            IDiagnosticWriter diagnostics)
+        {
+            if (flags.HasFlag(TypePropertyFlags.WriteOnly))
+            {
+                var writeOnlyDiagnostic = DiagnosticBuilder.ForPosition(propertyExpressionPositionable).WriteOnlyProperty(shouldWarn, baseType, propertyName);
+                diagnostics.Write(writeOnlyDiagnostic);
+
+                if (writeOnlyDiagnostic.IsError())
+                {
+                    return ErrorType.Empty();
+                }
+            }
+
+            if (!isSafeAccess && flags.HasFlag(TypePropertyFlags.FallbackProperty))
+            {
+                diagnostics.Write(DiagnosticBuilder.ForPosition(propertyExpressionPositionable).FallbackPropertyUsed(propertyName));
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -265,9 +274,16 @@ namespace Bicep.Core.TypeSystem
         /// <param name="baseType">The base object type</param>
         /// <param name="propertyExpressionPositionable">The position of the property name expression</param>
         /// <param name="propertyName">The resolved property name</param>
+        /// <param name="isSafeAccess">Whether the expression accessing this property uses null-conditional access.</param>
         /// <param name="shouldWarn">Whether diagnostics with a configurable level should be issued as warnings</param>
         /// <param name="diagnostics">Sink for diagnostics are not included in the return type symbol</param>
-        public static TypeSymbol GetNamedPropertyType(ObjectType baseType, IPositionable propertyExpressionPositionable, string propertyName, bool shouldWarn, IDiagnosticWriter diagnostics)
+        public static TypeSymbol GetNamedPropertyType(
+            ObjectType baseType,
+            IPositionable propertyExpressionPositionable,
+            string propertyName,
+            bool isSafeAccess,
+            bool shouldWarn,
+            IDiagnosticWriter diagnostics)
         {
             if (baseType.TypeKind == TypeKind.Any)
             {
@@ -275,33 +291,13 @@ namespace Bicep.Core.TypeSystem
                 return LanguageConstants.Any;
             }
 
-            ErrorType? GenerateAccessError(TypePropertyFlags flags)
-            {
-                if (flags.HasFlag(TypePropertyFlags.WriteOnly))
-                {
-                    var writeOnlyDiagnostic = DiagnosticBuilder.ForPosition(propertyExpressionPositionable).WriteOnlyProperty(shouldWarn, baseType, propertyName);
-                    diagnostics.Write(writeOnlyDiagnostic);
-
-                    if (writeOnlyDiagnostic.IsError())
-                    {
-                        return ErrorType.Empty();
-                    }
-                }
-
-                if (flags.HasFlag(TypePropertyFlags.FallbackProperty))
-                {
-                    diagnostics.Write(DiagnosticBuilder.ForPosition(propertyExpressionPositionable).FallbackPropertyUsed(propertyName));
-                }
-
-                return null;
-            };
-
             // is there a declared property with this name
             var declaredProperty = baseType.Properties.TryGetValue(propertyName);
             if (declaredProperty != null)
             {
                 // there is - return its type or any error raised by its use
-                return GenerateAccessError(declaredProperty.Flags) ?? declaredProperty.TypeReference.Type;
+                return GenerateAccessError(declaredProperty.Flags, baseType, propertyExpressionPositionable, propertyName, isSafeAccess, shouldWarn, diagnostics)
+                    ?? declaredProperty.TypeReference.Type;
             }
 
             // the property is not declared
@@ -309,28 +305,50 @@ namespace Bicep.Core.TypeSystem
             if (baseType.AdditionalPropertiesType != null)
             {
                 // yes - return the additional property type or any error raised by its use
-                return GenerateAccessError(baseType.AdditionalPropertiesFlags) ?? baseType.AdditionalPropertiesType.Type;
+                return GenerateAccessError(baseType.AdditionalPropertiesFlags, baseType, propertyExpressionPositionable, propertyName, isSafeAccess, shouldWarn, diagnostics)
+                    ?? baseType.AdditionalPropertiesType.Type;
             }
 
-            var availableProperties = baseType.Properties.Values
-                .Where(p => !p.Flags.HasFlag(TypePropertyFlags.WriteOnly))
-                .Select(p => p.Name)
-                .OrderBy(x => x);
+            return GetUnknownPropertyType(
+                baseType,
+                baseType.Properties.Values,
+                propertyExpressionPositionable,
+                propertyName,
+                shouldWarn,
+                diagnostics);
+        }
 
-            var unknownPropertyDiagnostic = GetUnknownPropertyDiagnostic(baseType, propertyName, shouldWarn)
+        private static TypeSymbol GetUnknownPropertyType(
+            TypeSymbol baseType,
+            IEnumerable<TypeProperty> properties,
+            IPositionable propertyExpressionPositionable,
+            string propertyName,
+            bool shouldWarn,
+            IDiagnosticWriter diagnostics)
+        {
+            var unknownPropertyDiagnostic = GetUnknownPropertyDiagnostic(baseType, properties, propertyName, shouldWarn)
                 .Invoke(DiagnosticBuilder.ForPosition(propertyExpressionPositionable));
 
             diagnostics.Write(unknownPropertyDiagnostic);
 
-            return (unknownPropertyDiagnostic.IsError()) ? ErrorType.Empty() : LanguageConstants.Any;
+            return unknownPropertyDiagnostic.IsError() ? ErrorType.Empty() : LanguageConstants.Any;
         }
 
         public static DiagnosticBuilder.DiagnosticBuilderDelegate GetUnknownPropertyDiagnostic(ObjectType baseType, string propertyName, bool shouldWarn)
+            => GetUnknownPropertyDiagnostic(baseType, baseType.Properties.Values, propertyName, shouldWarn);
+
+        public static DiagnosticBuilder.DiagnosticBuilderDelegate GetUnknownPropertyDiagnostic(
+            TypeSymbol baseType,
+            IEnumerable<TypeProperty> properties,
+            string propertyName,
+            bool shouldWarn)
         {
-            var availableProperties = baseType.Properties.Values
+            var availableProperties = properties
                 .Where(p => !p.Flags.HasFlag(TypePropertyFlags.WriteOnly))
                 .Select(p => p.Name)
-                .OrderBy(x => x);
+                .Distinct()
+                .OrderBy(x => x)
+                .ToList();
 
             return availableProperties.Any() switch
             {

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -46,6 +46,15 @@ namespace Bicep.Core.TypeSystem
             };
         }
 
+        public static TypeSymbol CollapseOrCreateTypeUnion(IEnumerable<ITypeReference> itemTypes)
+        {
+            var unionType = CreateTypeUnion(itemTypes);
+            return TypeCollapser.TryCollapse(unionType) ?? unionType;
+        }
+
+        public static TypeSymbol CollapseOrCreateTypeUnion(params ITypeReference[] itemTypes)
+            => CollapseOrCreateTypeUnion((IEnumerable<ITypeReference>)itemTypes);
+
         private static TypeProperty GetCombinedTypeProperty(IEnumerable<ObjectType> objectTypes, string propertyName)
         {
             var flags = TypePropertyFlags.None;

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -1279,8 +1279,7 @@ namespace Bicep.LanguageServer.Completions
                 TestType testType => GetProperties(testType.Body.Type),
                 ObjectType objectType => objectType.Properties.Values,
                 DiscriminatedObjectType discriminated => discriminated.DiscriminatorProperty.AsEnumerable(),
-                UnionType unionType when unionType.Members.All(x => x.Type is ObjectType)
-                    => GetProperties(TypeHelper.CreateObjectTypeFromObjectUnion(unionType.Members.OfType<ObjectType>().ToList())),
+                UnionType unionType => GetProperties(TypeHelper.TryCollapseTypes(unionType.Members)),
                 _ => [],
             }).Where(p => !p.Flags.HasFlag(TypePropertyFlags.FallbackProperty));
         }


### PR DESCRIPTION
Resolves #15397

Worked on this as an alternative way to address #15114 (instead of #15398). This PR does two things:

1. If a ternary has a literally-typed condition (i.e., it is definitely true or definitely false), the type engine will use the type of the active branch's expression. E.g., the type of `true ? 'a' : 'b'` is `'a'`, and the type of `false ? 'a' : 'b'` is `'b'`. There was a TODO comment in TypeAssignmentVisitor suggesting this change.
2. If the types of both branches can be combined instead of represented as a union, the type engine will do so. For example, the type of `unknownCondition ? 'a' : 'b'` is `'a' | 'b'` (a union), but the type of `unknownCondition ? [stringParam] : [intParam]` is `[int | string]` (assuming the type of `stringParam` is `string` and the type of `intParam` is `int`). This change relies on existing type collapsing logic, so it will handle things like combining refinements on string types and combining objects into tagged unions if possible.

One change I made to the TypeCollapser is to collapse objects that *can't* be combined into a tagged union into an object whose properties are a union of the possible property types of the inputs. This is similar to how we collapse tuple types. Given a template like the following:

```bicep
param a {
  foo: string
}

param b {
  bar: string
  *: int
}

param condition bool

var value = condition ? a : b
```

`value` would have a type of `{ bar: string, foo: int | string, *: int }`, with all properties flagged as optional.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15399)