### PR TITLE
Drop back to 4.11-compiler-compatibe code analysis

### DIFF
--- a/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/Bicep.VSLanguageServerClient.IntegrationTests.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/Bicep.VSLanguageServerClient.IntegrationTests.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="7.0.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.12.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.11.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.IntegrationTests/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "Microsoft.CodeAnalysis.CSharp.CodeStyle": {
         "type": "Direct",
-        "requested": "[4.12.0, )",
-        "resolved": "4.12.0",
-        "contentHash": "5S+LHLhm0am4MWQQMN0O3VyKA/St5JCqH1yv+1YGZl2klIJlLlmNA/KTLCVJSC1kZPIKR1MFF/3g9FqsyzIyCQ=="
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "lcKLcYWr0vtRcGcmLs9WMilKT1DwoOaDIGvkuIX5t2exqVluHGCEBoE/R5zsoealJUDJb8BTu6ODPwpDb/JZug=="
       },
       "Microsoft.IO.Redist": {
         "type": "Direct",

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/Bicep.VSLanguageServerClient.TestServices.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/Bicep.VSLanguageServerClient.TestServices.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.12.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.TestServices/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.CodeAnalysis.CSharp.CodeStyle": {
         "type": "Direct",
-        "requested": "[4.12.0, )",
-        "resolved": "4.12.0",
-        "contentHash": "5S+LHLhm0am4MWQQMN0O3VyKA/St5JCqH1yv+1YGZl2klIJlLlmNA/KTLCVJSC1kZPIKR1MFF/3g9FqsyzIyCQ=="
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "lcKLcYWr0vtRcGcmLs9WMilKT1DwoOaDIGvkuIX5t2exqVluHGCEBoE/R5zsoealJUDJb8BTu6ODPwpDb/JZug=="
       },
       "Microsoft.IO.Redist": {
         "type": "Direct",

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/Bicep.VSLanguageServerClient.UnitTests.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/Bicep.VSLanguageServerClient.UnitTests.csproj
@@ -7,7 +7,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="7.0.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.12.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.11.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient.UnitTests/packages.lock.json
@@ -19,9 +19,9 @@
       },
       "Microsoft.CodeAnalysis.CSharp.CodeStyle": {
         "type": "Direct",
-        "requested": "[4.12.0, )",
-        "resolved": "4.12.0",
-        "contentHash": "5S+LHLhm0am4MWQQMN0O3VyKA/St5JCqH1yv+1YGZl2klIJlLlmNA/KTLCVJSC1kZPIKR1MFF/3g9FqsyzIyCQ=="
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "lcKLcYWr0vtRcGcmLs9WMilKT1DwoOaDIGvkuIX5t2exqVluHGCEBoE/R5zsoealJUDJb8BTu6ODPwpDb/JZug=="
       },
       "Microsoft.IO.Redist": {
         "type": "Direct",

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/Bicep.VSLanguageServerClient.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="3.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.12.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/vs-bicep/Bicep.VSLanguageServerClient/packages.lock.json
+++ b/src/vs-bicep/Bicep.VSLanguageServerClient/packages.lock.json
@@ -26,9 +26,9 @@
       },
       "Microsoft.CodeAnalysis.CSharp.CodeStyle": {
         "type": "Direct",
-        "requested": "[4.12.0, )",
-        "resolved": "4.12.0",
-        "contentHash": "5S+LHLhm0am4MWQQMN0O3VyKA/St5JCqH1yv+1YGZl2klIJlLlmNA/KTLCVJSC1kZPIKR1MFF/3g9FqsyzIyCQ=="
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "lcKLcYWr0vtRcGcmLs9WMilKT1DwoOaDIGvkuIX5t2exqVluHGCEBoE/R5zsoealJUDJb8BTu6ODPwpDb/JZug=="
       },
       "Microsoft.IO.Redist": {
         "type": "Direct",


### PR DESCRIPTION
Hopefully to fix mirror - those build images use msbuild 17.11, which is incompatible with 17.12 used by github.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16111)