### PR TITLE
Disable rollForward in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
   "sdk": {
     "allowPrerelease": false,
     "version": "8.0.404",
-    "rollForward": "latestPatch"
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
This breaks our build every time there's a .NET SDK release, because of package lock conflicts.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16177)