### PR TITLE
Skip an MSBuild e2e test in ADO

### DIFF
--- a/src/Bicep.MSBuild.E2eTests/src/simpleMultiTargeting.test.ts
+++ b/src/Bicep.MSBuild.E2eTests/src/simpleMultiTargeting.test.ts
@@ -4,7 +4,9 @@
 import { describe, expect, it } from "vitest";
 import { Example } from "./example";
 
-describe("msbuild", () => {
+const runningInAzurePipelines = !!process.env.TF_BUILD;
+
+describe.skipIf(runningInAzurePipelines)("msbuild", () => {
   it("should build a multi-targeting project with default output paths successfully", () => {
     const example = new Example("simpleMultiTarget");
     example.cleanProjectDir();


### PR DESCRIPTION
Forgot to do this when submitting my Jest -> Vitest migration PR. This fixes a failure in official build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15501)