### PR TITLE
Reuse already updated object types when recursively removing type property flags

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.404",
+    "version": "8.0.405",
     "rollForward": "disable"
   }
 }

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -27,9 +27,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/Bicep.Core.UnitTests/Diagnostics/Linter/Common/FindPossibleSecretsVisitorTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/Linter/Common/FindPossibleSecretsVisitorTests.cs
@@ -105,7 +105,6 @@ namespace Bicep.Core.UnitTests.Diagnostics.Linter.Common
                 output test = v.listAnything().keys[0].value
             "
             )]
-        /* TODO: blocked by https://github.com/Azure/bicep/issues/4833
         [DataRow(@"
                 param storageName string
 
@@ -119,8 +118,8 @@ namespace Bicep.Core.UnitTests.Diagnostics.Linter.Common
                   value: storage.listAnything().keys[0].value
                 }
             ",
-            "Outputs should not contain secrets. function 'listAnything'"
-        )]*/
+            "function 'listAnything'"
+        )]
         [DataRow(
             @"
                 param storageName string

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -448,9 +448,9 @@ namespace Bicep.Core.Emit
 
                 case "outputs":
                     var moduleSymbol = reference.Module;
-                    var hasSecureValues = expression.SourceSyntax is null
-                        || FindPossibleSecretsVisitor.FindPossibleSecretsInExpression(context.SemanticModel, expression.SourceSyntax).Any();
-                    if (context.SemanticModel.Features.SecureOutputsEnabled && hasSecureValues)
+                    if (context.SemanticModel.Features.SecureOutputsEnabled &&
+                        (expression.SourceSyntax is null ||
+                        FindPossibleSecretsVisitor.FindPossibleSecretsInExpression(context.SemanticModel, expression.SourceSyntax).Any()))
                     {
                         var deploymentResourceId = GetFullyQualifiedResourceId(moduleSymbol, reference.IndexContext?.Index);
                         var apiVersion = new JTokenExpression(EmitConstants.NestedDeploymentResourceApiVersion);

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -186,9 +186,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.PowerPlatform.ResourceStack": {
         "type": "Direct",

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/Bicep.IO/packages.lock.json
+++ b/src/Bicep.IO/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/Bicep.Local.Deploy/packages.lock.json
+++ b/src/Bicep.Local.Deploy/packages.lock.json
@@ -52,9 +52,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/Bicep.Local.Extension.Mock/packages.lock.json
+++ b/src/Bicep.Local.Extension.Mock/packages.lock.json
@@ -21,9 +21,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -23,9 +23,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.11, )",
-        "resolved": "8.0.11",
-        "contentHash": "zk5lnZrYJgtuJG8L4v17Ej8rZ3PUcR2iweNV08BaO5LbYHIi2wNaVNcJoLxvqgQdnjLlKnCCfVGLDr6QHeAarQ=="
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
       },
       "Microsoft.NET.Sdk.WebAssembly.Pack": {
         "type": "Direct",


### PR DESCRIPTION
Resolves #16219

The server crash reported in #16219 was caused by https://github.com/Azure/bicep/pull/15825/files#diff-7d66583c4922f57735a4eac96cd074d356e8eace34ec5900860f093f3d0cbc69R701. The FindPossibleSecretsVisitor relies on object identity to detect and stop infinitely walking recursive types, and the linked line caused otherwise identical object types within the assigned type of a `resource` symbol to have different identities.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16235)