### PR TITLE
File I/O Abstraction: Replace `IFileResolver.TryAcquireFileLock`

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -15,6 +15,7 @@ using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Registry;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.IO.FileSystem;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.DependencyInjection;
@@ -82,8 +83,8 @@ namespace Bicep.Cli.IntegrationTests
             {
                 // ensure something got restored
 
-                Directory.Exists(settings.FeatureOverrides!.CacheRootDirectory).Should().BeTrue();
-                Directory.EnumerateFiles(settings.FeatureOverrides.CacheRootDirectory!, "*.json", SearchOption.AllDirectories).Should().NotBeEmpty();
+                settings.FeatureOverrides!.CacheRootDirectory!.Exists().Should().BeTrue();
+                Directory.EnumerateFiles(settings.FeatureOverrides.CacheRootDirectory!.Uri.GetFileSystemPath(), "*.json", SearchOption.AllDirectories).Should().NotBeEmpty();
             }
 
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -1689,7 +1689,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -1523,7 +1523,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -1403,7 +1403,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.Core.IntegrationTests/AzTypesViaRegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/AzTypesViaRegistryTests.cs
@@ -40,9 +40,7 @@ namespace Bicep.Core.IntegrationTests
         {
             var indexJson = FileHelper.SaveResultFile(TestContext, "types/index.json", EmptyIndexJson);
 
-            var cacheRoot = FileHelper.GetUniqueTestOutputPath(TestContext);
-            Directory.CreateDirectory(cacheRoot);
-
+            var cacheRoot = FileHelper.GetCacheRootDirectory(TestContext).EnsureExists();
             var services = new ServiceBuilder()
                 .WithFeatureOverrides(new(ExtensibilityEnabled: true, CacheRootDirectory: cacheRoot))
                 .WithContainerRegistryClientFactory(RegistryHelper.CreateOciClientForAzExtension());
@@ -62,8 +60,7 @@ namespace Bicep.Core.IntegrationTests
             var manifest = BicepTestConstants.GetBicepExtensionManifest(blobResult.Value, configResult.Value);
             await client.SetManifestAsync(manifest, artifactRegistryAddress.ExtensionVersion);
 
-            var cacheRoot = FileHelper.GetUniqueTestOutputPath(TestContext);
-            Directory.CreateDirectory(cacheRoot);
+            var cacheRoot = FileHelper.GetCacheRootDirectory(TestContext).EnsureExists();
 
             return new ServiceBuilder()
                 .WithFeatureOverrides(new(ExtensibilityEnabled: true, CacheRootDirectory: cacheRoot))

--- a/src/Bicep.Core.IntegrationTests/ExtensionRegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensionRegistryTests.cs
@@ -78,8 +78,7 @@ output joke string = dadJoke.body.joke
     [TestMethod]
     public async Task Extensions_published_to_filesystem_can_be_compiled()
     {
-        var cacheDirectory = FileHelper.GetCacheRootPath(TestContext);
-        Directory.CreateDirectory(cacheDirectory);
+        var cacheDirectory = FileHelper.GetCacheRootDirectory(TestContext).EnsureExists();
         var services = new ServiceBuilder().WithFeatureOverrides(new(CacheRootDirectory: cacheDirectory, ExtensibilityEnabled: true));
 
         var typesTgz = ThirdPartyTypeHelper.GetTestTypesTgz();

--- a/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
@@ -55,9 +55,7 @@ namespace Bicep.Core.IntegrationTests
             var indexJsonBeta = FileHelper.SaveResultFile(TestContext, "types/index-beta.json", EmptyIndexJsonBeta);
             var indexJsonV10 = FileHelper.SaveResultFile(TestContext, "types/index-v1.0.json", EmptyIndexJsonV10);
 
-            var cacheRoot = FileHelper.GetUniqueTestOutputPath(TestContext);
-            Directory.CreateDirectory(cacheRoot);
-
+            var cacheRoot = FileHelper.GetCacheRootDirectory(TestContext).EnsureExists();
             var services = new ServiceBuilder()
                 .WithFeatureOverrides(new(ExtensibilityEnabled: true, CacheRootDirectory: cacheRoot))
                 .WithContainerRegistryClientFactory(RegistryHelper.CreateOciClientForMsGraphExtension());
@@ -78,8 +76,7 @@ namespace Bicep.Core.IntegrationTests
             var manifest = BicepTestConstants.GetBicepExtensionManifest(blobResult.Value, configResult.Value);
             await client.SetManifestAsync(manifest, artifactRegistryAddress.ExtensionVersion);
 
-            var cacheRoot = FileHelper.GetUniqueTestOutputPath(TestContext);
-            Directory.CreateDirectory(cacheRoot);
+            var cacheRoot = FileHelper.GetCacheRootDirectory(TestContext).EnsureExists();
 
             return new ServiceBuilder()
                 .WithFeatureOverrides(new(ExtensibilityEnabled: true, CacheRootDirectory: cacheRoot))

--- a/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SourceArchiveTests.cs
@@ -15,6 +15,7 @@ using Bicep.Core.UnitTests.Extensions;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
+using Bicep.IO.Abstraction;
 using Bicep.LanguageServer.Handlers;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,12 +34,12 @@ namespace Bicep.Core.IntegrationTests
         #region Helpers
 
         [NotNull]
-        private string? CacheRoot { get; set; }
+        private IDirectoryHandle? CacheRoot { get; set; }
 
         [TestInitialize]
         public void TestInitialize()
         {
-            CacheRoot = FileHelper.GetUniqueTestOutputPath(TestContext);
+            CacheRoot = FileHelper.GetCacheRootDirectory(TestContext);
             MockFileSystem = new(MockFiles);
         }
 

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -1587,7 +1587,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -1576,7 +1576,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Core.UnitTests/ApiVersion/ApiVersionProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/ApiVersion/ApiVersionProviderTests.cs
@@ -81,8 +81,7 @@ namespace Bicep.Core.UnitTests.ApiVersions
 
         private ApiVersionProvider CreateDefaultApiVersionProvider(IEnumerable<ResourceTypeReference>? resourceTypeReferences = null)
             => new(
-                new FeatureProvider(
-                    IConfigurationManager.GetBuiltInConfiguration()),
-                    resourceTypeReferences ?? []);
+                new FeatureProvider(IConfigurationManager.GetBuiltInConfiguration(), BicepTestConstants.FileExplorer),
+                resourceTypeReferences ?? []);
     }
 }

--- a/src/Bicep.Core.UnitTests/Assertions/OciModuleRegistryAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/OciModuleRegistryAssertions.cs
@@ -4,6 +4,8 @@
 using System.IO.Abstractions;
 using Bicep.Core.Registry;
 using Bicep.Core.UnitTests.Registry;
+using Bicep.IO.Abstraction;
+using Bicep.IO.FileSystem;
 using FluentAssertions;
 using FluentAssertions.Primitives;
 
@@ -33,15 +35,7 @@ namespace Bicep.Core.UnitTests.Assertions
             return new(this);
         }
 
-        public static void ShouldOnlyHaveValidModules(IFileSystem fileSystem, string cacheRootDirectory)
-        {
-            foreach (var module in CachedModules.GetCachedRegistryModules(fileSystem, cacheRootDirectory))
-            {
-                module.Should().BeValid();
-            }
-        }
-
-        private static void ShouldHaveValidCachedModules(IFileSystem fileSystem, string cacheRootDirectory, bool? withSource = null)
+        private static void ShouldHaveValidCachedModules(IFileSystem fileSystem, IDirectoryHandle cacheRootDirectory, bool? withSource = null)
         {
             var modules = CachedModules.GetCachedRegistryModules(fileSystem, cacheRootDirectory);
             modules.Should().HaveCountGreaterThan(0);

--- a/src/Bicep.Core.UnitTests/Assertions/OciModuleRegistryAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/OciModuleRegistryAssertions.cs
@@ -24,14 +24,9 @@ namespace Bicep.Core.UnitTests.Assertions
 
         protected override string Identifier => "OciArtifactRegistry";
 
-        public AndConstraint<OciArtifactRegistryAssertions> HaveValidCachedModulesWithSources()
-            => HaveValidCachedModules(withSource: true);
-        public AndConstraint<OciArtifactRegistryAssertions> HaveValidCachedModulesWithoutSources()
-            => HaveValidCachedModules(withSource: false);
-
-        public AndConstraint<OciArtifactRegistryAssertions> HaveValidCachedModules(bool? withSource = null)
+        public AndConstraint<OciArtifactRegistryAssertions> HaveValidCachedModules(IFileSystem fileSystem, bool? withSource = null)
         {
-            ShouldHaveValidCachedModules(Subject.FileSystem, Subject.CacheRootDirectory, withSource);
+            ShouldHaveValidCachedModules(fileSystem, Subject.CacheRootDirectory, withSource);
             return new(this);
         }
 

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -78,7 +78,7 @@ namespace Bicep.Core.UnitTests
         public static readonly IServiceProvider EmptyServiceProvider = new Mock<IServiceProvider>(MockBehavior.Loose).Object;
 
         public static IArtifactRegistryProvider CreateRegistryProvider(IServiceProvider services) =>
-            new DefaultArtifactRegistryProvider(services, FileResolver, FileSystem, ClientFactory, TemplateSpecRepositoryFactory, FeatureProviderFactory, BuiltInOnlyConfigurationManager);
+            new DefaultArtifactRegistryProvider(services, FileResolver, ClientFactory, TemplateSpecRepositoryFactory, FeatureProviderFactory, BuiltInOnlyConfigurationManager);
 
         public static IModuleDispatcher CreateModuleDispatcher(IServiceProvider services) =>
             new ModuleDispatcher(CreateRegistryProvider(services), IConfigurationManager.WithStaticConfiguration(BuiltInConfiguration));

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -44,13 +44,13 @@ namespace Bicep.Core.UnitTests
 
         public static readonly FileResolver FileResolver = new(FileSystem);
 
-        public static readonly IFileExplorer fileExplorer = new FileSystemFileExplorer(FileSystem);
+        public static readonly IFileExplorer FileExplorer = new FileSystemFileExplorer(FileSystem);
 
         public static readonly FeatureProviderOverrides FeatureOverrides = new();
 
         public static readonly ConfigurationManager ConfigurationManager = CreateFilesystemConfigurationManager();
 
-        public static readonly IFeatureProviderFactory FeatureProviderFactory = new OverriddenFeatureProviderFactory(new FeatureProviderFactory(ConfigurationManager), FeatureOverrides);
+        public static readonly IFeatureProviderFactory FeatureProviderFactory = new OverriddenFeatureProviderFactory(new FeatureProviderFactory(ConfigurationManager, FileExplorer), FeatureOverrides);
 
         public static readonly IResourceTypeProviderFactory ResourceTypeProviderFactory = new ResourceTypeProviderFactory(FileSystem);
 
@@ -73,7 +73,7 @@ namespace Bicep.Core.UnitTests
 
         public static readonly IConfigurationManager BuiltInOnlyConfigurationManager = IConfigurationManager.WithStaticConfiguration(BuiltInConfiguration);
 
-        public static readonly IFeatureProvider Features = new OverriddenFeatureProvider(new FeatureProvider(BuiltInConfiguration), FeatureOverrides);
+        public static readonly IFeatureProvider Features = new OverriddenFeatureProvider(new FeatureProvider(BuiltInConfiguration, FileExplorer), FeatureOverrides);
 
         public static readonly IServiceProvider EmptyServiceProvider = new Mock<IServiceProvider>(MockBehavior.Loose).Object;
 
@@ -137,7 +137,7 @@ namespace Bicep.Core.UnitTests
         public static ConfigurationManager CreateFilesystemConfigurationManager() => new(new FileSystemFileExplorer(new OnDiskFileSystem()));
 
         public static IFeatureProviderFactory CreateFeatureProviderFactory(FeatureProviderOverrides featureOverrides, IConfigurationManager? configurationManager = null)
-            => new OverriddenFeatureProviderFactory(new FeatureProviderFactory(configurationManager ?? CreateFilesystemConfigurationManager()), featureOverrides);
+            => new OverriddenFeatureProviderFactory(new FeatureProviderFactory(configurationManager ?? CreateFilesystemConfigurationManager(), FileExplorer), featureOverrides);
 
         private static IModuleRestoreScheduler CreateMockModuleRestoreScheduler()
         {

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.UnitTests.Utils;
+using Bicep.IO.Abstraction;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.UnitTests.Features;
 
 public record FeatureProviderOverrides(
-    string? CacheRootDirectory = null,
+    IDirectoryHandle? CacheRootDirectory = null,
     bool? RegistryEnabled = default,
     bool? SymbolicNameCodegenEnabled = default,
     bool? ExtensibilityEnabled = default,
@@ -44,7 +45,7 @@ public record FeatureProviderOverrides(
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
         bool? ExtensibilityV2EmittingEnabled = default
     ) : this(
-        FileHelper.GetCacheRootPath(testContext),
+        FileHelper.GetCacheRootDirectory(testContext),
         RegistryEnabled,
         SymbolicNameCodegenEnabled,
         ExtensibilityEnabled,

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
@@ -30,7 +30,7 @@ public class FeatureProviderTests
         var fileExplorer = new FileSystemFileExplorer(fileSystem);
         var configManager = new ConfigurationManager(fileExplorer);
         var configuration = configManager.GetConfiguration(new Uri(this.CreatePath("repo/main.bicep")));
-        var fpm = new FeatureProviderFactory(configManager);
+        var fpm = new FeatureProviderFactory(configManager, fileExplorer);
 
         var control = fpm.GetFeatureProvider(new Uri("file:///main.bicep"));
         var sut = fpm.GetFeatureProvider(new Uri(this.CreatePath("repo/main.bicep")));
@@ -50,7 +50,7 @@ public class FeatureProviderTests
         var fileExplorer = new FileSystemFileExplorer(fileSystem);
         var configManager = new ConfigurationManager(fileExplorer);
         var configuration = configManager.GetConfiguration(new Uri(this.CreatePath("repo/main.bicep")));
-        var fpm = new FeatureProviderFactory(configManager);
+        var fpm = new FeatureProviderFactory(configManager, fileExplorer);
 
         var control = fpm.GetFeatureProvider(new Uri("file:///main.bicep"));
         control.ExtensibilityEnabled.Should().BeFalse();

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Features;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.UnitTests.Features;
 
@@ -18,7 +19,7 @@ public class OverriddenFeatureProvider : IFeatureProvider
 
     public string AssemblyVersion => overrides.AssemblyVersion ?? features.AssemblyVersion;
 
-    public string CacheRootDirectory => overrides.CacheRootDirectory ?? features.CacheRootDirectory;
+    public IDirectoryHandle CacheRootDirectory => overrides.CacheRootDirectory ?? features.CacheRootDirectory;
 
     public bool SymbolicNameCodegenEnabled => overrides.SymbolicNameCodegenEnabled ?? features.SymbolicNameCodegenEnabled;
 

--- a/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
+++ b/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
@@ -8,6 +8,8 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Bicep.Core.SourceCode;
 using Bicep.Core.Utils;
+using Bicep.IO.Abstraction;
+using Bicep.IO.FileSystem;
 using FluentAssertions;
 
 namespace Bicep.Core.UnitTests.Registry;
@@ -17,9 +19,9 @@ namespace Bicep.Core.UnitTests.Registry;
 public static class CachedModules
 {
     // Get all cached modules from the local on-disk registry cache
-    public static ImmutableArray<CachedModule> GetCachedRegistryModules(IFileSystem fileSystem, string cacheRootDirectory)
+    public static ImmutableArray<CachedModule> GetCachedRegistryModules(IFileSystem fileSystem, IDirectoryHandle cacheRootDirectory)
     {
-        var cacheDir = fileSystem.DirectoryInfo.New(cacheRootDirectory);
+        var cacheDir = fileSystem.DirectoryInfo.New(cacheRootDirectory.Uri.GetFileSystemPath());
         if (!cacheDir.Exists)
         {
             return [];

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -9,6 +9,7 @@ using Bicep.Core.SourceCode;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.IO.Abstraction;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -770,9 +771,10 @@ namespace Bicep.Core.UnitTests.Registry
             return (OciArtifactRegistry, OciArtifactReference);
         }
 
-        private IFeatureProvider GetFeatures(string cacheRootDirectory)
+        private IFeatureProvider GetFeatures(string cacheRootDirectoryPath)
         {
             var features = StrictMock.Of<IFeatureProvider>();
+            var cacheRootDirectory = BicepTestConstants.FileExplorer.GetDirectory(IOUri.FromLocalFilePath(cacheRootDirectoryPath));
 
             features.Setup(m => m.CacheRootDirectory).Returns(cacheRootDirectory);
 

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -680,7 +680,7 @@ namespace Bicep.Core.UnitTests.Registry
 
             await RestoreModule(ociRegistry, moduleReference);
 
-            ociRegistry.Should().HaveValidCachedModules(withSource: publishSource);
+            ociRegistry.Should().HaveValidCachedModules(BicepTestConstants.FileSystem, withSource: publishSource);
             var actualSourceResult = ociRegistry.TryGetSource(moduleReference);
 
             if (sources is { })

--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -5,6 +5,8 @@ using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Reflection;
 using System.Text;
+using Bicep.IO.Abstraction;
+using Bicep.IO.FileSystem;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -78,7 +80,13 @@ namespace Bicep.Core.UnitTests.Utils
             return outputDirectory;
         }
 
-        public static string GetCacheRootPath(TestContext testContext) => GetUniqueTestOutputPath(testContext);
+        public static IDirectoryHandle GetCacheRootDirectory(TestContext testContext)
+        {
+            var path = GetUniqueTestOutputPath(testContext);
+            var uri = IOUri.FromLocalFilePath(path);
+
+            return BicepTestConstants.FileExplorer.GetDirectory(uri);
+        }
 
         public static ImmutableDictionary<string, string> BuildEmbeddedFileDictionary(Assembly containingAssembly, string streamNamePrefix)
         {

--- a/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
@@ -10,6 +10,7 @@ using Bicep.Core.Registry.Oci;
 using Bicep.Core.Registry.PublicRegistry;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Registry;
+using Bicep.IO.Abstraction;
 using Bicep.IO.FileSystem;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -97,22 +98,16 @@ namespace Bicep.Core.UnitTests.Utils
             return (registry, blobClient);
         }
 
-        public static async Task<(MockRegistryBlobClient, Mock<IContainerRegistryClientFactory>)> PublishArtifactLayersToMockClient(string tempDirectory, string registry, Uri registryUri, string repository, string? mediaType, string? artifactType, string? configContents, IEnumerable<(string mediaType, string contents)> layers)
+        public static async Task<(MockRegistryBlobClient, Mock<IContainerRegistryClientFactory>)> PublishArtifactLayersToMockClient(string registry, Uri registryUri, string repository, string? mediaType, string? artifactType, string? configContents, IEnumerable<(string mediaType, string contents)> layers)
         {
             var client = new MockRegistryBlobClient();
 
             var clientFactory = StrictMock.Of<IContainerRegistryClientFactory>();
             clientFactory.Setup(m => m.CreateAuthenticatedBlobClient(It.IsAny<RootConfiguration>(), registryUri, repository)).Returns(client);
 
-            var templateSpecRepositoryFactory = BicepTestConstants.TemplateSpecRepositoryFactory;
-
-            Directory.CreateDirectory(tempDirectory);
-
             var containerRegistryManager = new AzureContainerRegistryManager(clientFactory.Object);
+            var configurationManager = new ConfigurationManager(BicepTestConstants.FileExplorer);
 
-            var fs = new MockFileSystem();
-            var fileExplorer = new FileSystemFileExplorer(fs);
-            var configurationManager = new ConfigurationManager(fileExplorer);
             var parentUri = new Uri("http://test.bicep", UriKind.Absolute);
             var configuration = configurationManager.GetConfiguration(parentUri);
 

--- a/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
@@ -88,7 +88,6 @@ namespace Bicep.Core.UnitTests.Utils
 
             var registry = new OciArtifactRegistry(
                 BicepTestConstants.FileResolver,
-                BicepTestConstants.FileSystem,
                 clientFactory.Object,
                 featureProvider,
                 BicepTestConstants.BuiltInConfiguration,

--- a/src/Bicep.Core.UnitTests/Utils/SourceArchiveBuilder.cs
+++ b/src/Bicep.Core.UnitTests/Utils/SourceArchiveBuilder.cs
@@ -19,18 +19,10 @@ namespace Bicep.Core.UnitTests.Utils
         private static string Rooted(string path) => $"/{path}";
 #endif
 
-        private string? cacheRoot = null;
-
         // First will be entrypoint, must be a bicep file
         private List<ISourceFile> SourceFiles = new();
 
         private ISourceFile EntrypointFile => SourceFiles[0];
-
-        public SourceArchiveBuilder WithCacheRoot(string cacheRoot)
-        {
-            this.cacheRoot = cacheRoot;
-            return this;
-        }
 
         public SourceArchiveBuilder WithBicepFile(Uri fileUri, string contents)
         {
@@ -62,7 +54,7 @@ namespace Bicep.Core.UnitTests.Utils
 
             return SourceArchive.PackSourcesIntoStream(
                 EntrypointFile.Uri,
-                cacheRoot,
+                null,
                 SourceFiles.Select(x => new SourceFileWithArtifactReference(x, null)).ToArray());
         }
 

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -1565,7 +1565,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -67,7 +67,7 @@ namespace Bicep.Core.Features
 
         private IDirectoryHandle GetCacheRootDirectory(string? customPath) =>
             this.GetCacheRootDirectoryFromLocalPath(string.IsNullOrWhiteSpace(customPath)
-                ? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+                ? $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}/.bicep"
                 : customPath);
 
         private IDirectoryHandle GetCacheRootDirectoryFromLocalPath(string localPath) =>

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -3,6 +3,7 @@
 
 using Bicep.Core.Configuration;
 using Bicep.Core.Intermediate;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Features
 {
@@ -10,12 +11,15 @@ namespace Bicep.Core.Features
     {
         private readonly RootConfiguration configuration;
 
-        public FeatureProvider(RootConfiguration configuration)
+        private readonly IFileExplorer fileExplorer;
+
+        public FeatureProvider(RootConfiguration configuration, IFileExplorer fileExplorer)
         {
             this.configuration = configuration;
+            this.fileExplorer = fileExplorer;
         }
 
-        public string CacheRootDirectory => GetCacheRootDirectory(this.configuration.CacheRootDirectory);
+        public IDirectoryHandle CacheRootDirectory => GetCacheRootDirectory(this.configuration.CacheRootDirectory);
 
         public bool SymbolicNameCodegenEnabled => this.configuration.ExperimentalFeaturesEnabled.SymbolicNameCodegen;
 
@@ -61,21 +65,12 @@ namespace Bicep.Core.Features
             return Enum.TryParse<T>(str, true, out var value) ? value : defaultValue;
         }
 
-        private static string GetDefaultCachePath()
-        {
-            string basePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        private IDirectoryHandle GetCacheRootDirectory(string? customPath) =>
+            this.GetCacheRootDirectoryFromLocalPath(string.IsNullOrWhiteSpace(customPath)
+                ? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+                : customPath);
 
-            return Path.Combine(basePath, ".bicep");
-        }
-
-        private static string GetCacheRootDirectory(string? customPath)
-        {
-            if (string.IsNullOrWhiteSpace(customPath))
-            {
-                return GetDefaultCachePath();
-            }
-
-            return customPath;
-        }
+        private IDirectoryHandle GetCacheRootDirectoryFromLocalPath(string localPath) =>
+            this.fileExplorer.GetDirectory(IOUri.FromLocalFilePath(localPath));
     }
 }

--- a/src/Bicep.Core/Features/FeatureProviderFactory.cs
+++ b/src/Bicep.Core/Features/FeatureProviderFactory.cs
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Bicep.Core.Configuration;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Features;
 
 public class FeatureProviderFactory : IFeatureProviderFactory
 {
     private readonly IConfigurationManager configurationManager;
+    private readonly IFileExplorer fileExplorer;
 
-    public FeatureProviderFactory(IConfigurationManager configurationManager)
+    public FeatureProviderFactory(IConfigurationManager configurationManager, IFileExplorer fileExplorer)
     {
         this.configurationManager = configurationManager;
+        this.fileExplorer = fileExplorer;
     }
 
-    public IFeatureProvider GetFeatureProvider(Uri templateUri) => new FeatureProvider(configurationManager.GetConfiguration(templateUri));
+    public IFeatureProvider GetFeatureProvider(Uri templateUri) => new FeatureProvider(configurationManager.GetConfiguration(templateUri), this.fileExplorer);
 }

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -1,13 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.IO.Abstraction;
+
 namespace Bicep.Core.Features;
 
 public interface IFeatureProvider
 {
     string AssemblyVersion { get; }
 
-    string CacheRootDirectory { get; }
+    IDirectoryHandle CacheRootDirectory { get; }
 
     bool SymbolicNameCodegenEnabled { get; }
 

--- a/src/Bicep.Core/FileSystem/FileResolver.cs
+++ b/src/Bicep.Core/FileSystem/FileResolver.cs
@@ -16,12 +16,6 @@ namespace Bicep.Core.FileSystem
             this.fileSystem = fileSystem;
         }
 
-        public IDisposable? TryAcquireFileLock(Uri fileUri)
-        {
-            RequireFileUri(fileUri);
-            return FileLock.TryAcquire(fileSystem, fileUri.LocalPath);
-        }
-
         public ResultWithDiagnosticBuilder<string> TryRead(Uri fileUri)
             => TryReadInternal<string>(fileUri, 0, stream =>
             {

--- a/src/Bicep.Core/FileSystem/IFileResolver.cs
+++ b/src/Bicep.Core/FileSystem/IFileResolver.cs
@@ -12,12 +12,6 @@ public record FileWithEncoding(
 public interface IFileResolver
 {
     /// <summary>
-    /// Attempts to acquire a cross-process lock via a zero-length lock file. The lock file should not be used to store any content. Returns null if lock was not taken.
-    /// </summary>
-    /// <param name="fileUri">The URI of the lock file</param>
-    IDisposable? TryAcquireFileLock(Uri fileUri);
-
-    /// <summary>
     /// Tries to read a file contents to string. If an exception is encountered, returns null and sets a non-null failureMessage.
     /// </summary>
     /// <param name="fileUri">The file URI to read.</param>

--- a/src/Bicep.Core/Registry/DefaultArtifactRegistryProvider.cs
+++ b/src/Bicep.Core/Registry/DefaultArtifactRegistryProvider.cs
@@ -14,17 +14,15 @@ namespace Bicep.Core.Registry
     public class DefaultArtifactRegistryProvider : IArtifactRegistryProvider
     {
         private readonly IFileResolver fileResolver;
-        private readonly IFileSystem fileSystem;
         private readonly IContainerRegistryClientFactory clientFactory;
         private readonly ITemplateSpecRepositoryFactory templateSpecRepositoryFactory;
         private readonly IFeatureProviderFactory featureProviderFactory;
         private readonly IConfigurationManager configurationManager;
         private readonly IServiceProvider serviceProvider;
 
-        public DefaultArtifactRegistryProvider(IServiceProvider serviceProvider, IFileResolver fileResolver, IFileSystem fileSystem, IContainerRegistryClientFactory clientFactory, ITemplateSpecRepositoryFactory templateSpecRepositoryFactory, IFeatureProviderFactory featureProviderFactory, IConfigurationManager configurationManager)
+        public DefaultArtifactRegistryProvider(IServiceProvider serviceProvider, IFileResolver fileResolver, IContainerRegistryClientFactory clientFactory, ITemplateSpecRepositoryFactory templateSpecRepositoryFactory, IFeatureProviderFactory featureProviderFactory, IConfigurationManager configurationManager)
         {
             this.fileResolver = fileResolver;
-            this.fileSystem = fileSystem;
             this.clientFactory = clientFactory;
             this.templateSpecRepositoryFactory = templateSpecRepositoryFactory;
             this.featureProviderFactory = featureProviderFactory;
@@ -45,9 +43,9 @@ namespace Bicep.Core.Registry
             var builder = ImmutableArray.CreateBuilder<IArtifactRegistry>();
 
             // Using IServiceProvider instead of constructor injection due to a dependency cycle
-            builder.Add(new LocalModuleRegistry(fileResolver, fileSystem, features, templateUri));
-            builder.Add(new OciArtifactRegistry(this.fileResolver, this.fileSystem, this.clientFactory, features, configuration, serviceProvider.GetRequiredService<IPublicRegistryModuleMetadataProvider>(), templateUri));
-            builder.Add(new TemplateSpecModuleRegistry(this.fileResolver, this.fileSystem, this.templateSpecRepositoryFactory, features, configuration, templateUri));
+            builder.Add(new LocalModuleRegistry(fileResolver, features, templateUri));
+            builder.Add(new OciArtifactRegistry(this.fileResolver, this.clientFactory, features, configuration, serviceProvider.GetRequiredService<IPublicRegistryModuleMetadataProvider>(), templateUri));
+            builder.Add(new TemplateSpecModuleRegistry(this.fileResolver, this.templateSpecRepositoryFactory, features, configuration, templateUri));
 
             return builder.ToImmutableArray();
         }

--- a/src/Bicep.Core/Registry/ExternalArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/ExternalArtifactRegistry.cs
@@ -19,12 +19,9 @@ namespace Bicep.Core.Registry
         // interval at which we will retry acquiring the lock on the artifact directory in the cache
         private static readonly TimeSpan ArtifactDirectoryContentionRetryInterval = TimeSpan.FromMilliseconds(300);
 
-        public IFileSystem FileSystem { get; }
-
-        protected ExternalArtifactRegistry(IFileResolver fileResolver, IFileSystem fileSystem)
+        protected ExternalArtifactRegistry(IFileResolver fileResolver)
         {
             this.FileResolver = fileResolver;
-            this.FileSystem = fileSystem;
         }
 
         protected IFileResolver FileResolver { get; }

--- a/src/Bicep.Core/Registry/ExternalArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/ExternalArtifactRegistry.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Tracing;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Registry
 {
@@ -17,6 +18,7 @@ namespace Bicep.Core.Registry
 
         // interval at which we will retry acquiring the lock on the artifact directory in the cache
         private static readonly TimeSpan ArtifactDirectoryContentionRetryInterval = TimeSpan.FromMilliseconds(300);
+
         public IFileSystem FileSystem { get; }
 
         protected ExternalArtifactRegistry(IFileResolver fileResolver, IFileSystem fileSystem)
@@ -29,17 +31,17 @@ namespace Bicep.Core.Registry
 
         protected abstract void WriteArtifactContentToCache(TArtifactReference reference, TArtifactEntity entity);
 
-        protected abstract string GetArtifactDirectoryPath(TArtifactReference reference);
+        protected abstract IDirectoryHandle GetArtifactDirectory(TArtifactReference reference);
 
-        protected abstract Uri GetArtifactLockFileUri(TArtifactReference reference);
+        protected abstract IFileHandle GetArtifactLockFile(TArtifactReference reference);
 
         protected async Task WriteArtifactContentToCacheAsync(TArtifactReference reference, TArtifactEntity entity)
         {
             // this has to be after downloading the artifact content so we don't create directories for non-existent artifacts
-            var artifactDirectoryPath = this.GetArtifactDirectoryPath(reference);
+            var artifactDirectory = this.GetArtifactDirectory(reference);
 
             // creating the directory doesn't require locking
-            CreateArtifactDirectory(artifactDirectoryPath);
+            CreateArtifactDirectory(artifactDirectory);
 
             /*
              * We have already downloaded the artifact content from the registry.
@@ -49,12 +51,12 @@ namespace Bicep.Core.Registry
              * We are not trying to prevent tampering with the artifact cache by the user.
              */
 
-            var lockFileUri = this.GetArtifactLockFileUri(reference);
+            var lockFile = this.GetArtifactLockFile(reference);
             var stopwatch = Stopwatch.StartNew();
 
             while (stopwatch.Elapsed < ArtifactDirectoryContentionTimeout)
             {
-                using (var @lock = this.FileResolver.TryAcquireFileLock(lockFileUri))
+                using (var @lock = lockFile.TryLock())
                 {
                     // the placement of "if" inside "using" guarantees that even an exception thrown by the condition results in the lock being released
                     // (current condition can't throw, but this potentially avoids future regression)
@@ -79,33 +81,32 @@ namespace Bicep.Core.Registry
             }
 
             // we have exceeded the timeout
-            throw new ExternalArtifactException($"Exceeded the timeout of \"{ArtifactDirectoryContentionTimeout}\" to acquire the lock on file \"{lockFileUri}\".");
+            throw new ExternalArtifactException($"Exceeded the timeout of \"{ArtifactDirectoryContentionTimeout}\" to acquire the lock on file \"{lockFile.Uri}\".");
         }
 
-        private void CreateArtifactDirectory(string artifactDirectoryPath)
+        private void CreateArtifactDirectory(IDirectoryHandle artifactDirectory)
         {
-            Debug.Assert(Path.IsPathFullyQualified(artifactDirectoryPath), $"Artifact directory must be fully qualified: \"{artifactDirectoryPath}\"");
             try
             {
                 // ensure that the directory exists
-                FileSystem.Directory.CreateDirectory(artifactDirectoryPath);
+                artifactDirectory.EnsureExists();
             }
             catch (Exception exception)
             {
-                throw new ExternalArtifactException($"Unable to create the local artifact directory \"{artifactDirectoryPath}\". {exception.Message}", exception);
+                throw new ExternalArtifactException($"Unable to create the local artifact directory \"{artifactDirectory.Uri}\". {exception.Message}", exception);
             }
         }
 
-        private void DeleteArtifactDirectory(string artifactDirectoryPath)
+        private void DeleteArtifactDirectory(IDirectoryHandle artifactDirectory)
         {
             try
             {
                 // recursively delete the directory
-                FileSystem.Directory.Delete(artifactDirectoryPath, true);
+                artifactDirectory.Delete();
             }
             catch (Exception exception)
             {
-                throw new ExternalArtifactException($"Unable to delete the local artifact directory \"{artifactDirectoryPath}\". {exception.Message}", exception);
+                throw new ExternalArtifactException($"Unable to delete the local artifact directory \"{artifactDirectory.Uri}\". {exception.Message}", exception);
             }
         }
 
@@ -118,18 +119,18 @@ namespace Bicep.Core.Registry
              * We are not trying to prevent tampering with the artifact cache by the user.
              */
 
-            var lockFileUri = this.GetArtifactLockFileUri(reference);
+            var lockFile = this.GetArtifactLockFile(reference);
             var stopwatch = Stopwatch.StartNew();
 
             while (stopwatch.Elapsed < ArtifactDirectoryContentionTimeout)
             {
-                if (!this.FileResolver.FileExists(lockFileUri))
+                if (!lockFile.Exists())
                 {
                     // no lock exists, proceed
-                    var artifactDirectoryPath = this.GetArtifactDirectoryPath(reference);
+                    var artifactDirectory = this.GetArtifactDirectory(reference);
 
                     // delete the directory and its contents on disk
-                    DeleteArtifactDirectory(artifactDirectoryPath);
+                    DeleteArtifactDirectory(artifactDirectory);
 
                     return;
                 }
@@ -141,7 +142,7 @@ namespace Bicep.Core.Registry
                         // saying there's a race condition on Linux with the DeleteOnClose flag on the FileStream.
                         // We will attempt to delete the file. If it throws, the lock is still open and will continue
                         // to wait until retry interval expires
-                        FileSystem.File.Delete(lockFileUri.LocalPath);
+                        lockFile.Delete();
                     }
                     catch (IOException) { break; }
                 }
@@ -152,7 +153,7 @@ namespace Bicep.Core.Registry
             }
 
             // we have exceeded the timeout
-            throw new ExternalArtifactException($"Exceeded the timeout of \"{ArtifactDirectoryContentionTimeout}\" for the lock on file \"{lockFileUri}\" to be released.");
+            throw new ExternalArtifactException($"Exceeded the timeout of \"{ArtifactDirectoryContentionTimeout}\" for the lock on file \"{lockFile.Uri}\" to be released.");
         }
 
         // base implementation for cache invalidation that should fit all external registries
@@ -165,7 +166,7 @@ namespace Bicep.Core.Registry
                 using var timer = new ExecutionTimer($"Delete artifact {reference.FullyQualifiedReference} from cache");
                 try
                 {
-                    if (FileSystem.Directory.Exists(GetArtifactDirectoryPath(reference)))
+                    if (GetArtifactDirectory(reference).Exists())
                     {
                         await this.TryDeleteArtifactDirectoryAsync(reference);
                     }

--- a/src/Bicep.Core/Registry/Oci/OciArtifactResult.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactResult.cs
@@ -10,17 +10,15 @@ namespace Bicep.Core.Registry.Oci
         // media types are case-insensitive (they are lowercase by convention only)
         public static readonly StringComparison MediaTypeComparison = StringComparison.OrdinalIgnoreCase;
 
-        public OciArtifactResult(BinaryData manifestBits, string manifestDigest, IEnumerable<OciArtifactLayer> layers)
+        public OciArtifactResult(BinaryData manifestData, string manifestDigest, IEnumerable<OciArtifactLayer> layers)
         {
-            this.manifestBits = manifestBits;
-            this.Manifest = OciManifest.FromBinaryData(manifestBits) ?? throw new InvalidArtifactException("Unable to deserialize OCI manifest");
+            this.ManifestData = manifestData;
+            this.Manifest = OciManifest.FromBinaryData(manifestData) ?? throw new InvalidArtifactException("Unable to deserialize OCI manifest");
             this.ManifestDigest = manifestDigest;
             this.Layers = layers.ToImmutableArray();
         }
 
-        private readonly BinaryData manifestBits;
-
-        public Stream ToStream() => manifestBits.ToStream();
+        public BinaryData ManifestData { get; }
 
         public OciManifest Manifest { get; init; }
 

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -39,13 +39,12 @@ namespace Bicep.Core.Registry
 
         public OciArtifactRegistry(
             IFileResolver FileResolver,
-            IFileSystem fileSystem,
             IContainerRegistryClientFactory clientFactory,
             IFeatureProvider features,
             RootConfiguration configuration,
             IPublicRegistryModuleMetadataProvider publicRegistryModuleMetadataProvider,
             Uri parentModuleUri)
-            : base(FileResolver, fileSystem)
+            : base(FileResolver)
         {
             this.cacheDirectory = features.CacheRootDirectory.GetDirectory(ArtifactReferenceSchemes.Oci);
             this.client = new AzureContainerRegistryManager(clientFactory);
@@ -434,11 +433,7 @@ namespace Bicep.Core.Registry
 
                     var file = this.GetArtifactFile(reference, ArtifactFileType.ExtensionBinary);
                     sourceData.WriteTo(file);
-
-                    if (!OperatingSystem.IsWindows())
-                    {
-                        file.SetUnixFileMode(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-                    }
+                    file.MakeExecutable();
                 }
             }
 

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -18,6 +18,7 @@ using Bicep.Core.Semantics;
 using Bicep.Core.SourceCode;
 using Bicep.Core.Tracing;
 using Bicep.Core.Utils;
+using Bicep.IO.Abstraction;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace Bicep.Core.Registry
@@ -26,7 +27,7 @@ namespace Bicep.Core.Registry
     {
         private readonly AzureContainerRegistryManager client;
 
-        private readonly string cachePath;
+        private readonly IDirectoryHandle cacheDirectory;
 
         private readonly RootConfiguration configuration;
 
@@ -46,7 +47,7 @@ namespace Bicep.Core.Registry
             Uri parentModuleUri)
             : base(FileResolver, fileSystem)
         {
-            this.cachePath = FileSystem.Path.Combine(features.CacheRootDirectory, ArtifactReferenceSchemes.Oci);
+            this.cacheDirectory = features.CacheRootDirectory.GetDirectory(ArtifactReferenceSchemes.Oci);
             this.client = new AzureContainerRegistryManager(clientFactory);
             this.configuration = configuration;
             this.features = features;
@@ -56,7 +57,7 @@ namespace Bicep.Core.Registry
 
         public override string Scheme => ArtifactReferenceSchemes.Oci;
 
-        public string CacheRootDirectory => this.features.CacheRootDirectory;
+        public IDirectoryHandle CacheRootDirectory => this.features.CacheRootDirectory;
 
         public override RegistryCapabilities GetCapabilities(ArtifactType artifactType, OciArtifactReference reference)
         {
@@ -90,14 +91,14 @@ namespace Bicep.Core.Registry
 
             var artifactFilesNotFound = reference.Type switch
             {
-                ArtifactType.Module => !this.FileResolver.FileExists(this.GetArtifactFileUri(reference, ArtifactFileType.ModuleMain)),
-                ArtifactType.Extension => !this.FileResolver.FileExists(this.GetArtifactFileUri(reference, ArtifactFileType.Extension)),
+                ArtifactType.Module => !this.GetArtifactFile(reference, ArtifactFileType.ModuleMain).Exists(),
+                ArtifactType.Extension => !this.GetArtifactFile(reference, ArtifactFileType.Extension).Exists(),
                 _ => throw new UnreachableException()
             };
 
             return artifactFilesNotFound ||
-                !this.FileResolver.FileExists(this.GetArtifactFileUri(reference, ArtifactFileType.Manifest)) ||
-                !this.FileResolver.FileExists(this.GetArtifactFileUri(reference, ArtifactFileType.Metadata));
+                !this.GetArtifactFile(reference, ArtifactFileType.Manifest).Exists() ||
+                !this.GetArtifactFile(reference, ArtifactFileType.Metadata).Exists();
         }
 
         public override async Task<bool> CheckArtifactExists(ArtifactType artifactType, OciArtifactReference reference)
@@ -146,8 +147,8 @@ namespace Bicep.Core.Registry
                 _ => throw new UnreachableException()
             };
 
-            var localUri = this.GetArtifactFileUri(reference, artifactFileType);
-            return new(localUri);
+            var file = this.GetArtifactFile(reference, artifactFileType);
+            return new(file.Uri.ToUri());
         }
 
         public override string? TryGetDocumentationUri(OciArtifactReference ociArtifactModuleReference)
@@ -189,17 +190,18 @@ namespace Bicep.Core.Registry
 
         private OciManifest GetCachedManifest(OciArtifactReference ociArtifactModuleReference)
         {
-            string manifestFilePath = this.GetArtifactFilePath(ociArtifactModuleReference, ArtifactFileType.Manifest);
+            var manifestFile = this.GetArtifactFile(ociArtifactModuleReference, ArtifactFileType.Manifest);
 
             try
             {
-                string manifestFileContents = FileSystem.File.ReadAllText(manifestFilePath);
-                var manifest = JsonSerializer.Deserialize(manifestFileContents, OciManifestSerializationContext.Default.OciManifest);
-                return manifest ?? throw new Exception($"Deserialization of cached manifest \"{manifestFilePath}\" failed");
+                using var manifestFileStream = manifestFile.OpenRead();
+                var manifest = JsonSerializer.Deserialize(manifestFileStream, OciManifestSerializationContext.Default.OciManifest);
+
+                return manifest ?? throw new Exception($"Deserialization of cached manifest \"{manifestFile.Uri}\" failed");
             }
             catch (Exception ex)
             {
-                throw new ExternalArtifactException($"Could not retrieve artifact manifest from \"{manifestFilePath}\"", ex);
+                throw new ExternalArtifactException($"Could not retrieve artifact manifest from \"{manifestFile.Uri}\"", ex);
             }
         }
 
@@ -229,7 +231,7 @@ namespace Bicep.Core.Registry
             // CONSIDER: Run these in parallel
             foreach (var reference in referencesEvaluated)
             {
-                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectoryPath(reference)}");
+                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference)}");
                 var (result, errorMessage) = await this.TryRestoreArtifactAsync(configuration, reference);
 
                 if (result is null)
@@ -373,9 +375,8 @@ namespace Bicep.Core.Registry
             // write manifest
             // it's important to write the original stream here rather than serialize the manifest object
             // this way we guarantee the manifest hash will match
-            var manifestFileUri = this.GetArtifactFileUri(reference, ArtifactFileType.Manifest);
-            using var manifestStream = result.ToStream();
-            this.FileResolver.Write(manifestFileUri, manifestStream);
+            var manifestFile = this.GetArtifactFile(reference, ArtifactFileType.Manifest);
+            result.ManifestData.WriteTo(manifestFile);
 
             // write data file
             var mainLayer = result.GetMainLayer();
@@ -392,8 +393,7 @@ namespace Bicep.Core.Registry
                 _ => throw new InvalidOperationException($"Unexpected artifact type \"{result.GetType().Name}\"."),
             };
 
-            using var dataStream = mainLayer.Data.ToStream();
-            this.FileResolver.Write(this.GetArtifactFileUri(reference, moduleFileType), dataStream);
+            mainLayer.Data.WriteTo(this.GetArtifactFile(reference, moduleFileType));
 
             if (result is OciModuleArtifactResult moduleArtifact)
             {
@@ -407,7 +407,7 @@ namespace Bicep.Core.Registry
                     //   info on disk and can handle the layer data as they want to.
                     // The manifest can be used to determine what's in each layer file.
                     //  (https://github.com/Azure/bicep/issues/11900)
-                    this.FileResolver.Write(this.GetArtifactFileUri(reference, ArtifactFileType.Source), sourceData.ToStream());
+                    sourceData.WriteTo(this.GetArtifactFile(reference, ArtifactFileType.Source));
                 }
             }
 
@@ -432,12 +432,12 @@ namespace Bicep.Core.Registry
                         throw new InvalidOperationException($"The extension \"{reference}\" does not support architecture {architecture.Name}.");
                     }
 
-                    using var binaryStream = sourceData.ToStream();
-                    var binaryUri = this.GetArtifactFileUri(reference, ArtifactFileType.ExtensionBinary);
-                    this.FileResolver.Write(binaryUri, binaryStream);
+                    var file = this.GetArtifactFile(reference, ArtifactFileType.ExtensionBinary);
+                    sourceData.WriteTo(file);
+
                     if (!OperatingSystem.IsWindows())
                     {
-                        this.FileSystem.File.SetUnixFileMode(binaryUri.LocalPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+                        file.SetUnixFileMode(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
                     }
                 }
             }
@@ -447,10 +447,11 @@ namespace Bicep.Core.Registry
             using var metadataStream = new MemoryStream();
             OciSerialization.Serialize(metadataStream, metadata);
             metadataStream.Position = 0;
-            this.FileResolver.Write(this.GetArtifactFileUri(reference, ArtifactFileType.Metadata), metadataStream);
+
+            metadataStream.WriteTo(this.GetArtifactFile(reference, ArtifactFileType.Metadata));
         }
 
-        protected override string GetArtifactDirectoryPath(OciArtifactReference reference)
+        protected override IDirectoryHandle GetArtifactDirectory(OciArtifactReference reference)
         {
             // cachePath is already set to %userprofile%\.bicep\br or ~/.bicep/br by default depending on OS
             // we need to split each component of the reference into a sub directory to fit within the max file name length limit on linux and mac
@@ -487,10 +488,10 @@ namespace Bicep.Core.Registry
                 throw new InvalidOperationException("Module reference is missing both tag and digest.");
             }
 
-            return FileSystem.Path.Combine(this.cachePath, registry, repository, tagOrDigest);
+            return this.cacheDirectory.GetDirectory($"{registry}/{repository}/{tagOrDigest}");
         }
 
-        protected override Uri GetArtifactLockFileUri(OciArtifactReference reference) => this.GetArtifactFileUri(reference, ArtifactFileType.Lock);
+        protected override IFileHandle GetArtifactLockFile(OciArtifactReference reference) => this.GetArtifactFile(reference, ArtifactFileType.Lock);
 
         private async Task<(OciArtifactResult?, string? errorMessage)> TryRestoreArtifactAsync(RootConfiguration configuration, OciArtifactReference reference)
         {
@@ -527,18 +528,7 @@ namespace Bicep.Core.Registry
         private static bool CheckAllInnerExceptionsAreRequestFailures(AggregateException exception) =>
             exception.InnerExceptions.All(inner => inner is RequestFailedException);
 
-        private Uri GetArtifactFileUri(OciArtifactReference reference, ArtifactFileType fileType)
-        {
-            string localFilePath = this.GetArtifactFilePath(reference, fileType);
-            if (Uri.TryCreate(localFilePath, UriKind.Absolute, out var uri))
-            {
-                return uri;
-            }
-
-            throw new NotImplementedException($"Local artifact file path is malformed: \"{localFilePath}\"");
-        }
-
-        private string GetArtifactFilePath(OciArtifactReference reference, ArtifactFileType fileType)
+        private IFileHandle GetArtifactFile(OciArtifactReference reference, ArtifactFileType fileType)
         {
             var fileName = fileType switch
             {
@@ -552,15 +542,17 @@ namespace Bicep.Core.Registry
                 _ => throw new NotImplementedException($"Unexpected artifact file type '{fileType}'.")
             };
 
-            return FileSystem.Path.Combine(this.GetArtifactDirectoryPath(reference), fileName);
+            return this.GetArtifactDirectory(reference).GetFile(fileName);
         }
 
         public override ResultWithException<SourceArchive> TryGetSource(OciArtifactReference reference)
         {
-            var zipPath = GetArtifactFilePath(reference, ArtifactFileType.Source);
-            if (FileSystem.File.Exists(zipPath))
+            var sourceFile = GetArtifactFile(reference, ArtifactFileType.Source);
+            if (sourceFile.Exists())
             {
-                return SourceArchive.UnpackFromStream(FileSystem.File.OpenRead(zipPath));
+                using var sourceStream = sourceFile.OpenRead();
+
+                return SourceArchive.UnpackFromStream(sourceStream);
             }
 
             // No sources available (presumably they weren't published)
@@ -568,7 +560,7 @@ namespace Bicep.Core.Registry
         }
 
         public override Uri? TryGetExtensionBinary(OciArtifactReference reference)
-            => GetArtifactFileUri(reference, ArtifactFileType.ExtensionBinary);
+            => GetArtifactFile(reference, ArtifactFileType.ExtensionBinary).Uri.ToUri();
 
         private enum ArtifactFileType
         {

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -27,8 +27,8 @@ namespace Bicep.Core.Registry
 
         private readonly Uri parentModuleUri;
 
-        public TemplateSpecModuleRegistry(IFileResolver fileResolver, IFileSystem fileSystem, ITemplateSpecRepositoryFactory repositoryFactory, IFeatureProvider featureProvider, RootConfiguration configuration, Uri parentModuleUri)
-            : base(fileResolver, fileSystem)
+        public TemplateSpecModuleRegistry(IFileResolver fileResolver, ITemplateSpecRepositoryFactory repositoryFactory, IFeatureProvider featureProvider, RootConfiguration configuration, Uri parentModuleUri)
+            : base(fileResolver)
         {
             this.repositoryFactory = repositoryFactory;
             this.featureProvider = featureProvider;

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Semantics;
 using Bicep.Core.SourceCode;
 using Bicep.Core.Tracing;
 using Bicep.Core.Utils;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Registry
 {
@@ -54,7 +55,7 @@ namespace Bicep.Core.Registry
         }
 
         public override bool IsArtifactRestoreRequired(TemplateSpecModuleReference reference) =>
-            !this.FileResolver.FileExists(this.GetModuleEntryPointUri(reference));
+            !this.GetModuleEntryPointFile(reference).Exists();
 
         public override Task PublishModule(TemplateSpecModuleReference reference, BinaryData compiled, BinaryData? bicepSources, string? documentationUri, string? description)
             => throw new NotSupportedException("Template Spec modules cannot be published.");
@@ -67,7 +68,7 @@ namespace Bicep.Core.Registry
 
         public override ResultWithDiagnosticBuilder<Uri> TryGetLocalArtifactEntryPointUri(TemplateSpecModuleReference reference)
         {
-            var localUri = this.GetModuleEntryPointUri(reference);
+            var localUri = this.GetModuleEntryPointFile(reference).Uri.ToUri();
             return new(localUri);
         }
 
@@ -77,7 +78,7 @@ namespace Bicep.Core.Registry
 
             foreach (var reference in references)
             {
-                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectoryPath(reference)}");
+                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference)}");
                 try
                 {
                     var repository = this.repositoryFactory.CreateRepository(configuration, reference.SubscriptionId);
@@ -109,21 +110,14 @@ namespace Bicep.Core.Registry
         }
 
         protected override void WriteArtifactContentToCache(TemplateSpecModuleReference reference, TemplateSpecEntity entity) =>
-            FileSystem.File.WriteAllText(this.GetModuleEntryPointPath(reference), entity.Content);
+            this.GetModuleEntryPointFile(reference).WriteAllText(entity.Content);
 
-        protected override string GetArtifactDirectoryPath(TemplateSpecModuleReference reference) => FileSystem.Path.Combine(
-            this.featureProvider.CacheRootDirectory,
-            this.Scheme,
-            reference.SubscriptionId.ToLowerInvariant(),
-            reference.ResourceGroupName.ToLowerInvariant(),
-            reference.TemplateSpecName.ToLowerInvariant(),
-            reference.Version.ToLowerInvariant());
+        protected override IDirectoryHandle GetArtifactDirectory(TemplateSpecModuleReference reference) => this.featureProvider.CacheRootDirectory.GetDirectory(
+            $"{this.Scheme}/{reference.SubscriptionId}/{reference.ResourceGroupName}/{reference.TemplateSpecName}/{reference.Version}".ToLowerInvariant());
 
-        protected override Uri GetArtifactLockFileUri(TemplateSpecModuleReference reference) => new(FileSystem.Path.Combine(this.GetArtifactDirectoryPath(reference), "lock"), UriKind.Absolute);
+        protected override IFileHandle GetArtifactLockFile(TemplateSpecModuleReference reference) => this.GetArtifactDirectory(reference).GetFile("lock");
 
-        private string GetModuleEntryPointPath(TemplateSpecModuleReference reference) => FileSystem.Path.Combine(this.GetArtifactDirectoryPath(reference), "main.json");
-
-        private Uri GetModuleEntryPointUri(TemplateSpecModuleReference reference) => new(this.GetModuleEntryPointPath(reference), UriKind.Absolute);
+        private IFileHandle GetModuleEntryPointFile(TemplateSpecModuleReference reference) => this.GetArtifactDirectory(reference).GetFile("main.json");
 
         public override async Task<IDictionary<ArtifactReference, DiagnosticBuilder.DiagnosticBuilderDelegate>> InvalidateArtifactsCache(IEnumerable<TemplateSpecModuleReference> references)
         {

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -988,7 +988,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -1576,7 +1576,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -1576,7 +1576,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -983,7 +983,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.IO.UnitTests/packages.lock.json
+++ b/src/Bicep.IO.UnitTests/packages.lock.json
@@ -203,10 +203,23 @@
           "TestableIO.System.IO.Abstractions.Wrappers": "21.1.3"
         }
       },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ==",
+        "dependencies": {
+          "System.Text.Json": "6.0.0"
+        }
+      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "1.6.0",
         "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -225,6 +238,23 @@
         "dependencies": {
           "System.Security.AccessControl": "6.0.0",
           "System.Windows.Extensions": "6.0.0"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0"
         }
       },
       "System.Windows.Extensions": {
@@ -260,7 +290,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },
@@ -287,6 +318,14 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Windows.Extensions": {
         "type": "Transitive",
@@ -321,6 +360,14 @@
         "resolved": "6.0.0",
         "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Windows.Extensions": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -353,6 +400,14 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Windows.Extensions": {
         "type": "Transitive",
@@ -387,6 +442,14 @@
         "resolved": "6.0.0",
         "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Windows.Extensions": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -419,6 +482,14 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Windows.Extensions": {
         "type": "Transitive",
@@ -453,6 +524,14 @@
         "resolved": "6.0.0",
         "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
       "System.Windows.Extensions": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -485,6 +564,14 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "System.Windows.Extensions": {
         "type": "Transitive",

--- a/src/Bicep.IO/Abstraction/IDirectoryHandle.cs
+++ b/src/Bicep.IO/Abstraction/IDirectoryHandle.cs
@@ -11,7 +11,9 @@ namespace Bicep.IO.Abstraction
 {
     public interface IDirectoryHandle : IIOHandle
     {
-        void EnsureExists();
+        IDirectoryHandle EnsureExists();
+
+        void Delete();
 
         IDirectoryHandle? GetParent();
 

--- a/src/Bicep.IO/Abstraction/IFileHandle.cs
+++ b/src/Bicep.IO/Abstraction/IFileHandle.cs
@@ -22,8 +22,7 @@ namespace Bicep.IO.Abstraction
 
         void Delete();
 
-        [UnsupportedOSPlatform("windows")]
-        void SetUnixFileMode(UnixFileMode fileMode);
+        void MakeExecutable();
 
         IFileLock? TryLock();
     }

--- a/src/Bicep.IO/Abstraction/IFileHandle.cs
+++ b/src/Bicep.IO/Abstraction/IFileHandle.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -13,9 +14,16 @@ namespace Bicep.IO.Abstraction
     {
         IDirectoryHandle GetParent();
 
+        IFileHandle EnsureExists();
+
         Stream OpenRead();
 
         Stream OpenWrite();
+
+        void Delete();
+
+        [UnsupportedOSPlatform("windows")]
+        void SetUnixFileMode(UnixFileMode fileMode);
 
         IFileLock? TryLock();
     }

--- a/src/Bicep.IO/Abstraction/IFileHandleReadWriteExtensions.cs
+++ b/src/Bicep.IO/Abstraction/IFileHandleReadWriteExtensions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bicep.IO.Abstraction
+{
+    public static class IFileHandleReadWriteExtensions
+    {
+        public static void WriteTo(this BinaryData binaryData, IFileHandle fileHandle)
+        {
+            using var dataStream = binaryData.ToStream();
+            using var fileStream = fileHandle.OpenWrite();
+            dataStream.CopyTo(fileStream);
+        }
+
+        public static void WriteTo(this Stream stream, IFileHandle fileHandle)
+        {
+            using var fileStream = fileHandle.OpenWrite();
+            stream.CopyTo(fileStream);
+        }
+
+        public static void WriteAllText(this IFileHandle fileHandle, string content)
+        {
+            using var fileStream = fileHandle.OpenWrite();
+            using var writer = new StreamWriter(fileStream);
+
+            writer.Write(content);
+        }
+
+        public static string ReadAllText(this IFileHandle fileHandle)
+        {
+            using var fileStream = fileHandle.OpenRead();
+            using var reader = new StreamReader(fileStream);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/src/Bicep.IO/Abstraction/IOUri.cs
+++ b/src/Bicep.IO/Abstraction/IOUri.cs
@@ -24,7 +24,7 @@ namespace Bicep.IO.Abstraction
     {
         public static class GlobalSettings
         {
-            public static bool LocalFilePathCaseSensitive { get; set; } = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            public static bool LocalFilePathCaseSensitive { get; set; } = OperatingSystem.IsLinux();
 
             public static StringComparer LocalFilePathComparer => LocalFilePathCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 

--- a/src/Bicep.IO/Abstraction/IOUri.cs
+++ b/src/Bicep.IO/Abstraction/IOUri.cs
@@ -60,6 +60,19 @@ namespace Bicep.IO.Abstraction
 
         public static implicit operator string(IOUri identifier) => identifier.ToString();
 
+        public static IOUri FromLocalFilePath(string localFilePath)
+        {
+            var fileUri = new Uri(new Uri("file://"), localFilePath);
+            var path = Uri.UnescapeDataString(fileUri.AbsolutePath);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !fileUri.AbsolutePath.StartsWith('/'))
+            {
+                path = "/" + path;
+            }
+
+            return new IOUri(IOUriScheme.File, "", path);
+        }
+
         public override string ToString() => this.TryGetLocalFilePath() ?? this.ToUriString();
 
         // See: The "file" URI Scheme (https://datatracker.ietf.org/doc/html/rfc8089).
@@ -67,7 +80,16 @@ namespace Bicep.IO.Abstraction
         public string? TryGetLocalFilePath() => this.IsLocalFile ? new UriBuilder { Scheme = this.Scheme, Host = "", Path = Path }.Uri.LocalPath : null;
 
         // See: Uniform Resource Identifier (URI): Generic Syntax (https://datatracker.ietf.org/doc/html/rfc3986).
-        public string ToUriString() => this.Authority is null ? $"{Scheme}:{Path}" : $"{Scheme}://{Authority}{Path}";
+        public string ToUriString()
+        {
+            var escapedSegments = Path.Split('/').Select(Uri.EscapeDataString);
+            var excapedPath = string.Join('/', escapedSegments);
+
+            return this.Authority is null ? $"{Scheme}:{Uri.EscapeDataString(Path)}" : $"{Scheme}://{Authority}{Path}";
+        }
+
+        // TODO: Remove after file abstractio migration is complete.
+        public Uri ToUri() => new UriBuilder { Scheme = this.Scheme, Host = "", Path = Path }.Uri;
 
         public static bool operator ==(IOUri left, IOUri right) => left.Equals(right);
 

--- a/src/Bicep.IO/Bicep.IO.csproj
+++ b/src/Bicep.IO/Bicep.IO.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.IO.Abstractions" Version="21.1.3" />
+    <PackageReference Include="System.Memory.Data" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Bicep.IO/FileSystem/FileSystemDirectoryHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemDirectoryHandle.cs
@@ -21,7 +21,14 @@ namespace Bicep.IO.FileSystem
 
         public override bool Exists() => this.FileSystem.Directory.Exists(Uri.GetFileSystemPath());
 
-        public void EnsureExists() => this.FileSystem.Directory.CreateDirectory(this.Uri.GetFileSystemPath());
+        public IDirectoryHandle EnsureExists()
+        {
+            this.FileSystem.Directory.CreateDirectory(this.Uri.GetFileSystemPath());
+
+            return this;
+        }
+
+        public void Delete() => this.FileSystem.Directory.Delete(this.Uri.GetFileSystemPath(), recursive: true);
 
         public IDirectoryHandle GetDirectory(string relativePath)
         {

--- a/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection.Metadata;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
 using Bicep.IO.Abstraction;
@@ -20,11 +21,20 @@ namespace Bicep.IO.FileSystem
         {
         }
 
-        public override bool Exists() => this.FileSystem.File.Exists(Uri.GetFileSystemPath());
+        public override bool Exists() => this.FileSystem.File.Exists(this.Uri.GetFileSystemPath());
+
+        public IFileHandle EnsureExists()
+        {
+            using (this.FileSystem.File.Open(this.Uri.GetFileSystemPath(), FileMode.Append, FileAccess.Write))
+            {
+            }
+
+            return this;
+        }
 
         public IDirectoryHandle GetParent()
         {
-            var parentDirectoryPath = this.FileSystem.Path.GetDirectoryName(Uri.GetFileSystemPath());
+            var parentDirectoryPath = this.FileSystem.Path.GetDirectoryName(this.Uri.GetFileSystemPath());
 
             if (string.IsNullOrEmpty(parentDirectoryPath))
             {
@@ -34,15 +44,20 @@ namespace Bicep.IO.FileSystem
             return new FileSystemDirectoryHandle(this.FileSystem, parentDirectoryPath);
         }
 
-        public Stream OpenRead() => this.FileSystem.File.OpenRead(Uri.GetFileSystemPath());
+        public Stream OpenRead() => this.FileSystem.File.OpenRead(this.Uri.GetFileSystemPath());
 
         public Stream OpenWrite()
         {
             this.GetParent().EnsureExists();
 
-            return this.FileSystem.File.OpenWrite(Uri.GetFileSystemPath());
+            return this.FileSystem.File.OpenWrite(this.Uri.GetFileSystemPath());
         }
 
-        public IFileLock? TryLock() => FileSystemStreamLock.TryCreate(this.FileSystem, Uri.GetFileSystemPath());
+        public void Delete() => this.FileSystem.File.Delete(this.Uri.GetFileSystemPath());
+
+        [UnsupportedOSPlatform("windows")]
+        public void SetUnixFileMode(UnixFileMode fileMode) => this.FileSystem.File.SetUnixFileMode(this.Uri.GetFileSystemPath(), fileMode);
+
+        public IFileLock? TryLock() => FileSystemStreamLock.TryCreate(this.FileSystem, this.Uri.GetFileSystemPath());
     }
 }

--- a/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
@@ -55,8 +55,13 @@ namespace Bicep.IO.FileSystem
 
         public void Delete() => this.FileSystem.File.Delete(this.Uri.GetFileSystemPath());
 
-        [UnsupportedOSPlatform("windows")]
-        public void SetUnixFileMode(UnixFileMode fileMode) => this.FileSystem.File.SetUnixFileMode(this.Uri.GetFileSystemPath(), fileMode);
+        public void MakeExecutable()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                this.FileSystem.File.SetUnixFileMode(this.Uri.GetFileSystemPath(), UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
 
         public IFileLock? TryLock() => FileSystemStreamLock.TryCreate(this.FileSystem, this.Uri.GetFileSystemPath());
     }

--- a/src/Bicep.IO/FileSystem/FileSystemIOHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemIOHandle.cs
@@ -17,7 +17,7 @@ namespace Bicep.IO.FileSystem
     public abstract class FileSystemIOHandle : IIOHandle
     {
         protected FileSystemIOHandle(IFileSystem fileSystem, string fileSystemPath)
-            : this(fileSystem, CreateIdentifier(fileSystem, fileSystemPath))
+            : this(fileSystem, CreateUri(fileSystem, fileSystemPath))
         {
         }
 
@@ -47,7 +47,7 @@ namespace Bicep.IO.FileSystem
             return this.GetType() == other.GetType() && Uri == other.Uri;
         }
 
-        private static IOUri CreateIdentifier(IFileSystem fileSystem, string fileSystemPath)
+        private static IOUri CreateUri(IFileSystem fileSystem, string fileSystemPath)
         {
             FileSystemPathException.ThrowIfWhiteSpace(fileSystemPath);
             FileSystemPathException.ThrowIfUnsupportedWindowsDosDevicePath(fileSystemPath);

--- a/src/Bicep.IO/packages.lock.json
+++ b/src/Bicep.IO/packages.lock.json
@@ -40,6 +40,15 @@
           "TestableIO.System.IO.Abstractions.Wrappers": "21.1.3"
         }
       },
+      "System.Memory.Data": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "ntFHArH3I4Lpjf5m4DCXQHJuGwWPNVJPaAvM95Jy/u+2Yzt2ryiyIN04LAogkjP9DeRcEOiviAjQotfmPq/FrQ==",
+        "dependencies": {
+          "System.Text.Json": "6.0.0"
+        }
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -49,6 +58,28 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0"
+        }
       },
       "TestableIO.System.IO.Abstractions": {
         "type": "Transitive",
@@ -64,12 +95,75 @@
         }
       }
     },
-    "net8.0/linux-arm64": {},
-    "net8.0/linux-musl-x64": {},
-    "net8.0/linux-x64": {},
-    "net8.0/osx-arm64": {},
-    "net8.0/osx-x64": {},
-    "net8.0/win-arm64": {},
-    "net8.0/win-x64": {}
+    "net8.0/linux-arm64": {
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    },
+    "net8.0/linux-musl-x64": {
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    },
+    "net8.0/linux-x64": {
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    },
+    "net8.0/osx-arm64": {
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    },
+    "net8.0/osx-x64": {
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    },
+    "net8.0/win-arm64": {
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    },
+    "net8.0/win-x64": {
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      }
+    }
   }
 }

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -17,6 +17,7 @@ using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
+using Bicep.IO.Abstraction;
 using Bicep.LangServer.IntegrationTests.Assertions;
 using Bicep.LangServer.IntegrationTests.Extensions;
 using Bicep.LangServer.IntegrationTests.Helpers;
@@ -1203,9 +1204,10 @@ AzureMetrics
             return bicepCompilationManager.Object;
         }
 
-        private IFeatureProviderFactory GetFeatureProviderFactory(Uri uri, string rootDirectory)
+        private IFeatureProviderFactory GetFeatureProviderFactory(Uri uri, string rootDirectoryPath)
         {
             var features = StrictMock.Of<IFeatureProvider>();
+            var rootDirectory = BicepTestConstants.FileExplorer.GetDirectory(IOUri.FromLocalFilePath(rootDirectoryPath));
             features.Setup(m => m.CacheRootDirectory).Returns(rootDirectory);
 
             var featureProviderFactory = StrictMock.Of<IFeatureProviderFactory>();

--- a/src/Bicep.LangServer.IntegrationTests/LangServerScenarioTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/LangServerScenarioTests.cs
@@ -74,11 +74,11 @@ param foo: string
                 source,
                 publishSource: false);
 
-        var cacheRootPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+        var cacheRoot = FileHelper.GetCacheRootDirectory(TestContext);
         var helper = await MultiFileLanguageServerHelper.StartLanguageServer(
             TestContext,
             services => services
-                .WithFeatureOverrides(new(CacheRootDirectory: cacheRootPath))
+                .WithFeatureOverrides(new(CacheRootDirectory: cacheRoot))
                 .WithContainerRegistryClientFactory(clientFactory)
                 .AddSingleton<IModuleRestoreScheduler, ModuleRestoreScheduler>());
 

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -1598,7 +1598,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -424,7 +424,7 @@ output length int =
             var serviceWithGraph = new ServiceBuilder().WithFeatureOverrides(featureOverrides);
 
             var compilationWithMSGraph = serviceWithGraph.BuildCompilation(contents);
-            var features = new OverriddenFeatureProvider(new FeatureProvider(BicepTestConstants.BuiltInConfiguration), featureOverrides);
+            var features = new OverriddenFeatureProvider(new FeatureProvider(BicepTestConstants.BuiltInConfiguration, BicepTestConstants.FileExplorer), featureOverrides);
             var completionsWithMSGraph = await completionProvider.GetFilteredCompletions(compilationWithMSGraph, BicepCompletionContext.Create(features, compilationWithMSGraph, cursor), CancellationToken.None);
 
             completionsWithMSGraph.Should().Contain(c => c.Label.Contains("microsoftGraph"));

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -1607,7 +1607,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -1401,7 +1401,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
@@ -1586,7 +1586,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Local.Deploy/packages.lock.json
+++ b/src/Bicep.Local.Deploy/packages.lock.json
@@ -1270,7 +1270,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.Local.Extension.Mock/packages.lock.json
+++ b/src/Bicep.Local.Extension.Mock/packages.lock.json
@@ -1059,7 +1059,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -1811,7 +1811,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -1805,7 +1805,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -1811,7 +1811,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -1219,7 +1219,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -1683,7 +1683,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       },
       "bicep.langserver": {

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -1084,7 +1084,8 @@
       "bicep.io": {
         "type": "Project",
         "dependencies": {
-          "System.IO.Abstractions": "[21.1.3, )"
+          "System.IO.Abstractions": "[21.1.3, )",
+          "System.Memory.Data": "[6.0.0, )"
         }
       }
     },


### PR DESCRIPTION
As part of the ongoing file I/O abstraction migration, this PR removes `IFileResolver.TryAcquireFileLock` and transitions it to the new file I/O API. The updates, including changes to `IFeatureProvider`, `*ArtifactRegistry`, and several related tests, are inevitable side effects of what initially seemed like a straightforward update.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15826)