### PR TITLE
Try to fix restore conflict in integration tests

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -36,6 +36,9 @@ namespace Bicep.Core.IntegrationTests.Emit
 
         private async Task<Compilation> GetCompilation(DataSet dataSet, FeatureProviderOverrides features)
         {
+            // Use a unique cache root directory for each test run to avoid conflicts
+            features = features with { CacheRootDirectory = FileHelper.GetCacheRootDirectory(TestContext) };
+
             var outputDirectory = dataSet.SaveFilesToTestDirectory(TestContext);
             var clientFactory = dataSet.CreateMockRegistryClients();
             var templateSpecRepositoryFactory = dataSet.CreateMockTemplateSpecRepositoryFactory(TestContext);


### PR DESCRIPTION
A shot in the dark to try and fix:

```
Failed ValidBicep_TemplateEmiterShouldProduceExpectedTemplate_Registry_LF [423 ms]
  Error Message:
   Expected AssertionExtensions to be empty, but found at least one item {"[BCP190 (Error)] The artifact with reference "br:mock-registry-one.invalid/demo/plan:v2" has not been restored."}.
  Stack Trace:
     at FluentAssertions.Execution.LateBoundTestFramework.Throw(String message)
   at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
   at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
   at FluentAssertions.Execution.GivenSelector`1.FailWith(String message, Object[] args)
   at FluentAssertions.Collections.GenericCollectionAssertions`3.BeEmpty(String because, Object[] becauseArgs)
   at Bicep.Core.UnitTests.Assertions.IDiagnosticCollectionAssertions.NotHaveErrors(String because, Object[] becauseArgs) in C:\__w\1\s\bicep\src\Bicep.Core.UnitTests\Assertions\IDiagnosticCollectionExtensions.cs:line 114
   at Bicep.Core.IntegrationTests.Emit.TemplateEmitterTests.ValidBicep_TemplateEmiterShouldProduceExpectedTemplate(DataSet dataSet) in C:\__w\1\s\bicep\src\Bicep.Core.IntegrationTests\Emit\TemplateEmitterTests.cs:line 64
 ```