### PR TITLE
Only add an explicit dependency on an existing resource when the deployments engine will use the GET response

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ExistingResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExistingResourceTests.cs
@@ -1,0 +1,361 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.IntegrationTests;
+
+[TestClass]
+public class ExistingResourceTests
+{
+    [NotNull]
+    public TestContext? TestContext { get; set; }
+
+    [TestMethod]
+    public void Implicit_dependencies_on_existing_resources_are_reflected_in_symbolic_name_template()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)),
+            """
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+              name: replace(deployedSa.name, '1', '2')
+            }
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              properties: {
+                allowSharedKeyAccess: existingSa.properties.allowSharedKeyAccess
+              }
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveJsonAtPath("$.resources.newSa.dependsOn", """["existingSa"]""");
+        result.Template.Should().HaveJsonAtPath("$.resources.existingSa.dependsOn", """["deployedSa"]""");
+    }
+
+    [TestMethod]
+    public void Explicit_dependencies_on_existing_resources_are_reflected_in_symbolic_name_template()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)),
+            """
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+              name: replace(deployedSa.name, '1', '2')
+            }
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              dependsOn: [
+                existingSa
+              ]
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveJsonAtPath("$.resources.newSa.dependsOn", """["existingSa"]""");
+        result.Template.Should().HaveJsonAtPath("$.resources.existingSa.dependsOn", """["deployedSa"]""");
+    }
+
+    [TestMethod]
+    public void Implicit_dependencies_on_existing_resources_are_expressed_as_direct_dependencies_on_transitive_dependencies_in_non_symbolic_name_template()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: false)),
+            """
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+              name: replace(deployedSa.name, '1', '2')
+            }
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              properties: {
+                allowSharedKeyAccess: existingSa.properties.allowSharedKeyAccess
+              }
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.GetProperty("resources").Should().BeOfType<JArray>()
+            .Subject.Count.Should().Be(2);
+        result.Template.Should().HaveJsonAtPath("$.resources[1].dependsOn", """["[resourceId('Microsoft.Storage/storageAccounts', 'account1')]"]""");
+    }
+
+    [TestMethod]
+    public void Explicit_dependencies_on_existing_resources_are_expressed_as_direct_dependencies_on_transitive_dependencies_in_non_symbolic_name_template()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: false)),
+            """
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+              name: replace(deployedSa.name, '1', '2')
+            }
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              dependsOn: [
+                existingSa
+              ]
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.GetProperty("resources").Should().BeOfType<JArray>()
+            .Subject.Count.Should().Be(2);
+        result.Template.Should().HaveJsonAtPath("$.resources[1].dependsOn", """["[resourceId('Microsoft.Storage/storageAccounts', 'account1')]"]""");
+    }
+
+    [TestMethod]
+    public void Implicit_dependencies_on_deployed_resource_identifying_properties_are_expressed_in_symbolic_name_template()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)),
+            """
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+            
+            resource secondDeployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: replace(deployedSa.name, '1', '2')
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: replace(secondDeployedSa.name, '2', '3')
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveJsonAtPath("$.resources.newSa.dependsOn", """["secondDeployedSa"]""");
+        result.Template.Should().HaveJsonAtPath("$.resources.secondDeployedSa.dependsOn", """["deployedSa"]""");
+    }
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void Implicit_dependencies_on_existing_resource_identifying_properties_are_expressed_as_direct_dependencies_on_transitive_dependencies_in_symbolic_name_template(bool useArrayAccess)
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)),
+            $$"""
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+            
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+              name: replace(deployedSa.name, '1', '2')
+            }
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              properties: {
+                allowSharedKeyAccess: bool(existingSa{{(useArrayAccess ? "['name']" : ".name")}})
+              }
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveJsonAtPath("$.resources.newSa.dependsOn", """["deployedSa"]""");
+        result.Template.Should().HaveJsonAtPath("$.resources.existingSa.dependsOn", """["deployedSa"]""");
+    }
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void Implicit_dependencies_on_existing_resource_collection_identifying_properties_are_expressed_as_direct_dependencies_on_transitive_dependencies_in_symbolic_name_template(bool useArrayAccess)
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)),
+            $$"""
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+            
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = [for i in range(0, 1): {
+              name: '${replace(deployedSa.name, '1', '2')}_${i}'
+            }]
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              properties: {
+                allowSharedKeyAccess: bool(existingSa[0]{{(useArrayAccess ? "['name']" : ".name")}})
+              }
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveJsonAtPath("$.resources.newSa.dependsOn", """["deployedSa"]""");
+        result.Template.Should().HaveJsonAtPath("$.resources.existingSa.dependsOn", """["deployedSa"]""");
+    }
+
+    [TestMethod]
+    public void Existing_resource_function_calls_are_expressed_as_direct_dependencies_on_transitive_dependencies_in_symbolic_name_template()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)),
+            """
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+            
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+              name: replace(deployedSa.name, '1', '2')
+            }
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              properties: {
+                allowSharedKeyAccess: !empty(existingSa.listKeys().keys)
+              }
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveJsonAtPath("$.resources.newSa.dependsOn", """["deployedSa"]""");
+        result.Template.Should().HaveJsonAtPath("$.resources.existingSa.dependsOn", """["deployedSa"]""");
+    }
+
+    [TestMethod]
+    public void Existing_resource_collection_function_calls_are_expressed_as_direct_dependencies_on_transitive_dependencies_in_symbolic_name_template()
+    {
+        var result = CompilationHelper.Compile(
+            new ServiceBuilder().WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)),
+            """
+            resource deployedSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account1'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+            }
+            
+            resource existingSa 'Microsoft.Storage/storageAccounts@2023-05-01' existing = [for i in range(0, 1): {
+              name: '${replace(deployedSa.name, '1', '2')}_${i}'
+            }]
+
+            resource newSa 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+              name: 'account3'
+              location: resourceGroup().location
+              sku: {
+                name: 'Standard_LRS'
+              }
+              kind: 'StorageV2'
+              properties: {
+                allowSharedKeyAccess: !empty(existingSa[0].listKeys().keys)
+              }
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveJsonAtPath("$.resources.newSa.dependsOn", """["deployedSa"]""");
+        result.Template.Should().HaveJsonAtPath("$.resources.existingSa.dependsOn", """["deployedSa"]""");
+    }
+}

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -5065,7 +5065,7 @@ resource foo3 'Microsoft.Storage/storageAccounts@2022-09-01' = {
 "));
 
         var evaluated = TemplateEvaluator.Evaluate(result.Template);
-        evaluated.Should().HaveValueAtPath("resources.foo3.dependsOn", new JArray("foo2"));
+        evaluated.Should().HaveValueAtPath("resources.foo3.dependsOn", new JArray("foo1"));
     }
 
     // https://github.com/Azure/bicep/issues/11292

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -6315,7 +6315,7 @@ param p invalidRecursiveObjectType = {}
 
         if (enableSymbolicNameCodegen)
         {
-            result.Template.Should().HaveJsonAtPath("$.resources.secret.dependsOn", """["sa"]""");
+            result.Template.Should().HaveJsonAtPath("$.resources.secret.dependsOn", """["mod"]""");
         }
         else
         {

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12632249060210513106"
+      "templateHash": "14846102413726496336"
     }
   },
   "parameters": {
@@ -1851,10 +1851,7 @@
             }
           }
         }
-      },
-      "dependsOn": [
-        "kv"
-      ]
+      }
     },
     "secureModule2": {
       "type": "Microsoft.Resources/deployments",
@@ -1912,10 +1909,7 @@
             }
           }
         }
-      },
-      "dependsOn": [
-        "scopedKv"
-      ]
+      }
     },
     "secureModuleLooped": {
       "copy": {
@@ -1977,11 +1971,7 @@
             }
           }
         }
-      },
-      "dependsOn": [
-        "[format('loopedKv[{0}]', copyIndex())]",
-        "[format('loopedKv[{0}]', copyIndex())]"
-      ]
+      }
     },
     "secureModuleCondition": {
       "type": "Microsoft.Resources/deployments",
@@ -2024,10 +2014,7 @@
             }
           }
         }
-      },
-      "dependsOn": [
-        "kv"
-      ]
+      }
     },
     "withSpace": {
       "type": "Microsoft.Resources/deployments",

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16972434704035043060"
+      "templateHash": "236868819280717113"
     }
   },
   "parameters": {
@@ -71,19 +71,13 @@
       "properties": {
         "size": "[reference('existingParent').size]",
         "style": "[reference('existingParent::existingChild').style]"
-      },
-      "dependsOn": [
-        "existingParent::existingChild"
-      ]
+      }
     },
     "existingParent::existingChild": {
       "existing": true,
       "type": "My.Rp/parentType/childType",
       "apiVersion": "2020-12-01",
-      "name": "[format('{0}/{1}', 'existingParent', 'existingChild')]",
-      "dependsOn": [
-        "existingParent"
-      ]
+      "name": "[format('{0}/{1}', 'existingParent', 'existingChild')]"
     },
     "conditionParent::conditionChild::conditionGrandchild": {
       "condition": "[and(and(parameters('createParent'), parameters('createChild')), parameters('createGrandchild'))]",

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12953345672979673276"
+      "templateHash": "15062227467638827925"
     }
   },
   "parameters": {
@@ -665,10 +665,7 @@
     "p3_child1": {
       "type": "Microsoft.Rp1/resource1/child1",
       "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', 'res1', 'child1')]",
-      "dependsOn": [
-        "p3_res1"
-      ]
+      "name": "[format('{0}/{1}', 'res1', 'child1')]"
     },
     "p4_res1": {
       "existing": true,
@@ -682,10 +679,7 @@
       "type": "Microsoft.Rp1/resource1/child1",
       "apiVersion": "2020-06-01",
       "scope": "/",
-      "name": "[format('{0}/{1}', 'res1', 'child1')]",
-      "dependsOn": [
-        "p4_res1"
-      ]
+      "name": "[format('{0}/{1}', 'res1', 'child1')]"
     },
     "sqlServer": {
       "type": "Microsoft.Sql/servers",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/NameValues.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/NameValues.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11528852364160566097"
+      "templateHash": "14248540637091011874"
     }
   },
   "parameters": {
@@ -56,10 +56,7 @@
         "secret": "[variables('apimNameValueSet')[copyIndex()].isSecret]",
         "value": "[variables('apimNameValueSet')[copyIndex()].value]",
         "tags": "[variables('apimNameValueSet')[copyIndex()].tags]"
-      },
-      "dependsOn": [
-        "parentAPIM"
-      ]
+      }
     }
   },
   "outputs": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/groups.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/groups.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "403029788224868668"
+      "templateHash": "6816770503491912011"
     }
   },
   "parameters": {
@@ -47,10 +47,7 @@
       "properties": {
         "displayName": "[variables('groupsSet')[copyIndex()].groupDisplayName]",
         "description": "[variables('groupsSet')[copyIndex()].groupDescription]"
-      },
-      "dependsOn": [
-        "parentAPIM"
-      ]
+      }
     }
   },
   "outputs": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13726378283629199613"
+      "templateHash": "2208926443863165998"
     }
   },
   "parameters": {
@@ -163,7 +163,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "403029788224868668"
+              "templateHash": "6816770503491912011"
             }
           },
           "parameters": {
@@ -204,10 +204,7 @@
               "properties": {
                 "displayName": "[variables('groupsSet')[copyIndex()].groupDisplayName]",
                 "description": "[variables('groupsSet')[copyIndex()].groupDescription]"
-              },
-              "dependsOn": [
-                "parentAPIM"
-              ]
+              }
             }
           },
           "outputs": {
@@ -251,7 +248,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "8034218730798252475"
+              "templateHash": "16793550498477002119"
             }
           },
           "parameters": {
@@ -301,10 +298,7 @@
                 "email": "[variables('usersSet')[copyIndex()].email]",
                 "state": "[variables('usersSet')[copyIndex()].state]",
                 "note": "[variables('usersSet')[copyIndex()].notes]"
-              },
-              "dependsOn": [
-                "parentAPIM"
-              ]
+              }
             }
           }
         }
@@ -336,7 +330,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "11528852364160566097"
+              "templateHash": "14248540637091011874"
             }
           },
           "parameters": {
@@ -386,10 +380,7 @@
                 "secret": "[variables('apimNameValueSet')[copyIndex()].isSecret]",
                 "value": "[variables('apimNameValueSet')[copyIndex()].value]",
                 "tags": "[variables('apimNameValueSet')[copyIndex()].tags]"
-              },
-              "dependsOn": [
-                "parentAPIM"
-              ]
+              }
             }
           },
           "outputs": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/users.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/api-management-modular/users.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8034218730798252475"
+      "templateHash": "16793550498477002119"
     }
   },
   "parameters": {
@@ -56,10 +56,7 @@
         "email": "[variables('usersSet')[copyIndex()].email]",
         "state": "[variables('usersSet')[copyIndex()].state]",
         "note": "[variables('usersSet')[copyIndex()].notes]"
-      },
-      "dependsOn": [
-        "parentAPIM"
-      ]
+      }
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/azure-bastion/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/azure-bastion/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5898567106534730923"
+      "templateHash": "12715898051173612753"
     }
   },
   "parameters": {
@@ -149,10 +149,7 @@
             ]
           }
         }
-      },
-      "dependsOn": [
-        "existingVirtualNetwork"
-      ]
+      }
     },
     "bastionHost": {
       "type": "Microsoft.Network/bastionHosts",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/databricks-all-in-one-template-for-vnet-injection/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/databricks-all-in-one-template-for-vnet-injection/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16714276462655423062"
+      "templateHash": "14481747842301389436"
     }
   },
   "parameters": {
@@ -275,7 +275,6 @@
         }
       },
       "dependsOn": [
-        "managedResourceGroup",
         "vnet"
       ]
     }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/function-premium-vnet-integration/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/function-premium-vnet-integration/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "18250750169409311102"
+      "templateHash": "746252077949181675"
     }
   },
   "parameters": {
@@ -217,7 +217,7 @@
       },
       "dependsOn": [
         "function",
-        "subnet"
+        "virtualNetwork"
       ]
     },
     "subnet": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/template-spec-deploy/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/template-spec-deploy/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15369804211876997670"
+      "templateHash": "12321629843193403120"
     }
   },
   "parameters": {
@@ -32,10 +32,7 @@
       "apiVersion": "2019-06-01-preview",
       "subscriptionId": "[parameters('templateSpecSub')]",
       "resourceGroup": "[parameters('templateSpecRg')]",
-      "name": "[format('{0}/{1}', parameters('templateSpecName'), parameters('templateSpecVersion'))]",
-      "dependsOn": [
-        "ts"
-      ]
+      "name": "[format('{0}/{1}', parameters('templateSpecName'), parameters('templateSpecVersion'))]"
     },
     "ts": {
       "existing": true,
@@ -55,10 +52,7 @@
           "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('templateSpecSub'), parameters('templateSpecRg')), 'Microsoft.Resources/templateSpecs/versions', parameters('templateSpecName'), parameters('templateSpecVersion'))]"
         },
         "parameters": {}
-      },
-      "dependsOn": [
-        "ts"
-      ]
+      }
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/website-with-container/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/website-with-container/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13381616690819142544"
+      "templateHash": "15571119746721048953"
     }
   },
   "parameters": {
@@ -82,7 +82,6 @@
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('farmName'))]"
       },
       "dependsOn": [
-        "containerRegistry",
         "farm"
       ]
     },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/avd-image-builder-module.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9616745895991063718"
+      "templateHash": "2725585745262341266"
     }
   },
   "parameters": {
@@ -99,10 +99,7 @@
             "replicationRegions": []
           }
         ]
-      },
-      "dependsOn": [
-        "managedidentity"
-      ]
+      }
     },
     "aibdef": {
       "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/avd-backplane-with-network-and-storage-and-monitoring/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14611001828329396005"
+      "templateHash": "16802600261940372275"
     }
   },
   "parameters": {
@@ -1107,7 +1107,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9616745895991063718"
+              "templateHash": "2725585745262341266"
             }
           },
           "parameters": {
@@ -1200,10 +1200,7 @@
                     "replicationRegions": []
                   }
                 ]
-              },
-              "dependsOn": [
-                "managedidentity"
-              ]
+              }
             },
             "aibdef": {
               "condition": "[parameters('InvokeRunImageBuildThroughDeploymentScript')]",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/cloud-shell-vnet/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/cloud-shell-vnet/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16407625085363720986"
+      "templateHash": "14742848894010970609"
     }
   },
   "parameters": {
@@ -138,10 +138,7 @@
             }
           }
         ]
-      },
-      "dependsOn": [
-        "existingVNET"
-      ]
+      }
     },
     "networkProfile": {
       "type": "Microsoft.Network/networkProfiles",
@@ -237,8 +234,7 @@
         }
       },
       "dependsOn": [
-        "containerSubnet",
-        "existingVNET"
+        "containerSubnet"
       ]
     },
     "privateEndpoint": {
@@ -303,7 +299,6 @@
         }
       },
       "dependsOn": [
-        "existingVNET",
         "relaySubnet"
       ]
     },

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/aks.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/aks.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "10816695263040223841"
+      "templateHash": "15899882108574365379"
     }
   },
   "parameters": {
@@ -335,10 +335,7 @@
       "existing": true,
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-08-01",
-      "name": "[format('{0}/{1}', variables('virtualNetworkName'), parameters('aksSubnetName'))]",
-      "dependsOn": [
-        "virtualNetwork"
-      ]
+      "name": "[format('{0}/{1}', variables('virtualNetworkName'), parameters('aksSubnetName'))]"
     },
     "aksCluster": {
       "type": "Microsoft.ContainerService/managedClusters",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/aks.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/aks.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "17167772107049027399"
+      "templateHash": "10816695263040223841"
     }
   },
   "parameters": {
@@ -408,10 +408,7 @@
         "apiServerAccessProfile": {
           "enablePrivateCluster": "[parameters('aksClusterEnablePrivateCluster')]"
         }
-      },
-      "dependsOn": [
-        "aksSubnet"
-      ]
+      }
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14263039554121650817"
+      "templateHash": "7099217802857967896"
     }
   },
   "parameters": {
@@ -1620,7 +1620,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "10816695263040223841"
+              "templateHash": "15899882108574365379"
             }
           },
           "parameters": {
@@ -1949,10 +1949,7 @@
               "existing": true,
               "type": "Microsoft.Network/virtualNetworks/subnets",
               "apiVersion": "2020-08-01",
-              "name": "[format('{0}/{1}', variables('virtualNetworkName'), parameters('aksSubnetName'))]",
-              "dependsOn": [
-                "virtualNetwork"
-              ]
+              "name": "[format('{0}/{1}', variables('virtualNetworkName'), parameters('aksSubnetName'))]"
             },
             "aksCluster": {
               "type": "Microsoft.ContainerService/managedClusters",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "13138224916093371784"
+      "templateHash": "14263039554121650817"
     }
   },
   "parameters": {
@@ -1620,7 +1620,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "17167772107049027399"
+              "templateHash": "10816695263040223841"
             }
           },
           "parameters": {
@@ -2022,10 +2022,7 @@
                 "apiServerAccessProfile": {
                   "enablePrivateCluster": "[parameters('aksClusterEnablePrivateCluster')]"
                 }
-              },
-              "dependsOn": [
-                "aksSubnet"
-              ]
+              }
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "308803406197414192"
+      "templateHash": "140703399417510606"
     }
   },
   "parameters": {
@@ -115,10 +115,7 @@
           "rdb-backup-max-snapshot-count": "1",
           "rdb-storage-connection-string": "[format('DefaultEndpointsProtocol=https;BlobEndpoint=https://{0}.blob.{1};AccountName={2};AccountKey={3}', parameters('storageAccountName'), environment().suffixes.storage, parameters('storageAccountName'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value)]"
         }
-      },
-      "dependsOn": [
-        "storageAccount"
-      ]
+      }
     },
     "diagSettings": {
       "type": "Microsoft.Insights/diagnosticSettings",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/publish-api-to-apim-opendocs/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/publish-api-to-apim-opendocs/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6433078083851594853"
+      "templateHash": "15303901391681280108"
     }
   },
   "parameters": {
@@ -93,10 +93,7 @@
         "approvalRequired": "[variables('productsSet')[copyIndex()].isApprovalRequired]",
         "subscriptionsLimit": "[variables('productsSet')[copyIndex()].subscriptionLimit]",
         "state": "[variables('productsSet')[copyIndex()].publishState]"
-      },
-      "dependsOn": [
-        "apiManagementService"
-      ]
+      }
     },
     "functionAPI": {
       "type": "Microsoft.ApiManagement/service/apis",
@@ -106,10 +103,7 @@
         "format": "[parameters('apiFormat')]",
         "value": "[parameters('apiEndPointURL')]",
         "path": "[parameters('apiPath')]"
-      },
-      "dependsOn": [
-        "apiManagementService"
-      ]
+      }
     },
     "attachAPIToProducts": {
       "copy": {

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6525915520291992178"
+      "templateHash": "18004286018796895982"
     }
   },
   "parameters": {
@@ -59,7 +59,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9981193661517957529"
+              "templateHash": "4095861435543068833"
             }
           },
           "parameters": {
@@ -172,7 +172,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "4926441281649354787"
+                      "templateHash": "12233551922218996438"
                     }
                   },
                   "parameters": {
@@ -404,7 +404,6 @@
                       "dependsOn": [
                         "auditSettings",
                         "dummyDeployments",
-                        "logAnalyticsWorkspace",
                         "masterDb",
                         "sqlDatabases"
                       ]
@@ -438,7 +437,6 @@
                       },
                       "dependsOn": [
                         "dummyDeployments",
-                        "logAnalyticsWorkspace",
                         "masterDb",
                         "sqlDatabases"
                       ]
@@ -538,7 +536,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "2334572005318909582"
+                              "templateHash": "5796360048593136515"
                             }
                           },
                           "parameters": {
@@ -663,7 +661,6 @@
                               },
                               "dependsOn": [
                                 "auditSettings",
-                                "logAnalyticsWorkspace",
                                 "sqlDb",
                                 "transparentDataEncryption"
                               ]
@@ -696,7 +693,6 @@
                                 "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
                               },
                               "dependsOn": [
-                                "logAnalyticsWorkspace",
                                 "sqlDb",
                                 "transparentDataEncryption"
                               ]
@@ -886,10 +882,7 @@
                     }
                   }
                 }
-              },
-              "dependsOn": [
-                "[format('sqlPassKeyVaults[{0}]', copyIndex())]"
-              ]
+              }
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2334572005318909582"
+      "templateHash": "5796360048593136515"
     }
   },
   "parameters": {
@@ -131,7 +131,6 @@
       },
       "dependsOn": [
         "auditSettings",
-        "logAnalyticsWorkspace",
         "sqlDb",
         "transparentDataEncryption"
       ]
@@ -164,7 +163,6 @@
         "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
       },
       "dependsOn": [
-        "logAnalyticsWorkspace",
         "sqlDb",
         "transparentDataEncryption"
       ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4926441281649354787"
+      "templateHash": "12233551922218996438"
     }
   },
   "parameters": {
@@ -238,7 +238,6 @@
       "dependsOn": [
         "auditSettings",
         "dummyDeployments",
-        "logAnalyticsWorkspace",
         "masterDb",
         "sqlDatabases"
       ]
@@ -272,7 +271,6 @@
       },
       "dependsOn": [
         "dummyDeployments",
-        "logAnalyticsWorkspace",
         "masterDb",
         "sqlDatabases"
       ]
@@ -372,7 +370,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2334572005318909582"
+              "templateHash": "5796360048593136515"
             }
           },
           "parameters": {
@@ -497,7 +495,6 @@
               },
               "dependsOn": [
                 "auditSettings",
-                "logAnalyticsWorkspace",
                 "sqlDb",
                 "transparentDataEncryption"
               ]
@@ -530,7 +527,6 @@
                 "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
               },
               "dependsOn": [
-                "logAnalyticsWorkspace",
                 "sqlDb",
                 "transparentDataEncryption"
               ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9981193661517957529"
+      "templateHash": "4095861435543068833"
     }
   },
   "parameters": {
@@ -119,7 +119,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "4926441281649354787"
+              "templateHash": "12233551922218996438"
             }
           },
           "parameters": {
@@ -351,7 +351,6 @@
               "dependsOn": [
                 "auditSettings",
                 "dummyDeployments",
-                "logAnalyticsWorkspace",
                 "masterDb",
                 "sqlDatabases"
               ]
@@ -385,7 +384,6 @@
               },
               "dependsOn": [
                 "dummyDeployments",
-                "logAnalyticsWorkspace",
                 "masterDb",
                 "sqlDatabases"
               ]
@@ -485,7 +483,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "2334572005318909582"
+                      "templateHash": "5796360048593136515"
                     }
                   },
                   "parameters": {
@@ -610,7 +608,6 @@
                       },
                       "dependsOn": [
                         "auditSettings",
-                        "logAnalyticsWorkspace",
                         "sqlDb",
                         "transparentDataEncryption"
                       ]
@@ -643,7 +640,6 @@
                         "workspaceId": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId, parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName), 'Microsoft.OperationalInsights/workspaces', parameters('sqlDatabase').diagnosticLogsAndMetrics.name)]"
                       },
                       "dependsOn": [
-                        "logAnalyticsWorkspace",
                         "sqlDb",
                         "transparentDataEncryption"
                       ]
@@ -833,10 +829,7 @@
             }
           }
         }
-      },
-      "dependsOn": [
-        "[format('sqlPassKeyVaults[{0}]', copyIndex())]"
-      ]
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves #13674 

This PR updates Bicep's resource dependency inference to only record a direct dependency on an `existing` resource when the deployment will read data from the resource's remote state. In other cases, such as when a template author reads the `id` or `name` property or calls a function like `listKeys()` or `getSecret()` on the resource, the `ResourceDependencyVisitor` will instead take a direct dependency on the `existing` resource's dependencies. 

This update will have the effect of only reading the state of `existing` resources when it is actually used. The ARM backend performs tree shaking on the template and will only create GET jobs for `existing` resources that are depended on by other resources (whether implicitly or explicitly). There are two observable behavioral differences that result from this:
* A template using language version 2.0 will no longer require `/read` permissions on an `existing` resource unless it is actually read. This is particularly useful for KeyVault secret parameters, which require an `existing` resource and the `.getSecret` function, as it is not uncommon for a KeyVault to permit usage in ARM deployments but not grant `/read` permissions to the deploying principal. This causes templates compiled to languageVersion 2.0 to exhibit the same behavior as templates compiled to non-symbolic name templates.
* A template using language version 2.0 can have multiple `existing` resources pointing to the same resource ID so long as at most one of them is read from. (ARM's tree shaking of `existing` resources happens before the duplicate check.) There are still some cases where languageVersion: 2.0 behavior will diverge from a non-symbolic name template, but this change will bring their behavior much closer in line with each other. The following is an example of a template that would cause an error in language version 2.0 but raise no issues with a non-symbolic name template:
```bicep
param saName string

resource sa1 'Microsoft.Storage/storageAccounts@2023-05-01' = {
  name: saName
  location: resourceGroup().location
  sku: {
    name: 'Standard_GRS'
  }
  kind: 'StorageV2'
}

resource sa2 'Microsoft.Storage/storageAccounts@2023-05-01' = {
  name: saName
  location: resourceGroup().location
  sku: {
    name: 'Standard_GRS'
  }
  kind: 'StorageV2'
}

output out1 string = sa1.properties.primaryEndpoints.blob
output out2 string = sa2.properties.primaryEndpoints.blob
```
* Symbolic name users can still force that an existing resource be read and that its existence be checked before a separate resource is deployed by using an explicit dependency. This is an affordance only available in langauge version 2.0:
```bicep
resource sa1 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
  name: 'first'
}

resource sa2 'Microsoft.Storage/storageAccounts@2023-05-01' = {
  dependsOn: [
    sa1 // <-- The sa2 deployment won't start unless sa1 exists and is readable. This is a no-op in a non-symbolic name template
  ]
  name: 'second'
  location: resourceGroup().location
  sku: {
    name: 'Standard_GRS'
  }
  kind: 'StorageV2'
}
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15447)