### PR TITLE
Fix NuGet CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,7 +392,7 @@ jobs:
           - os: macos-latest
             rid: osx-x64
             runTests: true
-          - os: ubuntu-latest
+          - os: windows-latest
             rid: win-arm64
             runTests: false
           - os: ubuntu-latest
@@ -410,6 +410,8 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,6 +449,10 @@ jobs:
           name: bicep-nupkg-any
           path: ./src/Bicep.MSBuild.E2eTests/examples/local-packages
 
+      - name: Install mono
+        run: sudo apt update && sudo apt install mono-complete
+        if: ${{ matrix.rid == 'linux-x64' || matrix.rid == 'linux-arm64' }}
+
       - name: Build CLI Package
         run: dotnet build --configuration Release /p:RuntimeSuffix=${{ matrix.rid }} ./src/Bicep.Cli.Nuget/nuget.proj
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,7 +386,7 @@ jobs:
           - os: windows-latest
             rid: win-x64
             runTests: true
-          - os: windows-latest
+          - os: ubuntu-latest
             rid: linux-x64
             runTests: true
           - os: macos-latest
@@ -395,7 +395,7 @@ jobs:
           - os: windows-latest
             rid: win-arm64
             runTests: false
-          - os: windows-latest
+          - os: ubuntu-latest
             rid: linux-arm64
             runTests: false
           - os: macos-latest
@@ -410,6 +410,8 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.404'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -386,7 +386,7 @@ jobs:
           - os: windows-latest
             rid: win-x64
             runTests: true
-          - os: ubuntu-latest
+          - os: windows-latest
             rid: linux-x64
             runTests: true
           - os: macos-latest
@@ -395,7 +395,7 @@ jobs:
           - os: windows-latest
             rid: win-arm64
             runTests: false
-          - os: ubuntu-latest
+          - os: windows-latest
             rid: linux-arm64
             runTests: false
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -410,8 +410,6 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.404'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,7 +398,7 @@ jobs:
           - os: ubuntu-latest
             rid: linux-arm64
             runTests: false
-          - os: ubuntu-latest
+          - os: macos-latest
             rid: osx-arm64
             runTests: false
 
@@ -410,8 +410,6 @@ jobs:
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: global.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/src/Bicep.Cli.Nuget/nuget.proj
+++ b/src/Bicep.Cli.Nuget/nuget.proj
@@ -15,6 +15,7 @@
 
     <NugetExePath>$(PkgNuGet_CommandLine)\tools\NuGet.exe</NugetExePath>
     <NugetExePath Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">mono $(NugetExePath)</NugetExePath>
+    <NugetExePath Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">mono $(NugetExePath)</NugetExePath>
 
     <BicepBinariesDirectory>$(MSBuildProjectDirectory)\tools</BicepBinariesDirectory>
     <BicepExePathWindows>$(BicepBinariesDirectory)\bicep.exe</BicepExePathWindows>


### PR DESCRIPTION
The `Build CLI NuGet packages` CI step started failing on all branches on Friday for `linux-x64`, `linux-arm64`, `osx-arm64`, and `windows-arm64` targets. Updating the latter two to run on `osx-latest` and `windows-latest`, respectively, addressed those failures, but I could only get the Linux jobs to work by using `mono` to invoke the NuGet CLI. Linux jobs were previously invoking the Windows executable directly, and I'm not sure why that used to work or what caused it to stop working.
 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16028)