### PR TITLE
Fixed stack overflow when requesting completion in an object literal

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -5160,6 +5160,7 @@ module mod 'mod.bicep' = {
             var mainFile = await serverHelper.OpenFile("/main.bicep", text);
 
             var completions = await mainFile.RequestCompletion(cursor);
+            completions.Should().BeEmpty();
         }
     }
 }


### PR DESCRIPTION
When the user has an object literal value set on a module parameter of string literal union type, we were recursing infinitely which caused the stack overflow. We were not correctly collecting the properties from members of the collapsed union type.

This fixes #15569.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15579)