### PR TITLE
`use-safe-access` linter rule: Expand to check for nullable properties

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/LinterRuleTestsBase.cs
@@ -128,10 +128,11 @@ public class LinterRuleTestsBase
         return diagnostic.Code.StartsWith("BCP");
     }
 
-    protected static void AssertCodeFix(string expectedCode, string expectedFixTitle, string inputFile, string resultFile)
+    protected static void AssertCodeFix(string expectedCode, string expectedFixTitle, string inputFile, string resultFile, CompilationHelper.InputFile[]? supportingFiles = null)
     {
+        supportingFiles ??= [];
         var (file, cursor) = ParserHelper.GetFileWithSingleCursor(inputFile, '|');
-        var result = CompilationHelper.Compile(file);
+        var result = CompilationHelper.Compile([..supportingFiles, new("main.bicep", file)]);
 
         using (new AssertionScope().WithVisualCursor(result.Compilation.GetEntrypointSemanticModel().SourceFile, cursor))
         {

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSafeAccessRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSafeAccessRuleTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Analyzers.Linter.Rules;
+using Bicep.Core.UnitTests.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests;
@@ -9,8 +10,8 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests;
 [TestClass]
 public class UseSafeAccessRuleTests : LinterRuleTestsBase
 {
-    private void AssertCodeFix(string inputFile, string resultFile)
-        => AssertCodeFix(UseSafeAccessRule.Code, "Use the safe access (.?) operator", inputFile, resultFile);
+    private void AssertCodeFix(string inputFile, string resultFile, CompilationHelper.InputFile[]? supportingFiles = null)
+        => AssertCodeFix(UseSafeAccessRule.Code, "Use the safe access (.?) operator", inputFile, resultFile, supportingFiles);
 
     private void AssertNoDiagnostics(string inputFile)
         => AssertLinterRuleDiagnostics(UseSafeAccessRule.Code, inputFile, [], new(OnCompileErrors.Ignore, IncludePosition.None));
@@ -148,4 +149,95 @@ type roleAssignmentType = {
   roleDefinitionIdOrName: string
 }[]?
 """);
+
+    [TestMethod]
+    public void Codefix_recommends_safe_access_for_nullable_property_access() => AssertCodeFix("""
+param foo {
+  bar: string?
+}
+
+output bar string? = foo.b|ar
+""", """
+param foo {
+  bar: string?
+}
+
+output bar string? = foo.?bar
+""");
+
+    [TestMethod]
+    public void Rule_ignores_non_nullable_property_access() => AssertNoDiagnostics("""
+param foo {
+  bar: string
+}
+
+output bar string? = foo.bar
+""");
+
+    [TestMethod]
+    public void Codefix_recommends_safe_access_for_nullable_module_output_property_access() => AssertCodeFix("""
+module foo 'module.bicep' = {
+  name: 'foo'
+}
+
+output bar string? = foo.outputs.b|ar
+""", """
+module foo 'module.bicep' = {
+  name: 'foo'
+}
+
+output bar string? = foo.outputs.?bar
+""",
+supportingFiles: [new("module.bicep", """
+output bar string? = null
+""")]);
+
+    [TestMethod]
+    public void Codefix_recommends_safe_access_for_nullable_array_access() => AssertCodeFix("""
+param foo {
+  bar: string?
+}
+
+output bar string? = foo['b|ar']
+""", """
+param foo {
+  bar: string?
+}
+
+output bar string? = foo[?'bar']
+""");
+
+    [TestMethod]
+    public void Rule_ignores_non_nullable_array_access() => AssertNoDiagnostics("""
+param foo {
+  bar: string
+}
+
+output bar string? = foo['bar']
+""");
+
+    [TestMethod]
+    public void Rule_ignores_array_access_on_array() => AssertNoDiagnostics("""
+param foo (string | null)[]
+
+output bar string? = foo[0]
+""");
+
+    [TestMethod]
+    public void Codefix_recommends_safe_access_for_nullable_module_output_array_access() => AssertCodeFix("""
+module foo 'module.bicep' = {
+  name: 'foo'
+}
+
+output bar string? = foo.outputs['b|ar']
+""", """
+module foo 'module.bicep' = {
+  name: 'foo'
+}
+
+output bar string? = foo.outputs[?'bar']
+""",
+supportingFiles: [new("module.bicep", """
+output bar string? = null
+""")]);
 }

--- a/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs
@@ -18,6 +18,10 @@ namespace Bicep.Core.UnitTests.Utils
 {
     public static class CompilationHelper
     {
+        public record InputFile(
+            string FileName,
+            string Contents);
+
         public interface ICompilationResult
         {
             IEnumerable<IDiagnostic> Diagnostics { get; }
@@ -139,6 +143,9 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static CompilationResult Compile(IResourceTypeLoader resourceTypeLoader, params (string fileName, string fileContents)[] files)
             => Compile(new ServiceBuilder().WithFeatureOverrides(BicepTestConstants.FeatureOverrides).WithAzResourceTypeLoader(resourceTypeLoader), files);
+
+        public static CompilationResult Compile(params InputFile[] files)
+            => Compile(files.Select(x => (x.FileName, x.Contents)).ToArray());
 
         public static CompilationResult Compile(params (string fileName, string fileContents)[] files)
             => Compile(new ServiceBuilder().WithFeatureOverrides(BicepTestConstants.FeatureOverrides), files);

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -1069,7 +1069,7 @@ namespace Bicep.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use the safe access (.?) operator instead of checking object contents with the &apos;contains&apos; function..
+        ///   Looks up a localized string similar to Use the safe access (.?) operator..
         /// </summary>
         internal static string UseSafeAccessRule_Description {
             get {
@@ -1080,9 +1080,18 @@ namespace Bicep.Core {
         /// <summary>
         ///   Looks up a localized string similar to The syntax can be simplified by using the safe access (.?) operator..
         /// </summary>
-        internal static string UseSafeAccessRule_MessageFormat {
+        internal static string UseSafeAccessRule_ContainsReplacement_MessageFormat {
             get {
-                return ResourceManager.GetString("UseSafeAccessRule_MessageFormat", resourceCulture);
+                return ResourceManager.GetString("UseSafeAccessRule_ContainsReplacement_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The property being accessed may be null. Use the (.?) operator to handle this safely..
+        /// </summary>
+        internal static string UseSafeAccessRule_NullCheckReplacement_MessageFormat {
+            get {
+                return ResourceManager.GetString("UseSafeAccessRule_NullCheckReplacement_MessageFormat", resourceCulture);
             }
         }
         

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -512,13 +512,16 @@
     <value>Resource-derived types</value>
   </data>
   <data name="UseSafeAccessRule_Description" xml:space="preserve">
-    <value>Use the safe access (.?) operator instead of checking object contents with the 'contains' function.</value>
+    <value>Use the safe access (.?) operator.</value>
   </data>
   <data name="UseSafeAccessRule_CodeFix" xml:space="preserve">
     <value>Use the safe access (.?) operator</value>
   </data>
-  <data name="UseSafeAccessRule_MessageFormat" xml:space="preserve">
+  <data name="UseSafeAccessRule_ContainsReplacement_MessageFormat" xml:space="preserve">
     <value>The syntax can be simplified by using the safe access (.?) operator.</value>
+  </data>
+  <data name="UseSafeAccessRule_NullCheckReplacement_MessageFormat" xml:space="preserve">
+    <value>The property being accessed may be null. Use the (.?) operator to handle this safely.</value>
   </data>
   <data name="WhatIfShortCircuitingRuleDescription" xml:space="preserve">
     <value>Runtime values should not be used to determine resource IDs</value>

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -664,7 +664,7 @@
                 "use-safe-access": {
                   "allOf": [
                     {
-                      "description": "Use the safe access (.?) operator instead of checking object contents with the 'contains' function. Defaults to 'Warning'. See https://aka.ms/bicep/linter/use-safe-access"
+                      "description": "Use the safe access (.?) operator. Defaults to 'Warning'. See https://aka.ms/bicep/linter/use-safe-access"
                     },
                     {
                       "$ref": "#/definitions/rule-def-level-warning"


### PR DESCRIPTION
Some examples where a replacement will be suggested:

## Example 1
### Input
```bicep
param foo {
  bar: string?
}
output bar string? = foo.bar
```
### Replacement
```bicep
param foo {
  bar: string?
}
output bar string? = foo.?bar
```

## Example 2
`module.bicep` has declared the `bar` output as a nullable string.

### Input
```bicep
module foo 'module.bicep' = {
  name: 'foo'
}
output bar string? = foo.outputs.bar
```
### Replacement
```bicep
module foo 'module.bicep' = {
  name: 'foo'
}
output bar string? = foo.outputs.?bar
```

Closes #15823