### PR TITLE
Add optional linter rule to encourage usage of UDTs

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Dependencies_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Dependencies_LF/main.diagnostics.bicep
@@ -67,4 +67,5 @@ resource resE 'My.Rp/myResourceType/childType@2020-01-01' = {
 }
 
 output resourceCProperties object = resC.properties
+//@[27:33) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.diagnostics.bicep
@@ -5,16 +5,20 @@ output foo string = buildUrl(true, 'google.com', 'search')
 func sayHello(name string) string => 'Hi ${name}!'
 
 output hellos array = map(['Evie', 'Casper'], name => sayHello(name))
+//@[14:19) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 func objReturnType(name string) object => {
+//@[32:38) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   hello: 'Hi ${name}!'
 }
 
 func arrayReturnType(name string) array => [
+//@[34:39) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   name
 ]
 
 func asdf(name string) array => [
+//@[23:28) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   'asdf'
   name
 ]
@@ -25,13 +29,18 @@ type positiveInt = int
 func typedArg(input string[]) positiveInt => length(input)
 
 func barTest() array => ['abc', 'def']
+//@[15:20) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 func fooTest() array => map(barTest(), a => 'Hello ${a}!')
+//@[15:20) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 output fooValue array = fooTest()
+//@[16:21) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 func test() object => loadJsonContent('./repro-data.json')
+//@[12:18) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 func test2() string => loadTextContent('./repro-data.json')
 func test3() object => loadYamlContent('./repro-data.json')
+//@[13:19) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 func test4() string => loadFileAsBase64('./repro-data.json')
 
 // validate formatter works (https://github.com/Azure/bicep/issues/12913)

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/main.diagnostics.bicep
@@ -295,6 +295,7 @@ param funcvarparam bool = concat
 //@[06:18) [no-unused-params (Warning)] Parameter "funcvarparam" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |funcvarparam|
 //@[26:32) [BCP063 (Error)] The name "concat" is not a parameter, variable, resource or module. (bicep https://aka.ms/bicep/core-diagnostics#BCP063) |concat|
 output funcvarout array = padLeft
+//@[18:23) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[26:33) [BCP063 (Error)] The name "padLeft" is not a parameter, variable, resource or module. (bicep https://aka.ms/bicep/core-diagnostics#BCP063) |padLeft|
 
 // non-existent function

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidFunctions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidFunctions_LF/main.diagnostics.bicep
@@ -28,6 +28,7 @@ func noLambda3 = string 'asdf'
 //@[15:16) [BCP018 (Error)] Expected the "(" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) |=|
 
 func argLengthMismatch(a string, b string, c string) array => ([a, b, c])
+//@[53:58) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 var sdf = argLengthMismatch('asdf')
 //@[04:07) [no-unused-vars (Warning)] Variable "sdf" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |sdf|
 //@[27:35) [BCP071 (Error)] Expected 3 arguments, but got 1. (bicep https://aka.ms/bicep/core-diagnostics#BCP071) |('asdf')|
@@ -38,6 +39,7 @@ var asdfwdf = noLambda('asd')
 
 func sayHello(name string) string => 'Hi ${name}!'
 output hellos array = map(['Evie', 'Casper'], sayHello) // this syntax not supported currently, but should it be?
+//@[14:19) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[46:54) [BCP063 (Error)] The name "sayHello" is not a parameter, variable, resource or module. (bicep https://aka.ms/bicep/core-diagnostics#BCP063) |sayHello|
 
 func sayHelloBadNewlines(

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.diagnostics.bicep
@@ -1,4 +1,5 @@
 param ids array
+//@[10:15) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 var flatten1 = flatten('abc')
 //@[04:12) [no-unused-vars (Warning)] Variable "flatten1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |flatten1|
@@ -146,17 +147,23 @@ resource stg 'Microsoft.Storage/storageAccounts@2021-09-01' = [for i in range(0,
 }]
 
 output stgKeys array = map(range(0, 2), i => stg[i].listKeys().keys[0].value)
+//@[15:20) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[49:50) [BCP247 (Error)] Using lambda variables inside resource or module array access is not currently supported. Found the following lambda variable(s) being accessed: "i". (bicep https://aka.ms/bicep/core-diagnostics#BCP247) |i|
 output stgKeys2 array = map(range(0, 2), j => stg[((j + 2) % 123)].listKeys().keys[0].value)
+//@[16:21) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[50:65) [BCP247 (Error)] Using lambda variables inside resource or module array access is not currently supported. Found the following lambda variable(s) being accessed: "j". (bicep https://aka.ms/bicep/core-diagnostics#BCP247) |((j + 2) % 123)|
 output stgKeys3 array = map(ids, id => listKeys(id, stg[0].apiVersion).keys[0].value)
+//@[16:21) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[39:70) [outputs-should-not-contain-secrets (Warning)] Outputs should not contain secrets. Found possible secret: function 'listKeys' (bicep core linter https://aka.ms/bicep/linter/outputs-should-not-contain-secrets) |listKeys(id, stg[0].apiVersion)|
 //@[39:70) [BCP248 (Error)] Using lambda variables inside the "listKeys" function is not currently supported. Found the following lambda variable(s) being accessed: "id". (bicep https://aka.ms/bicep/core-diagnostics#BCP248) |listKeys(id, stg[0].apiVersion)|
 output accessTiers array = map(range(0, 2), k => stg[k].properties.accessTier)
+//@[19:24) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[53:54) [BCP247 (Error)] Using lambda variables inside resource or module array access is not currently supported. Found the following lambda variable(s) being accessed: "k". (bicep https://aka.ms/bicep/core-diagnostics#BCP247) |k|
 output accessTiers2 array = map(range(0, 2), x => map(range(0, 2), y => stg[x / y].properties.accessTier))
+//@[20:25) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[76:81) [BCP247 (Error)] Using lambda variables inside resource or module array access is not currently supported. Found the following lambda variable(s) being accessed: "x", "y". (bicep https://aka.ms/bicep/core-diagnostics#BCP247) |x / y|
 output accessTiers3 array = map(ids, foo => reference('${foo}').accessTier)
+//@[20:25) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[44:63) [BCP248 (Error)] Using lambda variables inside the "reference" function is not currently supported. Found the following lambda variable(s) being accessed: "foo". (bicep https://aka.ms/bicep/core-diagnostics#BCP248) |reference('${foo}')|
 
 module modLoop './empty.bicep' = [for item in range(0, 5): {
@@ -167,6 +174,7 @@ var modLoopNames = map(modLoop, i => i.name)
 //@[04:16) [no-unused-vars (Warning)] Variable "modLoopNames" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |modLoopNames|
 //@[23:30) [BCP144 (Error)] Directly referencing a resource or module collection is not currently supported here. Apply an array indexer to the expression. (bicep https://aka.ms/bicep/core-diagnostics#BCP144) |modLoop|
 output modOutputs array = map(range(0, 5), i => modLoop[i].outputs.foo)
+//@[18:23) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[43:70) [BCP070 (Error)] Argument of type "int => error" is not assignable to parameter of type "(any[, int]) => any". (bicep https://aka.ms/bicep/core-diagnostics#BCP070) |i => modLoop[i].outputs.foo|
 //@[56:57) [BCP247 (Error)] Using lambda variables inside resource or module array access is not currently supported. Found the following lambda variable(s) being accessed: "i". (bicep https://aka.ms/bicep/core-diagnostics#BCP247) |i|
 //@[67:70) [BCP052 (Error)] The type "outputs" does not contain property "foo". (bicep https://aka.ms/bicep/core-diagnostics#BCP052) |foo|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/main.diagnostics.bicep
@@ -622,6 +622,7 @@ module nonexistentArrays 'modulea.bicep' = [for evenMoreDuplicates in alsoDoesNo
 }]
 
 output directRefToCollectionViaOutput array = nonexistentArrays
+//@[038:043) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[046:063) [BCP144 (Error)] Directly referencing a resource or module collection is not currently supported here. Apply an array indexer to the expression. (bicep https://aka.ms/bicep/core-diagnostics#BCP144) |nonexistentArrays|
 
 module directRefToCollectionViaSingleBody 'modulea.bicep' = {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/main.diagnostics.bicep
@@ -21,10 +21,12 @@ output missingValue string =
 
 // #completionTest(31,32) -> arrayPlusSymbols
 output arrayCompletions array = 
+//@[24:29) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[32:32) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP009) ||
 
 // #completionTest(33,34) -> objectPlusSymbols
 output objectCompletions object = 
+//@[25:31) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[34:34) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP009) ||
 
 // #completionTest(29,30) -> boolPlusSymbols
@@ -142,37 +144,47 @@ output b bool = 'str'
 // wrong array output values
 output arr array = 32
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |arr|
+//@[11:16) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[19:21) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "32". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |32|
 output arr array = true
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |arr|
+//@[11:16) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[19:23) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "true". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |true|
 output arr array = false
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |arr|
+//@[11:16) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[19:24) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "false". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |false|
 output arr array = {
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |arr|
+//@[11:16) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[19:23) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "object". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |{\r\n}|
 }
 output arr array = 'str'
 //@[07:10) [BCP145 (Error)] Output "arr" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |arr|
+//@[11:16) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[19:24) [BCP033 (Error)] Expected a value of type "array" but the provided value is of type "'str'". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |'str'|
 
 // wrong object output values
 output o object = 32
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |o|
+//@[09:15) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[18:20) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "32". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |32|
 output o object = true
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |o|
+//@[09:15) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[18:22) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "true". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |true|
 output o object = false
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |o|
+//@[09:15) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[18:23) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "false". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |false|
 output o object = [
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |o|
+//@[09:15) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[18:22) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "<empty array>". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |[\r\n]|
 ]
 output o object = 'str'
 //@[07:08) [BCP145 (Error)] Output "o" is declared multiple times. Remove or rename the duplicates. (bicep https://aka.ms/bicep/core-diagnostics#BCP145) |o|
+//@[09:15) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[18:23) [BCP033 (Error)] Expected a value of type "object" but the provided value is of type "'str'". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |'str'|
 
 // a few expression cases
@@ -197,6 +209,7 @@ output notAttachableDecorators int = 32
 
 // nested loops inside output loops are not supported
 output noNestedLoops array = [for thing in things: {
+//@[21:26) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[43:49) [BCP057 (Error)] The name "things" does not exist in the current context. (bicep https://aka.ms/bicep/core-diagnostics#BCP057) |things|
   something: [
     [for thing in things: true]
@@ -207,10 +220,12 @@ output noNestedLoops array = [for thing in things: {
 
 // loops in inner properties inside outputs are not supported
 output noInnerLoopsInOutputs object = {
+//@[29:35) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   a: [for i in range(0,10): i]
 //@[06:09) [BCP138 (Error)] For-expressions are not supported in this context. For-expressions may be used as values of resource, module, variable, and output declarations, or values of resource and module properties. (bicep https://aka.ms/bicep/core-diagnostics#BCP138) |for|
 }
 output noInnerLoopsInOutputs2 object = {
+//@[30:36) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   a: [for i in range(0,10): {
 //@[06:09) [BCP138 (Error)] For-expressions are not supported in this context. For-expressions may be used as values of resource, module, variable, and output declarations, or values of resource and module properties. (bicep https://aka.ms/bicep/core-diagnostics#BCP138) |for|
     b: [for j in range(0,10): i+j]
@@ -229,14 +244,17 @@ output keyVaultSecretInterpolatedOutput string = '${kv.getSecret('mySecret')}'
 //@[49:78) [simplify-interpolation (Warning)] Remove unnecessary string interpolation. (bicep core linter https://aka.ms/bicep/linter/simplify-interpolation) |'${kv.getSecret('mySecret')}'|
 //@[52:76) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (bicep https://aka.ms/bicep/core-diagnostics#BCP180) |kv.getSecret('mySecret')|
 output keyVaultSecretObjectOutput object = {
+//@[34:40) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   secret: kv.getSecret('mySecret')
 //@[10:34) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (bicep https://aka.ms/bicep/core-diagnostics#BCP180) |kv.getSecret('mySecret')|
 }
 output keyVaultSecretArrayOutput array = [
+//@[33:38) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   kv.getSecret('mySecret')
 //@[02:26) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (bicep https://aka.ms/bicep/core-diagnostics#BCP180) |kv.getSecret('mySecret')|
 ]
 output keyVaultSecretArrayInterpolatedOutput array = [
+//@[45:50) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   '${kv.getSecret('mySecret')}'
 //@[05:29) [BCP180 (Error)] Function "getSecret" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator. (bicep https://aka.ms/bicep/core-diagnostics#BCP180) |kv.getSecret('mySecret')|
 ]

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/main.diagnostics.bicep
@@ -98,11 +98,13 @@ param boolCompletions bool =
 // #completionTest(30,31) -> arrayPlusSymbols
 param arrayCompletions array = 
 //@[06:022) [no-unused-params (Warning)] Parameter "arrayCompletions" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |arrayCompletions|
+//@[23:028) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[31:031) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP009) ||
 
 // #completionTest(32,33) -> objectPlusSymbols
 param objectCompletions object = 
 //@[06:023) [no-unused-params (Warning)] Parameter "objectCompletions" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |objectCompletions|
+//@[24:030) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[33:033) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP009) ||
 
 // badly escaped string
@@ -464,6 +466,7 @@ param invalidLength string
 ])
 param invalidPermutation array = [
 //@[06:024) [no-unused-params (Warning)] Parameter "invalidPermutation" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |invalidPermutation|
+//@[25:030) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 	'foobar'
 //@[01:009) [BCP034 (Error)] The enclosing array expected an item of type "'Microsoft.AnalysisServices/servers' | 'Microsoft.ApiManagement/service' | 'Microsoft.Automation/automationAccounts' | 'Microsoft.ContainerInstance/containerGroups' | 'Microsoft.ContainerRegistry/registries' | 'Microsoft.ContainerService/managedClusters' | 'Microsoft.Network/applicationGateways'", but the provided item was of type "'foobar'". (bicep https://aka.ms/bicep/core-diagnostics#BCP034) |'foobar'|
 	true
@@ -484,6 +487,7 @@ param invalidPermutation array = [
 ])
 param invalidDefaultWithAllowedArrayDecorator array = true
 //@[06:045) [no-unused-params (Warning)] Parameter "invalidDefaultWithAllowedArrayDecorator" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |invalidDefaultWithAllowedArrayDecorator|
+//@[46:051) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[54:058) [BCP033 (Error)] Expected a value of type "['Microsoft.AnalysisServices/servers', 'Microsoft.ApiManagement/service'] | ['Microsoft.Network/applicationGateways', 'Microsoft.Automation/automationAccounts']" but the provided value is of type "true". (bicep https://aka.ms/bicep/core-diagnostics#BCP033) |true|
 
 // unterminated multi-line comment

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.diagnostics.bicep
@@ -1748,6 +1748,7 @@ var directRefViaVar = premiumStorages
 //@[004:019) [no-unused-vars (Warning)] Variable "directRefViaVar" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |directRefViaVar|
 //@[022:037) [BCP144 (Error)] Directly referencing a resource or module collection is not currently supported here. Apply an array indexer to the expression. (bicep https://aka.ms/bicep/core-diagnostics#BCP144) |premiumStorages|
 output directRefViaOutput array = union(premiumStorages, stuffs)
+//@[026:031) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 //@[040:055) [BCP144 (Error)] Directly referencing a resource or module collection is not currently supported here. Apply an array indexer to the expression. (bicep https://aka.ms/bicep/core-diagnostics#BCP144) |premiumStorages|
 //@[057:063) [BCP144 (Error)] Directly referencing a resource or module collection is not currently supported here. Apply an array indexer to the expression. (bicep https://aka.ms/bicep/core-diagnostics#BCP144) |stuffs|
 
@@ -2199,7 +2200,9 @@ var issue3000stgManagedByExtended = issue3000stg.managedByExtended
 //@[049:066) [BCP187 (Warning)] The property "managedByExtended" does not exist in the resource or type definition, although it might still be valid. If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues. (bicep https://aka.ms/bicep/core-diagnostics#BCP187) |managedByExtended|
 
 param dataCollectionRule object
+//@[025:031) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 param tags object
+//@[011:017) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 var defaultLogAnalyticsWorkspace = {
   subscriptionId: subscription().subscriptionId
@@ -2257,8 +2260,10 @@ resource dataCollectionRuleRes2 'Microsoft.Insights/dataCollectionRules@2021-04-
 param issue4668_kind string = 'AzureCLI'
 @description('The identity that will be used to execute the Deployment Script.')
 param issue4668_identity object
+//@[025:031) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 @description('The properties of the Deployment Script.')
 param issue4668_properties object
+//@[027:033) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 resource issue4668_mainResource 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   name: 'testscript'
   location: 'westeurope'

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidTypeDeclarations_LF/main.diagnostics.bicep
@@ -128,6 +128,7 @@ type typeC = {
 type typeD = {
   type: 'd'
   value: object
+//@[09:015) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 }
 
 type typeE = {
@@ -192,6 +193,7 @@ type discriminatorDuplicatedMember1 = typeA | typeA
 @discriminator('type')
 type discriminatorDuplicatedMember2 = typeA | { type: 'a', config: object }
 //@[46:075) [BCP365 (Error)] The value "'a'" for discriminator property "type" is duplicated across multiple union member types. The value must be unique across all union member types. (bicep https://aka.ms/bicep/core-diagnostics#BCP365) |{ type: 'a', config: object }|
+//@[67:073) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 @discriminator('type')
 type discriminatorOnlyOneNonNullMember1 = typeA | null
@@ -305,6 +307,7 @@ output discriminatorOutputBadType1 typeA = { type: 'a', value: 'a' }
 @discriminator('type')
 //@[00:022) [BCP363 (Error)] The "discriminator" decorator can only be applied to object-only union types with unique member types. (bicep https://aka.ms/bicep/core-diagnostics#BCP363) |@discriminator('type')|
 output discriminatorOutputBadType2 object = { prop: 'value' }
+//@[35:041) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 type strings = string[]
 

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.diagnostics.bicep
@@ -89,6 +89,7 @@ var filteredLoop = filter(itemForLoop, i => i > 5)
 //@[04:016) [no-unused-vars (Warning)] Variable "filteredLoop" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |filteredLoop|
 
 output doggoGreetings array = [for item in mapObject: item.greeting]
+//@[22:027) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 resource storageAcc 'Microsoft.Storage/storageAccounts@2021-09-01' existing = {
   name: 'asdfsadf'

--- a/src/Bicep.Core.Samples/Files/baselines/LoadFunctions_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/LoadFunctions_CRLF/main.diagnostics.bicep
@@ -1,62 +1,62 @@
 var loadedText1 = loadTextContent('Assets/TextFile.CRLF.txt')
-//@[4:15) [no-unused-vars (Warning)] Variable "loadedText1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedText1|
+//@[04:15) [no-unused-vars (Warning)] Variable "loadedText1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedText1|
 var loadedText2 = sys.loadTextContent('Assets/TextFile.LF.txt')
-//@[4:15) [no-unused-vars (Warning)] Variable "loadedText2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedText2|
+//@[04:15) [no-unused-vars (Warning)] Variable "loadedText2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedText2|
 var loadedTextEncoding1 = loadTextContent('Assets/encoding-ascii.txt', 'us-ascii')
-//@[4:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding1|
+//@[04:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding1|
 var loadedTextEncoding2 = loadTextContent('Assets/encoding-utf8.txt', 'utf-8')
-//@[4:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding2|
+//@[04:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding2|
 var loadedTextEncoding3 = loadTextContent('Assets/encoding-utf16.txt', 'utf-16')
-//@[4:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding3" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding3|
+//@[04:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding3" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding3|
 var loadedTextEncoding4 = loadTextContent('Assets/encoding-utf16be.txt', 'utf-16BE')
-//@[4:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding4" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding4|
+//@[04:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding4" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding4|
 var loadedTextEncoding5 = loadTextContent('Assets/encoding-iso.txt', 'iso-8859-1')
-//@[4:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding5" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding5|
+//@[04:23) [no-unused-vars (Warning)] Variable "loadedTextEncoding5" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextEncoding5|
 
 var loadedBinary1 = loadFileAsBase64('Assets/binary')
-//@[4:17) [no-unused-vars (Warning)] Variable "loadedBinary1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedBinary1|
+//@[04:17) [no-unused-vars (Warning)] Variable "loadedBinary1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedBinary1|
 var loadedBinary2 = sys.loadFileAsBase64('Assets/binary')
-//@[4:17) [no-unused-vars (Warning)] Variable "loadedBinary2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedBinary2|
+//@[04:17) [no-unused-vars (Warning)] Variable "loadedBinary2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedBinary2|
 
 var loadedTextInterpolation1 = 'Text: ${loadTextContent('Assets/TextFile.CRLF.txt')}'
-//@[4:28) [no-unused-vars (Warning)] Variable "loadedTextInterpolation1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextInterpolation1|
+//@[04:28) [no-unused-vars (Warning)] Variable "loadedTextInterpolation1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextInterpolation1|
 var loadedTextInterpolation2 = 'Text: ${loadTextContent('Assets/TextFile.LF.txt')}'
-//@[4:28) [no-unused-vars (Warning)] Variable "loadedTextInterpolation2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextInterpolation2|
+//@[04:28) [no-unused-vars (Warning)] Variable "loadedTextInterpolation2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextInterpolation2|
 
 var loadedTextObject1 = {
-//@[4:21) [no-unused-vars (Warning)] Variable "loadedTextObject1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextObject1|
+//@[04:21) [no-unused-vars (Warning)] Variable "loadedTextObject1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextObject1|
   'text' : loadTextContent('Assets/TextFile.CRLF.txt')
-//@[2:08) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'text'|
+//@[02:08) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'text'|
 }
 var loadedTextObject2 = {
-//@[4:21) [no-unused-vars (Warning)] Variable "loadedTextObject2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextObject2|
+//@[04:21) [no-unused-vars (Warning)] Variable "loadedTextObject2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextObject2|
   'text' : loadTextContent('Assets/TextFile.LF.txt')  
-//@[2:08) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'text'|
+//@[02:08) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'text'|
 }
 var loadedBinaryInObject = {
-//@[4:24) [no-unused-vars (Warning)] Variable "loadedBinaryInObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedBinaryInObject|
+//@[04:24) [no-unused-vars (Warning)] Variable "loadedBinaryInObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedBinaryInObject|
   file: loadFileAsBase64('Assets/binary')
 }
 
 var loadedTextArray = [
-//@[4:19) [no-unused-vars (Warning)] Variable "loadedTextArray" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextArray|
+//@[04:19) [no-unused-vars (Warning)] Variable "loadedTextArray" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextArray|
   loadTextContent('Assets/TextFile.LF.txt')
   loadFileAsBase64('Assets/binary')
 ]
 
 var loadedTextArrayInObject = {
-//@[4:27) [no-unused-vars (Warning)] Variable "loadedTextArrayInObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextArrayInObject|
+//@[04:27) [no-unused-vars (Warning)] Variable "loadedTextArrayInObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextArrayInObject|
   'files' : [
-//@[2:09) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'files'|
+//@[02:09) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'files'|
     loadTextContent('Assets/TextFile.CRLF.txt')
     loadFileAsBase64('Assets/binary')
   ]
 }
 
 var loadedTextArrayInObjectFunctions = {
-//@[4:36) [no-unused-vars (Warning)] Variable "loadedTextArrayInObjectFunctions" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextArrayInObjectFunctions|
+//@[04:36) [no-unused-vars (Warning)] Variable "loadedTextArrayInObjectFunctions" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadedTextArrayInObjectFunctions|
   'files' : [
-//@[2:09) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'files'|
+//@[02:09) [prefer-unquoted-property-names (Warning)] Property names that are valid identifiers should be declared without quotation marks and accessed using dot notation. (bicep core linter https://aka.ms/bicep/linter/prefer-unquoted-property-names) |'files'|
     length(loadTextContent('Assets/TextFile.CRLF.txt'))
     sys.length(loadTextContent('Assets/TextFile.LF.txt'))
     length(loadFileAsBase64('Assets/binary'))
@@ -80,61 +80,61 @@ module module2 'modulea.bicep' = {
 }
 
 var textFileInSubdirectories = loadTextContent('Assets/../Assets/path/../path/../../Assets/path/to/deep/file/../../../to/deep/file/TextFile.txt')
-//@[4:28) [no-unused-vars (Warning)] Variable "textFileInSubdirectories" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |textFileInSubdirectories|
+//@[04:28) [no-unused-vars (Warning)] Variable "textFileInSubdirectories" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |textFileInSubdirectories|
 var binaryFileInSubdirectories = loadFileAsBase64('Assets/../Assets/path/../path/../../Assets/path/to/deep/file/../../../to/deep/file/binary')
-//@[4:30) [no-unused-vars (Warning)] Variable "binaryFileInSubdirectories" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |binaryFileInSubdirectories|
+//@[04:30) [no-unused-vars (Warning)] Variable "binaryFileInSubdirectories" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |binaryFileInSubdirectories|
 
 var loadWithEncoding01 = loadTextContent('Assets/encoding-iso.txt', 'iso-8859-1')
-//@[4:22) [no-unused-vars (Warning)] Variable "loadWithEncoding01" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding01|
+//@[04:22) [no-unused-vars (Warning)] Variable "loadWithEncoding01" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding01|
 var loadWithEncoding06 = loadTextContent('Assets/encoding-ascii.txt', 'us-ascii')
-//@[4:22) [no-unused-vars (Warning)] Variable "loadWithEncoding06" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding06|
+//@[04:22) [no-unused-vars (Warning)] Variable "loadWithEncoding06" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding06|
 var loadWithEncoding07 = loadTextContent('Assets/encoding-ascii.txt', 'iso-8859-1')
-//@[4:22) [no-unused-vars (Warning)] Variable "loadWithEncoding07" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding07|
+//@[04:22) [no-unused-vars (Warning)] Variable "loadWithEncoding07" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding07|
 var loadWithEncoding08 = loadTextContent('Assets/encoding-ascii.txt', 'utf-8')
-//@[4:22) [no-unused-vars (Warning)] Variable "loadWithEncoding08" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding08|
+//@[04:22) [no-unused-vars (Warning)] Variable "loadWithEncoding08" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding08|
 var loadWithEncoding11 = loadTextContent('Assets/encoding-utf8.txt', 'utf-8')
-//@[4:22) [no-unused-vars (Warning)] Variable "loadWithEncoding11" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding11|
+//@[04:22) [no-unused-vars (Warning)] Variable "loadWithEncoding11" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding11|
 var loadWithEncoding12 = loadTextContent('Assets/encoding-utf8-bom.txt', 'utf-8')
-//@[4:22) [no-unused-vars (Warning)] Variable "loadWithEncoding12" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding12|
+//@[04:22) [no-unused-vars (Warning)] Variable "loadWithEncoding12" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |loadWithEncoding12|
 
 var testJson = json(loadTextContent('./Assets/test.json.txt'))
 var testJsonString = testJson.string
-//@[4:18) [no-unused-vars (Warning)] Variable "testJsonString" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonString|
+//@[04:18) [no-unused-vars (Warning)] Variable "testJsonString" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonString|
 var testJsonInt = testJson.int
-//@[4:15) [no-unused-vars (Warning)] Variable "testJsonInt" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonInt|
+//@[04:15) [no-unused-vars (Warning)] Variable "testJsonInt" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonInt|
 var testJsonArrayVal = testJson.array[0]
-//@[4:20) [no-unused-vars (Warning)] Variable "testJsonArrayVal" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonArrayVal|
+//@[04:20) [no-unused-vars (Warning)] Variable "testJsonArrayVal" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonArrayVal|
 var testJsonObject = testJson.object
-//@[4:18) [no-unused-vars (Warning)] Variable "testJsonObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonObject|
+//@[04:18) [no-unused-vars (Warning)] Variable "testJsonObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonObject|
 var testJsonNestedString = testJson.object.nestedString
-//@[4:24) [no-unused-vars (Warning)] Variable "testJsonNestedString" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString|
+//@[04:24) [no-unused-vars (Warning)] Variable "testJsonNestedString" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString|
 
 var testJson2 = loadJsonContent('./Assets/test.json.txt')
-//@[4:13) [no-unused-vars (Warning)] Variable "testJson2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJson2|
+//@[04:13) [no-unused-vars (Warning)] Variable "testJson2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJson2|
 var testJsonString2 = testJson.string
-//@[4:19) [no-unused-vars (Warning)] Variable "testJsonString2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonString2|
+//@[04:19) [no-unused-vars (Warning)] Variable "testJsonString2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonString2|
 var testJsonString2_1 = loadJsonContent('./Assets/test.json.txt', '.string')
-//@[4:21) [no-unused-vars (Warning)] Variable "testJsonString2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonString2_1|
+//@[04:21) [no-unused-vars (Warning)] Variable "testJsonString2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonString2_1|
 var testJsonInt2 = testJson.int
-//@[4:16) [no-unused-vars (Warning)] Variable "testJsonInt2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonInt2|
+//@[04:16) [no-unused-vars (Warning)] Variable "testJsonInt2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonInt2|
 var testJsonInt2_1 = loadJsonContent('./Assets/test.json.txt', '.int')
-//@[4:18) [no-unused-vars (Warning)] Variable "testJsonInt2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonInt2_1|
+//@[04:18) [no-unused-vars (Warning)] Variable "testJsonInt2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonInt2_1|
 var testJsonArrayVal2 = testJson.array[0]
-//@[4:21) [no-unused-vars (Warning)] Variable "testJsonArrayVal2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonArrayVal2|
+//@[04:21) [no-unused-vars (Warning)] Variable "testJsonArrayVal2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonArrayVal2|
 var testJsonArrayVal2_1 = loadJsonContent('./Assets/test.json.txt', '.array[0]')
-//@[4:23) [no-unused-vars (Warning)] Variable "testJsonArrayVal2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonArrayVal2_1|
+//@[04:23) [no-unused-vars (Warning)] Variable "testJsonArrayVal2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonArrayVal2_1|
 var testJsonObject2 = testJson.object
-//@[4:19) [no-unused-vars (Warning)] Variable "testJsonObject2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonObject2|
+//@[04:19) [no-unused-vars (Warning)] Variable "testJsonObject2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonObject2|
 var testJsonObject2_1 = loadJsonContent('./Assets/test.json.txt', '.object')
 var testJsonNestedString2 = testJson.object.nestedString
-//@[4:25) [no-unused-vars (Warning)] Variable "testJsonNestedString2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString2|
+//@[04:25) [no-unused-vars (Warning)] Variable "testJsonNestedString2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString2|
 var testJsonNestedString2_1 = testJsonObject2_1.nestedString
-//@[4:27) [no-unused-vars (Warning)] Variable "testJsonNestedString2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString2_1|
+//@[04:27) [no-unused-vars (Warning)] Variable "testJsonNestedString2_1" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString2_1|
 var testJsonNestedString2_2 = loadJsonContent('./Assets/test.json.txt', '.object.nestedString')
-//@[4:27) [no-unused-vars (Warning)] Variable "testJsonNestedString2_2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString2_2|
+//@[04:27) [no-unused-vars (Warning)] Variable "testJsonNestedString2_2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonNestedString2_2|
 
 var testJsonTokensAsArray = loadJsonContent('./Assets/test2.json.txt', '.products[?(@.price > 3)].name')
-//@[4:25) [no-unused-vars (Warning)] Variable "testJsonTokensAsArray" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonTokensAsArray|
+//@[04:25) [no-unused-vars (Warning)] Variable "testJsonTokensAsArray" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |testJsonTokensAsArray|
 
 var testYaml = loadYamlContent('./Assets/test.yaml.txt')
 var testYamlString = testYaml.string
@@ -155,12 +155,16 @@ output testYamlString string = testYamlString
 output testYamlInt int = testYamlInt
 output testYamlBool bool = testYamlBool
 output testYamlArrayInt array = testYamlArrayInt
+//@[24:29) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 output testYamlArrayIntVal int = testYamlArrayIntVal
 output testYamlArrayString array = testYamlArrayString
+//@[27:32) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 output testYamlArrayStringVal string = testYamlArrayStringVal
 output testYamlArrayBool array = testYamlArrayBool
+//@[25:30) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 output testYamlArrayBoolVal bool = testYamlArrayBoolVal
 output testYamlObject object = testYamlObject
+//@[22:28) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 output testYamlObjectNestedString string = testYamlObjectNestedString
 output testYamlObjectNestedInt int = testYamlObjectNestedInt
 output testYamlObjectNestedBool bool = testYamlObjectNestedBool

--- a/src/Bicep.Core.Samples/Files/baselines/LoopsIndexed_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/LoopsIndexed_LF/main.diagnostics.bicep
@@ -1,5 +1,6 @@
 param name string
 param accounts array
+//@[15:020) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 param index int
 
 // single resource
@@ -81,9 +82,11 @@ output indexedCollectionVersion string = storageAccounts[index].apiVersion
 
 // general case property access
 output indexedCollectionIdentity object = storageAccounts[index].identity
+//@[33:039) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 // indexed access of two properties
 output indexedEndpointPair object = {
+//@[27:033) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   primary: storageAccounts[index].properties.primaryEndpoints.blob
   secondary: storageAccounts[index + 1].properties.secondaryEndpoints.blob
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Loops_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Loops_LF/main.diagnostics.bicep
@@ -1,5 +1,6 @@
 param name string
 param accounts array
+//@[15:020) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 param index int
 
 // single resource
@@ -81,9 +82,11 @@ output indexedCollectionVersion string = storageAccounts[index].apiVersion
 
 // general case property access
 output indexedCollectionIdentity object = storageAccounts[index].identity
+//@[33:039) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 // indexed access of two properties
 output indexedEndpointPair object = {
+//@[27:033) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   primary: storageAccounts[index].properties.primaryEndpoints.blob
   secondary: storageAccounts[index + 1].properties.secondaryEndpoints.blob
 }
@@ -414,6 +417,7 @@ resource filteredIndexedZones 'Microsoft.Network/dnsZones@2018-05-01' = [for (ac
 }]
 
 output lastNameServers array = filteredIndexedZones[length(accounts) - 1].properties.nameServers
+//@[23:028) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 module filteredIndexedModules 'passthrough.bicep' = [for (account, i) in accounts: if(account.enabled) {
   name: 'stuff-${i}'

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.diagnostics.bicep
@@ -137,8 +137,11 @@ resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
 output stringOutputA string = modATest.outputs.stringOutputA
 output stringOutputB string = modATest.outputs.stringOutputB
 output objOutput object = modATest.outputs.objOutput
+//@[17:23) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 output arrayOutput array = modATest.outputs.arrayOutput
+//@[19:24) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+//@[31:37) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 /*
   valid loop cases

--- a/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.diagnostics.bicep
@@ -12,13 +12,16 @@ output myOtherBool bool = true
 
 @sys.description('object array description')
 output suchEmpty array = [
+//@[17:22) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 ]
 
 output suchEmpty2 object = {
+//@[18:24) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 }
 
 @sys.description('object output description')
 output obj object = {
+//@[11:17) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   a: 'a'
   b: 12
   c: true
@@ -39,6 +42,7 @@ output obj object = {
 }
 
 output myArr array = [
+//@[13:18) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   'pirates'
   'say'
    false ? 'arr2' : 'arr'
@@ -71,4 +75,5 @@ output paramWithOverlappingOutput string = paramWithOverlappingOutput
 
 // top-level output loops are supported
 output generatedArray array = [for i in range(0,10): i]
+//@[22:27) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_CRLF/main.diagnostics.bicep
@@ -25,6 +25,7 @@ param myEscapedString string = 'First line\r\nSecond\ttabbed\tline'
 // object default value
 param foo object = {
 //@[06:009) [no-unused-params (Warning)] Parameter "foo" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |foo|
+//@[10:016) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   enabled: true
   name: 'this is my object'
   priority: 3
@@ -50,6 +51,7 @@ param foo object = {
 // array default value
 param myArrayParam array = [
 //@[06:018) [no-unused-params (Warning)] Parameter "myArrayParam" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |myArrayParam|
+//@[19:024) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   'a'
   'b'
   'c'
@@ -64,6 +66,7 @@ param password string
 @secure()
 param secretObject object
 //@[06:018) [no-unused-params (Warning)] Parameter "secretObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |secretObject|
+//@[19:025) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 // enum parameter
 @allowed([
@@ -84,6 +87,7 @@ param storageName string
 @maxLength(24)
 param someArray array
 //@[06:015) [no-unused-params (Warning)] Parameter "someArray" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |someArray|
+//@[16:021) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 // empty metadata
 @metadata({})
@@ -184,6 +188,7 @@ param decoratedBool bool = (true && false) != true
 @secure()
 param decoratedObject object = {
 //@[06:021) [no-unused-params (Warning)] Parameter "decoratedObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |decoratedObject|
+//@[22:028) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[29:265) [secure-parameter-default (Warning)] Secure parameters should not have hardcoded defaults (except for empty or newGuid()). (bicep core linter https://aka.ms/bicep/linter/secure-parameter-default) |= {\r\n  enabled: true\r\n  name: 'this is my object'\r\n  priority: 3\r\n  info: {\r\n    a: 'b'\r\n  }\r\n  empty: {\r\n  }\r\n  array: [\r\n    'string item'\r\n    12\r\n    true\r\n    [\r\n      'inner'\r\n      false\r\n    ]\r\n    {\r\n      a: 'b'\r\n    }\r\n  ]\r\n}|
   enabled: true
   name: 'this is my object'
@@ -215,6 +220,7 @@ param decoratedObject object = {
 @sys.description('An array.')
 param decoratedArray array = [
 //@[06:020) [no-unused-params (Warning)] Parameter "decoratedArray" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |decoratedArray|
+//@[21:026) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
     utcNow()
     newGuid()
 ]

--- a/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Parameters_LF/main.diagnostics.bicep
@@ -40,6 +40,7 @@ param myEscapedString string = 'First line\r\nSecond\ttabbed\tline'
 })
 param foo object = {
 //@[06:009) [no-unused-params (Warning)] Parameter "foo" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |foo|
+//@[10:016) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   enabled: true
   name: 'this is my object'
   priority: 3
@@ -65,6 +66,7 @@ param foo object = {
 // array default value
 param myArrayParam array = [
 //@[06:018) [no-unused-params (Warning)] Parameter "myArrayParam" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |myArrayParam|
+//@[19:024) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   'a'
   'b'
   'c'
@@ -79,6 +81,7 @@ param password string
 @secure()
 param secretObject object
 //@[06:018) [no-unused-params (Warning)] Parameter "secretObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |secretObject|
+//@[19:025) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 
 // enum parameter
 @allowed([
@@ -107,6 +110,7 @@ param storageName string
 @maxLength(24)
 param someArray array
 //@[06:015) [no-unused-params (Warning)] Parameter "someArray" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |someArray|
+//@[16:021) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 // empty metadata
 @metadata({})
@@ -209,6 +213,7 @@ param decoratedBool bool = /* comment1 */ /* comment2*/      /* comment3 */ /* c
 @secure()
 param decoratedObject object = {
 //@[06:021) [no-unused-params (Warning)] Parameter "decoratedObject" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-params) |decoratedObject|
+//@[22:028) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 //@[29:244) [secure-parameter-default (Warning)] Secure parameters should not have hardcoded defaults (except for empty or newGuid()). (bicep core linter https://aka.ms/bicep/linter/secure-parameter-default) |= {\n  enabled: true\n  name: 'this is my object'\n  priority: 3\n  info: {\n    a: 'b'\n  }\n  empty: {\n  }\n  array: [\n    'string item'\n    12\n    true\n    [\n      'inner'\n      false\n    ]\n    {\n      a: 'b'\n    }\n  ]\n}|
   enabled: true
   name: 'this is my object'
@@ -239,6 +244,7 @@ param decoratedObject object = {
 @sys.maxLength(20)
 @sys.description('An array.')
 param decoratedArray array = [
+//@[21:026) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
     utcNow()
     newGuid()
 ]

--- a/src/Bicep.Core.Samples/Files/baselines/Registry_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Registry_LF/main.diagnostics.bicep
@@ -91,6 +91,7 @@ module vnetDeploy 'ts:11111111-1111-1111-1111-111111111111/prod-rg/vnet-spec:v2'
 }]
 
 output siteUrls array = [for (site, i) in websites: siteDeploy[i].outputs.siteUrl]
+//@[16:21) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 module passthroughPort 'br:localhost:5000/passthrough/port:v1' = {
   scope: rg

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesManagementGroup_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesManagementGroup_CRLF/main.diagnostics.bicep
@@ -3,7 +3,9 @@ targetScope = 'managementGroup'
 param ownerPrincipalId string
 
 param contributorPrincipals array
+//@[28:33) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 param readerPrincipals array
+//@[23:28) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 resource owner 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: guid('owner', ownerPrincipalId)

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesSubscription_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesSubscription_CRLF/main.diagnostics.bicep
@@ -3,7 +3,9 @@ targetScope = 'subscription'
 param ownerPrincipalId string
 
 param contributorPrincipals array
+//@[28:33) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 param readerPrincipals array
+//@[23:28) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
 
 resource owner 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
   name: guid('owner', ownerPrincipalId)

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesTenant_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesTenant_CRLF/main.diagnostics.bicep
@@ -27,7 +27,7 @@ resource manyGroups 'Microsoft.Management/managementGroups@2020-05-01' = [for mg
 
 resource anotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for (mg, index) in managementGroups: {
   name: concat(mg.name, '-one-', index)
-//@[8:39) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter/prefer-interpolation) |concat(mg.name, '-one-', index)|
+//@[08:39) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter/prefer-interpolation) |concat(mg.name, '-one-', index)|
   properties: {
     displayName: '${mg.displayName} (${singleGroup.properties.displayName}) (set 1) (index ${index})'
   }
@@ -38,7 +38,7 @@ resource anotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for (m
 
 resource yetAnotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for mg in managementGroups: {
   name: concat(mg.name, '-two')
-//@[8:31) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter/prefer-interpolation) |concat(mg.name, '-two')|
+//@[08:31) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter/prefer-interpolation) |concat(mg.name, '-two')|
   properties: {
     displayName: '${mg.displayName} (${singleGroup.properties.displayName}) (set 2)'
   }
@@ -48,6 +48,7 @@ resource yetAnotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for
 }]
 
 output managementGroupIds array = [for i in range(0, length(managementGroups)): {
+//@[26:31) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |array|
   name: yetAnotherSet[i].name
   displayName: yetAnotherSet[i].properties.displayName
 }]

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.diagnostics.bicep
@@ -100,6 +100,7 @@ var cosmosDbEndpoint = cosmosDbRef.documentEndpoint
 
 param webSiteName string
 param cosmosDb object
+//@[15:21) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 resource site 'Microsoft.Web/sites@2019-08-01' = {
   name: webSiteName
   location: location

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.diagnostics.bicep
@@ -122,6 +122,7 @@ type typeC = {
 type typeD = {
   type: 'd'
   value: object
+//@[09:15) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
 }
 
 type typeE = {
@@ -222,6 +223,7 @@ type discriminatedUnionTuple1 = [
 type discriminatedUnionInlineTuple1 = [
   @discriminator('type')
   typeA | typeB | { type: 'c', value: object }
+//@[38:44) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter/use-user-defined-types) |object|
   string
 ]
 

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseUserDefinedTypesRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseUserDefinedTypesRuleTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Analyzers.Linter.Rules;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests;
+
+[TestClass]
+public class UseUserDefinedTypesRuleTests : LinterRuleTestsBase
+{
+    private void AssertDiagnostics(string inputFile, int expectedCount = 1)
+        => AssertLinterRuleDiagnostics(UseUserDefinedTypesRule.Code, inputFile, expectedCount);
+
+    private void AssertNoDiagnostics(string inputFile)
+        => AssertLinterRuleDiagnostics(UseUserDefinedTypesRule.Code, inputFile, [], new(OnCompileErrors.Ignore, IncludePosition.None));
+
+    [TestMethod]
+    public void Rule_ignores_user_defined_types() => AssertNoDiagnostics("""
+param foo {
+  bar: string
+}
+""");
+
+    [TestMethod]
+    public void Rule_defaults_to_off()
+    {
+        var result = CompilationHelper.Compile("""
+param foo object
+""");
+        result.ExcludingDiagnostics("no-unused-params").Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void Rule_flags_usage_of_object() => AssertDiagnostics("""
+param foo object
+""");
+
+    [TestMethod]
+    public void Rule_flags_usage_of_array() => AssertDiagnostics("""
+param foo object
+""");
+}

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseUserDefinedTypesRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseUserDefinedTypesRule.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.CodeAction;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Parsing;
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Syntax;
+using Bicep.Core.Syntax.Comparers;
+using Bicep.Core.Syntax.Visitors;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Types;
+
+namespace Bicep.Core.Analyzers.Linter.Rules;
+
+public sealed class UseUserDefinedTypesRule : LinterRuleBase
+{
+    public new const string Code = "use-user-defined-types";
+
+    public UseUserDefinedTypesRule() : base(
+        code: Code,
+        description: CoreResources.UseUserDefinedTypesRule_Description,
+        LinterRuleCategory.BestPractice,
+        docUri: new Uri($"https://aka.ms/bicep/linter/{Code}"),
+        // this is an optional coding standard, not something that should be enforced by default
+        overrideCategoryDefaultDiagnosticLevel: DiagnosticLevel.Off)
+    { }
+
+    public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
+    {
+        foreach (var typeVariable in SyntaxAggregator.AggregateByType<TypeVariableAccessSyntax>(model.Root.Syntax))
+        {
+            if (typeVariable.NameEquals(LanguageConstants.ObjectType) ||
+                typeVariable.NameEquals(LanguageConstants.ArrayType))
+            {
+                yield return CreateDiagnosticForSpan(diagnosticLevel, typeVariable.Span);
+            }
+        }
+    }
+}

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -1078,6 +1078,15 @@ namespace Bicep.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use user-defined types instead of &quot;object&quot; or &quot;array&quot;..
+        /// </summary>
+        internal static string UseUserDefinedTypesRule_Description {
+            get {
+                return ResourceManager.GetString("UseUserDefinedTypesRule_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The syntax can be simplified by using the safe access (.?) operator..
         /// </summary>
         internal static string UseSafeAccessRule_ContainsReplacement_MessageFormat {

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -514,6 +514,9 @@
   <data name="UseSafeAccessRule_Description" xml:space="preserve">
     <value>Use the safe access (.?) operator.</value>
   </data>
+  <data name="UseUserDefinedTypesRule_Description" xml:space="preserve">
+    <value>Use user-defined types instead of 'object' or 'array'.</value>
+  </data>
   <data name="UseSafeAccessRule_CodeFix" xml:space="preserve">
     <value>Use the safe access (.?) operator</value>
   </data>

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -751,6 +751,16 @@
                     }
                   ]
                 },
+                "use-user-defined-types": {
+                  "allOf": [
+                    {
+                      "description": "Use user-defined types instead of 'object' or 'array'. Defaults to 'Off'. See https://aka.ms/bicep/linter/use-user-defined-types"
+                    },
+                    {
+                      "$ref": "#/definitions/rule-def-level-off"
+                    }
+                  ]
+                },
                 "what-if-short-circuiting": {
                   "allOf": [
                     {


### PR DESCRIPTION
Adds a new linter rule with code `use-user-defined-types`, which is **off** by default.

Any usages of `array` or `object` types instead of user-defined types will be flagged by this rule. This makes it simpler for anyone looking to enforce user-defined types usage as a stricter coding standard.

Closes #15844
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/15845)