### PR TITLE
Allow accessing generated module names

### DIFF
--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -413,7 +413,7 @@ namespace Bicep.Core.Emit
                 case "name":
                     // the name is dependent on the name expression which could involve locals in case of a resource collection
 
-                    return (GetModuleNameExpression(reference.Module), Enumerable.Empty<LanguageExpression>(), false);
+                    return (GetModuleNameExpression(reference.Module, reference.IndexContext?.Index), Enumerable.Empty<LanguageExpression>(), false);
 
                 case "outputs":
                     var moduleSymbol = reference.Module;
@@ -421,7 +421,7 @@ namespace Bicep.Core.Emit
                     if (context.SemanticModel.Features.SecureOutputsEnabled &&
                         FindPossibleSecretsVisitor.FindPossibleSecretsInExpression(context.SemanticModel, moduleSymbol.DeclaringModule).Any())
                     {
-                        var deploymentResourceId = GetFullyQualifiedResourceId(moduleSymbol);
+                        var deploymentResourceId = GetFullyQualifiedResourceId(moduleSymbol, reference.IndexContext?.Index);
                         var apiVersion = new JTokenExpression(EmitConstants.NestedDeploymentResourceApiVersion);
                         return (CreateFunction(secureOutputsApi, deploymentResourceId, apiVersion),
                             Enumerable.Empty<LanguageExpression>(), expression.Flags.HasFlag(AccessExpressionFlags.SafeAccess));
@@ -506,16 +506,16 @@ namespace Bicep.Core.Emit
             return CreateFunction("format", new JTokenExpression(formatString).AsEnumerable().Concat(nameSegments));
         }
 
-        private LanguageExpression GetModuleNameExpression(ModuleSymbol moduleSymbol)
+        private LanguageExpression GetModuleNameExpression(ModuleSymbol moduleSymbol, Expression? indexExpression)
         {
-            SyntaxBase nameValueSyntax = GetModuleNameSyntax(moduleSymbol);
-            return ConvertExpression(nameValueSyntax);
-        }
+            if (moduleSymbol.TryGetBodyPropertyValue(LanguageConstants.ModuleNamePropertyName) is { } nameValueSyntax)
+            {
+                return ConvertExpression(nameValueSyntax);
+            }
 
-        public static SyntaxBase GetModuleNameSyntax(ModuleSymbol moduleSymbol)
-        {
-            // this condition should have already been validated by the type checker
-            return moduleSymbol.TryGetBodyPropertyValue(LanguageConstants.ModuleNamePropertyName) ?? throw new ArgumentException($"Expected module syntax body to contain property 'name'");
+            var generatedModuleNameExpression = ExpressionFactory.CreateGeneratedModuleName(moduleSymbol, indexExpression);
+
+            return ConvertExpression(generatedModuleNameExpression);
         }
 
         public LanguageExpression GetUnqualifiedResourceId(DeclaredResourceMetadata resource)
@@ -561,14 +561,14 @@ namespace Bicep.Core.Emit
             }
         }
 
-        public LanguageExpression GetFullyQualifiedResourceId(ModuleSymbol moduleSymbol)
+        public LanguageExpression GetFullyQualifiedResourceId(ModuleSymbol moduleSymbol, Expression? indexExpression)
         {
             return ScopeHelper.FormatFullyQualifiedResourceId(
                 context,
                 this,
                 context.ModuleScopeData[moduleSymbol],
                 TemplateWriter.NestedDeploymentResourceType,
-                GetModuleNameExpression(moduleSymbol).AsEnumerable());
+                GetModuleNameExpression(moduleSymbol, indexExpression).AsEnumerable());
         }
 
         public FunctionExpression GetModuleReferenceExpression(ModuleSymbol moduleSymbol, IndexReplacementContext? indexContext, bool isModuleOutputResource)
@@ -592,7 +592,7 @@ namespace Bicep.Core.Emit
 
             return CreateFunction(
                 referenceFunctionName,
-                GetConverter(indexContext).GetFullyQualifiedResourceId(moduleSymbol),
+                GetConverter(indexContext).GetFullyQualifiedResourceId(moduleSymbol, indexContext?.Index),
                 new JTokenExpression(EmitConstants.NestedDeploymentResourceApiVersion));
         }
 

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -137,7 +137,7 @@ namespace Bicep.Core.Emit
         {
             var converterForContext = this.converter.GetConverter(indexContext);
 
-            var resourceIdExpression = converterForContext.GetFullyQualifiedResourceId(moduleSymbol);
+            var resourceIdExpression = converterForContext.GetFullyQualifiedResourceId(moduleSymbol, indexContext?.Index);
             var serialized = ExpressionSerializer.SerializeExpression(resourceIdExpression);
 
             writer.WriteValue(serialized);

--- a/src/Bicep.Core/Intermediate/ExpressionFactory.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionFactory.cs
@@ -2,13 +2,18 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
+using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
+using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Intermediate;
 
 public static class ExpressionFactory
 {
+    private static readonly int MaxCopyIndexStringLength = LanguageConstants.MaxResourceCopyIndexValue.ToString().Length;
+
     public static ObjectPropertyExpression CreateObjectProperty(string name, Expression value, SyntaxBase? sourceSyntax = null)
         => new(
             sourceSyntax,
@@ -45,4 +50,50 @@ public static class ExpressionFactory
 
     public static FunctionCallExpression CreateFunctionCall(string functionName, IEnumerable<Expression> parameters, SyntaxBase? sourceSyntax = null)
         => new(sourceSyntax, functionName, parameters.ToImmutableArray());
+
+    public static FunctionCallExpression CreateGeneratedModuleName(ModuleSymbol moduleSymbol, Expression? indexExpression = null)
+    {
+        var formatParameters = new List<Expression>();
+        var formatParametersLength = 0;
+
+        if (moduleSymbol.IsCollection)
+        {
+            formatParameters.Add(indexExpression ?? new CopyIndexExpression(SourceSyntax: null, Name: null));
+            formatParametersLength += MaxCopyIndexStringLength;
+        }
+
+        formatParameters.Add(
+            CreateFunctionCall(
+                "uniqueString",
+                null,
+                CreateStringLiteral(moduleSymbol.Name, sourceSyntax: null),
+                CreatePropertyAccess(
+                    CreateFunctionCall("deployment", sourceSyntax: null),
+                    "name",
+                    null,
+                    AccessExpressionFlags.None)));
+
+        formatParametersLength += (int)SystemNamespaceType.UniqueStringHashLength;
+
+        // the format string will use a single dash delimiter per parameter
+        formatParametersLength += formatParameters.Count;
+
+        var maxSymbolicNamePrefixLength = LanguageConstants.MaxDeploymentNameLength - formatParametersLength;
+        var actualSymbolicNamePrefixLength = Math.Min(maxSymbolicNamePrefixLength, moduleSymbol.Name.Length);
+        var symbolicNamePrefix = moduleSymbol.Name[..actualSymbolicNamePrefixLength];
+
+        var formatStringExpression = ExpressionFactory.CreateStringLiteral(moduleSymbol.IsCollection
+            ? $"{symbolicNamePrefix}-{{0}}-{{1}}"
+            : $"{symbolicNamePrefix}-{{0}}");
+
+        Debug.Assert(actualSymbolicNamePrefixLength <= maxSymbolicNamePrefixLength, "The symbolic name prefix should not exceed the maximum length.");
+        Debug.Assert(formatParametersLength + maxSymbolicNamePrefixLength == LanguageConstants.MaxDeploymentNameLength, "The sum of the format parameters length and the symbolic name prefix length should equal the maximum deployment name length.");
+
+        // in loops, the generated name expression should be:
+        //   '<symbolicNamePrefix>-${copyIndex()}-${uniqueString('<symbolicName>', deployment().name)}'
+        // outside of loops, the name expression should be:
+        //   '<symbolicNamePrefix>-uniqueString('<symbolicName>', deployment().name)'
+
+        return CreateFunctionCall("format", formatParameters.Prepend(formatStringExpression));
+    }
 }

--- a/src/Bicep.Core/Semantics/SymbolExtensions.cs
+++ b/src/Bicep.Core/Semantics/SymbolExtensions.cs
@@ -16,17 +16,23 @@ namespace Bicep.Core.Semantics
         public static SyntaxBase? TryGetBodyPropertyValue(this ResourceSymbol resourceSymbol, string propertyName)
             => TryGetBodyProperty(resourceSymbol, propertyName)?.Value;
 
-        public static ObjectPropertySyntax UnTryGetBodyProperty(this ResourceSymbol resourceSymbol, string propertyName)
-            => resourceSymbol.TryGetBodyProperty(propertyName) ?? throw new ArgumentException($"Expected resource syntax body to contain property '{propertyName}'");
+        public static ObjectPropertySyntax GetBodyProperty(this ResourceSymbol resourceSymbol, string propertyName)
+            => resourceSymbol.TryGetBodyProperty(propertyName) ?? throw new ArgumentException($"Expected resource syntax body to contain property '{propertyName}'.");
 
-        public static SyntaxBase UnTryGetBodyPropertyValue(this ResourceSymbol resourceSymbol, string propertyName)
-            => resourceSymbol.TryGetBodyPropertyValue(propertyName) ?? throw new ArgumentException($"Expected resource syntax body to contain property '{propertyName}'");
+        public static SyntaxBase GetBodyPropertyValue(this ResourceSymbol resourceSymbol, string propertyName)
+            => resourceSymbol.TryGetBodyPropertyValue(propertyName) ?? throw new ArgumentException($"Expected resource syntax body to contain property '{propertyName}'.");
 
         public static ObjectPropertySyntax? TryGetBodyProperty(this ModuleSymbol moduleSymbol, string propertyName)
             => moduleSymbol.DeclaringModule.TryGetBody()?.TryGetPropertyByName(propertyName);
 
         public static SyntaxBase? TryGetBodyPropertyValue(this ModuleSymbol moduleSymbol, string propertyName)
             => TryGetBodyProperty(moduleSymbol, propertyName)?.Value;
+
+        public static ObjectPropertySyntax GetBodyProperty(this ModuleSymbol moduleSymbol, string propertyName)
+            => moduleSymbol.TryGetBodyProperty(propertyName) ?? throw new ArgumentException($"Expected module syntax body to contain property '{propertyName}'.");
+
+        public static SyntaxBase GetBodyPropertyValue(this ModuleSymbol moduleSymbol, string propertyName)
+            => moduleSymbol.TryGetBodyPropertyValue(propertyName) ?? throw new ArgumentException($"Expected module syntax body to contain property '{propertyName}'.");
 
         public static bool IsSecure(this ParameterSymbol parameterSymbol)
         {


### PR DESCRIPTION
Fixes #13295.

The remaining tasks involve resolving a couple of linter warnings and restricting the use of generated module names to Template Language version v2. I’ll address these in subsequent PRs.