### PR TITLE
Fix a test case for macOS

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepGetRecommendedConfigLocationHandlerTests.cs
@@ -88,7 +88,27 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
         private static IEnumerable<object[]> GetWorkspaceFoldersTestData()
         {
-#if WINDOWS_BUILD
+#if LINUX_BUILD
+            // Bicep file is in a workspace folder - return the first one that matches, or else the bicep file's folder
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/two/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/two/three/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1/two" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two" };
+            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two/three" };
+            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/three/four/bicepconfig.json", "/workspace1/two/three" };
+            yield return new object[] { new string[] { "/workspace1", "/workspace2" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace2", "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1/two/three\four", "/workspace1/two/three", "/workspace1/two", "/workspace1" }, "/workspace1/two/three/five/bicepconfig.json", "/workspace1/two/three" };
+            // Bicep file not in any workspace folder - return bicep file's folder
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace2/bicepconfig.json", "/workspace2" };
+            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/bicepconfig.json", "/workspace1/two" };
+            // Case sensitive - no match, return bicep file's folder
+            yield return new object[] { new string[] { "/Workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            // Folders partially match
+            yield return new object[] { new string[] { "/workspace" }, "/workspace1/bicepconfig.json", "/workspace1" };
+            yield return new object[] { new string[] { "/workspace1" }, "/workspace/bicepconfig.json", "/workspace" };
+#else
             // Bicep file is in a workspace folder - return the first one that matches, or else the bicep file's folder
             yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1" };
             yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace1\\two\\bicepconfig.json", "c:\\workspace1" };
@@ -110,26 +130,6 @@ namespace Bicep.LangServer.UnitTests.Handlers
             // Folders partially match
             yield return new object[] { new string[] { "c:\\workspace" }, "c:\\workspace1\\bicepconfig.json", "c:\\workspace1" };
             yield return new object[] { new string[] { "c:\\workspace1" }, "c:\\workspace\\bicepconfig.json", "c:\\workspace" };
-#else
-            // Bicep file is in a workspace folder - return the first one that matches, or else the bicep file's folder
-            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
-            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/two/bicepconfig.json", "/workspace1" };
-            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/two/three/bicepconfig.json", "/workspace1" };
-            yield return new object[] { new string[] { "/workspace1/two" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two" };
-            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/three/bicepconfig.json", "/workspace1/two/three" };
-            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/three/four/bicepconfig.json", "/workspace1/two/three" };
-            yield return new object[] { new string[] { "/workspace1", "/workspace2" }, "/workspace1/bicepconfig.json", "/workspace1" };
-            yield return new object[] { new string[] { "/workspace2", "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
-            yield return new object[] { new string[] { "/workspace1/two/three\four", "/workspace1/two/three", "/workspace1/two", "/workspace1" }, "/workspace1/two/three/five/bicepconfig.json", "/workspace1/two/three" };
-            // Bicep file not in any workspace folder - return bicep file's folder
-            yield return new object[] { new string[] { "/workspace1" }, "/workspace2/bicepconfig.json", "/workspace2" };
-            yield return new object[] { new string[] { "/workspace1/two/three" }, "/workspace1/two/bicepconfig.json", "/workspace1/two" };
-            // Case sensitive - no match, return bicep file's folder
-            yield return new object[] { new string[] { "/Workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
-            yield return new object[] { new string[] { "/workspace1" }, "/workspace1/bicepconfig.json", "/workspace1" };
-            // Folders partially match
-            yield return new object[] { new string[] { "/workspace" }, "/workspace1/bicepconfig.json", "/workspace1" };
-            yield return new object[] { new string[] { "/workspace1" }, "/workspace/bicepconfig.json", "/workspace" };
 #endif
         }
 


### PR DESCRIPTION
Previously, we were using the incorrect default case sensitivity for macOS within BicepGetRecommendedConfigLocationHandler.GetRecommendedConfigFileLocation. It was fixed by my first file IO abstraction PR. However, I missed a test failure on macOS because I didn’t realize the test included OS-specific directives. This PR fixes the test case for macOS.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15748)