### PR TITLE
Do not review - Anapandey/uri

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
@@ -114,6 +114,25 @@
     ]
   },
   {
+    "name": "buildUri",
+    "description": "Constructs a URI from specified components and returns an object with these components.",
+    "fixedParameters": [
+      {
+        "name": "components",
+        "description": "An object containing URI components such as scheme, host, port, path, and query.",
+        "type": "parseUri",
+        "required": true
+      }
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(components: parseUri): string",
+    "parameterTypeSignatures": [
+      "components: parseUri"
+    ]
+  },
+  {
     "name": "cidrHost",
     "description": "Calculates the usable IP address of the host with the specified index on the specified IP address range in CIDR notation.",
     "fixedParameters": [
@@ -1245,6 +1264,25 @@
     "typeSignature": "(network: string): parseCidr",
     "parameterTypeSignatures": [
       "network: string"
+    ]
+  },
+  {
+    "name": "parseUri",
+    "description": "Parses a URI string into its components (scheme, host, port, path, query).",
+    "fixedParameters": [
+      {
+        "name": "baseUrl",
+        "description": "The complete URI to parse.",
+        "type": "string",
+        "required": true
+      }
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "default",
+    "typeSignature": "(baseUrl: string): object",
+    "parameterTypeSignatures": [
+      "baseUrl: string"
     ]
   },
   {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -438,6 +438,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -2268,6 +2289,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/sysFunctions.json
@@ -168,6 +168,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1039,6 +1060,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -200,6 +200,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "childCompletionA",
     "kind": "module",
     "detail": "childCompletionA",
@@ -2529,6 +2550,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -200,6 +200,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "childCompletionA",
     "kind": "module",
     "detail": "childCompletionA",
@@ -2529,6 +2550,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -172,6 +172,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1165,6 +1186,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -158,6 +158,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1129,6 +1150,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -158,6 +158,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1115,6 +1136,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -158,6 +158,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1115,6 +1136,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -230,6 +230,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1817,6 +1838,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -216,6 +216,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1817,6 +1838,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -234,6 +234,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1803,6 +1824,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -234,6 +234,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1803,6 +1824,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -464,6 +464,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4719,6 +4740,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -433,6 +433,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4683,6 +4704,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -492,6 +492,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4711,6 +4732,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -720,6 +720,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4942,6 +4963,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -720,6 +720,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4942,6 +4963,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -720,6 +720,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4942,6 +4963,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -720,6 +720,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4942,6 +4963,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -954,6 +954,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -5176,6 +5197,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -954,6 +954,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -5176,6 +5197,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -954,6 +954,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -5176,6 +5197,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -954,6 +954,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -5176,6 +5197,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -478,6 +478,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4697,6 +4718,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -478,6 +478,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4697,6 +4718,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -478,6 +478,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4697,6 +4718,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -478,6 +478,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4697,6 +4718,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -468,6 +468,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4690,6 +4711,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -450,6 +450,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4669,6 +4690,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -450,6 +450,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4669,6 +4690,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -576,6 +576,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4812,6 +4833,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -450,6 +450,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4686,6 +4707,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -464,6 +464,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4700,6 +4721,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -464,6 +464,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4700,6 +4721,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -464,6 +464,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4700,6 +4721,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -464,6 +464,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4750,6 +4771,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -464,6 +464,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4714,6 +4735,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -464,6 +464,27 @@
     ]
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -4700,6 +4721,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -270,6 +270,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1843,6 +1864,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -270,6 +270,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1879,6 +1900,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -288,6 +288,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -1861,6 +1882,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -445,6 +445,27 @@
     }
   },
   {
+    "label": "buildUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nbuildUri(components: parseUri): string\n\n```  \nConstructs a URI from specified components and returns an object with these components.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_buildUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "buildUri($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "cidrHost",
     "kind": "function",
     "documentation": {
@@ -2475,6 +2496,27 @@
     "textEdit": {
       "range": {},
       "newText": "parseCidr($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
+    "label": "parseUri",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nparseUri(baseUrl: string): object\n\n```  \nParses a URI string into its components (scheme, host, port, path, query).  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_parseUri",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "parseUri($0)"
     },
     "command": {
       "title": "signature help",

--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -885,8 +885,9 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 CreateRow(10, "max", new[] { 10, 4, 1, 6 }),
                 CreateRow("foo/bar/baz", "join", new[] { "foo", "bar", "baz"}, "/"),
                 CreateRow("abc/123/True", "join", new object[] { "abc", 123, true }, "/"),
-                CreateRow("https://example.com:443/path/to/resource?key=value", "buildUri", ["https", "example.com", 443, "path/to/resource", "key=value"]),
-                CreateRow(new object[] {"https", "example.com", 443, "path/to/resource", "key=value"},"parseUri", "https://example.com:443/path/to/resource?key=value"),
+                CreateRow("https://example.com:443/path/to/resource?key=value", "buildUri",
+                new { scheme = "https", host = "example.com", port = 443, path = "path/to/resource", query = "key=value" }),
+                CreateRow(new object[] { "https", "example.com", 443, "path/to/resource", "key=value" }, "parseUri", "https://example.com:443/path/to/resource?key=value"),
             };
         }
 
@@ -929,13 +930,6 @@ namespace Bicep.Core.UnitTests.TypeSystem
             yield return CreateRow("length", TypeFactory.CreateIntegerType(0), LanguageConstants.Object);
             yield return CreateRow("length", TypeFactory.CreateIntegerType(0), LanguageConstants.Array);
             yield return CreateRow("length", LanguageConstants.Int, TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Object));
-
-            //buildUri
-            yield return CreateRow("buildUri", LanguageConstants.String, LanguageConstants.Object);
-
-            //parseUri
-            yield return CreateRow("parseUri", LanguageConstants.Object, LanguageConstants.String);
-
         }
         private static IEnumerable<object[]> GetAmbiguousMatchData()
         {

--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -885,6 +885,8 @@ namespace Bicep.Core.UnitTests.TypeSystem
                 CreateRow(10, "max", new[] { 10, 4, 1, 6 }),
                 CreateRow("foo/bar/baz", "join", new[] { "foo", "bar", "baz"}, "/"),
                 CreateRow("abc/123/True", "join", new object[] { "abc", 123, true }, "/"),
+                CreateRow("https://example.com:443/path/to/resource?key=value", "buildUri", ["https", "example.com", 443, "path/to/resource", "key=value"]),
+                CreateRow(new object[] {"https", "example.com", 443, "path/to/resource", "key=value"},"parseUri", "https://example.com:443/path/to/resource?key=value"),
             };
         }
 
@@ -927,8 +929,14 @@ namespace Bicep.Core.UnitTests.TypeSystem
             yield return CreateRow("length", TypeFactory.CreateIntegerType(0), LanguageConstants.Object);
             yield return CreateRow("length", TypeFactory.CreateIntegerType(0), LanguageConstants.Array);
             yield return CreateRow("length", LanguageConstants.Int, TypeHelper.CreateTypeUnion(LanguageConstants.String, LanguageConstants.Object));
-        }
 
+            //buildUri
+            yield return CreateRow("buildUri", LanguageConstants.String, LanguageConstants.Object);
+
+            //parseUri
+            yield return CreateRow("parseUri", LanguageConstants.Object, LanguageConstants.String);
+
+        }
         private static IEnumerable<object[]> GetAmbiguousMatchData()
         {
             // local function

--- a/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/FunctionResolverTests.cs
@@ -1051,14 +1051,14 @@ namespace Bicep.Core.UnitTests.TypeSystem
 
             foreach (var (key, value) in expectedParsedUri)
             {
-                parsedUriObject.Properties[key].Value.Type.Name.Should().Be(value ?? "null");
+                parsedUriObject.Properties[key].Value.Type.Name.Should().Be(value ?? "null"); // tbd
             }
 
-            var uriObject = new ObjectSyntax(
-                expectedParsedUri.Select(kvp => new ObjectPropertySyntax(
+            var uriObject = new ObjectSyntax( //tbd
+                expectedParsedUri.Select(kvp => new ObjectPropertySyntax( //tbd
                     TestSyntaxFactory.CreateString(kvp.Key),
                     kvp.Value is null
-                        ? new NullLiteralSyntax()
+                        ? new NullLiteralSyntax() //tbd
                         : TestSyntaxFactory.CreateString(kvp.Value)
                 )).ToList()
             );
@@ -1072,9 +1072,6 @@ namespace Bicep.Core.UnitTests.TypeSystem
 
             rebuiltUri.Should().Be(inputUri);
         }
-
-
-
 
         private static IEnumerable<FunctionOverload> GetMatches(
             string functionName,

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -149,6 +149,18 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("network", LanguageConstants.String, "String in CIDR notation containing an IP address range to be converted.")
                     .Build();
 
+                yield return new FunctionOverloadBuilder("buildUri")
+                    .WithReturnResultBuilder(TryDeriveLiteralReturnType("buildUri", LanguageConstants.String), LanguageConstants.String)
+                    .WithGenericDescription("Constructs a URI from specified components and returns an object with these components.")
+                    .WithRequiredParameter("components", GetParseOrBuildUri(), "An object containing URI components such as scheme, host, port, path, and query.")
+                    .Build();
+
+                yield return new FunctionOverloadBuilder("parseUri")
+                    .WithReturnResultBuilder(TryDeriveLiteralReturnType("parseUri", LanguageConstants.Object), LanguageConstants.Object)
+                    .WithGenericDescription("Parses a URI string into its components (scheme, host, port, path, query).")
+                    .WithRequiredParameter("baseUrl", LanguageConstants.String, "The complete URI to parse.")
+                    .Build();
+
                 yield return new FunctionOverloadBuilder("concat")
                     .WithReturnType(LanguageConstants.String)
                     .WithGenericDescription(ConcatDescription)
@@ -1112,6 +1124,18 @@ namespace Bicep.Core.Semantics.Namespaces
                 new TypeProperty("lastUsable", LanguageConstants.String),
                 new TypeProperty("cidr", TypeFactory.CreateIntegerType(0, 255)),
             }, null);
+        }
+
+        private static ObjectType GetParseOrBuildUri()
+        {
+            return new ObjectType("parseUri", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("scheme", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("host", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("port", LanguageConstants.Int),
+                new TypeProperty("path", LanguageConstants.String),
+                new TypeProperty("query", LanguageConstants.String),
+             }, null);
         }
 
         private static ResultWithDiagnosticBuilder<Uri> TryGetFileUriWithDiagnostics(IBinder binder, string filePath)


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15637)