### PR TITLE
Deprecate the term `provider`

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/PublishProviderCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishProviderCommandTests.cs
@@ -19,34 +19,6 @@ namespace Bicep.Cli.IntegrationTests;
 public class PublishExtensionCommandTests : TestBase
 {
     [TestMethod]
-    public async Task Publish_provider_prints_deprecation_warning()
-    {
-        var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(
-            TestContext,
-            typeof(PublishExtensionCommandTests).Assembly,
-            "Files/PublishExtensionCommandTests/TestExtension");
-
-        var registryStr = "example.com";
-        var registryUri = new Uri($"https://{registryStr}");
-        var repository = $"test/extension";
-        var version = "0.0.1";
-
-        var (clientFactory, blobClientMocks) = RegistryHelper.CreateMockRegistryClients((registryStr, repository));
-        var mockBlobClient = blobClientMocks[(registryUri, repository)];
-
-        var indexPath = Path.Combine(outputDirectory, "index.json");
-        var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
-
-        List<string> requiredArgs = ["publish-provider", indexPath, "--target", $"br:{registryStr}/{repository}:{version}"];
-
-        string[] args = [.. requiredArgs];
-
-        var result = await Bicep(settings, args);
-        result.Should().Succeed();
-        result.Should().HaveStderrMatch("*DEPRECATED: The command publish-provider is deprecated and will be removed in a future version of Bicep CLI. Use publish-extension instead.*");
-    }
-
-    [TestMethod]
     public async Task Publish_extension_should_succeed()
     {
         var outputDirectory = FileHelper.SaveEmbeddedResourcesWithPathPrefix(

--- a/src/Bicep.Cli/Arguments/PublishExtensionArguments.cs
+++ b/src/Bicep.Cli/Arguments/PublishExtensionArguments.cs
@@ -9,11 +9,6 @@ namespace Bicep.Cli.Arguments
     {
         public PublishExtensionArguments(string[] args, string commandName, IOContext io) : base(commandName)
         {
-            if (commandName.Equals(Constants.Command.PublishProvider, StringComparison.Ordinal))
-            {
-                io.WriteCommandDeprecationWarning(commandName, Constants.Command.PublishExtension);
-            }
-
             for (int i = 0; i < args.Length; i++)
             {
                 var isLast = args.Length == i + 1;

--- a/src/Bicep.Cli/Constants/CliConstants.cs
+++ b/src/Bicep.Cli/Constants/CliConstants.cs
@@ -15,7 +15,6 @@ namespace Bicep.Cli.Constants
         public const string Decompile = "decompile";
         public const string DecompileParams = "decompile-params";
         public const string Publish = "publish";
-        public const string PublishProvider = "publish-provider";
         public const string PublishExtension = "publish-extension";
         public const string Restore = "restore";
         public const string Lint = "lint";

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -92,9 +92,6 @@ namespace Bicep.Cli
                     case PublishArguments publishArguments when publishArguments.CommandName == Constants.Command.Publish: // bicep publish [options]
                         return await services.GetRequiredService<PublishCommand>().RunAsync(publishArguments);
 
-                    case PublishExtensionArguments publishProviderArguments when publishProviderArguments.CommandName == Constants.Command.PublishProvider: // bicep publish-provider [options]
-                        return await services.GetRequiredService<PublishExtensionCommand>().RunAsync(publishProviderArguments);
-
                     case PublishExtensionArguments publishProviderArguments when publishProviderArguments.CommandName == Constants.Command.PublishExtension: // bicep publish-extension [options]
                         return await services.GetRequiredService<PublishExtensionCommand>().RunAsync(publishProviderArguments);
 

--- a/src/Bicep.Cli/Services/ArgumentParser.cs
+++ b/src/Bicep.Cli/Services/ArgumentParser.cs
@@ -35,7 +35,6 @@ namespace Bicep.Cli.Services
                 Constants.Command.GenerateParamsFile => new GenerateParametersFileArguments(args[1..]),
                 Constants.Command.Decompile => new DecompileArguments(args[1..]),
                 Constants.Command.DecompileParams => new DecompileParamsArguments(args[1..]),
-                Constants.Command.PublishProvider => new PublishExtensionArguments(args[1..], Constants.Command.PublishProvider, io),
                 Constants.Command.PublishExtension => new PublishExtensionArguments(args[1..], Constants.Command.PublishExtension, io),
                 Constants.Command.Publish => new PublishArguments(args[1..], io),
                 Constants.Command.Restore => new RestoreArguments(args[1..]),

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
@@ -1887,7 +1887,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             public void LinterIgnoresNotAzureResources()
             {
                 CompileAndTestWithFakeDateAndTypes(@"
-                        provider kubernetes with {
+                        extension kubernetes with {
                           namespace: 'default'
                           kubeConfig: ''
                         }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1737,21 +1737,6 @@ namespace Bicep.Core.Diagnostics
                 $"Artifacts of type: \"{artifactType}\" are not supported."
             );
 
-            public Diagnostic ExtensionDeclarationKeywordIsDeprecated(ExtensionDeclarationSyntax syntax)
-            {
-                var codeFix = new CodeFix(
-                    $"Replace the {syntax.Keyword.Text} keyword with the extension keyword",
-                    true,
-                    CodeFixKind.QuickFix,
-                    new CodeReplacement(syntax.Keyword.Span, LanguageConstants.ExtensionKeyword));
-
-                return CoreWarning(
-                    "BCP381",
-                    @$"Declaring extension with the ""{syntax.Keyword.Text}"" keyword has been deprecated. Please use the ""extension"" keyword instead. Please see https://github.com/Azure/bicep/issues/14374 for more information.")
-                    with
-                { Fixes = [codeFix] };
-            }
-
             public Diagnostic TypeIsNotParameterizable(string typeName) => CoreError(
                 "BCP383",
                 $"The \"{typeName}\" type is not parameterizable.");

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -73,7 +73,6 @@ namespace Bicep.Core
         public const string FunctionKeyword = "func";
         public const string ExistingKeyword = "existing";
         public const string ImportKeyword = "import";
-        public const string ProviderKeyword = "provider";
         public const string ExtensionKeyword = "extension";
         public const string AssertKeyword = "assert";
         public const string WithKeyword = "with";

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -64,7 +64,6 @@ namespace Bicep.Core.Parsing
                             LanguageConstants.ModuleKeyword => this.ModuleDeclaration(leadingNodes),
                             LanguageConstants.TestKeyword => this.TestDeclaration(leadingNodes),
                             LanguageConstants.ImportKeyword => this.ImportDeclaration(leadingNodes),
-                            LanguageConstants.ProviderKeyword or
                             LanguageConstants.ExtensionKeyword => this.ExtensionDeclaration(ExpectKeyword(current.Text), leadingNodes),
                             LanguageConstants.AssertKeyword => this.AssertDeclaration(leadingNodes),
                             _ => leadingNodes.Length > 0

--- a/src/Bicep.Core/Syntax/ExtensionDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ExtensionDeclarationSyntax.cs
@@ -13,7 +13,7 @@ namespace Bicep.Core.Syntax
         public ExtensionDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, SyntaxBase specificationString, SyntaxBase withClause, SyntaxBase asClause)
             : base(leadingNodes)
         {
-            AssertKeyword(keyword, nameof(keyword), LanguageConstants.ImportKeyword, LanguageConstants.ProviderKeyword, LanguageConstants.ExtensionKeyword);
+            AssertKeyword(keyword, nameof(keyword), LanguageConstants.ImportKeyword, LanguageConstants.ExtensionKeyword);
             AssertSyntaxType(specificationString, nameof(specificationString), typeof(StringSyntax), typeof(SkippedTriviaSyntax), typeof(IdentifierSyntax));
 
             this.Keyword = keyword;

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -891,12 +891,6 @@ namespace Bicep.Core.TypeSystem
                     return ErrorType.Empty();
                 }
 
-                if (syntax.Keyword.IsKeyword(LanguageConstants.ImportKeyword) ||
-                    syntax.Keyword.IsKeyword(LanguageConstants.ProviderKeyword))
-                {
-                    diagnostics.Write(syntax.Keyword, x => x.ExtensionDeclarationKeywordIsDeprecated(syntax));
-                }
-
                 if (namespaceSymbol.DeclaredType is not NamespaceType namespaceType)
                 {
                     // We should have an error type here - return it directly.

--- a/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeActionTests.cs
@@ -514,32 +514,6 @@ param foo2 string", "param foo2 string")]
             updatedFile.Should().HaveSourceText(expectedText);
         }
 
-        [TestMethod]
-        public async Task Provider_codefix_works()
-        {
-            var server = await MultiFileLanguageServerHelper.StartLanguageServer(
-                TestContext,
-                services => services.WithFeatureOverrides(new(TestContext, ExtensibilityEnabled: true)));
-
-            (var codeActions, var bicepFile) = await GetCodeActionsForSyntaxTest(@"
-imp|ort 'br:example.azurecr.io/test/radius:1.0.0'
-", server: server);
-
-            var updatedFile = ApplyCodeAction(bicepFile, codeActions.Single(x => x.Title.StartsWith("Replace the import keyword with the extension keyword")));
-            updatedFile.Should().HaveSourceText(@"
-extension 'br:example.azurecr.io/test/radius:1.0.0'
-");
-
-            (codeActions, bicepFile) = await GetCodeActionsForSyntaxTest(@"
-pro|vider 'br:example.azurecr.io/test/radius:1.0.0'
-", server: server);
-
-            updatedFile = ApplyCodeAction(bicepFile, codeActions.Single(x => x.Title.StartsWith("Replace the provider keyword with the extension keyword")));
-            updatedFile.Should().HaveSourceText(@"
-extension 'br:example.azurecr.io/test/radius:1.0.0'
-");
-        }
-
         [DataRow("var|")]
         [DataRow("var |")]
         [DataTestMethod]


### PR DESCRIPTION
It's been several months since the provider keyword was marked as deprecated. Now is the time to fully deprecate it.

- Removed the `provider` keyword.
- Removed the `publish-provider` command.
- Removed the related diagnostic (BCP381).

Closes #14374.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16107)