### PR TITLE
Fix unhandled exception in import closure calculation

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1590,7 +1591,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1591,7 +1591,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1624,7 +1624,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1462,7 +1463,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1463,7 +1463,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1496,7 +1496,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -134,8 +134,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -147,19 +147,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -169,20 +169,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -223,12 +223,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1355,7 +1355,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1388,7 +1388,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -134,13 +134,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -168,10 +169,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -222,12 +223,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1354,7 +1355,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1509,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1510,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1543,7 +1543,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1509,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1510,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1543,7 +1543,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -169,13 +169,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -203,10 +204,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -257,12 +258,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1515,7 +1516,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -169,8 +169,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -182,19 +182,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -204,20 +204,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -258,12 +258,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1516,7 +1516,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1549,7 +1549,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Semver" Version="3.0.0" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="Azure.Deployments.Templates" Version="1.223.0" />
+    <PackageReference Include="Azure.Deployments.Templates" Version="1.224.0" />
     <PackageReference Include="Azure.Bicep.Types" Version="0.5.110" />
     <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.727" />
     <PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.644" />

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Bicep.Core</AssemblyName>
     <RootNamespace>Bicep.Core</RootNamespace>
@@ -40,7 +40,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Semver" Version="3.0.0" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="Azure.Deployments.Templates" Version="1.195.0" />
+    <PackageReference Include="Azure.Deployments.Templates" Version="1.223.0" />
     <PackageReference Include="Azure.Bicep.Types" Version="0.5.110" />
     <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.727" />
     <PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.644" />

--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmTemplateHelpers.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmTemplateHelpers.cs
@@ -1,24 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Azure.Deployments.Core.Definitions.Schema;
+using Azure.Deployments.Templates.Engines;
 
 namespace Bicep.Core.Emit.CompileTimeImports;
 
 internal static class ArmTemplateHelpers
 {
-    private const string ArmTypeRefPrefix = "#/definitions/";
-
     internal static ITemplateSchemaNode DereferenceArmType(SchemaValidationContext context, string typePointer)
     {
-        // TODO make LocalSchemaRefResolver in Azure.Deployments.Templates public
-        if (!typePointer.StartsWith(ArmTypeRefPrefix) ||
-            typePointer[ArmTypeRefPrefix.Length..].Contains('/') ||
-            context.Definitions is null ||
-            !context.Definitions.TryGetValue(typePointer[ArmTypeRefPrefix.Length..], out var typeDefinition))
+        if (LocalSchemaRefResolver.ResolveLocalReference(context, typePointer, out var node, out var failureMessage))
         {
-            throw new InvalidOperationException($"Invalid ARM template type reference ({typePointer}) encountered");
+            return node;
         }
 
-        return typeDefinition;
+        throw new InvalidOperationException($"Invalid ARM template type reference ({typePointer}) encountered: {failureMessage}");
     }
 }

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -53,13 +53,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Direct",
-        "requested": "[1.223.0, )",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "requested": "[1.224.0, )",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -280,8 +280,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -293,10 +293,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -53,13 +53,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Direct",
-        "requested": "[1.195.0, )",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "requested": "[1.223.0, )",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -280,22 +280,23 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -699,11 +700,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "8.0.1",
+        "contentHash": "vaoWjvkG1aenR2XdjaVivlCV9fADfgyhW5bZtXT23qaEea0lWiUljdQuze4E31vKM7ZWJaSUsbYIKE3rnzfZUg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -828,8 +826,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "4.5.2",
+        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1509,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1510,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1543,7 +1543,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1509,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1510,7 +1510,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1543,7 +1543,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -92,34 +92,35 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -648,11 +649,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "8.0.1",
+        "contentHash": "vaoWjvkG1aenR2XdjaVivlCV9fADfgyhW5bZtXT23qaEea0lWiUljdQuze4E31vKM7ZWJaSUsbYIKE3rnzfZUg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -795,8 +793,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "4.5.2",
+        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -959,7 +957,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -92,8 +92,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -105,22 +105,22 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -957,7 +957,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -152,13 +152,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -186,10 +187,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -240,12 +241,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1520,7 +1521,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -152,8 +152,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -165,19 +165,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -187,20 +187,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -241,12 +241,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1521,7 +1521,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1554,7 +1554,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -157,13 +157,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -191,10 +192,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -245,12 +246,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1529,7 +1530,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -170,19 +170,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -192,20 +192,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -246,12 +246,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1530,7 +1530,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1563,7 +1563,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -135,13 +135,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -169,10 +170,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -223,12 +224,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1351,7 +1352,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -135,8 +135,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -148,19 +148,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -170,20 +170,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -224,12 +224,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1352,7 +1352,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1385,7 +1385,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
@@ -139,13 +139,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -173,10 +174,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -227,12 +228,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1519,7 +1520,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -152,19 +152,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -174,20 +174,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -228,12 +228,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1520,7 +1520,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1553,7 +1553,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Local.Deploy/Bicep.Local.Deploy.csproj
+++ b/src/Bicep.Local.Deploy/Bicep.Local.Deploy.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Azure.Bicep.Local.Deploy</AssemblyName>
     <RootNamespace>Bicep.Local.Deploy</RootNamespace>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Deployments.Engine" Version="1.195.0" />
+    <PackageReference Include="Azure.Deployments.Engine" Version="1.224.0" />
     <PackageReference Include="Azure.Deployments.Extensibility.Core" Version="0.1.55" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
   </ItemGroup>

--- a/src/Bicep.Local.Deploy/LocalDeploymentEngineHost.cs
+++ b/src/Bicep.Local.Deploy/LocalDeploymentEngineHost.cs
@@ -162,4 +162,9 @@ public class LocalDeploymentEngineHost : DeploymentEngineHostBase
 
     public override IResourceTypeMetadataProvider GetResourceTypeMetadataProvider()
         => throw new NotImplementedException();
+
+    public override void ValidateNetworkAddress(Uri uri)
+    {
+        return;
+    }
 }

--- a/src/Bicep.Local.Deploy/LocalDeploymentSettings.cs
+++ b/src/Bicep.Local.Deploy/LocalDeploymentSettings.cs
@@ -266,6 +266,12 @@ public class LocalDeploymentSettings : IAzureDeploymentSettings
 
     public IReadOnlyDictionary<string, Uri> ExtensibilityHostUriOverridesBySubscriptionId => ImmutableDictionary<string, Uri>.Empty;
 
+    public int ExportTemplateTrackedResourcesLimit => int.MaxValue;
+
+    public int ExportTemplateMaximumExportedResourcesCount => int.MaxValue;
+
+    public bool EnforceAntiSSRF => false;
+
     IReadOnlyDictionary<string, IEnumerable<string>> IAzureDeploymentSettings.DisabledTenantDictionary => ImmutableDictionary<string, IEnumerable<string>>.Empty;
 
     IReadOnlyDictionary<string, IEnumerable<string>> IAzureDeploymentSettings.DisabledSubscriptionDictionary => ImmutableDictionary<string, IEnumerable<string>>.Empty;

--- a/src/Bicep.Local.Deploy/packages.lock.json
+++ b/src/Bicep.Local.Deploy/packages.lock.json
@@ -4,15 +4,15 @@
     "net8.0": {
       "Azure.Deployments.Engine": {
         "type": "Direct",
-        "requested": "[1.195.0, )",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "requested": "[1.224.0, )",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -128,8 +128,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -141,25 +141,25 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -189,12 +189,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1239,7 +1239,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Local.Deploy/packages.lock.json
+++ b/src/Bicep.Local.Deploy/packages.lock.json
@@ -128,13 +128,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -145,10 +146,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -188,12 +189,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1238,7 +1239,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Local.Extension.Mock/packages.lock.json
+++ b/src/Bicep.Local.Extension.Mock/packages.lock.json
@@ -97,34 +97,35 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -716,11 +717,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "8.0.1",
+        "contentHash": "vaoWjvkG1aenR2XdjaVivlCV9fADfgyhW5bZtXT23qaEea0lWiUljdQuze4E31vKM7ZWJaSUsbYIKE3rnzfZUg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -863,8 +861,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "4.5.2",
+        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -1027,7 +1025,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Local.Extension.Mock/packages.lock.json
+++ b/src/Bicep.Local.Extension.Mock/packages.lock.json
@@ -97,8 +97,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -110,22 +110,22 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1025,7 +1025,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1728,7 +1728,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1761,7 +1761,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1727,7 +1728,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -116,13 +116,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -150,10 +151,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -204,12 +205,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1721,7 +1722,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -116,8 +116,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -129,19 +129,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -151,20 +151,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -205,12 +205,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1722,7 +1722,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1755,7 +1755,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -134,19 +134,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -156,20 +156,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -210,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1728,7 +1728,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1761,7 +1761,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -121,13 +121,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -155,10 +156,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -209,12 +210,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1727,7 +1728,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -198,34 +198,35 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1193,7 +1194,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -198,8 +198,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -211,22 +211,22 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1194,7 +1194,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -98,8 +98,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -111,19 +111,19 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "NbN9AUSfoODkthSjOUOxWO9wrYSW50zk/sOQSbhn4a9WNvtSUFvY7/GFEIuEBkMV6FccXhtvmM6vloMjepY6cQ=="
+        "resolved": "1.224.0",
+        "contentHash": "RVHCA1iS7vsD1tOBHqsFBiOtShpV4qOsXkXrqJgw6yViZfzBBF9FadQrnoQzQj1Qq2n+RLki9A2ATmdb7gweuw=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "zL78BCS7X4qD3odiD60DDPsDNJ3P4hYMqXUBcUgXdiF8vyP67CNR3Eswt54Mve9GrZ2EGTrpkfu3UGz+mZ47pA==",
+        "resolved": "1.224.0",
+        "contentHash": "ocB7VsPADZJKTNdZiHb2hMLU/4uawpyKed2MRab0byRzGY/DoSuCHzdHh1SuA1lRBZ9ZKCyQ402dPBD3rnff+A==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.DiffEngine": "1.195.0",
-          "Azure.Deployments.Extensibility": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.DiffEngine": "1.224.0",
+          "Azure.Deployments.Extensibility": "1.224.0",
           "Azure.Deployments.ResourceMetadata": "1.17.0",
-          "Azure.Deployments.Templates": "1.195.0",
+          "Azure.Deployments.Templates": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Newtonsoft.Json": "13.0.3",
@@ -133,20 +133,20 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "KHYrkdncvCo/1VM0ogPUJPWBHQ6FC9yTxqm8E+AsBAxuEiV8+ZBclalp3aoOlBC+5jQV8KTT4BnhndZtajdkBA==",
+        "resolved": "1.224.0",
+        "contentHash": "pxSjw6fQygsmPnTuWcTkj1YspSFOduLaoR6KjldaSAxerZfKvwlCqQuG+Czvawd0NniWfah1lp4YFOziHtTSSg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.224.0",
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Newtonsoft.Json": "13.0.3",
           "System.Text.Json": "8.0.5"
@@ -187,12 +187,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1606,7 +1606,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",
@@ -1639,7 +1639,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.195.0, )",
+          "Azure.Deployments.Engine": "[1.224.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.55, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
           "Microsoft.NET.ILLink.Tasks": "[8.0.11, )"

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -98,13 +98,14 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
@@ -132,10 +133,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -186,12 +187,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1605,7 +1606,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -114,34 +114,35 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "DatHKc+hTtrluiTJ9yxfNCSq5NCseLUk/UmC2PyV4HmBBVv6PnR7rnGZVGW9ioDdjiYzKwWDenjzxdNXg41C6w==",
+        "resolved": "1.223.0",
+        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
           "System.Collections.Immutable": "8.0.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "+yhUcCkxqPZap4Adg9a1Tbs8mLH33STncDVyNFTNiQmzYd1f2ha+1I5G+j1xxG4KwD8UiVYbu2Z6nrlYMuSBkA==",
+        "resolved": "1.223.0",
+        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.195.0",
-        "contentHash": "Lx6DEz3Vyog7mi0JVUtx65rFB78aW0irC87Lz+8xlNsGVVLblIxAHePTJrgwUZOmCR+U37+h0XGFwAgW9G0+tQ==",
+        "resolved": "1.223.0",
+        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.195.0",
-          "Azure.Deployments.Expression": "1.195.0",
+          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Expression": "1.223.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -733,11 +734,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "8.0.1",
+        "contentHash": "vaoWjvkG1aenR2XdjaVivlCV9fADfgyhW5bZtXT23qaEea0lWiUljdQuze4E31vKM7ZWJaSUsbYIKE3rnzfZUg=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -880,8 +878,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+        "resolved": "4.5.2",
+        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",
@@ -1053,7 +1051,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.195.0, )",
+          "Azure.Deployments.Templates": "[1.223.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -114,8 +114,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "7Cyc8z0GTXWjxPxyImnYs1E+YOX/qWC5o8VO0OQIcHLnmvLEwa5NEzdJjUfeDcXFi7OdarHmAyV4cqt3frSwxA==",
+        "resolved": "1.224.0",
+        "contentHash": "Liui1eCyPil/bT8mnlmXBpepieco4a8czmaDZxQtUC1uefxNI+hLIgJXdwpSefNVhpJnyAFng+1JLGQW4+takg==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -127,22 +127,22 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "zrE1FH3bdrAtbSwr3vaefSLSLFUI8i6Zn2HWWOpAA3mnWXeMmHsqQ8Enc5cLeXAz7KMJ1Y6s9pkhgQWJmT60Yw==",
+        "resolved": "1.224.0",
+        "contentHash": "8qCvBWvT3e4RYG/blHXqL4xx8+LO10bgK8tfAe6koZagDvLkwBaC+BIf4+Tni0u2dZ6Fid4BGMxbashJomPLlA==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
           "IPNetwork2": "2.6.598",
           "Newtonsoft.Json": "13.0.3"
         }
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.223.0",
-        "contentHash": "tOTSV3P3AzZ5PXuL8/NtHztDZSSL4AbZOH62hpB4WloqFb62OSf1OPeip2kZttSvrSMJU2SJzblgLRCnkqUbAg==",
+        "resolved": "1.224.0",
+        "contentHash": "Oosjg9CiEp00XAdZS0OPScAdYjILPFiH6Lpyxhaqmr2dECTiAGkPfByPt2g4ci43Y+HxbBISIXhYJf1fyY0OFA==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.223.0",
-          "Azure.Deployments.Expression": "1.223.0",
+          "Azure.Deployments.Core": "1.224.0",
+          "Azure.Deployments.Expression": "1.224.0",
           "Microsoft.Automata.SRM": "1.2.2",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -1051,7 +1051,7 @@
           "Azure.Bicep.Types.Az": "[0.2.727, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.223.0, )",
+          "Azure.Deployments.Templates": "[1.224.0, )",
           "Azure.Identity": "[1.13.1, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "Bicep.IO": "[1.0.0, )",


### PR DESCRIPTION
Resolves #15750

Import closure calculation currently only supports ARM type pointers of the form `#/definitions/<type definition name>`, although ARM permits pointers that refer to any schema node. This PR replaces Bicep's type pointer resolution with a call into the resolver used by ARM.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15833)