### PR TITLE
MS Graph type provider warns on property mismatch

### DIFF
--- a/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Bicep.Core.Registry.PublicRegistry;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Providers;
 using Bicep.Core.TypeSystem.Providers.Az;
+using Bicep.Core.TypeSystem.Providers.MicrosoftGraph;
 using Bicep.Core.TypeSystem.Types;
 using Bicep.Core.UnitTests.Configuration;
 using Bicep.Core.UnitTests.Features;
@@ -128,6 +129,12 @@ public static class IServiceCollectionExtensions
 
     public static IServiceCollection WithAzResourceProvider(this IServiceCollection services, IAzResourceProvider azResourceProvider)
         => Register(services, azResourceProvider);
+
+    public static IServiceCollection WithMsGraphResourceTypeLoaderFactory(this IServiceCollection services, MicrosoftGraphResourceTypeLoader loader)
+    {
+        var provider = new MicrosoftGraphResourceTypeProvider(loader);
+        return Register(services, TestTypeHelper.CreateResourceTypeLoaderFactory(provider));
+    }
 
     public static IServiceCollection WithArmClientProvider(this IServiceCollection services, IArmClientProvider armClientProvider)
         => Register(services, armClientProvider);

--- a/src/Bicep.Core.UnitTests/TypeSystem/MicrosoftGraph/MicrosoftGraphResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/MicrosoftGraph/MicrosoftGraphResourceTypeProviderTests.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
+using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.TypeSystem.Providers.MicrosoftGraph;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
@@ -13,6 +16,7 @@ namespace Bicep.Core.UnitTests.TypeSystem.MicrosoftGraph
     [TestClass]
     public class MicrosoftGraphResourceTypeProviderTests
     {
+        private static ServiceBuilder Services => new();
 
         [TestMethod]
         public void MicrosoftGraphResourceTypeProvider_can_list_all_types_without_throwing()
@@ -25,6 +29,38 @@ namespace Bicep.Core.UnitTests.TypeSystem.MicrosoftGraph
 
             // verify there aren't any duplicates
             availableTypes.Select(x => x.FormatName().ToLowerInvariant()).Should().OnlyHaveUniqueItems();
+        }
+
+        [TestMethod]
+        public void MsGraphResourceTypeProvider_should_warn_for_property_mismatch()
+        {
+            Compilation createCompilation(string program) => Services
+                .WithMsGraphResourceTypeLoader(new MicrosoftGraphResourceTypeLoader())
+                .BuildCompilation(program);
+
+            var compilation = createCompilation(@"
+resource app 'Microsoft.Graph/applications@beta' = {
+  uniqueName: 'test'
+  displayName: 'test'
+  extraProp: 'extra'
+}
+");
+            compilation.Should().HaveDiagnostics(new[] {
+                ("BCP037", DiagnosticLevel.Warning, "The property \"extraProp\" is not allowed on objects of type \"Microsoft.Graph/applications\". Permissible properties include \"api\", \"appRoles\", \"authenticationBehaviors\", \"defaultRedirectUri\", \"dependsOn\", \"description\", \"disabledByMicrosoftStatus\", \"groupMembershipClaims\", \"identifierUris\", \"info\", \"isDeviceOnlyAuthSupported\", \"isFallbackPublicClient\", \"keyCredentials\", \"logo\", \"notes\", \"optionalClaims\", \"parentalControlSettings\", \"passwordCredentials\", \"publicClient\", \"requestSignatureVerification\", \"requiredResourceAccess\", \"samlMetadataUrl\", \"serviceManagementReference\", \"servicePrincipalLockConfiguration\", \"signInAudience\", \"spa\", \"tags\", \"tokenEncryptionKeyId\", \"verifiedPublisher\", \"web\", \"windows\". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues.")
+            });
+
+            compilation = createCompilation(@"
+resource app 'Microsoft.Graph/applications@beta' = {
+  uniqueName: 'test'
+  displayName: 'test'
+  spa: {
+    extraNestedProp: 'extra'
+  }
+}
+");
+            compilation.Should().HaveDiagnostics(new[] {
+                ("BCP037", DiagnosticLevel.Warning, "The property \"extraNestedProp\" is not allowed on objects of type \"MicrosoftGraphSpaApplication\". Permissible properties include \"redirectUris\". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues.")
+            });
         }
     }
 }

--- a/src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Registry.PublicRegistry;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.TypeSystem.Providers;
+using Bicep.Core.TypeSystem.Providers.MicrosoftGraph;
 using Bicep.Core.TypeSystem.Types;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.Workspaces;
@@ -60,6 +61,9 @@ public static class ServiceBuilderExtensions
 
     public static ServiceBuilder WithEmptyAzResources(this ServiceBuilder serviceBuilder)
         => serviceBuilder.WithRegistration(x => x.WithEmptyAzResources());
+
+    public static ServiceBuilder WithMsGraphResourceTypeLoader(this ServiceBuilder serviceBuilder, MicrosoftGraphResourceTypeLoader typeLoader)
+        => serviceBuilder.WithRegistration(x => x.WithMsGraphResourceTypeLoaderFactory(typeLoader));
 
     public static ServiceBuilder WithEnvironmentVariables(this ServiceBuilder serviceBuilder, params (string key, string? value)[] variables)
         => serviceBuilder.WithRegistration(x => x.WithEnvironmentVariables(variables));

--- a/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeFactory.cs
@@ -152,14 +152,15 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
 
         private static TypeSymbolValidationFlags GetValidationFlags(bool isResourceBodyType)
         {
+            var flags = TypeSymbolValidationFlags.WarnOnPropertyTypeMismatch;
             if (isResourceBodyType)
             {
                 // strict validation on top-level resource properties, as 'custom' top-level properties are not supported by the platform
-                return TypeSymbolValidationFlags.Default;
+                return flags | TypeSymbolValidationFlags.Default;
             }
 
             // in all other places, we should allow some wiggle room so that we don't block compilation if there are any swagger inaccuracies
-            return TypeSymbolValidationFlags.WarnOnTypeMismatch;
+            return flags | TypeSymbolValidationFlags.WarnOnTypeMismatch;
         }
 
         private static ResourceFlags ToResourceFlags(Azure.Bicep.Types.Concrete.ResourceFlags input)


### PR DESCRIPTION
Updating Ms Graph type loader to warn on property mismatch instead of error

https://github.com/microsoftgraph/msgraph-bicep-types/issues/191
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15824)