### PR TITLE
Rename `ISourceFile.FileUri` to `ISourceFile.Identifier`

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -120,7 +120,7 @@ namespace Bicep.Cli.IntegrationTests
                 {
                     var (line, character) = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, diagnostic.Span.Position);
                     var codeDescription = diagnostic.Uri == null ? string.Empty : $" [{diagnostic.Uri.AbsoluteUri}]";
-                    output.Add($"{bicepFile.FileUri.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}");
+                    output.Add($"{bicepFile.Identifier.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}");
                 }
             }
 

--- a/src/Bicep.Cli/Helpers/ExperimentalFeatureWarningProvider.cs
+++ b/src/Bicep.Cli/Helpers/ExperimentalFeatureWarningProvider.cs
@@ -12,7 +12,7 @@ public static class ExperimentalFeatureWarningProvider
     public static string? TryGetEnabledExperimentalFeatureWarningMessage(SourceFileGrouping sourceFileGrouping, IFeatureProviderFactory featureProviderFactory)
     {
         var experimentalFeaturesEnabled = sourceFileGrouping.SourceFiles
-            .Select(file => featureProviderFactory.GetFeatureProvider(file.FileUri))
+            .Select(file => featureProviderFactory.GetFeatureProvider(file.Identifier))
             .SelectMany(static features => features.EnabledFeatureMetadata.Where(f => f.impactsCompilation).Select(f => f.name))
             .Distinct()
             .ToImmutableArray();

--- a/src/Bicep.Cli/Helpers/ParamsFileHelper.cs
+++ b/src/Bicep.Cli/Helpers/ParamsFileHelper.cs
@@ -85,6 +85,6 @@ public static class ParamsFileHelper
             return sourceFile;
         }
 
-        return SourceFileFactory.CreateBicepParamFile(sourceFile.FileUri, newProgramSyntax.ToString());
+        return SourceFileFactory.CreateBicepParamFile(sourceFile.Identifier, newProgramSyntax.ToString());
     }
 }

--- a/src/Bicep.Cli/Logging/DiagnosticLogger.cs
+++ b/src/Bicep.Cli/Logging/DiagnosticLogger.cs
@@ -71,7 +71,7 @@ public class DiagnosticLogger
                 // build a a code description link if the Uri is assigned
                 var codeDescription = diagnostic.Uri == null ? string.Empty : $" [{diagnostic.Uri.AbsoluteUri}]";
 
-                var message = $"{bicepFile.FileUri.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}";
+                var message = $"{bicepFile.Identifier.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}";
 
                 logger.Log(ToLogLevel(diagnostic.Level), message);
             }
@@ -136,7 +136,7 @@ public class DiagnosticLogger
                     {
                         ArtifactLocation = new ArtifactLocation
                         {
-                            Uri = sourceFile.FileUri,
+                            Uri = sourceFile.Identifier,
                         },
                         Region = new Region
                         {

--- a/src/Bicep.Cli/Rpc/CliJsonRpcServer.cs
+++ b/src/Bicep.Cli/Rpc/CliJsonRpcServer.cs
@@ -75,7 +75,7 @@ public class CliJsonRpcServer : ICliJsonRpcProtocol
 
         var workspace = new Workspace();
         workspace.UpsertSourceFile(paramFile);
-        compilation = await compiler.CreateCompilation(paramFile.FileUri, workspace);
+        compilation = await compiler.CreateCompilation(paramFile.Identifier, workspace);
         var paramsResult = compilation.Emitter.Parameters();
 
         return new(
@@ -96,7 +96,7 @@ public class CliJsonRpcServer : ICliJsonRpcProtocol
         var fileUris = new HashSet<Uri>();
         foreach (var otherModel in compilation.GetAllBicepModels())
         {
-            fileUris.Add(otherModel.SourceFile.FileUri);
+            fileUris.Add(otherModel.SourceFile.Identifier);
             fileUris.UnionWith(otherModel.GetAuxiliaryFileReferences());
             if (otherModel.Configuration.ConfigFileIdentifier is { } configFileIdentifier)
             {
@@ -235,7 +235,7 @@ public class CliJsonRpcServer : ICliJsonRpcProtocol
         {
             foreach (var diagnostic in diagnostics)
             {
-                yield return new(bicepFile.FileUri.LocalPath, GetRange(bicepFile, diagnostic), diagnostic.Level.ToString(), diagnostic.Code, diagnostic.Message);
+                yield return new(bicepFile.Identifier.LocalPath, GetRange(bicepFile, diagnostic), diagnostic.Level.ToString(), diagnostic.Code, diagnostic.Message);
             }
         }
     }

--- a/src/Bicep.Core.IntegrationTests/DecoratorTests.cs
+++ b/src/Bicep.Core.IntegrationTests/DecoratorTests.cs
@@ -74,7 +74,7 @@ param inputb string
             };
 
             var compilation = Services.BuildCompilation(files, mainUri);
-            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.FileUri, kvp => kvp.Value);
+            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.Identifier, kvp => kvp.Value);
             var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => !d.IsError());
 
             using (new AssertionScope())
@@ -215,7 +215,7 @@ param inputb string
             };
 
             var compilation = Services.BuildCompilation(files, mainUri);
-            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.FileUri, kvp => kvp.Value);
+            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.Identifier, kvp => kvp.Value);
             var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => !d.IsError());
 
             using (new AssertionScope())

--- a/src/Bicep.Core.IntegrationTests/ExamplesTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExamplesTests.cs
@@ -42,7 +42,7 @@ namespace Bicep.Core.IntegrationTests
                     diagnostics.Where(d => !IsPermittedMissingTypeDiagnostic(d)),
                     diagnostics =>
                     {
-                        diagnostics.Should().BeEmpty("{0} should not have warnings or errors", file.FileUri.LocalPath);
+                        diagnostics.Should().BeEmpty("{0} should not have warnings or errors", file.Identifier.LocalPath);
                     });
             }
 

--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -652,7 +652,7 @@ resource fake 'Another.Fake/Type@2019-06-01' = {
 
 output storage resource 'Another.Fake/Type@2019-06-01' = fake
 "));
-            var diagnosticsMap = result.Compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.FileUri, kvp => kvp.Value);
+            var diagnosticsMap = result.Compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.Identifier, kvp => kvp.Value);
             using (new AssertionScope())
             {
                 diagnosticsMap[InMemoryFileResolver.GetFileUri("/path/to/module.bicep")].Should().HaveDiagnostics(new[]
@@ -769,7 +769,7 @@ module {symbolicName} 'mod.bicep' = [for x in []: {{
 
         private static (bool success, IDictionary<Uri, ImmutableArray<IDiagnostic>> diagnosticsByFile) GetSuccessAndDiagnosticsByFile(Compilation compilation)
         {
-            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.FileUri, kvp => kvp.Value);
+            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.Identifier, kvp => kvp.Value);
             var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => !d.IsError());
 
             return (success, diagnosticsByFile);

--- a/src/Bicep.Core.IntegrationTests/Scenarios/LocalJsonModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/LocalJsonModuleTests.cs
@@ -124,6 +124,6 @@ module mod 'module.json' = {
         }
 
         private static ImmutableDictionary<string, ImmutableArray<IDiagnostic>> GetDiagnosticsByFileName(Compilation compilation) =>
-            compilation.GetAllDiagnosticsByBicepFile().ToImmutableDictionary(kvp => Path.GetFileName(kvp.Key.FileUri.LocalPath), kvp => kvp.Value);
+            compilation.GetAllDiagnosticsByBicepFile().ToImmutableDictionary(kvp => Path.GetFileName(kvp.Key.Identifier.LocalPath), kvp => kvp.Value);
     }
 }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRule_InReferenceFunctions_Tests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRule_InReferenceFunctions_Tests.cs
@@ -43,7 +43,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     bicep);
                 using (new AssertionScope().WithFullSource(result.BicepFile))
                 {
-                    UseRecentApiVersionRuleTests.VerifyAllTypesAndDatesAreFake(result.BicepFile.GetOriginalSource());
+                    UseRecentApiVersionRuleTests.VerifyAllTypesAndDatesAreFake(result.BicepFile.Text);
 
                     var actual = UseRecentApiVersionRule.GetFunctionCallInfos(result.Compilation.GetEntrypointSemanticModel()).ToArray();
                     actual.Should().HaveCount(1, "Expecting a single function call per test");

--- a/src/Bicep.Core.UnitTests/SourceCode/SourceArchiveTests.cs
+++ b/src/Bicep.Core.UnitTests/SourceCode/SourceArchiveTests.cs
@@ -177,7 +177,7 @@ public class SourceArchiveTests
 
 
         using var stream = SourceArchive.PackSourcesIntoStream(
-            mainBicep.SourceFile.FileUri,
+            mainBicep.SourceFile.Identifier,
             CacheRoot, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, templateSpecMainJson2, externalModuleJson);
         stream.Length.Should().BeGreaterThan(0);
 
@@ -252,7 +252,7 @@ public class SourceArchiveTests
                 }
             },
         };
-        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.SourceFile.FileUri, CacheRoot, linksInput, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, localModuleBicep, externalModuleJson);
+        using var stream = SourceArchive.PackSourcesIntoStream(mainBicep.SourceFile.Identifier, CacheRoot, linksInput, mainBicep, mainJson, standaloneJson, templateSpecMainJson, localModuleJson, localModuleBicep, externalModuleJson);
         stream.Length.Should().BeGreaterThan(0);
 
         SourceArchive? sourceArchive = SourceArchive.UnpackFromStream(stream).TryUnwrap();
@@ -433,7 +433,7 @@ public class SourceArchiveTests
         }
         var files = inputPaths.Select(path => CreateSourceFile(fs, path, SourceArchive.SourceKind.Bicep, $"// {path}")).ToArray();
 
-        using var stream = SourceArchive.PackSourcesIntoStream(files[0].SourceFile.FileUri, CacheRoot, files);
+        using var stream = SourceArchive.PackSourcesIntoStream(files[0].SourceFile.Identifier, CacheRoot, files);
         SourceArchive sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
 
         sourceArchive.EntrypointRelativePath.Should().Be(expectedPaths[0], "entrypoint path should be correct");
@@ -447,7 +447,7 @@ public class SourceArchiveTests
 
         for (int i = 0; i < inputPaths.Length; ++i)
         {
-            var archivedTestFile = sourceArchive.SourceFiles.Single(f => f.Contents.Equals(files[i].SourceFile.GetOriginalSource()));
+            var archivedTestFile = sourceArchive.SourceFiles.Single(f => f.Contents.Equals(files[i].SourceFile.Text));
             archivedTestFile.Path.Should().Be(expectedPaths[i]);
             archivedTestFile.ArchivePath.Should().Be(expectedArchivePaths[i]);
         }
@@ -495,8 +495,8 @@ public class SourceArchiveTests
         var sutFile3 = inputBicepPath3 is null ? null : CreateSourceFile(fs, rootBicepFolder, inputBicepPath3, SourceArchive.SourceKind.Bicep, SecondaryDotBicepSource);
 
         using var stream = sutFile3 is null ?
-            SourceArchive.PackSourcesIntoStream(entrypointFile.SourceFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2) :
-            SourceArchive.PackSourcesIntoStream(entrypointFile.SourceFile.FileUri, CacheRoot, entrypointFile, sutFile1, sutFile2, sutFile3);
+            SourceArchive.PackSourcesIntoStream(entrypointFile.SourceFile.Identifier, CacheRoot, entrypointFile, sutFile1, sutFile2) :
+            SourceArchive.PackSourcesIntoStream(entrypointFile.SourceFile.Identifier, CacheRoot, entrypointFile, sutFile1, sutFile2, sutFile3);
 
         SourceArchive sourceArchive = SourceArchive.UnpackFromStream(stream).UnwrapOrThrow();
 

--- a/src/Bicep.Core.UnitTests/Utils/CompilationResultExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationResultExtensions.cs
@@ -47,11 +47,11 @@ public static class ICompilationResultExtensions
         var fix = fixable.Fixes.Single();
         var replacement = fix.Replacements.Single();
 
-        var originalFile = result.SourceFile.GetOriginalSource();
+        var sourceText = result.SourceFile.Text;
 
         return string.Concat(
-            originalFile.AsSpan(0, replacement.Span.Position),
+            sourceText.AsSpan(0, replacement.Span.Position),
             replacement.Text,
-            originalFile.AsSpan(replacement.Span.GetEndPosition()));
+            sourceText.AsSpan(replacement.Span.GetEndPosition()));
     }
 }

--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -68,7 +68,7 @@ public static class RegistryHelper
             throw new InvalidOperationException($"Module {moduleName} failed to produce a template.");
         }
 
-        var features = featureProviderFactory.GetFeatureProvider(result.BicepFile.FileUri);
+        var features = featureProviderFactory.GetFeatureProvider(result.BicepFile.Identifier);
         BinaryData? sourcesStream = publishSource ? BinaryData.FromStream(SourceArchive.PackSourcesIntoStream(dispatcher, result.Compilation.SourceFileGrouping, features.CacheRootDirectory)) : null;
         await dispatcher.PublishModule(targetReference, BinaryData.FromString(result.Template.ToString()), sourcesStream, documentationUri);
     }

--- a/src/Bicep.Core.UnitTests/Utils/SourceArchiveBuilder.cs
+++ b/src/Bicep.Core.UnitTests/Utils/SourceArchiveBuilder.cs
@@ -61,7 +61,7 @@ namespace Bicep.Core.UnitTests.Utils
             SourceFiles[0].Should().BeOfType<BicepFile>("Entrypoint should be a bicep file");
 
             return SourceArchive.PackSourcesIntoStream(
-                EntrypointFile.FileUri,
+                EntrypointFile.Identifier,
                 cacheRoot,
                 SourceFiles.Select(x => new SourceFileWithArtifactReference(x, null)).ToArray());
         }

--- a/src/Bicep.Core/Emit/CompilationEmitter.cs
+++ b/src/Bicep.Core/Emit/CompilationEmitter.cs
@@ -69,7 +69,7 @@ public class CompilationEmitter : ICompilationEmitter
                 }
             case ArmTemplateSemanticModel armTemplateModel:
                 {
-                    var template = armTemplateModel.SourceFile.GetOriginalSource();
+                    var template = armTemplateModel.SourceFile.Text;
                     var templateResult = new TemplateResult(true, ImmutableDictionary<BicepSourceFile, ImmutableArray<IDiagnostic>>.Empty, template, null);
 
                     return new ParametersResult(true, diagnostics, parametersData, null, templateResult);

--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmReferenceCollector.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmReferenceCollector.cs
@@ -23,7 +23,7 @@ internal partial class ArmReferenceCollector
     {
         if (templateFile.Template is not { } template)
         {
-            throw new InvalidOperationException($"Source template of {templateFile.FileUri} is not valid");
+            throw new InvalidOperationException($"Source template of {templateFile.Identifier} is not valid");
         }
 
         schemaContext = SchemaValidationContext.ForTemplate(template);

--- a/src/Bicep.Core/Emit/CompileTimeImports/ImportClosureInfo.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ImportClosureInfo.cs
@@ -38,7 +38,7 @@ public record ImportClosureInfo(ImmutableArray<DeclaredTypeExpression> ImportedT
 
     public static ImportClosureInfo Calculate(SemanticModel model)
     {
-        IntraTemplateSymbolicReferenceFactory referenceFactory = new(model.SourceFile.FileUri);
+        IntraTemplateSymbolicReferenceFactory referenceFactory = new(model.SourceFile.Identifier);
         var closure = CalculateImportClosure(model, referenceFactory);
         var closureMetadata = CalculateImportedSymbolNames(model, closure);
 
@@ -205,7 +205,7 @@ public record ImportClosureInfo(ImmutableArray<DeclaredTypeExpression> ImportedT
                 if (!targetModel.Exports.TryGetValue(name, out var exportMetadata))
                 {
                     throw new InvalidOperationException($"No export named {name} found in {TemplateIdentifier(
-                        model.SourceFile.FileUri,
+                        model.SourceFile.Identifier,
                         targetModel,
                         importedSymbolReference.ImportTarget)}");
                 }
@@ -441,9 +441,9 @@ public record ImportClosureInfo(ImmutableArray<DeclaredTypeExpression> ImportedT
 
     private static Uri GetSourceFileUri(ISemanticModel model) => model switch
     {
-        SemanticModel bicepModel => bicepModel.SourceFile.FileUri,
-        ArmTemplateSemanticModel armTemplate => armTemplate.SourceFile.FileUri,
-        TemplateSpecSemanticModel templateSpec => templateSpec.SourceFile.FileUri,
+        SemanticModel bicepModel => bicepModel.SourceFile.Identifier,
+        ArmTemplateSemanticModel armTemplate => armTemplate.SourceFile.Identifier,
+        TemplateSpecSemanticModel templateSpec => templateSpec.SourceFile.Identifier,
         _ => throw new InvalidOperationException($"Unrecognized module type {model.GetType().Name} encountered"),
     };
 

--- a/src/Bicep.Core/Emit/PlaceholderParametersBicepParamWriter.cs
+++ b/src/Bicep.Core/Emit/PlaceholderParametersBicepParamWriter.cs
@@ -22,7 +22,7 @@ namespace Bicep.Core.Emit
 
         public void Write(TextWriter writer, string existingContent)
         {
-            var bicepFileName = Path.GetFileName(semanticModel.SourceFile.FileUri.LocalPath);
+            var bicepFileName = Path.GetFileName(semanticModel.SourceFile.Identifier.LocalPath);
 
             var allParameterDeclarations = semanticModel.Root.ParameterDeclarations;
 

--- a/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
+++ b/src/Bicep.Core/Emit/PositionTrackingJsonTextWriter.cs
@@ -231,11 +231,11 @@ namespace Bicep.Core.Emit
             Array.Fill(weights, int.MaxValue);
 
             var sourceMapFileEntries = new List<SourceMapFileEntry>();
-            var entrypointFileName = System.IO.Path.GetFileName(sourceFile.FileUri.AbsolutePath);
+            var entrypointFileName = System.IO.Path.GetFileName(sourceFile.Identifier.AbsolutePath);
 
             foreach (var bicepFileEntry in this.rawSourceMap.Entries)
             {
-                var bicepRelativeFilePath = PathHelper.GetRelativePath(sourceFile.FileUri, bicepFileEntry.SourceFile.FileUri);
+                var bicepRelativeFilePath = PathHelper.GetRelativePath(sourceFile.Identifier, bicepFileEntry.SourceFile.Identifier);
                 var sourceMapEntries = new List<SourceMapEntry>();
 
                 foreach (var sourceMapEntry in bicepFileEntry.SourceMap)

--- a/src/Bicep.Core/Rewriters/RewriterHelper.cs
+++ b/src/Bicep.Core/Rewriters/RewriterHelper.cs
@@ -12,7 +12,7 @@ public static class RewriterHelper
 {
     private static (BicepSourceFile bicepFile, bool hasChanges) Rewrite(BicepCompiler compiler, Workspace workspace, BicepSourceFile bicepFile, Func<SemanticModel, SyntaxRewriteVisitor> rewriteVisitorBuilder)
     {
-        var compilation = compiler.CreateCompilationWithoutRestore(bicepFile.FileUri, workspace);
+        var compilation = compiler.CreateCompilationWithoutRestore(bicepFile.Identifier, workspace);
         var newProgramSyntax = rewriteVisitorBuilder(compilation.GetEntrypointSemanticModel()).Rewrite(bicepFile.ProgramSyntax);
 
         if (object.ReferenceEquals(bicepFile.ProgramSyntax, newProgramSyntax))
@@ -20,7 +20,7 @@ public static class RewriterHelper
             return (bicepFile, false);
         }
 
-        bicepFile = SourceFileFactory.CreateBicepFile(bicepFile.FileUri, newProgramSyntax.ToString());
+        bicepFile = SourceFileFactory.CreateBicepFile(bicepFile.Identifier, newProgramSyntax.ToString());
         return (bicepFile, true);
     }
 
@@ -28,7 +28,7 @@ public static class RewriterHelper
     {
         var workspace = new Workspace();
         workspace.UpsertSourceFiles(compilation.SourceFileGrouping.SourceFiles);
-        var fileUri = bicepFile.FileUri;
+        var fileUri = bicepFile.Identifier;
 
         // Changing the syntax changes the semantic model, so it's possible for rewriters to have dependencies on each other.
         // For example, fixing the casing of a type may fix type validation, causing another rewriter to apply.

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.Semantics
 
         public ArmTemplateSemanticModel(ArmTemplateFile sourceFile)
         {
-            Trace.WriteLine($"Building semantic model for {sourceFile.FileUri}");
+            Trace.WriteLine($"Building semantic model for {sourceFile.Identifier}");
 
             this.SourceFile = sourceFile;
 

--- a/src/Bicep.Core/Semantics/Compilation.cs
+++ b/src/Bicep.Core/Semantics/Compilation.cs
@@ -106,8 +106,8 @@ namespace Bicep.Core.Semantics
             this.ArtifactReferenceFactory,
             this,
             this.SourceFileGrouping,
-            this.ConfigurationManager.GetConfiguration(bicepFile.FileUri),
-            this.FeatureProviderFactory.GetFeatureProvider(bicepFile.FileUri),
+            this.ConfigurationManager.GetConfiguration(bicepFile.Identifier),
+            this.FeatureProviderFactory.GetFeatureProvider(bicepFile.Identifier),
             this.Environment,
             this.FileCache,
             bicepFile);

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -22,12 +22,12 @@ namespace Bicep.Core.Semantics
             BicepSourceFile sourceFile,
             NamespaceResolver namespaceResolver,
             LocalScope fileScope)
-            : base(sourceFile.FileUri.LocalPath)
+            : base(sourceFile.Identifier.LocalPath)
         {
             this.Context = context;
             this.Syntax = sourceFile.ProgramSyntax;
             this.NamespaceResolver = namespaceResolver;
-            this.FileUri = sourceFile.FileUri;
+            this.FileUri = sourceFile.Identifier;
             this.FileKind = sourceFile.FileKind;
             this.LocalScopes = fileScope.ChildScopes;
 

--- a/src/Bicep.Core/Semantics/ImportedSymbol.cs
+++ b/src/Bicep.Core/Semantics/ImportedSymbol.cs
@@ -28,7 +28,7 @@ public abstract class ImportedSymbol : DeclaredSymbol
     public abstract string? Description { get; }
 
     public ResultWithDiagnosticBuilder<ArtifactReference> TryGetArtifactReference()
-        => Context.ArtifactReferenceFactory.TryGetArtifactReference(EnclosingDeclaration, Context.SourceFile.FileUri);
+        => Context.ArtifactReferenceFactory.TryGetArtifactReference(EnclosingDeclaration, Context.SourceFile.Identifier);
 }
 
 public abstract class ImportedSymbol<T> : ImportedSymbol where T : ExportMetadata

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1342,7 +1342,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 .IsSuccess(out var result, out var errorDiagnostic))
             {
                 return new(
-                    new StringLiteralType(model.SourceFile.FileUri.MakeRelativeUri(result.FileUri).ToString(), result.Content, TypeSymbolValidationFlags.Default),
+                    new StringLiteralType(model.SourceFile.Identifier.MakeRelativeUri(result.FileUri).ToString(), result.Content, TypeSymbolValidationFlags.Default),
                     new StringLiteralExpression(functionCall, result.Content));
             }
 

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -190,7 +190,7 @@ namespace Bicep.Core.Semantics
         {
             var sb = new StringBuilder();
 
-            sb.Append($"Building semantic model for {sourceFile.FileUri} ({sourceFile.FileKind}). ");
+            sb.Append($"Building semantic model for {sourceFile.Identifier} ({sourceFile.FileKind}). ");
             var experimentalFeatures = features.EnabledFeatureMetadata.Select(x => x.name).ToArray();
             if (experimentalFeatures.Any())
             {

--- a/src/Bicep.Core/Semantics/WildcardImportSymbol.cs
+++ b/src/Bicep.Core/Semantics/WildcardImportSymbol.cs
@@ -31,7 +31,7 @@ public class WildcardImportSymbol : DeclaredSymbol, INamespaceSymbol
     public NamespaceType? TryGetNamespaceType() => this.Type as NamespaceType;
 
     public ResultWithDiagnosticBuilder<ArtifactReference> TryGetArtifactReference()
-        => Context.ArtifactReferenceFactory.TryGetArtifactReference(EnclosingDeclaration, Context.SourceFile.FileUri);
+        => Context.ArtifactReferenceFactory.TryGetArtifactReference(EnclosingDeclaration, Context.SourceFile.Identifier);
 
     public override IEnumerable<Diagnostic> GetDiagnostics()
     {

--- a/src/Bicep.Core/SourceCode/SourceCodeDocumentLinkHelper.cs
+++ b/src/Bicep.Core/SourceCode/SourceCodeDocumentLinkHelper.cs
@@ -34,7 +34,7 @@ public static class SourceCodeDocumentLinkHelper
         foreach (var grouping in sourceFileGrouping.ArtifactLookup.Values.GroupBy(x => x.Origin))
         {
             var referencingFile = grouping.Key;
-            var referencingFileLineStarts = TextCoordinateConverter.GetLineStarts(referencingFile.GetOriginalSource());
+            var referencingFileLineStarts = TextCoordinateConverter.GetLineStarts(referencingFile.Text);
             var linksForReferencingFile = new List<SourceCodeDocumentUriLink>();
 
             foreach (var artifact in grouping)
@@ -50,7 +50,7 @@ public static class SourceCodeDocumentLinkHelper
                 }
             }
 
-            dictionary.Add(referencingFile.FileUri, [.. linksForReferencingFile]);
+            dictionary.Add(referencingFile.Identifier, [.. linksForReferencingFile]);
         }
 
         return dictionary.ToImmutableDictionary();

--- a/src/Bicep.Core/Workspaces/ArmTemplateFile.cs
+++ b/src/Bicep.Core/Workspaces/ArmTemplateFile.cs
@@ -8,9 +8,7 @@ namespace Bicep.Core.Workspaces
 {
     public class ArmTemplateFile : ISourceFile
     {
-        private readonly string originalSource;
-
-        public ArmTemplateFile(Uri fileUri, string originalSource, Template? template, JObject? templateObject)
+        public ArmTemplateFile(Uri fileUri, string text, Template? template, JObject? templateObject)
         {
             if ((template is null && templateObject is not null) ||
                 (template is not null && templateObject is null))
@@ -18,15 +16,15 @@ namespace Bicep.Core.Workspaces
                 throw new ArgumentException($"Expected {nameof(template)} and {nameof(templateObject)} to both be non-null or both be null.");
             }
 
-            this.FileUri = fileUri;
+            this.Identifier = fileUri;
+            this.Text = text;
             this.Template = template;
             this.TemplateObject = templateObject;
-            this.originalSource = originalSource;
         }
 
-        public Uri FileUri { get; }
+        public Uri Identifier { get; }
 
-        public string GetOriginalSource() => originalSource;
+        public string Text { get; }
 
         public Template? Template { get; }
 

--- a/src/Bicep.Core/Workspaces/BicepSourceFile.cs
+++ b/src/Bicep.Core/Workspaces/BicepSourceFile.cs
@@ -13,7 +13,7 @@ namespace Bicep.Core.Workspaces
         {
             LineStarts = lineStarts;
             ProgramSyntax = programSyntax;
-            FileUri = fileUri;
+            Identifier = fileUri;
             Hierarchy = SyntaxHierarchy.Build(ProgramSyntax);
             LexingErrorLookup = lexingErrorLookup;
             ParsingErrorLookup = parsingErrorLookup;
@@ -22,7 +22,7 @@ namespace Bicep.Core.Workspaces
 
         protected BicepSourceFile(BicepSourceFile original)
         {
-            FileUri = original.FileUri;
+            Identifier = original.Identifier;
             LineStarts = original.LineStarts;
             ProgramSyntax = original.ProgramSyntax;
             Hierarchy = original.Hierarchy;
@@ -35,9 +35,9 @@ namespace Bicep.Core.Workspaces
 
         public ProgramSyntax ProgramSyntax { get; }
 
-        public Uri FileUri { get; }
+        public Uri Identifier { get; }
 
-        public string GetOriginalSource() => ProgramSyntax.ToString();
+        public string Text => ProgramSyntax.ToString();
 
         public abstract BicepSourceFileKind FileKind { get; }
 

--- a/src/Bicep.Core/Workspaces/ISourceFile.cs
+++ b/src/Bicep.Core/Workspaces/ISourceFile.cs
@@ -5,7 +5,8 @@ namespace Bicep.Core.Workspaces
 {
     public interface ISourceFile
     {
-        Uri FileUri { get; }
-        string GetOriginalSource();
+        Uri Identifier { get; }
+
+        string Text { get; }
     }
 }

--- a/src/Bicep.Core/Workspaces/SourceFileFactory.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileFactory.cs
@@ -100,7 +100,7 @@ namespace Bicep.Core.Workspaces
 
         public static TemplateSpecFile CreateTemplateSpecFile(Uri fileUri, string fileContents)
         {
-            TemplateSpecFile CreateErrorFile() => new(fileUri, null, new ArmTemplateFile(InMemoryMainTemplateUri, fileContents, null, null));
+            TemplateSpecFile CreateErrorFile() => new(fileUri, fileContents, null, new ArmTemplateFile(InMemoryMainTemplateUri, fileContents, null, null));
 
             try
             {
@@ -114,7 +114,7 @@ namespace Bicep.Core.Workspaces
 
                 var mainTemplateFile = CreateArmTemplateFile(new Uri("inmemory:///main.json"), mainTemplateObject.ToString());
 
-                return new(fileUri, templateSpecId, mainTemplateFile);
+                return new(fileUri, fileContents, templateSpecId, mainTemplateFile);
             }
             catch (Exception)
             {

--- a/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
@@ -91,7 +91,7 @@ namespace Bicep.Core.Workspaces
                 .SelectMany(current.GetFilesDependingOn)
                 .ToImmutableHashSet();
 
-            return builder.Build(current.EntryPoint.FileUri, featuresFactory, configurationManager, sourcefileExplorerbuild);
+            return builder.Build(current.EntryPoint.Identifier, featuresFactory, configurationManager, sourcefileExplorerbuild);
         }
 
         private SourceFileGrouping Build(Uri entryFileUri, IFeatureProviderFactory featuresFactory, IConfigurationManager configurationManager, ImmutableHashSet<ISourceFile>? sourcefileExplorerbuild = null)
@@ -107,7 +107,7 @@ namespace Bicep.Core.Workspaces
 
             if (entryFile is not BicepSourceFile bicepSourceFile)
             {
-                throw new InvalidOperationException($"Unexpected entry source file {entryFile.FileUri}");
+                throw new InvalidOperationException($"Unexpected entry source file {entryFile.Identifier}");
             }
 
             var sourceFileGraph = this.ReportFailuresForCycles();
@@ -162,7 +162,7 @@ namespace Bicep.Core.Workspaces
 
         private void PopulateRecursive(BicepSourceFile file, IFeatureProviderFactory featureProviderFactory, IConfigurationManager configurationManager, ImmutableHashSet<ISourceFile>? sourcefileExplorerbuild)
         {
-            var config = configurationManager.GetConfiguration(file.FileUri);
+            var config = configurationManager.GetConfiguration(file.Identifier);
             implicitExtensions[file] = [];
 
             // process "implicit" extensions (extensions defined in bicepconfig.json)
@@ -231,7 +231,7 @@ namespace Bicep.Core.Workspaces
                 return new(extensionName, extensionEntry, null);
             }
 
-            if (!dispatcher.TryGetArtifactReference(ArtifactType.Extension, extensionEntry.Value, file.FileUri).IsSuccess(out var artifactReference, out errorBuilder))
+            if (!dispatcher.TryGetArtifactReference(ArtifactType.Extension, extensionEntry.Value, file.Identifier).IsSuccess(out var artifactReference, out errorBuilder))
             {
                 // reference is not valid
                 return new(extensionName, extensionEntry, new(file, null, null, new(errorBuilder), RequiresRestore: false));
@@ -243,7 +243,7 @@ namespace Bicep.Core.Workspaces
 
         private ArtifactResolutionInfo GetArtifactRestoreResult(BicepSourceFile sourceFile, IArtifactReferenceSyntax referenceSyntax)
         {
-            if (!dispatcher.TryGetArtifactReference(referenceSyntax, sourceFile.FileUri).IsSuccess(out var artifactReference, out var errorBuilder))
+            if (!dispatcher.TryGetArtifactReference(referenceSyntax, sourceFile.Identifier).IsSuccess(out var artifactReference, out var errorBuilder))
             {
                 // artifact reference is not valid
                 return new(sourceFile, referenceSyntax, null, new(errorBuilder), RequiresRestore: false);
@@ -313,7 +313,7 @@ namespace Bicep.Core.Workspaces
                         { Length: 1 } when cycle[0] is BicepParamFile paramFile => new(x => x.CyclicParametersSelfReference()),
                         { Length: 1 } => new(x => x.CyclicModuleSelfReference()),
                         // the error message is generic so it should work for either bicep module or params
-                        _ => new(x => x.CyclicFile(cycle.Select(u => u.FileUri.LocalPath))),
+                        _ => new(x => x.CyclicFile(cycle.Select(u => u.Identifier.LocalPath))),
                     };
 
                     // overwrite to add the cycle error

--- a/src/Bicep.Core/Workspaces/TemplateSpecFile.cs
+++ b/src/Bicep.Core/Workspaces/TemplateSpecFile.cs
@@ -5,16 +5,17 @@ namespace Bicep.Core.Workspaces
 {
     public class TemplateSpecFile : ISourceFile
     {
-        public TemplateSpecFile(Uri fileUri, string? templateSpecId, ArmTemplateFile mainTemplateFile)
+        public TemplateSpecFile(Uri fileUri, string text, string? templateSpecId, ArmTemplateFile mainTemplateFile)
         {
-            this.FileUri = fileUri;
+            this.Identifier = fileUri;
+            this.Text = text;
             this.TemplateSpecId = templateSpecId;
             this.MainTemplateFile = mainTemplateFile;
         }
 
-        public Uri FileUri { get; }
+        public Uri Identifier { get; }
 
-        public string GetOriginalSource() => MainTemplateFile.GetOriginalSource();
+        public string Text { get; }
 
         public string? TemplateSpecId { get; }
 

--- a/src/Bicep.Core/Workspaces/Workspace.cs
+++ b/src/Bicep.Core/Workspaces/Workspace.cs
@@ -31,7 +31,7 @@ namespace Bicep.Core.Workspaces
 
             foreach (var newFile in files)
             {
-                if (activeFiles.TryGetValue(newFile.FileUri, out var oldFile))
+                if (activeFiles.TryGetValue(newFile.Identifier, out var oldFile))
                 {
                     if (oldFile == newFile)
                     {
@@ -43,7 +43,7 @@ namespace Bicep.Core.Workspaces
 
                 added.Add(newFile);
 
-                activeFiles[newFile.FileUri] = newFile;
+                activeFiles[newFile.Identifier] = newFile;
             }
 
             return (added.ToImmutableArray(), removed.ToImmutableArray());
@@ -53,9 +53,9 @@ namespace Bicep.Core.Workspaces
         {
             foreach (var file in files)
             {
-                if (activeFiles.TryGetValue(file.FileUri, out var treeToRemove) && treeToRemove == file)
+                if (activeFiles.TryGetValue(file.Identifier, out var treeToRemove) && treeToRemove == file)
                 {
-                    activeFiles.Remove(file.FileUri);
+                    activeFiles.Remove(file.Identifier);
                 }
             }
         }

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -44,8 +44,8 @@ namespace Bicep.Core.IntegrationTests
             {
                 foreach (var (bicepFile, diagnostics) in diagnosticsByBicepFile)
                 {
-                    var baselineFile = baselineFolder.GetFileOrEnsureCheckedIn(bicepFile.FileUri);
-                    var bicepOutput = filesToSave[bicepFile.FileUri];
+                    var baselineFile = baselineFolder.GetFileOrEnsureCheckedIn(bicepFile.Identifier);
+                    var bicepOutput = filesToSave[bicepFile.Identifier];
 
                     var sourceTextWithDiags = OutputHelper.AddDiagsToSourceText(bicepOutput, "\n", diagnostics, diag => OutputHelper.GetDiagLoggingString(bicepOutput, baselineFolder.OutputFolderPath, diag));
 

--- a/src/Bicep.Decompiler/BicepDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepDecompiler.cs
@@ -237,7 +237,7 @@ Following metadata was not decompiled:
             if (!object.ReferenceEquals(bicepFile.ProgramSyntax, newProgramSyntax))
             {
                 hasChanges = true;
-                var newFile = SourceFileFactory.CreateBicepFile(bicepFile.FileUri, newProgramSyntax.ToString());
+                var newFile = SourceFileFactory.CreateBicepFile(bicepFile.Identifier, newProgramSyntax.ToString());
                 workspace.UpsertSourceFile(newFile);
 
                 compilation = await bicepCompiler.CreateCompilation(entryUri, workspace, skipRestore: true);

--- a/src/Bicep.IO/Abstraction/ResourceIdentifier.cs
+++ b/src/Bicep.IO/Abstraction/ResourceIdentifier.cs
@@ -102,17 +102,11 @@ namespace Bicep.IO.Abstraction
             var hash = new HashCode();
 
             // Scheme and Authority are case-insenstive.
-            hash.Add(Scheme, StringComparer.OrdinalIgnoreCase);
-            hash.Add(Authority, StringComparer.OrdinalIgnoreCase);
-
-            if (this.IsLocal && this.IsFile)
-            {
-                hash.Add(Path, GlobalSettings.FilePathComparer);
-            }
-            else
-            {
-                hash.Add(Path, StringComparer.Ordinal);
-            }
+            hash.Add(this.Scheme, StringComparer.OrdinalIgnoreCase);
+            hash.Add(this.Authority, StringComparer.OrdinalIgnoreCase);
+            hash.Add(this.Path, this.IsLocal && this.IsFile ? GlobalSettings.FilePathComparer : StringComparer.Ordinal);
+            hash.Add(this.Query, StringComparer.Ordinal);
+            hash.Add(this.Fragment, StringComparer.Ordinal);
 
             return hash.ToHashCode();
         }
@@ -120,11 +114,13 @@ namespace Bicep.IO.Abstraction
         public override bool Equals(object? @object) => @object is ResourceIdentifier other && this.Equals(other);
 
         public bool Equals(ResourceIdentifier other) =>
-            string.Equals(Scheme, other.Scheme, StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(Authority, other.Authority, StringComparison.OrdinalIgnoreCase) &&
-            this.IsLocal && this.IsFile
+            string.Equals(this.Scheme, other.Scheme, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(this.Authority, other.Authority, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(this.Query, other.Query, StringComparison.Ordinal) &&
+            string.Equals(this.Fragment, other.Fragment, StringComparison.Ordinal) &&
+            (this.IsLocal && this.IsFile
                 ? string.Equals(Path, other.Path, GlobalSettings.FilePathComparison)
-                : string.Equals(Path, other.Path, StringComparison.Ordinal);
+                : string.Equals(Path, other.Path, StringComparison.Ordinal));
 
         public static bool operator ==(ResourceIdentifier left, ResourceIdentifier right) => left.Equals(right);
 

--- a/src/Bicep.IO/Abstraction/ResourceIdentifier.cs
+++ b/src/Bicep.IO/Abstraction/ResourceIdentifier.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace Bicep.IO.Abstraction
 {
     /// <summary>
-    /// A ResourceIdentifier is a RFC3986 URI with absolute path and without the query and fragment components.
+    /// A ResourceIdentifier is a RFC3986 URI with absolute path.
     /// </summary>
     public readonly struct ResourceIdentifier : IEquatable<ResourceIdentifier>
     {
@@ -25,7 +25,7 @@ namespace Bicep.IO.Abstraction
             public static StringComparison FilePathComparison => FilePathCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
         }
 
-        public ResourceIdentifier(string scheme, string authority, string path)
+        public ResourceIdentifier(string scheme, string? authority, string path, string? query = null, string? fragment = null)
         {
             if (!path.StartsWith('/'))
             {
@@ -35,6 +35,8 @@ namespace Bicep.IO.Abstraction
             this.Scheme = scheme;
             this.Authority = authority;
             this.Path = CanonicalizePath(path);
+            this.Query = query;
+            this.Fragment = fragment;
         }
 
         public string Scheme { get; }
@@ -42,6 +44,10 @@ namespace Bicep.IO.Abstraction
         public string? Authority { get; }
 
         public string Path { get; }
+
+        public string? Query { get; }
+
+        public string? Fragment { get; }
 
         public bool IsFile => this.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase);
 

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTestBase.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTestBase.cs
@@ -94,7 +94,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}_{Guid.NewGuid():D}/main.bicep"), file);
 
             server ??= await DefaultServer.GetAsync();
-            await server.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await server.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             var codeActions = await RequestCodeActions(server.Client, bicepFile, selection);
             return (codeActions.ToArray(), bicepFile);
@@ -130,7 +130,7 @@ namespace Bicep.LangServer.IntegrationTests
 
             var result = await client.RequestCodeAction(new CodeActionParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Range = new Range(startPosition, endPosition),
             });
 
@@ -142,10 +142,10 @@ namespace Bicep.LangServer.IntegrationTests
             // only support a small subset of possible edits for now - can always expand this later on
             codeAction.Edit!.Changes.Should().NotBeNull();
             codeAction.Edit.Changes.Should().HaveCount(1);
-            codeAction.Edit.Changes.Should().ContainKey(bicepFile.FileUri);
+            codeAction.Edit.Changes.Should().ContainKey(bicepFile.Identifier);
 
             var bicepText = bicepFile.ProgramSyntax.ToString();
-            var changes = codeAction.Edit.Changes![bicepFile.FileUri].ToArray();
+            var changes = codeAction.Edit.Changes![bicepFile.Identifier].ToArray();
 
             for (int i = 0; i < changes.Length; ++i)
             {
@@ -204,7 +204,7 @@ namespace Bicep.LangServer.IntegrationTests
                     "Rename should be positioned on the new identifier right after 'var ' or 'param ' or 'type '");
             }
 
-            return SourceFileFactory.CreateBicepFile(bicepFile.FileUri, bicepText);
+            return SourceFileFactory.CreateBicepFile(bicepFile.Identifier, bicepText);
         }
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -584,7 +584,7 @@ param fo|o {paramType}
         {
             var textEditContainer = await client.TextDocument.RequestDocumentFormatting(new DocumentFormattingParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Options = new FormattingOptions
                 {
                     TabSize = 2,
@@ -593,7 +593,7 @@ param fo|o {paramType}
                 },
             });
 
-            return SourceFileFactory.CreateBicepFile(bicepFile.FileUri, textEditContainer!.Single().NewText);
+            return SourceFileFactory.CreateBicepFile(bicepFile.Identifier, textEditContainer!.Single().NewText);
         }
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -367,7 +367,7 @@ resource service 'Microsoft.Storage/storageAccounts/fileServices@2021-02-01' = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri
+                bicepFile.Identifier
             );
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
@@ -659,7 +659,7 @@ module mod 'mod.bicep' = {
             };
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletions(cursors);
@@ -691,7 +691,7 @@ module mod 'mod.bicep' = {
             };
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletions(cursors);
@@ -926,7 +926,7 @@ module mod 'mod.bicep' = {
             };
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletions(cursors);
@@ -976,7 +976,7 @@ module mod 'mod.bicep' = {
             };
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletions(cursors);
@@ -1028,7 +1028,7 @@ module mod 'mod.bicep' = {
             };
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletions(cursors);
@@ -1664,7 +1664,7 @@ module bar2 'test.bicep' = [for item in list: |  ]
             };
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletions(cursors);
@@ -2147,7 +2147,7 @@ module a '|' = {
             };
 
             var bicepFile = SourceFileFactory.CreateBicepFile(mainUri, text);
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletion(cursor);
@@ -2199,7 +2199,7 @@ var modOut = m.outputs.inputTi|
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri,
+                bicepFile.Identifier,
                 services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
@@ -3307,7 +3307,7 @@ resource foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri,
+                bicepFile.Identifier,
                 services => services.WithNamespaceProvider(BuiltInTestTypes.Create())
             );
 
@@ -3517,7 +3517,7 @@ module aModule 'mod.bicep' = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri,
+                bicepFile.Identifier,
                 services => services.WithNamespaceProvider(BuiltInTestTypes.Create())
             );
 
@@ -3576,7 +3576,7 @@ module foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri,
+                bicepFile.Identifier,
                 services => services.WithNamespaceProvider(BuiltInTestTypes.Create())
             );
             var file = new FileRequestHelper(helper.Client, bicepFile);
@@ -4391,7 +4391,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestCompletion(cursors[0]);
@@ -4471,7 +4471,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
 
@@ -4515,7 +4515,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
 
@@ -4563,7 +4563,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
 
@@ -4625,7 +4625,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
 
@@ -4692,7 +4692,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
 
@@ -4746,7 +4746,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
 
@@ -4802,7 +4802,7 @@ param p validRecursiveObjectType = {
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 files,
-                bicepFile.FileUri);
+                bicepFile.Identifier);
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
 

--- a/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DefinitionTests.cs
@@ -781,7 +781,7 @@ param |foo| string
             var bicepFile = SourceFileFactory.CreateBicepFile(new($"file:///{testContext.TestName}/path/to/main.bicep"), file);
 
             var helper = await DefaultServer.GetAsync();
-            await helper.OpenFileOnceAsync(testContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(testContext, file, bicepFile.Identifier);
 
             var results = await RequestDefinitions(helper.Client, bicepFile, cursors);
 
@@ -804,7 +804,7 @@ param |foo| string
                 services.WithFileResolver(fileResolver)));
 
             var helper = await server.GetAsync();
-            await helper.OpenFileOnceAsync(testContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(testContext, file, bicepFile.Identifier);
             var results = await RequestDefinitions(helper.Client, bicepFile, cursors);
 
             assertAction(results);
@@ -819,7 +819,7 @@ param |foo| string
             {
                 var result = await client.RequestDefinition(new DefinitionParams()
                 {
-                    TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                    TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                     Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor)
                 });
 

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
@@ -72,7 +72,7 @@ namespace Bicep.LangServer.IntegrationTests
         }
 
         public async Task<PublishDiagnosticsParams> OpenFileOnceAsync(TestContext testContext, BicepSourceFile file)
-            => await OpenFileOnceAsync(testContext, file.ProgramSyntax.ToString(), file.FileUri);
+            => await OpenFileOnceAsync(testContext, file.ProgramSyntax.ToString(), file.Identifier);
 
         public async Task<PublishDiagnosticsParams> ChangeFileAsync(TestContext testContext, string text, DocumentUri documentUri, int version)
         {
@@ -109,7 +109,7 @@ namespace Bicep.LangServer.IntegrationTests
         }
 
         public async Task ChangeFileAsync(TestContext testContext, BicepFile file, int version)
-            => await ChangeFileAsync(testContext, file.ProgramSyntax.ToString(), file.FileUri, version);
+            => await ChangeFileAsync(testContext, file.ProgramSyntax.ToString(), file.Identifier, version);
 
         public void Dispose()
         {

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
@@ -46,7 +46,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             return await client.RequestCompletion(new CompletionParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor)
             });
         }
@@ -55,7 +55,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             return await client.RequestReferences(new ReferenceParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Context = new ReferenceContext
                 {
                     IncludeDeclaration = includeDeclaration
@@ -68,7 +68,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             return await client.RequestDocumentHighlight(new DocumentHighlightParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Position = PositionHelper.GetPosition(bicepFile.LineStarts, cursor)
             });
         }
@@ -78,7 +78,7 @@ namespace Bicep.LangServer.IntegrationTests
             return await client.RequestRename(new RenameParams
             {
                 NewName = expectedNewText,
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Position = PositionHelper.GetPosition(bicepFile.LineStarts, cursor),
             });
         }
@@ -87,14 +87,14 @@ namespace Bicep.LangServer.IntegrationTests
         {
             return await client.RequestCodeLens(new CodeLensParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
             });
         }
 
         public async Task<SignatureHelp?> RequestSignatureHelp(int cursor, SignatureHelpContext? context = null) =>
             await client.RequestSignatureHelp(new SignatureHelpParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor),
                 Context = context ?? new SignatureHelpContext
                 {
@@ -145,7 +145,7 @@ namespace Bicep.LangServer.IntegrationTests
             var originalFile = bicepFile.ProgramSyntax.ToString();
             var replaced = originalFile.Substring(0, start) + textToInsert + originalFile.Substring(end);
 
-            return SourceFileFactory.CreateBicepFile(bicepFile.FileUri, replaced);
+            return SourceFileFactory.CreateBicepFile(bicepFile.Identifier, replaced);
         }
 
         public BicepFile ApplyWorkspaceEdit(WorkspaceEdit? edit)
@@ -155,7 +155,7 @@ namespace Bicep.LangServer.IntegrationTests
             edit.DocumentChanges.Should().BeNull();
             edit.ChangeAnnotations.Should().BeNull();
 
-            var changes = edit.Changes![bicepFile.FileUri];
+            var changes = edit.Changes![bicepFile.Identifier];
 
             var replaced = bicepFile.ProgramSyntax.ToString();
             var offset = 0;
@@ -169,14 +169,14 @@ namespace Bicep.LangServer.IntegrationTests
                 offset += change.NewText.Length - (end - start);
             }
 
-            return SourceFileFactory.CreateBicepFile(bicepFile.FileUri, replaced);
+            return SourceFileFactory.CreateBicepFile(bicepFile.Identifier, replaced);
         }
 
         public async Task<Hover?> RequestHover(int cursor)
         {
             return await client.RequestHover(new HoverParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor)
             });
         }
@@ -185,7 +185,7 @@ namespace Bicep.LangServer.IntegrationTests
         {
             var response = await client.RequestDefinition(new DefinitionParams
             {
-                TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
+                TextDocument = new TextDocumentIdentifier(bicepFile.Identifier),
                 Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor)
             });
 
@@ -210,7 +210,7 @@ namespace Bicep.LangServer.IntegrationTests
             {
                 TextDocument = new TextDocumentIdentifier
                 {
-                    Uri = bicepFile.FileUri
+                    Uri = bicepFile.Identifier
                 },
                 Options = new FormattingOptions
                 {

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -210,7 +210,7 @@ output string test = testRes.prop|erties.rea|donly
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
@@ -245,7 +245,7 @@ output string test = testRes[3].prop|erties.rea|donly
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
@@ -279,7 +279,7 @@ output string test = testRes.prop|erties.rea|donly
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
@@ -321,7 +321,7 @@ resource test|Output string = 'str'
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
@@ -347,7 +347,7 @@ param constrainedSe|cureString string
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
@@ -391,11 +391,11 @@ output moduleOutput string = '${var|1}-${mod1.outputs.o|ut2}'
 
             var files = new Dictionary<Uri, string>
             {
-                [bicepFile.FileUri] = file,
-                [moduleFile.FileUri] = modFile
+                [bicepFile.Identifier] = file,
+                [moduleFile.Identifier] = modFile
             };
 
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
             var client = helper.Client;
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
@@ -434,11 +434,11 @@ output o1 string = mod|1.name
 
             var files = new Dictionary<Uri, string>
             {
-                [bicepFile.FileUri] = file,
-                [moduleFile.FileUri] = modFile
+                [bicepFile.Identifier] = file,
+                [moduleFile.Identifier] = modFile
             };
 
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
             var client = helper.Client;
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
@@ -482,11 +482,11 @@ output o1 string = mod|1.name
 
             var files = new Dictionary<Uri, string>
             {
-                [bicepFile.FileUri] = file,
-                [moduleTemplateFile.FileUri] = template!.ToString()
+                [bicepFile.Identifier] = file,
+                [moduleTemplateFile.Identifier] = template!.ToString()
             };
 
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
             var client = helper.Client;
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
@@ -615,11 +615,11 @@ output moduleOutput string = '${va|r1}-${mod1.outputs.ou|t2}'
 
             var files = new Dictionary<Uri, string>
             {
-                [bicepFile.FileUri] = file,
-                [moduleTemplateFile.FileUri] = template!.ToString()
+                [bicepFile.Identifier] = file,
+                [moduleTemplateFile.Identifier] = template!.ToString()
             };
 
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.FileUri, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Identifier, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
             var client = helper.Client;
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
@@ -685,7 +685,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
@@ -868,11 +868,11 @@ param foo|bar = true
 
             var files = new Dictionary<Uri, string>
             {
-                [paramsFile.FileUri] = bicepparamText,
-                [bicepFile.FileUri] = bicepText
+                [paramsFile.Identifier] = bicepparamText,
+                [bicepFile.Identifier] = bicepText
             };
 
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, paramsFile.FileUri);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, paramsFile.Identifier);
             var client = helper.Client;
 
             var hovers = await RequestHovers(client, paramsFile, cursors);
@@ -908,11 +908,11 @@ param foo|bar = true
 
             var files = new Dictionary<Uri, string>
             {
-                [mainFile.FileUri] = mainText,
-                [moduleFile.FileUri] = moduleText
+                [mainFile.Identifier] = mainText,
+                [moduleFile.Identifier] = moduleText
             };
 
-            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, mainFile.FileUri);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, mainFile.Identifier);
             var client = helper.Client;
 
             var hovers = await RequestHovers(client, mainFile, cursors);
@@ -1054,7 +1054,7 @@ There might also be a link to something [link](www.google.com)
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), text);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, text, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, text, bicepFile.Identifier);
 
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
@@ -1377,12 +1377,12 @@ AzureMetrics
 
         private static async Task<IEnumerable<Hover?>> RequestHovers(ILanguageClient client, BicepFile bicepFile, IEnumerable<int> cursors)
         {
-            return await RequestHovers(client, bicepFile.FileUri, bicepFile.LineStarts, cursors);
+            return await RequestHovers(client, bicepFile.Identifier, bicepFile.LineStarts, cursors);
         }
 
         private static async Task<IEnumerable<Hover?>> RequestHovers(ILanguageClient client, BicepParamFile paramFile, IEnumerable<int> cursors)
         {
-            return await RequestHovers(client, paramFile.FileUri, paramFile.LineStarts, cursors);
+            return await RequestHovers(client, paramFile.Identifier, paramFile.LineStarts, cursors);
         }
 
         private static async Task<IEnumerable<Hover?>> RequestHovers(ILanguageClient client, Uri fileUri, IReadOnlyList<int> lineStarts, IEnumerable<int> cursors)
@@ -1409,7 +1409,7 @@ AzureMetrics
             var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
-            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.FileUri);
+            await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Identifier);
 
             return await RequestHovers(helper.Client, bicepFile, cursors);
         }

--- a/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
@@ -93,12 +93,12 @@ namespace Bicep.LangServer.IntegrationTests
             var (fileContents, cursor) = ParserHelper.GetFileWithSingleCursor(fileWithCursor, '|');
             var file = SourceFileFactory.CreateBicepFile(fileUri, fileContents);
 
-            client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(file.FileUri, fileContents, 0));
+            client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParams(file.Identifier, fileContents, 0));
             await listeners.Diagnostics.WaitNext();
 
             var result = await client.SendRequest(new InsertResourceParams
             {
-                TextDocument = DocumentUri.From(file.FileUri),
+                TextDocument = DocumentUri.From(file.Identifier),
                 Position = PositionHelper.GetPosition(file.LineStarts, cursor),
                 ResourceId = resourceId,
             }, default);

--- a/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
@@ -53,7 +53,7 @@ var blah = '${test}'
         var locations = await file.RequestReferences(cursor, includeDeclaration: true);
 
         // all URIs should be the same in the results
-        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.FileUri);
+        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.Identifier);
 
         AnnotateWithLocations(file, locations).Should().EqualIgnoringTrailingWhitespace(outputAnnotated);
     }
@@ -80,7 +80,7 @@ var blah = '${test}'
         var locations = await file.RequestReferences(cursor, includeDeclaration: false);
 
         // all URIs should be the same in the results
-        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.FileUri);
+        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.Identifier);
 
         AnnotateWithLocations(file, locations).Should().EqualIgnoringTrailingWhitespace(outputAnnotated);
     }

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationManagerTests.cs
@@ -113,7 +113,7 @@ namespace Bicep.LangServer.UnitTests
 
             // The workspace should be refreshed.
             updatedFile.Should().NotBeNull();
-            updatedFile!.FileUri.Should().Be(originalFile.FileUri);
+            updatedFile!.Identifier.Should().Be(originalFile.Identifier);
             updatedFile.Should().NotBeSameAs(originalFile);
 
             document.Verify(m => m.SendNotification(It.IsAny<PublishDiagnosticsParams>()), Times.Never);

--- a/src/Bicep.LangServer/BicepCompilationManager.cs
+++ b/src/Bicep.LangServer/BicepCompilationManager.cs
@@ -473,7 +473,7 @@ namespace Bicep.LanguageServer
             properties.Add("Resources", semanticModel.DeclaredResources.Length.ToString());
             properties.Add("Variables", declarationsInMainFile.Count(x => x is VariableDeclarationSyntax).ToString());
 
-            properties.Add("CharCount", bicepFile.GetOriginalSource().Length.ToString());
+            properties.Add("CharCount", bicepFile.Text.Length.ToString());
 
             var (errorsCount, warningsCount) = CountErrorsAndWarnings(diagnostics);
             properties.Add("LineCount", bicepFile.LineStarts.Length.ToString());

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -90,7 +90,7 @@ namespace Bicep.LanguageServer.Completions
                 .Concat(GetParamValueCompletions(model, context))
                 .Concat(GetAssertValueCompletions(model, context))
                 .Concat(GetTypeArgumentCompletions(model, context))
-                .Concat(await moduleReferenceCompletionProvider.GetFilteredCompletions(model.SourceFile.FileUri, context, cancellationToken));
+                .Concat(await moduleReferenceCompletionProvider.GetFilteredCompletions(model.SourceFile.Identifier, context, cancellationToken));
         }
 
         private IEnumerable<CompletionItem> GetParamIdentifierCompletions(SemanticModel paramsSemanticModel, BicepCompletionContext paramsCompletionContext)
@@ -631,7 +631,7 @@ namespace Bicep.LanguageServer.Completions
             try
             {
                 // These should only fail if we're not able to resolve cwd path or the entered string
-                if (TryGetFilesForPathCompletions(model.SourceFile.FileUri, entered) is not { } fileCompletionInfo)
+                if (TryGetFilesForPathCompletions(model.SourceFile.Identifier, entered) is not { } fileCompletionInfo)
                 {
                     return [];
                 }
@@ -643,14 +643,14 @@ namespace Bicep.LanguageServer.Completions
 
                 if (context.Kind.HasFlag(BicepCompletionContextKind.ExtendsFilePath))
                 {
-                    var bicepParamFileItems = CreateFileCompletionItems(model.SourceFile.FileUri, replacementRange, fileCompletionInfo, IsBicepParamFile, CompletionPriority.High);
+                    var bicepParamFileItems = CreateFileCompletionItems(model.SourceFile.Identifier, replacementRange, fileCompletionInfo, IsBicepParamFile, CompletionPriority.High);
 
                     return bicepParamFileItems.Concat(dirItems);
                 }
 
                 // Prioritize .bicep files higher than other files.
-                var bicepFileItems = CreateFileCompletionItems(model.SourceFile.FileUri, replacementRange, fileCompletionInfo, IsBicepFile, CompletionPriority.High);
-                var armTemplateFileItems = CreateFileCompletionItems(model.SourceFile.FileUri, replacementRange, fileCompletionInfo, IsArmTemplateFileLike, CompletionPriority.Medium);
+                var bicepFileItems = CreateFileCompletionItems(model.SourceFile.Identifier, replacementRange, fileCompletionInfo, IsBicepFile, CompletionPriority.High);
+                var armTemplateFileItems = CreateFileCompletionItems(model.SourceFile.Identifier, replacementRange, fileCompletionInfo, IsArmTemplateFileLike, CompletionPriority.Medium);
 
                 if (model.Features.ExtendableParamFilesEnabled && context.Kind.HasFlag(BicepCompletionContextKind.UsingFilePath))
                 {
@@ -685,7 +685,7 @@ namespace Bicep.LanguageServer.Completions
 
                 if (model.SourceFileGrouping.SourceFiles.Any(sourceFile =>
                         sourceFile is ArmTemplateFile &&
-                        sourceFile.FileUri.LocalPath.Equals(fileUri.LocalPath, PathHelper.PathComparison)))
+                        sourceFile.Identifier.LocalPath.Equals(fileUri.LocalPath, PathHelper.PathComparison)))
                 {
                     return true;
                 }
@@ -1412,7 +1412,7 @@ namespace Bicep.LanguageServer.Completions
             var entered = (functionArgument.Syntax.Arguments.ElementAtOrDefault(functionArgument.ArgumentIndex)?.Expression as StringSyntax)?.TryGetLiteralValue() ?? string.Empty;
 
             // These should only fail if we're not able to resolve cwd path or the entered string
-            if (TryGetFilesForPathCompletions(model.SourceFile.FileUri, entered) is not { } fileCompletionInfo)
+            if (TryGetFilesForPathCompletions(model.SourceFile.Identifier, entered) is not { } fileCompletionInfo)
             {
                 return [];
             }
@@ -1421,20 +1421,20 @@ namespace Bicep.LanguageServer.Completions
             if (argType.ValidationFlags.HasFlag(TypeSymbolValidationFlags.IsStringJsonFilePath))
             {
                 // Prioritize .json or .jsonc files higher than other files.
-                var jsonItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (file) => PathHelper.HasExtension(file, "json") || PathHelper.HasExtension(file, "jsonc"), CompletionPriority.High);
-                var nonJsonItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (file) => !PathHelper.HasExtension(file, "json") && !PathHelper.HasExtension(file, "jsonc"), CompletionPriority.Medium);
+                var jsonItems = CreateFileCompletionItems(model.SourceFile.Identifier, context.ReplacementRange, fileCompletionInfo, (file) => PathHelper.HasExtension(file, "json") || PathHelper.HasExtension(file, "jsonc"), CompletionPriority.High);
+                var nonJsonItems = CreateFileCompletionItems(model.SourceFile.Identifier, context.ReplacementRange, fileCompletionInfo, (file) => !PathHelper.HasExtension(file, "json") && !PathHelper.HasExtension(file, "jsonc"), CompletionPriority.Medium);
                 fileItems = jsonItems.Concat(nonJsonItems);
             }
             else if (argType.ValidationFlags.HasFlag(TypeSymbolValidationFlags.IsStringYamlFilePath))
             {
                 // Prioritize .yaml or .yml files higher than other files.
-                var yamlItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (file) => PathHelper.HasExtension(file, "yaml") || PathHelper.HasExtension(file, "yml"), CompletionPriority.High);
-                var nonYamlItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (file) => !PathHelper.HasExtension(file, "yaml") && !PathHelper.HasExtension(file, "yml"), CompletionPriority.Medium);
+                var yamlItems = CreateFileCompletionItems(model.SourceFile.Identifier, context.ReplacementRange, fileCompletionInfo, (file) => PathHelper.HasExtension(file, "yaml") || PathHelper.HasExtension(file, "yml"), CompletionPriority.High);
+                var nonYamlItems = CreateFileCompletionItems(model.SourceFile.Identifier, context.ReplacementRange, fileCompletionInfo, (file) => !PathHelper.HasExtension(file, "yaml") && !PathHelper.HasExtension(file, "yml"), CompletionPriority.Medium);
                 fileItems = yamlItems.Concat(nonYamlItems);
             }
             else
             {
-                fileItems = CreateFileCompletionItems(model.SourceFile.FileUri, context.ReplacementRange, fileCompletionInfo, (_) => true, CompletionPriority.High);
+                fileItems = CreateFileCompletionItems(model.SourceFile.Identifier, context.ReplacementRange, fileCompletionInfo, (_) => true, CompletionPriority.High);
             }
 
             var dirItems = CreateDirectoryCompletionItems(context.ReplacementRange, fileCompletionInfo, CompletionPriority.Medium);

--- a/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildCommandHandler.cs
@@ -58,7 +58,7 @@ namespace Bicep.LanguageServer.Handlers
             var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetRefreshedCompilation(documentUri);
 
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
-                .FirstOrDefault(x => x.Key.FileUri == fileUri);
+                .FirstOrDefault(x => x.Key.Identifier == fileUri);
 
             if (diagnosticsByFile.Value.Any(x => x.IsError()))
             {

--- a/src/Bicep.LangServer/Handlers/BicepBuildParamsCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepBuildParamsCommandHandler.cs
@@ -59,7 +59,7 @@ namespace Bicep.LanguageServer.Handlers
             var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetRefreshedCompilation(documentUri);
             var fileUri = documentUri.ToUriEncoded();
 
-            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().FirstOrDefault(x => x.Key.FileUri == fileUri);
+            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().FirstOrDefault(x => x.Key.Identifier == fileUri);
 
             if (diagnosticsByFile.Value.Any(x => x.IsError()))
             {

--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -149,7 +149,7 @@ namespace Bicep.LanguageServer.Handlers
                     && context.Compilation.GetEntrypointSemanticModel().GetDeclaredType(stringToken) is { } stringType
                     && stringType.ValidationFlags.HasFlag(TypeSymbolValidationFlags.IsStringFilePath)
                     && stringToken.TryGetLiteralValue() is { } stringTokenValue
-                    && fileResolver.TryResolveFilePath(context.Compilation.SourceFileGrouping.EntryPoint.FileUri, stringTokenValue) is { } fileUri
+                    && fileResolver.TryResolveFilePath(context.Compilation.SourceFileGrouping.EntryPoint.Identifier, stringTokenValue) is { } fileUri
                     && fileResolver.FileExists(fileUri))
                 {
                     return GetFileDefinitionLocation(
@@ -165,7 +165,7 @@ namespace Bicep.LanguageServer.Handlers
                     context.Compilation.SourceFileGrouping.TryGetSourceFile(@using).IsSuccess(out var sourceFile))
                 {
                     return GetFileDefinitionLocation(
-                        sourceFile.FileUri,
+                        sourceFile.Identifier,
                         path,
                         context,
                         new() { Start = new(0, 0), End = new(0, 0) });
@@ -192,7 +192,7 @@ namespace Bicep.LanguageServer.Handlers
             {
                 // the client doesn't support the bicep-extsrc scheme or we're dealing with a local module
                 // just use the file URI
-                return sourceFile.FileUri;
+                return sourceFile.Identifier;
             }
 
             if (reference is OciArtifactReference ociArtifactReference)
@@ -363,7 +363,7 @@ namespace Bicep.LanguageServer.Handlers
             }
 
             var range = PositionHelper.GetNameRange(bicepModel.SourceFile.LineStarts, parameterSymbol.DeclaringSyntax);
-            var documentUri = bicepModel.SourceFile.FileUri;
+            var documentUri = bicepModel.SourceFile.Identifier;
 
             return new(new LocationOrLocationLink(new LocationLink
             {
@@ -394,7 +394,7 @@ namespace Bicep.LanguageServer.Handlers
                 return new(new LocationOrLocationLink(new LocationLink
                 {
                     OriginSelectionRange = originSelectionRange,
-                    TargetUri = bicepModel.SourceFile.FileUri,
+                    TargetUri = bicepModel.SourceFile.Identifier,
                     TargetRange = targetRange,
                     TargetSelectionRange = targetRange,
                 }));
@@ -477,8 +477,8 @@ namespace Bicep.LanguageServer.Handlers
         private static (Template?, Uri?) GetArmSourceTemplateInfo(CompilationContext context, IArtifactReferenceSyntax foreignTemplateReference)
             => context.Compilation.SourceFileGrouping.TryGetSourceFile(foreignTemplateReference).TryUnwrap() switch
             {
-                TemplateSpecFile templateSpecFile => (templateSpecFile.MainTemplateFile.Template, templateSpecFile.FileUri),
-                ArmTemplateFile armTemplateFile => (armTemplateFile.Template, armTemplateFile.FileUri),
+                TemplateSpecFile templateSpecFile => (templateSpecFile.MainTemplateFile.Template, templateSpecFile.Identifier),
+                ArmTemplateFile armTemplateFile => (armTemplateFile.Template, armTemplateFile.Identifier),
                 _ => (null, null),
             };
 
@@ -509,7 +509,7 @@ namespace Bicep.LanguageServer.Handlers
                             .FirstOrDefault(d => string.Equals(d.Name, propertyName)) is OutputSymbol outputSymbol)
                         {
                             return GetFileDefinitionLocation(
-                                bicepFile.FileUri,
+                                bicepFile.Identifier,
                                 underlinedSyntax,
                                 context,
                                 outputSymbol.DeclaringOutput.Name.ToRange(bicepFile.LineStarts));
@@ -520,7 +520,7 @@ namespace Bicep.LanguageServer.Handlers
                             .FirstOrDefault(d => string.Equals(d.Name, propertyName)) is ParameterSymbol parameterSymbol)
                         {
                             return GetFileDefinitionLocation(
-                                bicepFile.FileUri,
+                                bicepFile.Identifier,
                                 underlinedSyntax,
                                 context,
                                 parameterSymbol.DeclaringParameter.Name.ToRange(bicepFile.LineStarts));

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentScopeRequestHandler.cs
@@ -79,7 +79,7 @@ namespace Bicep.LanguageServer.Handlers
             var fileUri = documentUri.ToUriEncoded();
 
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
-                .FirstOrDefault(x => x.Key.FileUri == fileUri);
+                .FirstOrDefault(x => x.Key.Identifier == fileUri);
 
             if (diagnosticsByFile.Value.Any(x => x.IsError()))
             {

--- a/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
@@ -66,7 +66,7 @@ namespace Bicep.LanguageServer.Handlers
             var fileUri = documentUri.ToUriEncoded();
 
             var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile()
-                .FirstOrDefault(x => x.Key.FileUri == fileUri);
+                .FirstOrDefault(x => x.Key.Identifier == fileUri);
 
             if (diagnosticsByFile.Value.Any(x => x.IsError()))
             {

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -197,7 +197,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var workspace = new Workspace();
             workspace.UpsertSourceFile(bicepFile);
-            var compilation = compiler.CreateCompilationWithoutRestore(bicepFile.FileUri, workspace);
+            var compilation = compiler.CreateCompilationWithoutRestore(bicepFile.Identifier, workspace);
 
             bicepFile = RewriterHelper.RewriteMultiple(
                 compiler,

--- a/src/Bicep.LangServer/Snippets/SnippetCacheBuilder.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetCacheBuilder.cs
@@ -182,7 +182,7 @@ public class SnippetCacheBuilder
         var workspace = new Workspace();
         workspace.UpsertSourceFiles(bicepFile.AsEnumerable());
 
-        var compilation = await bicepCompiler.CreateCompilation(bicepFile.FileUri, workspace, skipRestore: true);
+        var compilation = await bicepCompiler.CreateCompilation(bicepFile.Identifier, workspace, skipRestore: true);
         var semanticModel = compilation.GetEntrypointSemanticModel();
 
         return ResourceDependencyVisitor.GetResourceDependencies(semanticModel);

--- a/src/Bicep.LangServer/Utils/DiagnosticsHelper.cs
+++ b/src/Bicep.LangServer/Utils/DiagnosticsHelper.cs
@@ -23,7 +23,7 @@ namespace Bicep.LanguageServer.Utils
                 // Build a code description link if the Uri is assigned
                 var codeDescription = diagnostic.Uri == null ? string.Empty : $" [{diagnostic.Uri.AbsoluteUri}]";
 
-                sb.AppendLine($"{diagnosticsByFile.Key.FileUri.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}");
+                sb.AppendLine($"{diagnosticsByFile.Key.Identifier.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}");
             }
 
             return sb.ToString();

--- a/src/Bicep.RegistryModuleTool/Extensions/BicepCompilerExtensions.cs
+++ b/src/Bicep.RegistryModuleTool/Extensions/BicepCompilerExtensions.cs
@@ -27,7 +27,7 @@ namespace Bicep.RegistryModuleTool.Extensions
                         hasError = true;
                     }
 
-                    if (!file.FileUri.LocalPath.Equals(skipWritingDiagnosticsPath, StringComparison.Ordinal))
+                    if (!file.Identifier.LocalPath.Equals(skipWritingDiagnosticsPath, StringComparison.Ordinal))
                     {
                         console.WriteDiagnostic(file, diagnostic);
                     }

--- a/src/Bicep.RegistryModuleTool/Extensions/ConsoleExtensions.cs
+++ b/src/Bicep.RegistryModuleTool/Extensions/ConsoleExtensions.cs
@@ -16,7 +16,7 @@ namespace Bicep.RegistryModuleTool.Extensions
         {
             (int line, int character) = TextCoordinateConverter.GetPosition(file.LineStarts, diagnostic.Span.Position);
             var codeDescription = diagnostic.Uri == null ? string.Empty : $" [{diagnostic.Uri.AbsoluteUri}]";
-            var message = $"{file.FileUri.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}";
+            var message = $"{file.Identifier.LocalPath}({line + 1},{character + 1}) : {diagnostic.Level} {diagnostic.Code}: {diagnostic.Message}{codeDescription}";
 
             switch (diagnostic.Level)
             {

--- a/src/Bicep.RegistryModuleTool/ModuleFileValidators/TestValidator.cs
+++ b/src/Bicep.RegistryModuleTool/ModuleFileValidators/TestValidator.cs
@@ -33,7 +33,7 @@ namespace Bicep.RegistryModuleTool.ModuleFileValidators
 
             var compilation = await this.compiler.CompileAsync(file.Path, this.console, this.mainBicepFile.Path);
             var hasMainBicepFileReference = compilation.SourceFileGrouping.SourceFiles
-                .Any(x => x.FileUri.LocalPath.Equals(this.mainBicepFile.Path, StringComparison.Ordinal));
+                .Any(x => x.Identifier.LocalPath.Equals(this.mainBicepFile.Path, StringComparison.Ordinal));
 
             if (!hasMainBicepFileReference)
             {


### PR DESCRIPTION
This PR introduces no functional changes and focuses solely on renaming properties of `ISourceFile` to isolate the change and minimize the scope of follow-up file I/O refactoring PRs.

The first commit also contains a minor change to add `Query` and `Fragment` to `Bicep.IO.ResourceIdentifier`, as `Query` may be required for the remote compilation service in the future.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15638)