### PR TITLE
Fix a test case for macOS

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
@@ -125,7 +125,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             yield return new object[] { new string[] { "/workspace1" }, "/workspace2/bicepconfig.json", "/workspace2" };
             yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/bicepconfig.json", "/workspace1/two" };
             // Case sensitive - no match, return bicep file's folder
-            yield return new object[] { new string[] { "/Workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/Workspace1" }, "/workspace1/bicepconfig.json", "/Workspace1" };
             yield return new object[] { new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
             // Folders partially match
             yield return new object[] { new string[] { "/workspace" }, "/workspace1/bicepconfig.json", "/workspace1" };


### PR DESCRIPTION
Previously, we were using the incorrect default case sensitivity for macOS within `BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation`. It was fixed by my first file IO abstraction PR. However, I missed a test failure on macOS because I didn’t realize the test included OS-specific directives. This PR fixes the test case for macOS.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15747)