### PR TITLE
Local Deploy: Support null for InnerError field

### DIFF
--- a/src/Bicep.Local.Deploy.IntegrationTests/MockExtensions.cs
+++ b/src/Bicep.Local.Deploy.IntegrationTests/MockExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Local.Extension.Protocol;
+using Moq;
+using Protocol = Bicep.Local.Extension.Protocol;
+
+namespace Bicep.Local.Deploy.IntegrationTests;
+
+public static class MockExtensions
+{
+    public static void SetupCreateOrUpdate<THandler>(this Mock<THandler> handlerMock, Func<Protocol.ResourceSpecification, Protocol.LocalExtensibilityOperationResponse> responseFunc)
+        where THandler : class, IGenericResourceHandler
+        => handlerMock.Setup(x => x.CreateOrUpdate(It.IsAny<Protocol.ResourceSpecification>(), It.IsAny<CancellationToken>()))
+            .Returns<Protocol.ResourceSpecification, CancellationToken>((req, _) =>
+                Task.FromResult(responseFunc(req)));
+}

--- a/src/Bicep.Local.Deploy.IntegrationTests/ProviderExtensionTests.cs
+++ b/src/Bicep.Local.Deploy.IntegrationTests/ProviderExtensionTests.cs
@@ -65,6 +65,18 @@ public class ProviderExtensionTests : TestBase
             }, cts.Token));
     }
 
+    private async Task RunExtensionTest(Func<Mock<IGenericResourceHandler>, BicepExtension.BicepExtensionClient, CancellationToken, Task> testFunc)
+    {
+        var socketPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.tmp");
+        var mockHandler = StrictMock.Of<IGenericResourceHandler>();
+
+        await RunExtensionTest(
+            ["--socket", socketPath],
+            () => GrpcChannelHelper.CreateDomainSocketChannel(socketPath),
+            builder => builder.AddGenericHandler(mockHandler.Object),
+            (client, token) => testFunc(mockHandler, client, token));
+    }
+
     private static IEnumerable<object[]> GetDataSets()
     {
         yield return new object[] { ChannelMode.UnixDomainSocket };
@@ -105,12 +117,9 @@ public class ProviderExtensionTests : TestBase
 
         var handlerMock = StrictMock.Of<IResourceHandler>();
         handlerMock.SetupGet(x => x.ResourceType).Returns("apps/Deployment");
-
-        handlerMock.Setup(x => x.CreateOrUpdate(It.IsAny<Protocol.ResourceSpecification>(), It.IsAny<CancellationToken>()))
-            .Returns<Protocol.ResourceSpecification, CancellationToken>((req, _) =>
-                Task.FromResult(new Protocol.LocalExtensibilityOperationResponse(
-                    new Protocol.Resource(req.Type, req.ApiVersion, "Succeeded", identifiers, req.Config, req.Properties),
-                    null)));
+        handlerMock.SetupCreateOrUpdate(req => new(
+                new(req.Type, req.ApiVersion, "Succeeded", identifiers, req.Config, req.Properties),
+                null));
 
         await RunExtensionTest(
             processArgs,
@@ -185,4 +194,26 @@ public class ProviderExtensionTests : TestBase
                 responseIdentifiers["namespace"]!.GetValue<string>().Should().Be(identifiers["namespace"]!.GetValue<string>());
             });
     }
+
+    [TestMethod]
+    public Task Error_details_and_inner_error_can_be_null() => RunExtensionTest(async (handlerMock, client, token) =>
+    {
+        Protocol.Error error = new("SomeErrorCode", "SomeTarget", "SomeMessage", null, null);
+        handlerMock.SetupCreateOrUpdate(req => new(null, new(error)));
+
+        var response = await client.CreateOrUpdateAsync(new() {
+            Type = "mockResource",
+            Properties = """
+{}
+""",
+        }, cancellationToken: token);
+
+        response.Should().NotBeNull();
+        response.ErrorData.Should().NotBeNull();
+        response.ErrorData.Error.Code.Should().Be(error.Code);
+        response.ErrorData.Error.Target.Should().Be(error.Target);
+        response.ErrorData.Error.Message.Should().Be(error.Message);
+        response.ErrorData.Error.Details.Should().BeNullOrEmpty();
+        response.ErrorData.Error.InnerError.Should().BeNullOrEmpty();
+    });
 }

--- a/src/Bicep.Local.Extension/Rpc/BicepExtensionImpl.cs
+++ b/src/Bicep.Local.Extension/Rpc/BicepExtensionImpl.cs
@@ -88,13 +88,16 @@ public class BicepExtensionImpl : BicepExtension.BicepExtensionBase
             {
                 Code = response.Error.Code,
                 Message = response.Error.Message,
-                InnerError = response.Error.InnerError?.ToJsonString(),
                 Target = response.Error.Target,
             }
         };
 
-        var errorDetails = Convert(response.Error.Details);
-        if (errorDetails is not null)
+        if (response.Error.InnerError?.ToJsonString() is {} innerError)
+        {
+            errorData.Error.InnerError = innerError;
+        }
+
+        if (Convert(response.Error.Details) is {} errorDetails)
         {
             errorData.Error.Details.AddRange(errorDetails);
         }


### PR DESCRIPTION
Fix a bug where setting `InnerError` to null would throw an unhandled exception.