### PR TITLE
Improve PowerShell detection logic in baseline update script

### DIFF
--- a/scripts/UpdateBaselines.ps1
+++ b/scripts/UpdateBaselines.ps1
@@ -1,7 +1,6 @@
-if (($PSVersionTable.Keys -contains "PSEdition") -and ($PSVersionTable.PSEdition -ne 'Desktop')) {
-    # PowerShell Core
+# https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing#passing-arguments-that-contain-quote-characters
+if ($PSVersionTable.PSVersion -ge [System.Version]"7.3") {
     dotnet test --filter "TestCategory=Baseline" -- 'TestRunParameters.Parameter(name="SetBaseLine", value="true")'
 } else {
-    # PowerShell Desktop
     dotnet test --filter "TestCategory=Baseline" -- 'TestRunParameters.Parameter(name=\"SetBaseLine\", value=\"true\")'
 }


### PR DESCRIPTION
I did some more digging as this wasn't working on my  Windows machine. I figured out the specific PowerShell version that triggered the change, and made the detection more accurate.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15522)