### PR TITLE
Emit symbolic name template when an optional module name is enabled.

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -731,7 +731,7 @@ module {symbolicName} 'mod.bicep' = {{}}
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
 
-            result.Template.Should().HaveValueAtPath("$.resources[0].name", $"[format('{symbolicNamePrefix}-{{0}}', uniqueString('{symbolicName}', deployment().name))]");
+            result.Template.Should().HaveValueAtPath($"$.resources.{symbolicName}.name", $"[format('{symbolicNamePrefix}-{{0}}', uniqueString('{symbolicName}', deployment().name))]");
         }
 
         [DataRow("a", "a")]
@@ -753,7 +753,7 @@ module {symbolicName} 'mod.bicep' = [for x in []: {{
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
 
-            result.Template.Should().HaveValueAtPath("$.resources[0].name", $"[format('{symbolicNamePrefix}-{{0}}-{{1}}', copyIndex(), uniqueString('{symbolicName}', deployment().name))]");
+            result.Template.Should().HaveValueAtPath($"$.resources.{symbolicName}.name", $"[format('{symbolicNamePrefix}-{{0}}-{{1}}', copyIndex(), uniqueString('{symbolicName}', deployment().name))]");
         }
 
         [DataRow("a", "a")]

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -40,7 +40,9 @@ namespace Bicep.Core.Emit
                         syntax is UnionTypeSyntax ||
                         syntax is NullableTypeSyntax,
                     resultSelector: result => result,
-                    continuationFunction: (result, syntax) => !result);
+                    continuationFunction: (result, syntax) => !result) ||
+                // there are optional module names
+                model.Root.ModuleDeclarations.Any(module => module.TryGetBodyProperty(LanguageConstants.ModuleNamePropertyName) is null);
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/Azure/bicep/issues/16056.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16114)