### PR TITLE
SecureOutput Feature Bug Fix

### DIFF
--- a/src/Bicep.Core.IntegrationTests/SecureOutputsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SecureOutputsTests.cs
@@ -34,28 +34,19 @@ public class SecureOutputsTests
         // https://github.com/Azure/bicep/issues/2163
         var result = CompilationHelper.Compile(new UnitTests.ServiceBuilder().WithFeatureOverrides(new(TestContext, SecureOutputsEnabled: true)),
             ("main.bicep", @"
-                @secure()
-                param myInput string
- 
                 module foo 'foo.bicep' = {
                   name: 'foo'
-                  params: {
-                    myInput : myInput
-                  }
                 }
  
-                output myOutput string = foo.outputs.myOutput
+                output myOutput string = foo.outputs.secureOutput
             "),
             ("foo.bicep", @"
                 @secure()
-                param myInput string
- 
-                @secure()
-                output myOutput string = myInput
+                output secureOutput string = '***secret***'
             ")
         );
 
-        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Diagnostics.Should().NotHaveAnyDiagnostics();
     }
 
     [TestMethod]
@@ -119,28 +110,64 @@ public class SecureOutputsTests
         // https://github.com/Azure/bicep/issues/2163
         var result = CompilationHelper.Compile(new UnitTests.ServiceBuilder().WithFeatureOverrides(new(TestContext, SecureOutputsEnabled: true)),
             ("main.bicep", @"
-                @secure()
-                param foo string
- 
-                module mod 'module.bicep' = {
-                  name: 'mod'
-                  params: {
-                    foo: foo
+                module foo 'foo.bicep' = {
+                  name: 'foo'
+                }
+
+                resource key 'Microsoft.KeyVault/vaults/secrets@2024-04-01-preview' = {
+                  name: 'secrets/mysecret'
+                  properties: {
+                    value: foo.outputs.secureOutput
                   }
                 }
- 
-                output bar string = mod.outputs.bar
-                "),
-            ("module.bicep", @"
+
+                module bar 'bar.bicep' = {
+                  name: 'bar'
+                }
+
+                module baz 'baz.bicep' = {
+                  name: 'baz'
+                  params: {
+                    secureInput: foo.outputs.secureOutput
+                  }
+                }
+
+                output outputNormalVal string = foo.outputs.normalOutput
+                output outputSecureVal string = foo.outputs.secureOutput
+                output outputNormalVal2 string = bar.outputs.normalOutput
+                output outputNormalVal3 string = baz.outputs.normalOutput
+            "),
+            ("foo.bicep", @"
                 @secure()
-                param foo string
- 
+                output secureOutput string = '***secret***'
+                output normalOutput string = 'normal'
+            "),
+            ("bar.bicep", @"
+                output normalOutput string = 'normal'
+            "),
+            ("baz.bicep", @"
                 @secure()
-                output bar string = foo
-            ")
+                param secureInput string
+
+                output normalOutput string = 'normal'"
+            )
         );
 
-        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
-        result.Template.Should().HaveValueAtPath("$.outputs['bar'].value", "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'mod'), '2022-09-01').bar]");
+        result.Diagnostics.Should().NotHaveAnyDiagnostics();
+
+        // Verify referencing secure output in a resource property will be translated to listOutputsWithSecureValues function
+        result.Template.Should().HaveValueAtPath("$.resources['0'].properties.value", "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'foo'), '2022-09-01').secureOutput]");
+
+        // Verify referencing secure output will be translated to listOutputsWithSecureValues function
+        result.Template.Should().HaveValueAtPath("$.outputs['outputSecureVal'].value", "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'foo'), '2022-09-01').secureOutput]");
+
+        // Verify referencing normal value from a deployment which contains secure outputs will be translated to listOutputsWithSecureValues function
+        result.Template.Should().HaveValueAtPath("$.outputs['outputNormalVal'].value", "[listOutputsWithSecureValues(resourceId('Microsoft.Resources/deployments', 'foo'), '2022-09-01').normalOutput]");
+
+        // Verify referencing normal value from a deployment which does NOT contain any secure outputs will be translated to normal reference function
+        result.Template.Should().HaveValueAtPath("$.outputs['outputNormalVal2'].value", "[reference(resourceId('Microsoft.Resources/deployments', 'bar'), '2022-09-01').outputs.normalOutput.value]");
+
+        // Verify referencing normal value from a deployment which does NOT contain any secure outputs but secure parameters will be translated to normal reference function
+        result.Template.Should().HaveValueAtPath("$.outputs['outputNormalVal3'].value", "[reference(resourceId('Microsoft.Resources/deployments', 'baz'), '2022-09-01').outputs.normalOutput.value]");
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/OutputsShouldNotContainSecretsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/OutputsShouldNotContainSecretsRule.cs
@@ -54,6 +54,12 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
             {
+                if (this.model.Features.SecureOutputsEnabled)
+                {
+                    // SecureOutputs feature is enabled, so we don't need to check for secrets in outputs
+                    return;
+                }
+
                 // Does the output name contain 'password' (suggesting it contains an actual password)?
                 if (syntax.Name.IdentifierName.Contains("password", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -448,9 +448,9 @@ namespace Bicep.Core.Emit
 
                 case "outputs":
                     var moduleSymbol = reference.Module;
-
                     if (context.SemanticModel.Features.SecureOutputsEnabled &&
-                        FindPossibleSecretsVisitor.FindPossibleSecretsInExpression(context.SemanticModel, moduleSymbol.DeclaringModule).Any())
+                        expression.SourceSyntax is not null &&
+                        FindPossibleSecretsVisitor.FindPossibleSecretsInExpression(context.SemanticModel, expression.SourceSyntax).Any())
                     {
                         var deploymentResourceId = GetFullyQualifiedResourceId(moduleSymbol, reference.IndexContext?.Index);
                         var apiVersion = new JTokenExpression(EmitConstants.NestedDeploymentResourceApiVersion);


### PR DESCRIPTION

Fix a bug in this pull request: 
Improve tests to cover edge cases.

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
