### PR TITLE
Reintroduce 'resourceInfo' code generation behind experimental feature

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -29,6 +29,9 @@ Enabling this feature makes the `name` property in the body of `module` declarat
 ### `resourceDerivedTypes`
 If enabled, templates can reuse resource types wherever a type is expected. For example, to declare a parameter `foo` that should be usable as the name of an Azure Storage account, the following syntax would be used: `param foo resourceInput<'Microsoft.Storage/storageAccounts@2022-09-01'>.name`. **NB:** Because resource types may be inaccurate in some cases, no constraints other than the ARM type primitive will be enforced on resource derived types within the ARM deployment engine. Resource-derived types will be checked by Bicep at compile time, but violations will be emitted as warnings rather than errors.
 
+### `resourceInfoCodegen`
+Enables the 'resourceInfo' function for simplified code generation.
+
 ### `resourceTypedParamsAndOutputs`
 Enables the type for a parameter or output to be of type resource to make it easier to pass resource references between modules. This feature is only partially implemented. See [Simplifying resource referencing](https://github.com/azure/bicep/issues/2245).
 
@@ -40,9 +43,6 @@ Enables basic source mapping to map an error location returned in the ARM templa
 
 ### `symbolicNameCodegen`
 Allows the ARM template layer to use a new schema to represent resources as an object dictionary rather than an array of objects. This feature improves the semantic equivalence of the Bicep and ARM templates, resulting in more reliable code generation. Enabling this feature has no effect on the Bicep layer's functionality.
-
-### `resourceInfoCodegen`
-Enables the 'resourceInfo' function for simplified code generation.
 
 ### `testFramework`
 Should be enabled in tandem with `assertions` experimental feature flag for expected functionality. Allows you to author client-side, offline unit-test test blocks that reference Bicep files and mock deployment parameters in a separate `test.bicep` file using the new `test` keyword. Test blocks can be run with the command *bicep test <filepath_to_file_with_test_blocks>* which runs all `assert` statements in the Bicep files referenced by the test blocks. For more information, see [Bicep Experimental Test Framework](https://github.com/Azure/bicep/issues/11967).

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -41,6 +41,9 @@ Enables basic source mapping to map an error location returned in the ARM templa
 ### `symbolicNameCodegen`
 Allows the ARM template layer to use a new schema to represent resources as an object dictionary rather than an array of objects. This feature improves the semantic equivalence of the Bicep and ARM templates, resulting in more reliable code generation. Enabling this feature has no effect on the Bicep layer's functionality.
 
+### `resourceInfoCodegen`
+Enables the 'resourceInfo' function for simplified code generation.
+
 ### `testFramework`
 Should be enabled in tandem with `assertions` experimental feature flag for expected functionality. Allows you to author client-side, offline unit-test test blocks that reference Bicep files and mock deployment parameters in a separate `test.bicep` file using the new `test` keyword. Test blocks can be run with the command *bicep test <filepath_to_file_with_test_blocks>* which runs all `assert` statements in the Bicep files referenced by the test blocks. For more information, see [Bicep Experimental Test Framework](https://github.com/Azure/bicep/issues/11967).
 

--- a/src/Bicep.Core.IntegrationTests/ExamplesTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExamplesTests.cs
@@ -24,9 +24,10 @@ namespace Bicep.Core.IntegrationTests
         [NotNull]
         public TestContext? TestContext { get; set; }
 
-        private async Task RunExampleTest(EmbeddedFile embeddedBicep, FeatureProviderOverrides features, string jsonFileExtension)
+        public static async Task RunExampleTest(TestContext testContext, EmbeddedFile embeddedBicep, FeatureProviderOverrides? features = null, string jsonFileExtension = ".json")
         {
-            var baselineFolder = BaselineFolder.BuildOutputFolder(TestContext, embeddedBicep);
+            features ??= new();
+            var baselineFolder = BaselineFolder.BuildOutputFolder(testContext, embeddedBicep);
             var bicepFile = baselineFolder.EntryFile;
             var jsonFile = baselineFolder.GetFileOrEnsureCheckedIn(Path.ChangeExtension(embeddedBicep.FileName, jsonFileExtension));
 
@@ -69,19 +70,20 @@ namespace Bicep.Core.IntegrationTests
         [DynamicData(nameof(GetExampleData), DynamicDataSourceType.Method)]
         [TestCategory(BaselineHelper.BaselineTestCategory)]
         public Task ExampleIsValid(EmbeddedFile embeddedBicep)
-            => RunExampleTest(embeddedBicep, new(), ".json");
+            => RunExampleTest(TestContext, embeddedBicep, new(), ".json");
 
         [DataTestMethod]
         [DynamicData(nameof(GetExampleData), DynamicDataSourceType.Method)]
         [TestCategory(BaselineHelper.BaselineTestCategory)]
         public Task ExampleIsValid_using_experimental_symbolic_names(EmbeddedFile embeddedBicep)
-            => RunExampleTest(embeddedBicep, new(SymbolicNameCodegenEnabled: true), ".symbolicnames.json");
+            => RunExampleTest(TestContext, embeddedBicep, new(SymbolicNameCodegenEnabled: true), ".symbolicnames.json");
 
         [DataTestMethod]
         [DynamicData(nameof(GetExtensibilityExampleData), DynamicDataSourceType.Method)]
         [TestCategory(BaselineHelper.BaselineTestCategory)]
         public Task ExampleIsValid_extensibility(EmbeddedFile embeddedBicep)
             => RunExampleTest(
+                TestContext,
                 embeddedBicep,
                 new(ExtensibilityEnabled: true),
                 ".json");

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/main.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/main.bicep
@@ -1,0 +1,30 @@
+targetScope = 'subscription'
+
+@description('Resource Group object definition.')
+param resourceGroup object
+
+var defaultResourceGroupProperties = {
+  tags: {}
+  deploy: true
+}
+
+// Deploy Resource Group
+resource sqlRg 'Microsoft.Resources/resourceGroups@2021-04-01' = if (union(
+  defaultResourceGroupProperties,
+  resourceGroup
+).deploy) {
+  name: resourceGroup.name
+  location: resourceGroup.location
+  tags: union(defaultResourceGroupProperties, resourceGroup).tags
+  properties: {}
+}
+
+// Start SQL Logical Servers deployment
+module sqlLogicalServers 'modules/sql-logical-servers.bicep' = {
+  name: 'sqlLogicalServers'
+  scope: sqlRg
+  params: {
+    sqlLogicalServers: resourceGroup.sqlLogicalServers
+    tags: union(defaultResourceGroupProperties, resourceGroup).tags
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/main.json
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/main.json
@@ -1,0 +1,927 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Resource info code generation"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "13614151664857895737"
+    }
+  },
+  "parameters": {
+    "resourceGroup": {
+      "type": "object",
+      "metadata": {
+        "description": "Resource Group object definition."
+      }
+    }
+  },
+  "variables": {
+    "defaultResourceGroupProperties": {
+      "tags": {},
+      "deploy": true
+    }
+  },
+  "resources": {
+    "sqlRg": {
+      "condition": "[union(variables('defaultResourceGroupProperties'), parameters('resourceGroup')).deploy]",
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2021-04-01",
+      "name": "[parameters('resourceGroup').name]",
+      "location": "[parameters('resourceGroup').location]",
+      "tags": "[union(variables('defaultResourceGroupProperties'), parameters('resourceGroup')).tags]",
+      "properties": {}
+    },
+    "sqlLogicalServers": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "sqlLogicalServers",
+      "resourceGroup": "[parameters('resourceGroup').name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "sqlLogicalServers": {
+            "value": "[parameters('resourceGroup').sqlLogicalServers]"
+          },
+          "tags": {
+            "value": "[union(variables('defaultResourceGroupProperties'), parameters('resourceGroup')).tags]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.1-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+            "_EXPERIMENTAL_FEATURES_ENABLED": [
+              "Resource info code generation"
+            ],
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "13329672431778592105"
+            }
+          },
+          "parameters": {
+            "sqlLogicalServers": {
+              "type": "array",
+              "metadata": {
+                "description": "SQL logical servers."
+              }
+            },
+            "tags": {
+              "type": "object"
+            }
+          },
+          "variables": {
+            "defaultSqlLogicalServerProperties": {
+              "name": "",
+              "tags": {},
+              "userName": "",
+              "passwordFromKeyVault": {
+                "subscriptionId": "[subscription().subscriptionId]",
+                "resourceGroupName": "",
+                "name": "",
+                "secretName": ""
+              },
+              "systemManagedIdentity": false,
+              "minimalTlsVersion": "1.2",
+              "publicNetworkAccess": "Enabled",
+              "azureActiveDirectoryAdministrator": {
+                "name": "",
+                "objectId": "",
+                "tenantId": "[subscription().tenantId]"
+              },
+              "firewallRules": [],
+              "azureDefender": {
+                "enabled": false,
+                "emailAccountAdmins": false,
+                "emailAddresses": [],
+                "disabledRules": [],
+                "vulnerabilityAssessments": {
+                  "recurringScans": false,
+                  "storageAccount": {
+                    "resourceGroupName": "",
+                    "name": "",
+                    "containerName": ""
+                  },
+                  "emailSubscriptionAdmins": false,
+                  "emails": []
+                }
+              },
+              "auditActionsAndGroups": [],
+              "diagnosticLogsAndMetrics": {
+                "name": "",
+                "resourceGroupName": "",
+                "subscriptionId": "[subscription().subscriptionId]",
+                "logs": [],
+                "metrics": [],
+                "auditLogs": false,
+                "microsoftSupportOperationsAuditLogs": false
+              },
+              "databases": []
+            }
+          },
+          "resources": {
+            "sqlPassKeyVaults": {
+              "copy": {
+                "name": "sqlPassKeyVaults",
+                "count": "[length(parameters('sqlLogicalServers'))]"
+              },
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2021-04-01-preview",
+              "subscriptionId": "[union(variables('defaultSqlLogicalServerProperties'), parameters('sqlLogicalServers')[copyIndex()]).passwordFromKeyVault.subscriptionId]",
+              "resourceGroup": "[parameters('sqlLogicalServers')[copyIndex()].passwordFromKeyVault.resourceGroupName]",
+              "name": "[parameters('sqlLogicalServers')[copyIndex()].passwordFromKeyVault.name]"
+            },
+            "sqlLogicalServer": {
+              "copy": {
+                "name": "sqlLogicalServer",
+                "count": "[length(parameters('sqlLogicalServers'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('sqlLogicalServer-{0}', copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "sqlLogicalServer": {
+                    "value": "[union(variables('defaultSqlLogicalServerProperties'), parameters('sqlLogicalServers')[copyIndex()])]"
+                  },
+                  "password": {
+                    "reference": {
+                      "keyVault": {
+                        "id": "[resourceInfo(format('sqlPassKeyVaults[{0}]', copyIndex())).id]"
+                      },
+                      "secretName": "[parameters('sqlLogicalServers')[copyIndex()].passwordFromKeyVault.secretName]"
+                    }
+                  },
+                  "tags": {
+                    "value": "[union(parameters('tags'), union(variables('defaultSqlLogicalServerProperties'), parameters('sqlLogicalServers')[copyIndex()]).tags)]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.1-experimental",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+                    "_EXPERIMENTAL_FEATURES_ENABLED": [
+                      "Resource info code generation"
+                    ],
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "dev",
+                      "templateHash": "9063000392065399736"
+                    }
+                  },
+                  "parameters": {
+                    "sqlLogicalServer": {
+                      "type": "object",
+                      "metadata": {
+                        "description": "SQL Logical server."
+                      }
+                    },
+                    "password": {
+                      "type": "securestring",
+                      "metadata": {
+                        "description": "The SQL Logical Server password."
+                      }
+                    },
+                    "tags": {
+                      "type": "object"
+                    }
+                  },
+                  "variables": {
+                    "defaultAuditActionsAndGroups": [
+                      "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+                      "FAILED_DATABASE_AUTHENTICATION_GROUP",
+                      "BATCH_COMPLETED_GROUP"
+                    ],
+                    "defaultSqlDatabaseProperties": {
+                      "name": "",
+                      "status": "",
+                      "tags": {},
+                      "skuName": "",
+                      "tier": "",
+                      "zoneRedundant": false,
+                      "collation": "SQL_Latin1_General_CP1_CI_AS",
+                      "dataMaxSize": 0,
+                      "hybridBenefit": false,
+                      "readReplicas": 0,
+                      "minimumCores": 0,
+                      "autoPauseDelay": 0,
+                      "dataEncryption": "Enabled",
+                      "shortTermBackupRetention": 0,
+                      "longTermBackup": {
+                        "enabled": false,
+                        "weeklyRetention": "P1W",
+                        "monthlyRetention": "P4W",
+                        "yearlyRetention": "P52W",
+                        "weekOfYear": 1
+                      },
+                      "azureDefender": {
+                        "enabled": false,
+                        "emailAccountAdmins": false,
+                        "emailAddresses": [],
+                        "disabledRules": [],
+                        "vulnerabilityAssessments": {
+                          "recurringScans": false,
+                          "storageAccount": {
+                            "resourceGroupName": "",
+                            "name": "",
+                            "containerName": ""
+                          },
+                          "emailSubscriptionAdmins": false,
+                          "emails": []
+                        }
+                      },
+                      "auditActionsAndGroups": [],
+                      "diagnosticLogsAndMetrics": {
+                        "name": "",
+                        "resourceGroupName": "",
+                        "subscriptionId": "[subscription().subscriptionId]",
+                        "logs": [],
+                        "metrics": [],
+                        "auditLogs": false
+                      }
+                    }
+                  },
+                  "resources": {
+                    "sqlLogicalServerRes": {
+                      "type": "Microsoft.Sql/servers",
+                      "apiVersion": "2021-02-01-preview",
+                      "name": "[parameters('sqlLogicalServer').name]",
+                      "location": "[resourceGroup().location]",
+                      "tags": "[parameters('tags')]",
+                      "identity": {
+                        "type": "[if(parameters('sqlLogicalServer').systemManagedIdentity, 'SystemAssigned', 'None')]"
+                      },
+                      "properties": {
+                        "administratorLogin": "[parameters('sqlLogicalServer').userName]",
+                        "administratorLoginPassword": "[parameters('password')]",
+                        "version": "12.0",
+                        "minimalTlsVersion": "[parameters('sqlLogicalServer').minimalTlsVersion]",
+                        "publicNetworkAccess": "[parameters('sqlLogicalServer').publicNetworkAccess]"
+                      }
+                    },
+                    "azureAdIntegration": {
+                      "condition": "[not(empty(parameters('sqlLogicalServer').azureActiveDirectoryAdministrator.objectId))]",
+                      "type": "Microsoft.Sql/servers/administrators",
+                      "apiVersion": "2021-02-01-preview",
+                      "name": "[format('{0}/{1}', parameters('sqlLogicalServer').name, 'ActiveDirectory')]",
+                      "properties": {
+                        "administratorType": "ActiveDirectory",
+                        "login": "[parameters('sqlLogicalServer').azureActiveDirectoryAdministrator.name]",
+                        "sid": "[parameters('sqlLogicalServer').azureActiveDirectoryAdministrator.objectId]",
+                        "tenantId": "[parameters('sqlLogicalServer').azureActiveDirectoryAdministrator.tenantId]"
+                      },
+                      "dependsOn": [
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "azureDefender": {
+                      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+                      "apiVersion": "2021-02-01-preview",
+                      "name": "[format('{0}/{1}', parameters('sqlLogicalServer').name, 'Default')]",
+                      "properties": {
+                        "state": "[if(parameters('sqlLogicalServer').azureDefender.enabled, 'Enabled', 'Disabled')]",
+                        "emailAddresses": "[parameters('sqlLogicalServer').azureDefender.emailAddresses]",
+                        "emailAccountAdmins": "[parameters('sqlLogicalServer').azureDefender.emailAccountAdmins]",
+                        "disabledAlerts": "[parameters('sqlLogicalServer').azureDefender.disabledRules]"
+                      },
+                      "dependsOn": [
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "storageAccountVulnerabilityAssessments": {
+                      "condition": "[and(and(parameters('sqlLogicalServer').azureDefender.enabled, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.recurringScans), not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)))]",
+                      "existing": true,
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2021-04-01",
+                      "resourceGroup": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
+                      "name": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name]"
+                    },
+                    "vulnerabilityAssessments": {
+                      "condition": "[and(and(parameters('sqlLogicalServer').azureDefender.enabled, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.recurringScans), not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)))]",
+                      "type": "Microsoft.Sql/servers/vulnerabilityAssessments",
+                      "apiVersion": "2021-02-01-preview",
+                      "name": "[format('{0}/{1}', parameters('sqlLogicalServer').name, 'default')]",
+                      "properties": {
+                        "recurringScans": {
+                          "isEnabled": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.recurringScans]",
+                          "emailSubscriptionAdmins": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emailSubscriptionAdmins]",
+                          "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
+                        },
+                        "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
+                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                      },
+                      "dependsOn": [
+                        "azureDefender",
+                        "sqlLogicalServerRes",
+                        "storageAccountVulnerabilityAssessments"
+                      ]
+                    },
+                    "auditSettings": {
+                      "type": "Microsoft.Sql/servers/auditingSettings",
+                      "apiVersion": "2021-02-01-preview",
+                      "name": "[format('{0}/{1}', parameters('sqlLogicalServer').name, 'default')]",
+                      "properties": {
+                        "state": "[if(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, 'Enabled', 'Disabled')]",
+                        "auditActionsAndGroups": "[if(not(empty(parameters('sqlLogicalServer').auditActionsAndGroups)), parameters('sqlLogicalServer').auditActionsAndGroups, variables('defaultAuditActionsAndGroups'))]",
+                        "storageEndpoint": "",
+                        "storageAccountAccessKey": "",
+                        "storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
+                        "retentionDays": 0,
+                        "isAzureMonitorTargetEnabled": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs]",
+                        "isDevopsAuditEnabled": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.microsoftSupportOperationsAuditLogs]"
+                      },
+                      "dependsOn": [
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "dummyDeployments": {
+                      "copy": {
+                        "name": "dummyDeployments",
+                        "count": "[length(range(0, 5))]",
+                        "mode": "serial",
+                        "batchSize": 1
+                      },
+                      "condition": "[and(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)))]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2021-04-01",
+                      "name": "[format('dummyTemplateSqlServer-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": []
+                        }
+                      },
+                      "dependsOn": [
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "masterDb": {
+                      "condition": "[or(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)))]",
+                      "existing": true,
+                      "type": "Microsoft.Sql/servers/databases",
+                      "apiVersion": "2021-02-01-preview",
+                      "name": "[format('{0}/{1}', parameters('sqlLogicalServer').name, 'master')]",
+                      "dependsOn": [
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "logAnalyticsWorkspace": {
+                      "condition": "[or(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name)))]",
+                      "existing": true,
+                      "type": "Microsoft.OperationalInsights/workspaces",
+                      "apiVersion": "2020-10-01",
+                      "subscriptionId": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.subscriptionId]",
+                      "resourceGroup": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.resourceGroupName]",
+                      "name": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name]"
+                    },
+                    "auditDiagnosticSettings": {
+                      "condition": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.auditLogs]",
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('sqlLogicalServer').name, 'master')]",
+                      "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
+                      "properties": {
+                        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+                        "logs": [
+                          {
+                            "category": "SQLSecurityAuditEvents",
+                            "enabled": true
+                          },
+                          {
+                            "category": "DevOpsOperationsAudit",
+                            "enabled": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.microsoftSupportOperationsAuditLogs]"
+                          }
+                        ]
+                      },
+                      "dependsOn": [
+                        "auditSettings",
+                        "dummyDeployments",
+                        "sqlDatabases",
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "diagnosticSettings": {
+                      "condition": "[not(empty(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.name))]",
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2017-05-01-preview",
+                      "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', parameters('sqlLogicalServer').name, 'master')]",
+                      "name": "sendLogsAndMetrics",
+                      "properties": {
+                        "copy": [
+                          {
+                            "name": "logs",
+                            "count": "[length(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.logs)]",
+                            "input": {
+                              "category": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.logs[copyIndex('logs')]]",
+                              "enabled": true
+                            }
+                          },
+                          {
+                            "name": "metrics",
+                            "count": "[length(parameters('sqlLogicalServer').diagnosticLogsAndMetrics.metrics)]",
+                            "input": {
+                              "category": "[parameters('sqlLogicalServer').diagnosticLogsAndMetrics.metrics[copyIndex('metrics')]]",
+                              "enabled": true
+                            }
+                          }
+                        ],
+                        "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                      },
+                      "dependsOn": [
+                        "dummyDeployments",
+                        "sqlDatabases",
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "sqlFirewallRules": {
+                      "copy": {
+                        "name": "sqlFirewallRules",
+                        "count": "[length(parameters('sqlLogicalServer').firewallRules)]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('sqlFirewallRule-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "sqlFirewallRule": {
+                            "value": "[parameters('sqlLogicalServer').firewallRules[copyIndex()]]"
+                          },
+                          "sqlServerName": {
+                            "value": "[parameters('sqlLogicalServer').name]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.1-experimental",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+                            "_EXPERIMENTAL_FEATURES_ENABLED": [
+                              "Resource info code generation"
+                            ],
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "dev",
+                              "templateHash": "4976635434886085941"
+                            }
+                          },
+                          "parameters": {
+                            "sqlFirewallRule": {
+                              "type": "object",
+                              "metadata": {
+                                "description": "Firewall rule"
+                              }
+                            },
+                            "sqlServerName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the SQL Logical server."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "firewallRule": {
+                              "type": "Microsoft.Sql/servers/firewallRules",
+                              "apiVersion": "2021-02-01-preview",
+                              "name": "[format('{0}/{1}', parameters('sqlServerName'), parameters('sqlFirewallRule').name)]",
+                              "properties": {
+                                "startIpAddress": "[parameters('sqlFirewallRule').startIpAddress]",
+                                "endIpAddress": "[parameters('sqlFirewallRule').endIpAddress]"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "sqlLogicalServerRes"
+                      ]
+                    },
+                    "sqlDatabases": {
+                      "copy": {
+                        "name": "sqlDatabases",
+                        "count": "[length(parameters('sqlLogicalServer').databases)]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('sqlDb-{0}-{1}', uniqueString(parameters('sqlLogicalServer').name), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "sqlServerName": {
+                            "value": "[parameters('sqlLogicalServer').name]"
+                          },
+                          "sqlDatabase": {
+                            "value": "[union(variables('defaultSqlDatabaseProperties'), parameters('sqlLogicalServer').databases[copyIndex()])]"
+                          },
+                          "tags": {
+                            "value": "[union(parameters('tags'), union(variables('defaultSqlDatabaseProperties'), parameters('sqlLogicalServer').databases[copyIndex()]).tags)]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.1-experimental",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+                            "_EXPERIMENTAL_FEATURES_ENABLED": [
+                              "Resource info code generation"
+                            ],
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "dev",
+                              "templateHash": "14139997266340008402"
+                            }
+                          },
+                          "parameters": {
+                            "sqlServerName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the SQL server."
+                              }
+                            },
+                            "sqlDatabase": {
+                              "type": "object",
+                              "metadata": {
+                                "description": "The SQL database parameters object."
+                              }
+                            },
+                            "tags": {
+                              "type": "object"
+                            }
+                          },
+                          "resources": {
+                            "sqlDb": {
+                              "type": "Microsoft.Sql/servers/databases",
+                              "apiVersion": "2020-02-02-preview",
+                              "name": "[format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name)]",
+                              "location": "[resourceGroup().location]",
+                              "tags": "[parameters('tags')]",
+                              "sku": {
+                                "name": "[parameters('sqlDatabase').skuName]",
+                                "tier": "[parameters('sqlDatabase').tier]"
+                              },
+                              "properties": {
+                                "zoneRedundant": "[parameters('sqlDatabase').zoneRedundant]",
+                                "collation": "[parameters('sqlDatabase').collation]",
+                                "maxSizeBytes": "[if(equals(parameters('sqlDatabase').dataMaxSize, 0), null(), mul(mul(mul(1024, 1024), 1024), parameters('sqlDatabase').dataMaxSize))]",
+                                "licenseType": "[if(parameters('sqlDatabase').hybridBenefit, 'BasePrice', 'LicenseIncluded')]",
+                                "readScale": "[if(equals(parameters('sqlDatabase').readReplicas, 0), 'Disabled', 'Enabled')]",
+                                "readReplicaCount": "[parameters('sqlDatabase').readReplicas]",
+                                "minCapacity": "[if(equals(parameters('sqlDatabase').minimumCores, 0), null(), parameters('sqlDatabase').minimumCores)]",
+                                "autoPauseDelay": "[if(equals(parameters('sqlDatabase').autoPauseDelay, 0), null(), parameters('sqlDatabase').autoPauseDelay)]"
+                              }
+                            },
+                            "transparentDataEncryption": {
+                              "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+                              "apiVersion": "2014-04-01",
+                              "name": "[format('{0}/{1}/{2}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1], 'current')]",
+                              "properties": {
+                                "status": "[parameters('sqlDatabase').dataEncryption]"
+                              },
+                              "dependsOn": [
+                                "sqlDb"
+                              ]
+                            },
+                            "longTermBackup": {
+                              "condition": "[parameters('sqlDatabase').longTermBackup.enabled]",
+                              "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
+                              "apiVersion": "2021-02-01-preview",
+                              "name": "[format('{0}/{1}/{2}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1], 'default')]",
+                              "properties": {
+                                "weeklyRetention": "[parameters('sqlDatabase').longTermBackup.weeklyRetention]",
+                                "monthlyRetention": "[parameters('sqlDatabase').longTermBackup.monthlyRetention]",
+                                "yearlyRetention": "[parameters('sqlDatabase').longTermBackup.yearlyRetention]",
+                                "weekOfYear": "[parameters('sqlDatabase').longTermBackup.weekOfYear]"
+                              },
+                              "dependsOn": [
+                                "shortTermBackup",
+                                "sqlDb",
+                                "transparentDataEncryption"
+                              ]
+                            },
+                            "storageAccountVulnerabilityAssessments": {
+                              "condition": "[and(and(parameters('sqlDatabase').azureDefender.enabled, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.recurringScans), not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)))]",
+                              "existing": true,
+                              "type": "Microsoft.Storage/storageAccounts",
+                              "apiVersion": "2021-04-01",
+                              "resourceGroup": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName]",
+                              "name": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name]"
+                            },
+                            "vulnerabilityAssessments": {
+                              "condition": "[and(and(parameters('sqlDatabase').azureDefender.enabled, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.recurringScans), not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)))]",
+                              "type": "Microsoft.Sql/servers/databases/vulnerabilityAssessments",
+                              "apiVersion": "2021-02-01-preview",
+                              "name": "[format('{0}/{1}/{2}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1], 'default')]",
+                              "properties": {
+                                "recurringScans": {
+                                  "isEnabled": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.recurringScans]",
+                                  "emailSubscriptionAdmins": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emailSubscriptionAdmins]",
+                                  "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
+                                },
+                                "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
+                                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                              },
+                              "dependsOn": [
+                                "azureDefender",
+                                "sqlDb",
+                                "storageAccountVulnerabilityAssessments",
+                                "transparentDataEncryption"
+                              ]
+                            },
+                            "logAnalyticsWorkspace": {
+                              "condition": "[or(parameters('sqlDatabase').diagnosticLogsAndMetrics.auditLogs, not(empty(parameters('sqlDatabase').diagnosticLogsAndMetrics.name)))]",
+                              "existing": true,
+                              "type": "Microsoft.OperationalInsights/workspaces",
+                              "apiVersion": "2020-10-01",
+                              "subscriptionId": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.subscriptionId]",
+                              "resourceGroup": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.resourceGroupName]",
+                              "name": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.name]"
+                            },
+                            "auditDiagnosticSettings": {
+                              "condition": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.auditLogs]",
+                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "apiVersion": "2017-05-01-preview",
+                              "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1])]",
+                              "name": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
+                              "properties": {
+                                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]",
+                                "logs": [
+                                  {
+                                    "category": "SQLSecurityAuditEvents",
+                                    "enabled": true
+                                  }
+                                ]
+                              },
+                              "dependsOn": [
+                                "auditSettings",
+                                "sqlDb",
+                                "transparentDataEncryption"
+                              ]
+                            },
+                            "diagnosticSettings": {
+                              "condition": "[not(empty(parameters('sqlDatabase').diagnosticLogsAndMetrics.name))]",
+                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "apiVersion": "2017-05-01-preview",
+                              "scope": "[format('Microsoft.Sql/servers/{0}/databases/{1}', split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[0], split(format('{0}/{1}', parameters('sqlServerName'), parameters('sqlDatabase').name), '/')[1])]",
+                              "name": "sendLogsAndMetrics",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "logs",
+                                    "count": "[length(parameters('sqlDatabase').diagnosticLogsAndMetrics.logs)]",
+                                    "input": {
+                                      "category": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.logs[copyIndex('logs')]]",
+                                      "enabled": true
+                                    }
+                                  },
+                                  {
+                                    "name": "metrics",
+                                    "count": "[length(parameters('sqlDatabase').diagnosticLogsAndMetrics.metrics)]",
+                                    "input": {
+                                      "category": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.metrics[copyIndex('metrics')]]",
+                                      "enabled": true
+                                    }
+                                  }
+                                ],
+                                "workspaceId": "[resourceInfo('logAnalyticsWorkspace').id]"
+                              },
+                              "dependsOn": [
+                                "sqlDb",
+                                "transparentDataEncryption"
+                              ]
+                            },
+                            "shortTermBackup": {
+                              "condition": "[not(equals(parameters('sqlDatabase').shortTermBackupRetention, 0))]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('shortTermBackup-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "sqlDatabase": {
+                                    "value": "[parameters('sqlDatabase')]"
+                                  },
+                                  "sqlServerName": {
+                                    "value": "[parameters('sqlServerName')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.1-experimental",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+                                    "_EXPERIMENTAL_FEATURES_ENABLED": [
+                                      "Resource info code generation"
+                                    ],
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "dev",
+                                      "templateHash": "7779336692846569211"
+                                    }
+                                  },
+                                  "parameters": {
+                                    "sqlDatabase": {
+                                      "type": "object"
+                                    },
+                                    "sqlServerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "resources": {
+                                    "shortTermBackup": {
+                                      "type": "Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies",
+                                      "apiVersion": "2021-02-01-preview",
+                                      "name": "[format('{0}/{1}/Default', parameters('sqlServerName'), parameters('sqlDatabase').name)]",
+                                      "properties": {
+                                        "retentionDays": "[parameters('sqlDatabase').shortTermBackupRetention]"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "sqlDb",
+                                "transparentDataEncryption"
+                              ]
+                            },
+                            "azureDefender": {
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('azureDefender-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "sqlDatabase": {
+                                    "value": "[parameters('sqlDatabase')]"
+                                  },
+                                  "sqlServerName": {
+                                    "value": "[parameters('sqlServerName')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.1-experimental",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+                                    "_EXPERIMENTAL_FEATURES_ENABLED": [
+                                      "Resource info code generation"
+                                    ],
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "dev",
+                                      "templateHash": "7591742739918175141"
+                                    }
+                                  },
+                                  "parameters": {
+                                    "sqlDatabase": {
+                                      "type": "object"
+                                    },
+                                    "sqlServerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "resources": {
+                                    "azureDefender": {
+                                      "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
+                                      "apiVersion": "2021-02-01-preview",
+                                      "name": "[format('{0}/{1}/Default', parameters('sqlServerName'), parameters('sqlDatabase').name)]",
+                                      "properties": {
+                                        "state": "[if(parameters('sqlDatabase').azureDefender.enabled, 'Enabled', 'Disabled')]",
+                                        "emailAddresses": "[parameters('sqlDatabase').azureDefender.emailAddresses]",
+                                        "emailAccountAdmins": "[parameters('sqlDatabase').azureDefender.emailAccountAdmins]",
+                                        "disabledAlerts": "[parameters('sqlDatabase').azureDefender.disabledRules]"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "sqlDb",
+                                "transparentDataEncryption"
+                              ]
+                            },
+                            "auditSettings": {
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('auditSettings-{0}', uniqueString(parameters('sqlServerName'), parameters('sqlDatabase').name))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "sqlDatabase": {
+                                    "value": "[parameters('sqlDatabase')]"
+                                  },
+                                  "sqlServerName": {
+                                    "value": "[parameters('sqlServerName')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.1-experimental",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+                                    "_EXPERIMENTAL_FEATURES_ENABLED": [
+                                      "Resource info code generation"
+                                    ],
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "dev",
+                                      "templateHash": "12199939005745757465"
+                                    }
+                                  },
+                                  "parameters": {
+                                    "sqlDatabase": {
+                                      "type": "object"
+                                    },
+                                    "sqlServerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "variables": {
+                                    "defaultAuditActionsAndGroups": [
+                                      "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
+                                      "FAILED_DATABASE_AUTHENTICATION_GROUP",
+                                      "BATCH_COMPLETED_GROUP"
+                                    ]
+                                  },
+                                  "resources": {
+                                    "auditSettings": {
+                                      "type": "Microsoft.Sql/servers/databases/auditingSettings",
+                                      "apiVersion": "2021-02-01-preview",
+                                      "name": "[format('{0}/{1}/Default', parameters('sqlServerName'), parameters('sqlDatabase').name)]",
+                                      "properties": {
+                                        "state": "[if(parameters('sqlDatabase').diagnosticLogsAndMetrics.auditLogs, 'Enabled', 'Disabled')]",
+                                        "auditActionsAndGroups": "[if(not(empty(parameters('sqlDatabase').auditActionsAndGroups)), parameters('sqlDatabase').auditActionsAndGroups, variables('defaultAuditActionsAndGroups'))]",
+                                        "storageEndpoint": "",
+                                        "storageAccountAccessKey": "",
+                                        "storageAccountSubscriptionId": "00000000-0000-0000-0000-000000000000",
+                                        "retentionDays": 0,
+                                        "isAzureMonitorTargetEnabled": "[parameters('sqlDatabase').diagnosticLogsAndMetrics.auditLogs]"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "sqlDb",
+                                "transparentDataEncryption"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "sqlLogicalServerRes"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "sqlRg"
+      ]
+    }
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/audit-settings.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/audit-settings.bicep
@@ -1,0 +1,24 @@
+param sqlDatabase object
+param sqlServerName string
+
+var defaultAuditActionsAndGroups = [
+  'SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP'
+  'FAILED_DATABASE_AUTHENTICATION_GROUP'
+  'BATCH_COMPLETED_GROUP'
+]
+
+// Audit settings need for enabling auditing to Log Analytics workspace
+resource auditSettings 'Microsoft.Sql/servers/databases/auditingSettings@2021-02-01-preview' = {
+  name: '${sqlServerName}/${sqlDatabase.name}/Default'
+  properties: {
+    state: sqlDatabase.diagnosticLogsAndMetrics.auditLogs ? 'Enabled' : 'Disabled'
+    auditActionsAndGroups: !empty(sqlDatabase.auditActionsAndGroups)
+      ? sqlDatabase.auditActionsAndGroups
+      : defaultAuditActionsAndGroups
+    storageEndpoint: ''
+    storageAccountAccessKey: ''
+    storageAccountSubscriptionId: '00000000-0000-0000-0000-000000000000'
+    retentionDays: 0
+    isAzureMonitorTargetEnabled: sqlDatabase.diagnosticLogsAndMetrics.auditLogs
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/azure-defender.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/azure-defender.bicep
@@ -1,0 +1,13 @@
+param sqlDatabase object
+param sqlServerName string
+
+// Azure Defender
+resource azureDefender 'Microsoft.Sql/servers/databases/securityAlertPolicies@2021-02-01-preview' = {
+  name: '${sqlServerName}/${sqlDatabase.name}/Default'
+  properties: {
+    state: sqlDatabase.azureDefender.enabled ? 'Enabled' : 'Disabled'
+    emailAddresses: sqlDatabase.azureDefender.emailAddresses
+    emailAccountAdmins: sqlDatabase.azureDefender.emailAccountAdmins
+    disabledAlerts: sqlDatabase.azureDefender.disabledRules
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/short-term-backup.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/short-term-backup.bicep
@@ -1,0 +1,10 @@
+param sqlDatabase object
+param sqlServerName string
+
+// Short term backup
+resource shortTermBackup 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2021-02-01-preview' = {
+  name: '${sqlServerName}/${sqlDatabase.name}/Default'
+  properties: {
+    retentionDays: sqlDatabase.shortTermBackupRetention
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-database.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-database.bicep
@@ -1,0 +1,153 @@
+@description('The name of the SQL server.')
+param sqlServerName string
+
+@description('The SQL database parameters object.')
+param sqlDatabase object
+
+param tags object
+
+resource sqlDb 'Microsoft.Sql/servers/databases@2020-02-02-preview' = {
+  name: '${sqlServerName}/${sqlDatabase.name}'
+  location: resourceGroup().location
+  tags: tags
+  sku: {
+    name: sqlDatabase.skuName
+    tier: sqlDatabase.tier
+  }
+  properties: {
+    zoneRedundant: sqlDatabase.zoneRedundant
+    collation: sqlDatabase.collation
+    maxSizeBytes: sqlDatabase.dataMaxSize == 0 ? null : 1024 * 1024 * 1024 * sqlDatabase.dataMaxSize
+    licenseType: sqlDatabase.hybridBenefit ? 'BasePrice' : 'LicenseIncluded'
+    readScale: sqlDatabase.readReplicas == 0 ? 'Disabled' : 'Enabled'
+    readReplicaCount: sqlDatabase.readReplicas
+    minCapacity: sqlDatabase.minimumCores == 0 ? null : sqlDatabase.minimumCores
+    autoPauseDelay: sqlDatabase.autoPauseDelay == 0 ? null : sqlDatabase.autoPauseDelay
+  }
+}
+
+// Transparent Data Encryption
+resource transparentDataEncryption 'Microsoft.Sql/servers/databases/transparentDataEncryption@2014-04-01' = {
+  name: 'current'
+  parent: sqlDb
+  properties: {
+    status: sqlDatabase.dataEncryption
+  }
+}
+
+// Short term backup
+module shortTermBackup 'short-term-backup.bicep' = if (!(sqlDatabase.shortTermBackupRetention == 0)) {
+  dependsOn: [transparentDataEncryption, sqlDb]
+  name: 'shortTermBackup-${uniqueString(sqlServerName, sqlDatabase.name)}'
+  params: {
+    sqlDatabase: sqlDatabase
+    sqlServerName: sqlServerName
+  }
+}
+
+// Long term backup
+resource longTermBackup 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2021-02-01-preview' = if (sqlDatabase.longTermBackup.enabled) {
+  dependsOn: [transparentDataEncryption, shortTermBackup]
+  name: 'default'
+  parent: sqlDb
+  properties: {
+    weeklyRetention: sqlDatabase.longTermBackup.weeklyRetention
+    monthlyRetention: sqlDatabase.longTermBackup.monthlyRetention
+    yearlyRetention: sqlDatabase.longTermBackup.yearlyRetention
+    weekOfYear: sqlDatabase.longTermBackup.weekOfYear
+  }
+}
+
+// Azure Defender
+module azureDefender 'azure-defender.bicep' = {
+  dependsOn: [transparentDataEncryption, sqlDb]
+  name: 'azureDefender-${uniqueString(sqlServerName, sqlDatabase.name)}'
+  params: {
+    sqlDatabase: sqlDatabase
+    sqlServerName: sqlServerName
+  }
+}
+
+// Get existing storage account
+resource storageAccountVulnerabilityAssessments 'Microsoft.Storage/storageAccounts@2021-04-01' existing = if (sqlDatabase.azureDefender.enabled && sqlDatabase.azureDefender.vulnerabilityAssessments.recurringScans && !empty(sqlDatabase.azureDefender.vulnerabilityAssessments.storageAccount.name)) {
+  scope: resourceGroup(sqlDatabase.azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName)
+  name: sqlDatabase.azureDefender.vulnerabilityAssessments.storageAccount.name
+}
+
+// Vulnerability Assessments
+// Can be enabled only if Azure Defender is enabled as well
+resource vulnerabilityAssessments 'Microsoft.Sql/servers/databases/vulnerabilityAssessments@2021-02-01-preview' = if (sqlDatabase.azureDefender.enabled && sqlDatabase.azureDefender.vulnerabilityAssessments.recurringScans && !empty(sqlDatabase.azureDefender.vulnerabilityAssessments.storageAccount.name)) {
+  dependsOn: [transparentDataEncryption, azureDefender]
+  name: 'default'
+  parent: sqlDb
+  properties: {
+    recurringScans: {
+      isEnabled: sqlDatabase.azureDefender.vulnerabilityAssessments.recurringScans
+      emailSubscriptionAdmins: sqlDatabase.azureDefender.vulnerabilityAssessments.emailSubscriptionAdmins
+      emails: sqlDatabase.azureDefender.vulnerabilityAssessments.emails
+    }
+    storageContainerPath: !empty(sqlDatabase.azureDefender.vulnerabilityAssessments.storageAccount.name)
+      ? '${storageAccountVulnerabilityAssessments.properties.primaryEndpoints.blob}${sqlDatabase.azureDefender.vulnerabilityAssessments.storageAccount.containerName}'
+      : ''
+    storageAccountAccessKey: !empty(sqlDatabase.azureDefender.vulnerabilityAssessments.storageAccount.name)
+      ? storageAccountVulnerabilityAssessments.listKeys().keys[0].value
+      : ''
+  }
+}
+
+// Audit settings need for enabling auditing to Log Analytics workspace
+module auditSettings 'audit-settings.bicep' = {
+  dependsOn: [transparentDataEncryption, sqlDb]
+  name: 'auditSettings-${uniqueString(sqlServerName, sqlDatabase.name)}'
+  params: {
+    sqlDatabase: sqlDatabase
+    sqlServerName: sqlServerName
+  }
+}
+
+// Get existing Log Analytics workspace
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = if (sqlDatabase.diagnosticLogsAndMetrics.auditLogs || !empty(sqlDatabase.diagnosticLogsAndMetrics.name)) {
+  scope: resourceGroup(
+    sqlDatabase.diagnosticLogsAndMetrics.subscriptionId,
+    sqlDatabase.diagnosticLogsAndMetrics.resourceGroupName
+  )
+  name: sqlDatabase.diagnosticLogsAndMetrics.name
+}
+
+// Sends audit logs to Log Analytics Workspace
+resource auditDiagnosticSettings 'microsoft.insights/diagnosticSettings@2017-05-01-preview' = if (sqlDatabase.diagnosticLogsAndMetrics.auditLogs) {
+  dependsOn: [transparentDataEncryption, auditSettings]
+  scope: sqlDb
+  name: 'SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1'
+  properties: {
+    workspaceId: logAnalyticsWorkspace.id
+    logs: [
+      {
+        category: 'SQLSecurityAuditEvents'
+        enabled: true
+      }
+    ]
+  }
+}
+
+// Send other logs and metrics to Log Analytics
+resource diagnosticSettings 'microsoft.insights/diagnosticSettings@2017-05-01-preview' = if (!empty(sqlDatabase.diagnosticLogsAndMetrics.name)) {
+  dependsOn: [transparentDataEncryption]
+  scope: sqlDb
+  name: 'sendLogsAndMetrics'
+  properties: {
+    workspaceId: logAnalyticsWorkspace.id
+    logs: [
+      for log in sqlDatabase.diagnosticLogsAndMetrics.logs: {
+        category: log
+        enabled: true
+      }
+    ]
+    metrics: [
+      for metric in sqlDatabase.diagnosticLogsAndMetrics.metrics: {
+        category: metric
+        enabled: true
+      }
+    ]
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-firewall-rule.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-firewall-rule.bicep
@@ -1,0 +1,13 @@
+@description('Firewall rule')
+param sqlFirewallRule object
+
+@description('The name of the SQL Logical server.')
+param sqlServerName string
+
+resource firewallRule 'Microsoft.Sql/servers/firewallRules@2021-02-01-preview' = {
+  name: '${sqlServerName}/${sqlFirewallRule.name}'
+  properties: {
+    startIpAddress: sqlFirewallRule.startIpAddress
+    endIpAddress: sqlFirewallRule.endIpAddress
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-logical-server.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-logical-server.bicep
@@ -1,0 +1,247 @@
+@description('SQL Logical server.')
+param sqlLogicalServer object
+
+@description('The SQL Logical Server password.')
+@secure()
+param password string
+
+param tags object
+
+var defaultAuditActionsAndGroups = [
+  'SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP'
+  'FAILED_DATABASE_AUTHENTICATION_GROUP'
+  'BATCH_COMPLETED_GROUP'
+]
+
+var defaultSqlDatabaseProperties = {
+  name: ''
+  status: ''
+  tags: {}
+  skuName: ''
+  tier: ''
+  zoneRedundant: false
+  collation: 'SQL_Latin1_General_CP1_CI_AS'
+  dataMaxSize: 0
+  hybridBenefit: false
+  readReplicas: 0
+  minimumCores: 0
+  autoPauseDelay: 0
+  dataEncryption: 'Enabled'
+  shortTermBackupRetention: 0
+  longTermBackup: {
+    enabled: false
+    weeklyRetention: 'P1W'
+    monthlyRetention: 'P4W'
+    yearlyRetention: 'P52W'
+    weekOfYear: 1
+  }
+  azureDefender: {
+    enabled: false
+    emailAccountAdmins: false
+    emailAddresses: []
+    disabledRules: []
+    vulnerabilityAssessments: {
+      recurringScans: false
+      storageAccount: {
+        resourceGroupName: ''
+        name: ''
+        containerName: ''
+      }
+      emailSubscriptionAdmins: false
+      emails: []
+    }
+  }
+  auditActionsAndGroups: []
+  diagnosticLogsAndMetrics: {
+    name: ''
+    resourceGroupName: ''
+    subscriptionId: subscription().subscriptionId
+    logs: []
+    metrics: []
+    auditLogs: false
+  }
+}
+
+resource sqlLogicalServerRes 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: sqlLogicalServer.name
+  location: resourceGroup().location
+  tags: tags
+  identity: {
+    type: sqlLogicalServer.systemManagedIdentity ? 'SystemAssigned' : 'None'
+  }
+  properties: {
+    administratorLogin: sqlLogicalServer.userName
+    administratorLoginPassword: password
+    version: '12.0'
+    minimalTlsVersion: sqlLogicalServer.minimalTlsVersion
+    publicNetworkAccess: sqlLogicalServer.publicNetworkAccess
+  }
+}
+
+// Azure Active Directory integration
+resource azureAdIntegration 'Microsoft.Sql/servers/administrators@2021-02-01-preview' = if (!empty(sqlLogicalServer.azureActiveDirectoryAdministrator.objectId)) {
+  name: 'ActiveDirectory'
+  parent: sqlLogicalServerRes
+  properties: {
+    administratorType: 'ActiveDirectory'
+    login: sqlLogicalServer.azureActiveDirectoryAdministrator.name
+    sid: sqlLogicalServer.azureActiveDirectoryAdministrator.objectId
+    tenantId: sqlLogicalServer.azureActiveDirectoryAdministrator.tenantId
+  }
+}
+
+// Azure Defender
+resource azureDefender 'Microsoft.Sql/servers/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'Default'
+  parent: sqlLogicalServerRes
+  properties: {
+    state: sqlLogicalServer.azureDefender.enabled ? 'Enabled' : 'Disabled'
+    emailAddresses: sqlLogicalServer.azureDefender.emailAddresses
+    emailAccountAdmins: sqlLogicalServer.azureDefender.emailAccountAdmins
+    disabledAlerts: sqlLogicalServer.azureDefender.disabledRules
+  }
+}
+
+// Get existing storage account
+resource storageAccountVulnerabilityAssessments 'Microsoft.Storage/storageAccounts@2021-04-01' existing = if (sqlLogicalServer.azureDefender.enabled && sqlLogicalServer.azureDefender.vulnerabilityAssessments.recurringScans && !empty(sqlLogicalServer.azureDefender.vulnerabilityAssessments.storageAccount.name)) {
+  scope: resourceGroup(sqlLogicalServer.azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName)
+  name: sqlLogicalServer.azureDefender.vulnerabilityAssessments.storageAccount.name
+}
+
+// Vulnerability Assessments
+// Can be enabled only if Azure Defender is enabled as well
+resource vulnerabilityAssessments 'Microsoft.Sql/servers/vulnerabilityAssessments@2021-02-01-preview' = if (sqlLogicalServer.azureDefender.enabled && sqlLogicalServer.azureDefender.vulnerabilityAssessments.recurringScans && !empty(sqlLogicalServer.azureDefender.vulnerabilityAssessments.storageAccount.name)) {
+  dependsOn: [azureDefender]
+  name: 'default'
+  parent: sqlLogicalServerRes
+  properties: {
+    recurringScans: {
+      isEnabled: sqlLogicalServer.azureDefender.vulnerabilityAssessments.recurringScans
+      emailSubscriptionAdmins: sqlLogicalServer.azureDefender.vulnerabilityAssessments.emailSubscriptionAdmins
+      emails: sqlLogicalServer.azureDefender.vulnerabilityAssessments.emails
+    }
+    storageContainerPath: !empty(sqlLogicalServer.azureDefender.vulnerabilityAssessments.storageAccount.name)
+      ? '${storageAccountVulnerabilityAssessments.properties.primaryEndpoints.blob}${sqlLogicalServer.azureDefender.vulnerabilityAssessments.storageAccount.containerName}'
+      : ''
+    storageAccountAccessKey: !empty(sqlLogicalServer.azureDefender.vulnerabilityAssessments.storageAccount.name)
+      ? storageAccountVulnerabilityAssessments.listKeys().keys[0].value
+      : ''
+  }
+}
+
+// Audit settings need for enabling auditing to Log Analytics workspace
+resource auditSettings 'Microsoft.Sql/servers/auditingSettings@2021-02-01-preview' = {
+  name: 'default'
+  parent: sqlLogicalServerRes
+  properties: {
+    state: sqlLogicalServer.diagnosticLogsAndMetrics.auditLogs ? 'Enabled' : 'Disabled'
+    auditActionsAndGroups: !empty(sqlLogicalServer.auditActionsAndGroups)
+      ? sqlLogicalServer.auditActionsAndGroups
+      : defaultAuditActionsAndGroups
+    storageEndpoint: ''
+    storageAccountAccessKey: ''
+    storageAccountSubscriptionId: '00000000-0000-0000-0000-000000000000'
+    retentionDays: 0
+    isAzureMonitorTargetEnabled: sqlLogicalServer.diagnosticLogsAndMetrics.auditLogs
+    isDevopsAuditEnabled: sqlLogicalServer.diagnosticLogsAndMetrics.microsoftSupportOperationsAuditLogs
+  }
+}
+
+// SQL Logical Server Firewall Rules
+module sqlFirewallRules 'sql-firewall-rule.bicep' = [
+  for (firewallRules, index) in sqlLogicalServer.firewallRules: {
+    dependsOn: [sqlLogicalServerRes]
+    name: 'sqlFirewallRule-${uniqueString(sqlLogicalServer.name)}-${index}'
+    params: {
+      sqlFirewallRule: sqlLogicalServer.firewallRules[index]
+      sqlServerName: sqlLogicalServer.name
+    }
+  }
+]
+
+// SQL Databases
+module sqlDatabases 'sql-database.bicep' = [
+  for (sqlDatabase, index) in sqlLogicalServer.databases: {
+    dependsOn: [sqlLogicalServerRes]
+    name: 'sqlDb-${uniqueString(sqlLogicalServer.name)}-${index}'
+    params: {
+      sqlServerName: sqlLogicalServer.name
+      sqlDatabase: union(defaultSqlDatabaseProperties, sqlLogicalServer.databases[index])
+      tags: union(tags, union(defaultSqlDatabaseProperties, sqlLogicalServer.databases[index]).tags)
+    }
+  }
+]
+
+// Empty deployment that serves as artificial delay until master database resource is created
+@batchSize(1)
+resource dummyDeployments 'Microsoft.Resources/deployments@2021-04-01' = [
+  for (dummyDeployment, index) in range(0, 5): if (sqlLogicalServer.diagnosticLogsAndMetrics.auditLogs && !empty(sqlLogicalServer.diagnosticLogsAndMetrics.name)) {
+    dependsOn: [sqlLogicalServerRes]
+    name: 'dummyTemplateSqlServer-${uniqueString(sqlLogicalServer.name)}-${index}'
+    properties: {
+      mode: 'Incremental'
+      template: {
+        '$schema': 'https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#'
+        contentVersion: '1.0.0.0'
+        resources: []
+      }
+    }
+  }
+]
+
+// Get existing master database
+resource masterDb 'Microsoft.Sql/servers/databases@2021-02-01-preview' existing = if (sqlLogicalServer.diagnosticLogsAndMetrics.auditLogs || !empty(sqlLogicalServer.diagnosticLogsAndMetrics.name)) {
+  name: 'master'
+  parent: sqlLogicalServerRes
+}
+
+// Get existing Log Analytics workspace
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = if (sqlLogicalServer.diagnosticLogsAndMetrics.auditLogs || !empty(sqlLogicalServer.diagnosticLogsAndMetrics.name)) {
+  scope: resourceGroup(
+    sqlLogicalServer.diagnosticLogsAndMetrics.subscriptionId,
+    sqlLogicalServer.diagnosticLogsAndMetrics.resourceGroupName
+  )
+  name: sqlLogicalServer.diagnosticLogsAndMetrics.name
+}
+
+// Sends audit logs to Log Analytics Workspace
+resource auditDiagnosticSettings 'microsoft.insights/diagnosticSettings@2017-05-01-preview' = if (sqlLogicalServer.diagnosticLogsAndMetrics.auditLogs) {
+  dependsOn: [auditSettings, sqlDatabases, dummyDeployments]
+  scope: masterDb
+  name: 'SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1'
+  properties: {
+    workspaceId: logAnalyticsWorkspace.id
+    logs: [
+      {
+        category: 'SQLSecurityAuditEvents'
+        enabled: true
+      }
+      {
+        category: 'DevOpsOperationsAudit'
+        enabled: sqlLogicalServer.diagnosticLogsAndMetrics.microsoftSupportOperationsAuditLogs
+      }
+    ]
+  }
+}
+
+// Send other logs and metrics to Log Analytics
+resource diagnosticSettings 'microsoft.insights/diagnosticSettings@2017-05-01-preview' = if (!empty(sqlLogicalServer.diagnosticLogsAndMetrics.name)) {
+  dependsOn: [sqlDatabases, dummyDeployments]
+  scope: masterDb
+  name: 'sendLogsAndMetrics'
+  properties: {
+    workspaceId: logAnalyticsWorkspace.id
+    logs: [
+      for log in sqlLogicalServer.diagnosticLogsAndMetrics.logs: {
+        category: log
+        enabled: true
+      }
+    ]
+    metrics: [
+      for metric in sqlLogicalServer.diagnosticLogsAndMetrics.metrics: {
+        category: metric
+        enabled: true
+      }
+    ]
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-logical-servers.bicep
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/modules/sql-logical-servers.bicep
@@ -1,0 +1,72 @@
+@description('SQL logical servers.')
+param sqlLogicalServers array
+param tags object
+
+var defaultSqlLogicalServerProperties = {
+  name: ''
+  tags: {}
+  userName: ''
+  passwordFromKeyVault: {
+    subscriptionId: subscription().subscriptionId
+    resourceGroupName: ''
+    name: ''
+    secretName: ''
+  }
+  systemManagedIdentity: false
+  minimalTlsVersion: '1.2'
+  publicNetworkAccess: 'Enabled'
+  azureActiveDirectoryAdministrator: {
+    name: ''
+    objectId: ''
+    tenantId: subscription().tenantId
+  }
+  firewallRules: []
+  azureDefender: {
+    enabled: false
+    emailAccountAdmins: false
+    emailAddresses: []
+    disabledRules: []
+    vulnerabilityAssessments: {
+      recurringScans: false
+      storageAccount: {
+        resourceGroupName: ''
+        name: ''
+        containerName: ''
+      }
+      emailSubscriptionAdmins: false
+      emails: []
+    }
+  }
+  auditActionsAndGroups: []
+  diagnosticLogsAndMetrics: {
+    name: ''
+    resourceGroupName: ''
+    subscriptionId: subscription().subscriptionId
+    logs: []
+    metrics: []
+    auditLogs: false
+    microsoftSupportOperationsAuditLogs: false
+  }
+  databases: []
+}
+
+resource sqlPassKeyVaults 'Microsoft.KeyVault/vaults@2021-04-01-preview' existing = [
+  for keyVault in sqlLogicalServers: {
+    name: keyVault.passwordFromKeyVault.name
+    scope: resourceGroup(
+      union(defaultSqlLogicalServerProperties, keyVault).passwordFromKeyVault.subscriptionId,
+      keyVault.passwordFromKeyVault.resourceGroupName
+    )
+  }
+]
+
+module sqlLogicalServer 'sql-logical-server.bicep' = [
+  for (sqlLogicalServer, index) in sqlLogicalServers: {
+    name: 'sqlLogicalServer-${index}'
+    params: {
+      sqlLogicalServer: union(defaultSqlLogicalServerProperties, sqlLogicalServer)
+      password: sqlPassKeyVaults[index].getSecret(sqlLogicalServer.passwordFromKeyVault.secretName)
+      tags: union(tags, union(defaultSqlLogicalServerProperties, sqlLogicalServer).tags)
+    }
+  }
+]

--- a/src/Bicep.Core.IntegrationTests/SymbolicNameGenerationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SymbolicNameGenerationTests.cs
@@ -14,6 +14,7 @@ using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Baselines;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.Utils;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -33,4 +34,38 @@ public class SymbolicNameTests
     [EmbeddedFilesTestData(@"Files/SymbolicNameTests/ResourceInfo/.*/main\.bicep")]
     public async Task ResourceInfoCodegenEnabled_output_is_valid(EmbeddedFile bicepFile)
         => await ExamplesTests.RunExampleTest(TestContext, bicepFile, new(ResourceInfoCodegenEnabled: true));
+
+    [TestMethod]
+    public void Unqualified_names_are_output_correctly()
+    {
+        var result = CompilationHelper.Compile(new ServiceBuilder().WithFeatureOverrides(new(ResourceInfoCodegenEnabled: true)), """
+resource noParent 'Microsoft.Test/parent/child@2020-01-01' = {
+  name: 'parent/noParent'
+}
+
+resource foo 'Microsoft.Test/parent@2020-01-01' = {
+  name: 'parent'
+
+  resource nested 'child' = {
+    name: 'nested'
+  }
+}
+
+resource parentProperty 'Microsoft.Test/parent/child@2020-01-01' = {
+  parent: foo
+  name: 'parentProperty'
+}
+
+output noParent string = noParent.name
+output nested string = foo::nested.name
+output parentProperty string = parentProperty.name
+""");
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyCompilationBlockingDiagnostics();
+        var evaluated = TemplateEvaluator.Evaluate(result.Template).ToJToken();
+        
+        evaluated.Should().HaveValueAtPath("$.outputs['noParent'].value", "parent/noParent");
+        evaluated.Should().HaveValueAtPath("$.outputs['nested'].value", "nested");
+        evaluated.Should().HaveValueAtPath("$.outputs['parentProperty'].value", "parentProperty");
+    }
 }

--- a/src/Bicep.Core.IntegrationTests/SymbolicNameGenerationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SymbolicNameGenerationTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using Bicep.Core.Configuration;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Resources;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Types;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Baselines;
+using Bicep.Core.UnitTests.Features;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.IntegrationTests;
+
+
+[TestClass]
+public class SymbolicNameTests
+{
+    [NotNull]
+    public TestContext? TestContext { get; set; }
+
+    [TestMethod]
+    [TestCategory(BaselineHelper.BaselineTestCategory)]
+    [EmbeddedFilesTestData(@"Files/SymbolicNameTests/ResourceInfo/.*/main\.bicep")]
+    public async Task ResourceInfoCodegenEnabled_output_is_valid(EmbeddedFile bicepFile)
+        => await ExamplesTests.RunExampleTest(TestContext, bicepFile, new(ResourceInfoCodegenEnabled: true));
+}

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -111,7 +111,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "optionalModuleNames": false,
           "localDeploy": false,
           "resourceDerivedTypes": false,
-          "secureOutputs": false
+          "secureOutputs": false,
+          "resourceInfoCodegen": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -192,7 +193,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "optionalModuleNames": false,
           "localDeploy": false,
           "resourceDerivedTypes": false,
-          "secureOutputs": false
+          "secureOutputs": false,
+          "resourceInfoCodegen": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -298,7 +300,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "optionalModuleNames": false,
           "localDeploy": false,
           "resourceDerivedTypes": false,
-          "secureOutputs": false
+          "secureOutputs": false,
+          "resourceInfoCodegen": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -389,7 +392,8 @@ namespace Bicep.Core.UnitTests.Configuration
                 OptionalModuleNames: false,
                 LocalDeploy: false,
                 ResourceDerivedTypes: false,
-                SecureOutputs: false);
+                SecureOutputs: false,
+                ResourceInfoCodegen: false);
 
             configuration.WithExperimentalFeaturesEnabled(experimentalFeaturesEnabled).Should().HaveContents(/*lang=json,strict*/ """
             {
@@ -474,7 +478,8 @@ namespace Bicep.Core.UnitTests.Configuration
                 "optionalModuleNames": false,
                 "localDeploy": false,
                 "resourceDerivedTypes": false,
-                "secureOutputs": false
+                "secureOutputs": false,
+                "resourceInfoCodegen": false
             },
             "formatting": {
                 "indentKind": "Space",
@@ -845,7 +850,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "optionalModuleNames": false,
           "localDeploy": false,
           "resourceDerivedTypes": false,
-          "secureOutputs": false
+          "secureOutputs": false,
+          "resourceInfoCodegen": false
         },
         "formatting": {
           "indentKind": "Space",

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -22,6 +22,7 @@ public record FeatureProviderOverrides(
     bool? LocalDeployEnabled = default,
     bool? ResourceDerivedTypesEnabled = default,
     bool? SecureOutputsEnabled = default,
+    bool? ResourceInfoCodegenEnabled = default,
     bool? ExtendableParamFilesEnabled = default,
     string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
     bool? ExtensibilityV2EmittingEnabled = default)
@@ -41,6 +42,7 @@ public record FeatureProviderOverrides(
         bool? LocalDeployEnabled = default,
         bool? ResourceDerivedTypesEnabled = default,
         bool? SecureOutputsEnabled = default,
+        bool? ResourceInfoCodegenEnabled = default,
         bool? ExtendableParamFilesEnabled = default,
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
         bool? ExtensibilityV2EmittingEnabled = default
@@ -59,6 +61,7 @@ public record FeatureProviderOverrides(
         LocalDeployEnabled,
         ResourceDerivedTypesEnabled,
         SecureOutputsEnabled,
+        ResourceInfoCodegenEnabled,
         ExtendableParamFilesEnabled,
         AssemblyVersion,
         ExtensibilityV2EmittingEnabled)

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -43,6 +43,8 @@ public class OverriddenFeatureProvider : IFeatureProvider
 
     public bool SecureOutputsEnabled => overrides.SecureOutputsEnabled ?? features.SecureOutputsEnabled;
 
+    public bool ResourceInfoCodegenEnabled => overrides.ResourceInfoCodegenEnabled ?? features.ResourceInfoCodegenEnabled;
+
     public bool ExtendableParamFilesEnabled => overrides.ExtendableParamFilesEnabled ?? features.ExtendableParamFilesEnabled;
 
     public bool ExtensibilityV2EmittingEnabled => overrides.ExtensibilityV2EmittingEnabled ?? features.ExtensibilityV2EmittingEnabled;

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -19,7 +19,8 @@ public record ExperimentalFeaturesEnabled(
     bool OptionalModuleNames,
     bool LocalDeploy,
     bool ResourceDerivedTypes,
-    bool SecureOutputs)
+    bool SecureOutputs,
+    bool ResourceInfoCodegen)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
         => element.ToNonNullObject<ExperimentalFeaturesEnabled>();

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -241,6 +241,15 @@ namespace Bicep.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Resource info code generation.
+        /// </summary>
+        internal static string ExperimentalFeatureNames_ResourceInfoCodegen {
+            get {
+                return ResourceManager.GetString("ExperimentalFeatureNames_ResourceInfoCodegen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Test framework.
         /// </summary>
         internal static string ExperimentalFeatureNames_TestFramework {

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -496,6 +496,9 @@
   <data name="ExperimentalFeatureNames_SymbolicNameCodegen" xml:space="preserve">
     <value>Symbolic name code generation</value>
   </data>
+  <data name="ExperimentalFeatureNames_ResourceInfoCodegen" xml:space="preserve">
+    <value>Resource info code generation</value>
+  </data>
   <data name="ExperimentalFeatureNames_TestFramework" xml:space="preserve">
     <value>Test framework</value>
   </data>

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -20,6 +20,8 @@ namespace Bicep.Core.Emit
                 UseExperimentalTemplateLanguageVersion ||
                 // symbolic name codegen has been explicitly enabled
                 model.Features.SymbolicNameCodegenEnabled ||
+                // resourceinfo codegen has been enabled
+                model.Features.ResourceInfoCodegenEnabled ||
                 // there are any user-defined type declarations
                 model.Root.TypeDeclarations.Any() ||
                 // there are any user-defined function declarations

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Intermediate;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
+using Bicep.Core.TypeSystem.Providers.Az;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 using Newtonsoft.Json.Linq;
 
@@ -373,41 +374,60 @@ namespace Bicep.Core.Emit
                 if (context.SemanticModel.Features.ResourceInfoCodegenEnabled)
                 {
                     // Use simplified "resourceInfo" code generation.
+
+                    LanguageExpression getResourceInfoExpression()
+                    {
+                        var symbolExpression = GenerateSymbolicReference(declaredResource, indexContext);
+                        return AppendProperties(CreateFunction("resourceInfo", symbolExpression), new JTokenExpression(propertyName));
+                    }
+
                     switch (propertyName)
                     {
-                        case "id":
-                        case "name":
-                        case "type":
-                        case "apiVersion":
-                            var symbolExpression = GenerateSymbolicReference(declaredResource, indexContext);
-                            var resourceInfoExpression = AppendProperties(CreateFunction("resourceInfo", symbolExpression), new JTokenExpression(propertyName));
+                        case AzResourceTypeProvider.ResourceIdPropertyName:
+                        case AzResourceTypeProvider.ResourceTypePropertyName:
+                        case AzResourceTypeProvider.ResourceApiVersionPropertyName:
+                            return (getResourceInfoExpression(), [], safeAccess);
+                        case AzResourceTypeProvider.ResourceNamePropertyName:
+                            var nameExpression = getResourceInfoExpression();
+                            if (declaredResource.Parent is {})
+                            {
+                                // resourceInfo('foo').name will always return a fully-qualified name, whereas using "foo.name" in Bicep
+                                // will give different results depending on whether the resource has a parent (either syntactically, or with the 'parent' property) or not.
+                                // We must preserve this behavior by using "last(split(..., '/'))" to convert from qualified -> unqualified, to avoid this being a breaking change.
+                                nameExpression = CreateFunction(
+                                    "last",
+                                    CreateFunction(
+                                        "split",
+                                        nameExpression,
+                                        new JTokenExpression("/")));
+                            }
 
-                            return (resourceInfoExpression, [], safeAccess);
+                            return (nameExpression, [], safeAccess);
                     }
                 }
 
                 switch (propertyName)
                 {
-                    case "id":
+                    case AzResourceTypeProvider.ResourceIdPropertyName:
                         // the ID is dependent on the name expression which could involve locals in case of a resource collection
-                        return (GetFullyQualifiedResourceId(resource), Enumerable.Empty<LanguageExpression>(), safeAccess);
-                    case "name":
+                        return (GetFullyQualifiedResourceId(resource), [], safeAccess);
+                    case AzResourceTypeProvider.ResourceNamePropertyName:
                         // the name is dependent on the name expression which could involve locals in case of a resource collection
 
                         // Note that we don't want to return the fully-qualified resource name in the case of name property access.
                         // we should return whatever the user has set as the value of the 'name' property for a predictable user experience.
-                        return (ConvertExpression(declaredResource.NameSyntax), Enumerable.Empty<LanguageExpression>(), safeAccess);
-                    case "type":
-                        return (new JTokenExpression(resource.TypeReference.FormatType()), Enumerable.Empty<LanguageExpression>(), safeAccess);
-                    case "apiVersion":
+                        return (ConvertExpression(declaredResource.NameSyntax), [], safeAccess);
+                    case AzResourceTypeProvider.ResourceTypePropertyName:
+                        return (new JTokenExpression(resource.TypeReference.FormatType()), [], safeAccess);
+                    case AzResourceTypeProvider.ResourceApiVersionPropertyName:
                         var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
-                        return (new JTokenExpression(apiVersion), Enumerable.Empty<LanguageExpression>(), safeAccess);
+                        return (new JTokenExpression(apiVersion), [], safeAccess);
                     case "properties" when !safeAccess:
                         // use the reference() overload without "full" to generate a shorter expression
                         // this is dependent on the name expression which could involve locals in case of a resource collection
-                        return (GetReferenceExpression(resource, indexContext, false), Enumerable.Empty<LanguageExpression>(), safeAccess);
+                        return (GetReferenceExpression(resource, indexContext, false), [], safeAccess);
                     default:
-                        return (GetReferenceExpression(resource, indexContext, true), new[] { new JTokenExpression(propertyName) }, safeAccess);
+                        return (GetReferenceExpression(resource, indexContext, true), [new JTokenExpression(propertyName)], safeAccess);
                 }
             }
             else

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -51,6 +51,8 @@ namespace Bicep.Core.Features
 
         public bool SecureOutputsEnabled => configuration.ExperimentalFeaturesEnabled.SecureOutputs;
 
+        public bool ResourceInfoCodegenEnabled => this.configuration.ExperimentalFeaturesEnabled.ResourceInfoCodegen;
+
         public bool ExtensibilityV2EmittingEnabled => ReadBooleanEnvVar("BICEP_EXTENSIBILITY_V2_EMITTING_ENABLED", defaultValue: false);
 
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -35,6 +35,8 @@ public interface IFeatureProvider
 
     bool SecureOutputsEnabled { get; }
 
+    bool ResourceInfoCodegenEnabled { get; }
+
     bool ExtensibilityV2EmittingEnabled { get; }
 
     IEnumerable<(string name, bool impactsCompilation, bool usesExperimentalArmEngineFeature)> EnabledFeatureMetadata
@@ -46,6 +48,7 @@ public interface IFeatureProvider
             foreach (var (enabled, name, impactsCompilation, usesExperimentalArmEngineFeature) in new[]
             {
                 (SymbolicNameCodegenEnabled, CoreResources.ExperimentalFeatureNames_SymbolicNameCodegen, false, false), // Symbolic name codegen is listed as not impacting compilation because it is GA
+                (ResourceInfoCodegenEnabled, CoreResources.ExperimentalFeatureNames_ResourceInfoCodegen, true, true),
                 (ExtensibilityEnabled, CoreResources.ExperimentalFeatureNames_Extensibility, true, true),
                 (ResourceTypedParamsAndOutputsEnabled, CoreResources.ExperimentalFeatureNames_ResourceTypedParamsAndOutputs, true, false),
                 (SourceMappingEnabled, CoreResources.ExperimentalFeatureNames_SourceMapping, true, false),

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -835,7 +835,7 @@
         },
         "resourceInfoCodegen": {
             "type": "boolean",
-            "description": "Enables the 'resourceInfo' function for simplified code generation. See https://aka.ms/bicep/experimental-features#resourceinfo"
+            "description": "Enables the 'resourceInfo' function for simplified code generation. See https://aka.ms/bicep/experimental-features#resourceinfocodegen"
         }
       },
       "additionalProperties": false

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -832,6 +832,10 @@
         "secureOutputs": {
             "type": "boolean",
             "description": "If enabled, users can use the secure decorator for outputs. See https://aka.ms/bicep/experimental-features#secureoutputs"
+        },
+        "resourceInfoCodegen": {
+            "type": "boolean",
+            "description": "Enables the 'resourceInfo' function for simplified code generation. See https://aka.ms/bicep/experimental-features#resourceinfo"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
The original issues with the resourceInfo function have been fixed in the backend. This PR brings back the simplified code generation using the `resourceInfo` function for `id`, `type`, `name` and `apiVersion` properties, behind an experimental feature flag.

Closes #12597
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16045)