### PR TITLE
InsertResource - correctly strip read-only properties

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/InsertResourceCommandTests.cs
@@ -166,7 +166,6 @@ namespace Bicep.LangServer.IntegrationTests
                 resource myName 'My.Rp/myTypes@2020-01-01' = {
                   name: 'myName'
                   properties: {
-                    readOnlyProp: 'abc'
                     readWriteProp: 'def'
                     writeOnlyProp: 'ghi'
                     int64Prop: 9223372036854775807
@@ -286,7 +285,6 @@ namespace Bicep.LangServer.IntegrationTests
                 resource myRg 'Microsoft.Resources/resourceGroups@2020-01-01' = {
                   name: 'myRg'
                   properties: {
-                    readOnlyProp: 'abc'
                     readWriteProp: 'def'
                     writeOnlyProp: 'ghi'
                   }
@@ -359,7 +357,6 @@ namespace Bicep.LangServer.IntegrationTests
                 resource childName 'My.Rp/myTypes/childType@2020-01-01' = {
                   name: 'myName/childName'
                   properties: {
-                    readOnlyProp: 'abc'
                     readWriteProp: 'def'
                     writeOnlyProp: 'ghi'
                   }
@@ -512,7 +509,6 @@ output myOutput string = 'myOutput'
                 resource myName 'My.Rp/myTypes@2020-01-01' = {
                   name: 'myName'
                   properties: {
-                    readOnlyProp: 'abc'
                     readWriteProp: 'def'
                     writeOnlyProp: 'ghi'
                   }

--- a/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
+++ b/src/Bicep.LangServer/Handlers/InsertResourceHandler.cs
@@ -208,7 +208,7 @@ namespace Bicep.LanguageServer.Handlers
                 model => new ReadOnlyPropertyRemovalRewriter(model));
 
             var printerOptions = configuration.Formatting.Data;
-            var printed = PrettyPrinterV2.PrintValid(program, printerOptions);
+            var printed = PrettyPrinterV2.PrintValid(bicepFile.ProgramSyntax, printerOptions);
 
             var newline = printerOptions.NewlineKind.ToEscapeSequence();
             var newlineCharacters = newline.ToCharArray();


### PR DESCRIPTION
Looks like this was inadvertently changed with #13290 (screenshot below). This PR restores the old behavior:
![image](https://github.com/user-attachments/assets/dba22f2f-45fd-454e-ab6c-9f8fbd09d092)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15689)