### PR TITLE
Emit type and apiVersion separately for local and v2 ext resources

### DIFF
--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -1227,7 +1227,9 @@ namespace Bicep.Core.Emit
                     }
                 }
 
-                if (metadata.IsAzResource)
+                if (metadata.IsAzResource ||
+                    this.Context.SemanticModel.Features.LocalDeployEnabled ||
+                    this.Context.SemanticModel.Features.ExtensibilityV2EmittingEnabled)
                 {
                     emitter.EmitProperty("type", metadata.TypeReference.FormatType());
                     if (metadata.TypeReference.ApiVersion is not null)

--- a/src/Bicep.Local.Deploy.IntegrationTests/EndToEndDeploymentTests.cs
+++ b/src/Bicep.Local.Deploy.IntegrationTests/EndToEndDeploymentTests.cs
@@ -111,6 +111,8 @@ param coords = {
         extensionMock.Setup(x => x.CreateOrUpdate(It.Is<ResourceSpecification>(req => req.Properties["uri"]!.ToString() == "https://api.weather.gov/points/47.6363726,-122.1357068"), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((req, _) =>
             {
+                req.Type.Should().Be("request");
+                req.ApiVersion.Should().Be("v1");
                 req.Properties["body"] = """
 {
   "properties": {
@@ -126,6 +128,8 @@ param coords = {
         extensionMock.Setup(x => x.CreateOrUpdate(It.Is<ResourceSpecification>(req => req.Properties["uri"]!.ToString() == "https://api.weather.gov/gridpoints/SEW/131,68/forecast"), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((req, _) =>
             {
+                req.Type.Should().Be("request");
+                req.ApiVersion.Should().Be("v1");
                 req.Properties["body"] = """
 {
   "properties": {


### PR DESCRIPTION
Fixes https://github.com/Azure/bicep/issues/15761.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15762)