### PR TITLE
Offer code fix to fully qualify function call for shadowed decorator functions

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -6731,4 +6731,20 @@ var subnetId = vNet::subnets[0].id
             ("BCP034", DiagnosticLevel.Error, "The enclosing array expected an item of type \"module[] | (resource | module) | resource[]\", but the provided item was of type \"never\"."),
         });
     }
+
+    [TestMethod]
+    public void Test_Issue16112()
+    {
+        var result = CompilationHelper.Compile("""
+            @description('A description of this resource is required to document the purpose for which it was created.')
+            param descriptionParam string
+
+            var description = 'foo'
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP265", DiagnosticLevel.Error, "The name \"description\" is not a function. Did you mean \"sys.description\"?"),
+        });
+    }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/NamespaceResolver.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/NamespaceResolver.cs
@@ -75,9 +75,10 @@ namespace Bicep.Core.Semantics.Namespaces
                 : null)
             .WhereNotNull();
 
-        public IEnumerable<FunctionSymbol> GetKnownFunctions(string functionName)
+        public IEnumerable<FunctionSymbol> GetKnownFunctions(string functionName, bool includeDecorators)
             => this.namespaceTypes.Values
-                .Select(type => type.MethodResolver.TryGetFunctionSymbol(functionName))
+                .Select(type => type.MethodResolver.TryGetFunctionSymbol(functionName) ??
+                    (includeDecorators ? type.DecoratorResolver.TryGetDecoratorFunctionSymbol(functionName) : null))
                 .OfType<FunctionSymbol>();
 
         public IEnumerable<string> GetKnownFunctionNames(bool includeDecorators)

--- a/src/Bicep.Core/TypeSystem/DecoratorResolver.cs
+++ b/src/Bicep.Core/TypeSystem/DecoratorResolver.cs
@@ -25,6 +25,9 @@ namespace Bicep.Core.TypeSystem
 
         public IReadOnlyDictionary<string, FunctionSymbol> GetKnownDecoratorFunctions() => this.functionResolver.GetKnownFunctions();
 
+        public FunctionSymbol? TryGetDecoratorFunctionSymbol(string name)
+            => this.functionResolver.TryGetFunctionSymbol(name);
+
         public IEnumerable<Decorator> GetMatches(FunctionSymbol symbol, IList<TypeSymbol> argumentTypes)
         {
             foreach (var overload in FunctionResolver.GetMatches(symbol, argumentTypes, out var _, out var _))

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1921,7 +1921,9 @@ namespace Bicep.Core.TypeSystem
                     case ImportedFunctionSymbol importedFunction:
                         return GetFunctionSymbolType(importedFunction, syntax, errors, diagnostics);
 
-                    case Symbol symbolInfo when binder.NamespaceResolver.GetKnownFunctions(symbolInfo.Name).FirstOrDefault() is { } knownFunction:
+                    case Symbol symbolInfo when binder.NamespaceResolver
+                            .GetKnownFunctions(symbolInfo.Name, binder.GetParent(syntax) is DecoratorSyntax)
+                            .FirstOrDefault() is { } knownFunction:
                         // A function exists, but it's being shadowed by another symbol in the file
                         return ErrorType.Create(
                             errors.Append(


### PR DESCRIPTION
Resolves #16112 

The compiler will check if a non-function symbol being invoked as a function shadows a built-in function, but this was not happening for decorator functions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16116)