### PR TITLE
adding support for variables, objects and arrays in extended param files

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -546,5 +546,74 @@ param stringParam =  /*TODO*/
             }
             }"));
         }
+
+        [TestMethod]
+        public void Using_variables_objects_arrays_in_base_parameters_file_should_succeed()
+        {
+            var result = CompilationHelper.CompileParams(
+              ("bicepconfig.json", @"
+                {
+                    ""experimentalFeaturesEnabled"": {
+                        ""extendableParamFiles"": true
+                    }
+                }
+              "),
+              ("parameters.bicepparam", @"
+                using 'main.bicep'
+                extends 'shared.bicepparam'
+              "),
+              ("shared.bicepparam", @"
+                using none
+
+                var var_foo = 'foo'
+                param foo = var_foo
+
+                var var_bar = {
+                    a: 'a'
+                    b: 'b'
+                }
+
+                param bar = var_bar
+
+                var var_baz = [
+                    var_foo
+                    var_bar
+                ]
+
+                param baz = var_baz
+              "),
+              ("main.bicep", @"
+                param foo string = ''
+                param bar object = {}
+                param baz array = []
+              "));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+            result.Parameters.Should().DeepEqual(JToken.Parse(@"{
+                ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"",
+                ""contentVersion"": ""1.0.0.0"",
+                ""parameters"": {
+                    ""foo"": {
+                        ""value"": ""bar""
+                    },
+                    ""bar"": {
+                        ""value"": {
+                            ""a"": ""a"",
+                            ""b"": ""b""
+                        }
+                    },
+                    ""baz"": {
+                        ""value"": [
+                            ""foo"",
+                            {
+                                ""a"": ""a"",
+                                ""b"": ""b""
+                            }
+                        ]
+                    }
+                }
+            }"));
+        }
     }
 }

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -570,7 +570,7 @@ namespace Bicep.Core.Semantics
 
         private IEnumerable<IDiagnostic> GatherTypeMismatchDiagnostics()
         {
-            foreach (var assignmentSymbol in Root.ParameterAssignments)
+            foreach (var assignmentSymbol in Root.ParameterAssignments.Where(x => x.Context.SourceFile == Root.Context.SourceFile))
             {
                 if (assignmentSymbol.Type is not ErrorType &&
                     assignmentSymbol.Type is not NullType && // `param x = null` is equivalent to skipping the assignment altogether


### PR DESCRIPTION
# Contributing a Pull Request

Fixes #14654 

This pull request introduces new test cases to ensure that variables, objects, and arrays can be used in base parameter files in Bicep, and refines the logic for gathering parameter mismatch diagnostics.

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature

## New test cases:

* [`src/Bicep.Core.IntegrationTests/ParametersTests.cs`](diffhunk://#diff-051fb83ff7d6dd1c6bbf284f2a6771c51b8bc588974b16bba277b7dcc263b2b1R549-R617): Added a test method `Using_variables_objects_arrays_in_base_parameters_file_should_succeed` to verify that variables, objects, and arrays can be used in base parameter files without causing diagnostics errors.

## Diagnostic logic refinement:

* [`src/Bicep.Core/Semantics/SemanticModel.cs`](diffhunk://#diff-e902771dc168022b477390efc35e9aaa7cfb008c3ecb603ab851597096331e72L573-R573): Modified the `GatherTypeMismatchDiagnostics` method to filter parameter assignments based on the source file context, ensuring diagnostics are only gathered for assignments within the same source file.