### PR TITLE
File IO abstraction part 6: Simplify `SourceFileFactory`

### DIFF
--- a/src/Bicep.Core.UnitTests/Assertions/AssertionScopeExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/AssertionScopeExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
@@ -55,6 +56,15 @@ namespace Bicep.Core.UnitTests.Assertions
             assertionScope.AddReportable(
                 contextName,
                 () => PrintHelper.PrintWithAnnotations(bicepFile, annotations, 1, true));
+
+            return assertionScope;
+        }
+
+        public static AssertionScope WithAnnotatedSource(AssertionScope assertionScope, string fileText, ImmutableArray<int> lineStarts, string contextName, IEnumerable<PrintHelper.Annotation> annotations)
+        {
+            assertionScope.AddReportable(
+                contextName,
+                () => PrintHelper.PrintWithAnnotations(fileText, lineStarts, annotations, 1, true));
 
             return assertionScope;
         }

--- a/src/Bicep.Core.UnitTests/SourceCode/SourceArchiveTests.cs
+++ b/src/Bicep.Core.UnitTests/SourceCode/SourceArchiveTests.cs
@@ -154,7 +154,7 @@ public class SourceArchiveTests
             sourceKind switch
             {
                 SourceArchive.SourceKind.ArmTemplate => SourceFileFactory.CreateArmTemplateFile(uri, actualContents),
-                SourceArchive.SourceKind.Bicep => SourceFileFactory.CreateSourceFile(uri, actualContents),
+                SourceArchive.SourceKind.Bicep => SourceFileFactory.CreateBicepFile(uri, actualContents),
                 SourceArchive.SourceKind.TemplateSpec => SourceFileFactory.CreateTemplateSpecFile(uri, actualContents),
                 _ => throw new Exception($"Unrecognized source kind: {sourceKind}")
             },

--- a/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/PrintHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using System.Text;
 using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrintV2;
@@ -48,11 +49,14 @@ namespace Bicep.Core.UnitTests.Utils
             return string.Join("\n", [.. GetProgramTextLines(bicepFile)]);
         }
 
-        public static string PrintWithAnnotations(BicepSourceFile bicepFile, IEnumerable<Annotation> annotations, int context, bool includeLineNumbers)
+        public static string PrintWithAnnotations(BicepSourceFile bicepFile, IEnumerable<Annotation> annotations, int context, bool includeLineNumbers) =>
+            PrintWithAnnotations(bicepFile.ProgramSyntax.ToString(), bicepFile.LineStarts, annotations, context, includeLineNumbers);
+
+        public static string PrintWithAnnotations(string fileText, ImmutableArray<int> lineStarts, IEnumerable<Annotation> annotations, int context, bool includeLineNumbers)
         {
             var annotationPositions = annotations.ToDictionary(
                 x => x,
-                x => TextCoordinateConverter.GetPosition(bicepFile.LineStarts, x.Span.Position));
+                x => TextCoordinateConverter.GetPosition(lineStarts, x.Span.Position));
 
             if (annotationPositions.Count == 0)
             {
@@ -60,7 +64,7 @@ namespace Bicep.Core.UnitTests.Utils
             }
 
             var output = new StringBuilder();
-            var programLines = GetProgramTextLines(bicepFile);
+            var programLines = StringUtils.SplitOnNewLine(fileText).ToArray();
 
             var annotationsByLine = annotationPositions.ToLookup(x => x.Value.line, x => x.Key);
 
@@ -68,7 +72,7 @@ namespace Bicep.Core.UnitTests.Utils
             var maxLine = annotationPositions.Values.Aggregate(0, (max, curr) => Math.Max(curr.line, max)) + 1;
 
             minLine = Math.Max(0, minLine - context);
-            maxLine = Math.Min(bicepFile.LineStarts.Length, maxLine + context);
+            maxLine = Math.Min(lineStarts.Length, maxLine + context);
             var digits = maxLine.ToString().Length;
 
             for (var i = minLine; i < maxLine; i++)

--- a/src/Bicep.Core/Parsing/StringUtils.cs
+++ b/src/Bicep.Core/Parsing/StringUtils.cs
@@ -75,10 +75,7 @@ namespace Bicep.Core.Parsing
             ReplaceNewlines(value, "\n");
 
         public static IEnumerable<string> SplitOnNewLine(string value) =>
-            value.Split(
-                new string[] { "\r\n", "\r", "\n" },
-                StringSplitOptions.None
-            );
+            value.Split(["\r\n", "\r", "\n"], StringSplitOptions.None);
 
         public static string NormalizeIndent(string value)
         {

--- a/src/Bicep.Core/Workspaces/SourceFileFactory.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileFactory.cs
@@ -47,6 +47,11 @@ namespace Bicep.Core.Workspaces
                 return CreateTemplateSpecFile(fileUri, fileContents);
             }
 
+            if (sourceFileType is not null)
+            {
+                throw new ArgumentException($"Unexpected source file type {sourceFileType.Name}");
+            }
+
             if (PathHelper.HasArmTemplateLikeExtension(fileUri))
             {
                 return CreateArmTemplateFile(fileUri, fileContents);

--- a/src/Bicep.Core/Workspaces/SourceFileFactory.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileFactory.cs
@@ -62,9 +62,9 @@ namespace Bicep.Core.Workspaces
                 return CreateBicepParamFile(fileUri, fileContents);
             }
 
-            // The file does not have an extension. Assuming it is a Bicep file. ote that
+            // The file does not have an extension. Assuming it is a Bicep file. Note that
             // this is only possible when a module reference path is provided without an
-            // extension. When a an untilted file (whose URI has no extension) in VS Code,
+            // extension. When an untilted file (whose URI has no extension) in VS Code,
             // sourceFileType will be set by BicepCompilationManager.
             return CreateBicepFile(fileUri, fileContents);
         }

--- a/src/Bicep.Core/Workspaces/SourceFileFactory.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.CodeDom;
 using Azure.Deployments.Core.Configuration;
 using Azure.Deployments.Core.Constants;
 using Azure.Deployments.Core.Definitions.Schema;
@@ -23,29 +24,32 @@ namespace Bicep.Core.Workspaces
             LineInfoHandling = LineInfoHandling.Ignore,
         };
 
-        public static BicepSourceFile? TryCreateSourceFileByBicepLanguageId(Uri fileUri, string fileContents, string languageId) => languageId switch
-        {
-            LanguageConstants.LanguageId => CreateBicepFile(fileUri, fileContents),
-            LanguageConstants.ParamsLanguageId => CreateBicepParamFile(fileUri, fileContents),
-            _ => null
-        };
 
-
-        public static BicepSourceFile? TryCreateSourceFileByFileKind(Uri fileUri, string fileContents, BicepSourceFileKind? fileKind) => fileKind switch
+        public static ISourceFile CreateSourceFile(Uri fileUri, string fileContents, Type? sourceFileType = null)
         {
-            BicepSourceFileKind.BicepFile => CreateBicepFile(fileUri, fileContents),
-            BicepSourceFileKind.ParamsFile => CreateBicepParamFile(fileUri, fileContents),
-            null => null,
-            _ => throw new NotImplementedException($"Unexpected file kind '{fileKind}'.")
-        };
+            if (sourceFileType == typeof(BicepFile))
+            {
+                return CreateBicepFile(fileUri, fileContents);
+            }
 
-        public static ISourceFile? TryCreateSourceFile(Uri fileUri, string fileContents, ArtifactReference? moduleReference = null)
-        {
+            if (sourceFileType == typeof(BicepParamFile))
+            {
+                return CreateBicepParamFile(fileUri, fileContents);
+            }
+
+            if (sourceFileType == typeof(ArmTemplateFile))
+            {
+                return CreateArmTemplateFile(fileUri, fileContents);
+            }
+
+            if (sourceFileType == typeof(TemplateSpecFile))
+            {
+                return CreateTemplateSpecFile(fileUri, fileContents);
+            }
+
             if (PathHelper.HasArmTemplateLikeExtension(fileUri))
             {
-                return moduleReference is TemplateSpecModuleReference
-                    ? CreateTemplateSpecFile(fileUri, fileContents)
-                    : CreateArmTemplateFile(fileUri, fileContents);
+                return CreateArmTemplateFile(fileUri, fileContents);
             }
 
             if (PathHelper.HasBicepExtension(fileUri))
@@ -58,11 +62,12 @@ namespace Bicep.Core.Workspaces
                 return CreateBicepParamFile(fileUri, fileContents);
             }
 
-            return null;
+            // The file does not have an extension. Assuming it is a Bicep file. ote that
+            // this is only possible when a module reference path is provided without an
+            // extension. When a an untilted file (whose URI has no extension) in VS Code,
+            // sourceFileType will be set by BicepCompilationManager.
+            return CreateBicepFile(fileUri, fileContents);
         }
-
-        public static ISourceFile CreateSourceFile(Uri fileUri, string fileContents, ArtifactReference? moduleReference = null) =>
-            TryCreateSourceFile(fileUri, fileContents, moduleReference) ?? CreateBicepFile(fileUri, fileContents);
 
         public static BicepParamFile CreateBicepParamFile(Uri fileUri, string fileContents)
         {

--- a/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGroupingBuilder.cs
@@ -7,6 +7,7 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
+using Bicep.Core.Modules;
 using Bicep.Core.Navigation;
 using Bicep.Core.Registry;
 using Bicep.Core.Registry.Oci;
@@ -133,7 +134,10 @@ namespace Bicep.Core.Workspaces
                 return new(failureBuilder);
             }
 
-            sourceFile = SourceFileFactory.CreateSourceFile(fileUri, fileContents, moduleReference);
+
+            sourceFile = moduleReference is TemplateSpecModuleReference
+                ? SourceFileFactory.CreateSourceFile(fileUri, fileContents, typeof(TemplateSpecFile))
+                : SourceFileFactory.CreateSourceFile(fileUri, fileContents);
 
             return new(sourceFile);
         }

--- a/src/Bicep.LangServer.IntegrationTests/Assertions/AssertionScopeExtensions.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Assertions/AssertionScopeExtensions.cs
@@ -5,6 +5,7 @@ using Bicep.Core.Parsing;
 using Bicep.Core.Text;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
+using Bicep.LangServer.IntegrationTests.Helpers;
 using FluentAssertions.Execution;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
@@ -12,19 +13,12 @@ namespace Bicep.LangServer.IntegrationTests.Assertions
 {
     public static class AssertionScopeExtensions
     {
-        public static AssertionScope WithAnnotations<T>(this AssertionScope assertionScope, BicepSourceFile bicepFile, string contextName, IEnumerable<T>? data, Func<T, string> messageFunc, Func<T, Range> rangeFunc)
+        public static AssertionScope WithAnnotations<T>(this AssertionScope assertionScope, LanguageClientFile bicepFile, string contextName, IEnumerable<T>? data, Func<T, string> messageFunc, Func<T, Range> rangeFunc)
             => Core.UnitTests.Assertions.AssertionScopeExtensions.WithAnnotatedSource(
                 assertionScope,
-                bicepFile,
+                bicepFile.Text,
+                bicepFile.LineStarts,
                 contextName,
-                (data ?? []).Select(x => new PrintHelper.Annotation(FromRange(bicepFile, rangeFunc(x)), messageFunc(x))));
-
-        public static TextSpan FromRange(BicepSourceFile bicepFile, Range range)
-        {
-            var position = TextCoordinateConverter.GetOffset(bicepFile.LineStarts, range.Start.Line, range.Start.Character);
-            var length = TextCoordinateConverter.GetOffset(bicepFile.LineStarts, range.End.Line, range.End.Character) - position;
-
-            return new TextSpan(position, length);
-        }
+                (data ?? []).Select(x => new PrintHelper.Annotation(bicepFile.GetSpan(rangeFunc(x)), messageFunc(x))));
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/Assertions/LanguageClientFileAssertions.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Assertions/LanguageClientFileAssertions.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bicep.Core.Parsing;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.LangServer.IntegrationTests.Helpers;
+using FluentAssertions;
+using FluentAssertions.Primitives;
+
+namespace Bicep.LangServer.IntegrationTests.Assertions
+{
+    public static class LanguageClientFileExtensions
+    {
+        public static LanguageClientFileAssertions Should(this LanguageClientFile instance)
+        {
+            return new LanguageClientFileAssertions(instance);
+        }
+    }
+
+    public class LanguageClientFileAssertions : ReferenceTypeAssertions<LanguageClientFile,  LanguageClientFileAssertions>
+    {
+        public LanguageClientFileAssertions(LanguageClientFile file)
+            : base(file)
+        {
+            
+        }
+
+        protected override string Identifier => nameof(LanguageClientFile);
+
+        public AndConstraint<LanguageClientFileAssertions> HaveSourceText(string expected, string because = "", params object[] becauseArgs)
+        {
+            var actual = this.Subject.Text.NormalizeNewlines();
+            expected = expected.NormalizeNewlines();
+
+            actual.Should().EqualWithLineByLineDiff(expected, because, becauseArgs);
+
+            return new AndConstraint<LanguageClientFileAssertions>(this);
+        }
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/DeployBicepFileActionTest.cs
+++ b/src/Bicep.LangServer.IntegrationTests/DeployBicepFileActionTest.cs
@@ -18,6 +18,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Moq;
 using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 
@@ -45,7 +46,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
             var bicepparamFileUri = InMemoryFileResolver.GetFileUri("/path/to/param.bicepparam");
 
-            var fileTextsByUri = new Dictionary<Uri, string>()
+            var fileTextsByUri = new Dictionary<DocumentUri, string>()
             {
                 [bicepFileUri] = "",
                 [bicepparamFileUri] = ""
@@ -99,7 +100,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
             var bicepparamFileUri = InMemoryFileResolver.GetFileUri("/path/to/param.bicepparam");
 
-            var fileTextsByUri = new Dictionary<Uri, string>()
+            var fileTextsByUri = new Dictionary<DocumentUri, string>()
             {
                 [bicepFileUri] = "",
                 [bicepparamFileUri] = ""
@@ -154,7 +155,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
             var paramFileUri = InMemoryFileResolver.GetFileUri("/path/to/param.json");
 
-            var fileTextsByUri = new Dictionary<Uri, string>()
+            var fileTextsByUri = new Dictionary<DocumentUri, string>()
             {
                 [bicepFileUri] = "",
                 [paramFileUri] = ""
@@ -207,7 +208,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
             var invalidParamFilePath = @"c:\parameter.json";
 
-            var fileTextsByUri = new Dictionary<Uri, string>()
+            var fileTextsByUri = new Dictionary<DocumentUri, string>()
             {
                 [bicepFileUri] = "",
             };
@@ -262,7 +263,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
             var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", "invalid_parameters_file");
 
-            var fileTextsByUri = new Dictionary<Uri, string>()
+            var fileTextsByUri = new Dictionary<DocumentUri, string>()
             {
                 [bicepFileUri] = "",
             };
@@ -318,7 +319,7 @@ namespace Bicep.LangServer.IntegrationTests
             var bicepFileUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicep");
             var parametersFilePath = FileHelper.SaveResultFile(TestContext, "parameters.json", "invalid_parameters_file");
 
-            var fileTextsByUri = new Dictionary<Uri, string>()
+            var fileTextsByUri = new Dictionary<DocumentUri, string>()
             {
                 [bicepFileUri] = "",
             };

--- a/src/Bicep.LangServer.IntegrationTests/ExpressionAndTypeExtractorTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ExpressionAndTypeExtractorTests.cs
@@ -15,6 +15,7 @@ using Bicep.Core.UnitTests.PrettyPrintV2;
 using Bicep.Core.UnitTests.Serialization;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
+using Bicep.LangServer.IntegrationTests.Assertions;
 using Bicep.LangServer.IntegrationTests.Helpers;
 using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Refactor;

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageClientFile.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageClientFile.cs
@@ -21,11 +21,9 @@ namespace Bicep.LangServer.IntegrationTests.Helpers
 
         public DocumentUri Uri { get; }
 
-        public TextDocumentIdentifier DocumentIdentifier => new(this.Uri);
-
         public string Text { get; }
 
-        ImmutableArray<int> LineStarts { get; }
+        public ImmutableArray<int> LineStarts { get; }
 
         public Position GetPosition(int offset) => TextCoordinateConverter.GetPosition(this.LineStarts, offset);
 
@@ -34,5 +32,15 @@ namespace Bicep.LangServer.IntegrationTests.Helpers
             Start = GetPosition(span.Position),
             End = GetPosition(span.Position + span.Length),
         };
+
+        public int GetOffset(Position position) => TextCoordinateConverter.GetOffset(this.LineStarts, position.Line, position.Character);
+
+        public TextSpan GetSpan(Range range)
+        {
+            var start = this.GetOffset(range.Start);
+            var end = this.GetOffset(range.End);
+
+            return new TextSpan(start, end - start);
+        }
     }
 }

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageClientFile.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageClientFile.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Parsing;
+using Bicep.Core.Text;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace Bicep.LangServer.IntegrationTests.Helpers
+{
+    public class LanguageClientFile
+    {
+        public LanguageClientFile(DocumentUri uri, string text)
+        {
+            this.Uri = uri;
+            this.Text = text;
+            this.LineStarts = TextCoordinateConverter.GetLineStarts(text);
+        }
+
+        public DocumentUri Uri { get; }
+
+        public TextDocumentIdentifier DocumentIdentifier => new(this.Uri);
+
+        public string Text { get; }
+
+        ImmutableArray<int> LineStarts { get; }
+
+        public Position GetPosition(int offset) => TextCoordinateConverter.GetPosition(this.LineStarts, offset);
+
+        public Range GetRange(TextSpan span) => new()
+        {
+            Start = GetPosition(span.Position),
+            End = GetPosition(span.Position + span.Length),
+        };
+    }
+}

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/LanguageServerHelper.cs
@@ -69,17 +69,17 @@ namespace Bicep.LangServer.IntegrationTests
         /// No further file opening is possible.
         /// </summary>
         public static Task<LanguageServerHelper> StartServerWithText(TestContext testContext, string text, DocumentUri documentUri, Action<IServiceCollection>? onRegisterServices = null)
-            => StartServerWithText(testContext, new Dictionary<Uri, string> { [documentUri.ToUriEncoded()] = text }, documentUri.ToUriEncoded(), onRegisterServices);
+            => StartServerWithText(testContext, new Dictionary<DocumentUri, string> { [documentUri] = text }, documentUri, onRegisterServices);
 
         /// <summary>
         /// Starts a language client/server pair that will load the specified Bicep text and wait for the diagnostics to be published.
         /// No further file opening is possible.
         /// </summary>
-        public static async Task<LanguageServerHelper> StartServerWithText(TestContext testContext, IReadOnlyDictionary<Uri, string> fileContentsByUri, Uri entryFileUri, Action<IServiceCollection>? onRegisterServices = null)
+        public static async Task<LanguageServerHelper> StartServerWithText(TestContext testContext, IReadOnlyDictionary<DocumentUri, string> fileContentsByUri, DocumentUri entryFileUri, Action<IServiceCollection>? onRegisterServices = null)
         {
             var diagnosticsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
 
-            var fileResolver = new InMemoryFileResolver(fileContentsByUri);
+            var fileResolver = new InMemoryFileResolver(fileContentsByUri.ToDictionary(x => x.Key.ToUriEncoded(), x => x.Value));
             var fileExplorer = new FileSystemFileExplorer(fileResolver.MockFileSystem);
             var helper = await LanguageServerHelper.StartServer(
                 testContext,

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/MultiFileLanguageServerHelper.cs
@@ -71,8 +71,8 @@ namespace Bicep.LangServer.IntegrationTests
             return await diagsListener.WaitNext();
         }
 
-        public async Task<PublishDiagnosticsParams> OpenFileOnceAsync(TestContext testContext, BicepSourceFile file)
-            => await OpenFileOnceAsync(testContext, file.ProgramSyntax.ToString(), file.Uri);
+        public async Task<PublishDiagnosticsParams> OpenFileOnceAsync(TestContext testContext, LanguageClientFile file)
+            => await OpenFileOnceAsync(testContext, file.Text, file.Uri);
 
         public async Task<PublishDiagnosticsParams> ChangeFileAsync(TestContext testContext, string text, DocumentUri documentUri, int version)
         {

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
@@ -10,6 +10,7 @@ using Bicep.LanguageServer.Utils;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Threading;
+using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
@@ -19,15 +20,15 @@ namespace Bicep.LangServer.IntegrationTests
     public class FileRequestHelper
     {
         private readonly ILanguageClient client;
-        private readonly BicepSourceFile bicepFile;
+        private readonly LanguageClientFile bicepFile;
 
-        public FileRequestHelper(ILanguageClient client, BicepSourceFile bicepFile)
+        public FileRequestHelper(ILanguageClient client, LanguageClientFile bicepFile)
         {
             this.client = client;
             this.bicepFile = bicepFile;
         }
 
-        public BicepSourceFile Source => bicepFile;
+        public LanguageClientFile Source => bicepFile;
 
         public async Task<ImmutableArray<CompletionList>> RequestCompletions(IEnumerable<int> cursors)
         {
@@ -103,7 +104,7 @@ namespace Bicep.LangServer.IntegrationTests
                 }
             });
 
-        public BicepFile ApplyCompletion(CompletionList completions, string label, params string[] tabStops)
+        public LanguageClientFile ApplyCompletion(CompletionList completions, string label, params string[] tabStops)
         {
             // Should().Contain is superfluous here, but it gives a better assertion message when it fails
             completions.Should().Contain(x => x.Label == label);
@@ -112,7 +113,7 @@ namespace Bicep.LangServer.IntegrationTests
             return ApplyCompletion(completions.Single(x => x.Label == label), tabStops);
         }
 
-        public BicepFile ApplyCompletion(CompletionItem completion, params string[] tabStops)
+        public LanguageClientFile ApplyCompletion(CompletionItem completion, params string[] tabStops)
         {
             var start = PositionHelper.GetOffset(bicepFile.LineStarts, completion.TextEdit!.TextEdit!.Range.Start);
             var end = PositionHelper.GetOffset(bicepFile.LineStarts, completion.TextEdit!.TextEdit!.Range.End);
@@ -142,13 +143,13 @@ namespace Bicep.LangServer.IntegrationTests
                     throw new InvalidOperationException();
             }
 
-            var originalFile = bicepFile.ProgramSyntax.ToString();
-            var replaced = originalFile.Substring(0, start) + textToInsert + originalFile.Substring(end);
+            var originalFile = bicepFile.Text;
+            var replaced = string.Concat(originalFile.AsSpan(0, start), textToInsert, originalFile.AsSpan(end));
 
-            return SourceFileFactory.CreateBicepFile(bicepFile.Uri, replaced);
+            return new(bicepFile.Uri, replaced);
         }
 
-        public async Task<BicepFile> RequestAndApplyCompletion(int cursor, string label)
+        public async Task<LanguageClientFile> RequestAndApplyCompletion(int cursor, string label)
         {
             var completionList = await RequestCompletion(cursor);
             var completion = completionList.Should().ContainSingle(x => x.Label == label).Subject;
@@ -156,7 +157,7 @@ namespace Bicep.LangServer.IntegrationTests
             return ApplyCompletion(completion);
         }
 
-        public BicepFile ApplyWorkspaceEdit(WorkspaceEdit? edit)
+        public LanguageClientFile ApplyWorkspaceEdit(WorkspaceEdit? edit)
         {
             // not yet supported by this logic
             edit!.Changes.Should().NotBeNull();
@@ -165,19 +166,19 @@ namespace Bicep.LangServer.IntegrationTests
 
             var changes = edit.Changes![bicepFile.Uri];
 
-            var replaced = bicepFile.ProgramSyntax.ToString();
+            var replaced = bicepFile.Text;
             var offset = 0;
 
             foreach (var change in changes)
             {
-                var start = PositionHelper.GetOffset(bicepFile.LineStarts, change.Range.Start);
-                var end = PositionHelper.GetOffset(bicepFile.LineStarts, change.Range.End);
+                var start = bicepFile.GetOffset(change.Range.Start);
+                var end = bicepFile.GetOffset(change.Range.End);
 
-                replaced = replaced.Substring(0, start + offset) + change.NewText + replaced.Substring(end + offset);
+                replaced = string.Concat(replaced.AsSpan(0, start + offset), change.NewText, replaced.AsSpan(end + offset));
                 offset += change.NewText.Length - (end - start);
             }
 
-            return SourceFileFactory.CreateBicepFile(bicepFile.Uri, replaced);
+            return new(bicepFile.Uri, replaced);
         }
 
         public async Task<Hover?> RequestHover(int cursor)
@@ -252,15 +253,12 @@ namespace Bicep.LangServer.IntegrationTests
 
         public async Task<FileRequestHelper> OpenFile(string text)
             => await OpenFile(
-                new Uri($"file:///{Guid.NewGuid():D}/{testContext.TestName}/main.bicep"),
+                DocumentUri.From($"file:///{Guid.NewGuid():D}/{testContext.TestName}/main.bicep"),
                 text);
 
-        public async Task<FileRequestHelper> OpenFile(Uri fileUri, string text)
+        public async Task<FileRequestHelper> OpenFile(DocumentUri fileUri, string text)
         {
-            BicepSourceFile bicepFile = PathHelper.HasBicepparamsExtension(fileUri) ?
-                SourceFileFactory.CreateBicepParamFile(fileUri, text) :
-                SourceFileFactory.CreateBicepFile(fileUri, text);
-
+            var bicepFile = new LanguageClientFile(fileUri, text);
             var helper = await languageServerHelperLazy.GetValueAsync();
             await helper.OpenFileOnceAsync(testContext, bicepFile);
 

--- a/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HighlightTests.cs
@@ -73,6 +73,7 @@ var blah = '${test}'
 
     private static string AnnotateWithHighlights(FileRequestHelper file, DocumentHighlightContainer? highlights)
         => PrintHelper.PrintWithAnnotations(
-            file.Source,
-            highlights!.Select(x => new PrintHelper.Annotation(Assertions.AssertionScopeExtensions.FromRange(file.Source, x.Range), x.Kind.ToString())), 1, true);
+            file.Source.Text,
+            file.Source.LineStarts,
+            highlights!.Select(x => new PrintHelper.Annotation(file.Source.GetSpan(x.Range), x.Kind.ToString())), 1, true);
 }

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -16,7 +16,6 @@ using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
-using Bicep.Core.Workspaces;
 using Bicep.IO.Abstraction;
 using Bicep.LangServer.IntegrationTests.Assertions;
 using Bicep.LangServer.IntegrationTests.Extensions;
@@ -208,7 +207,7 @@ output string test = testRes.prop|erties.rea|donly
 ",
                 '|');
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Uri);
@@ -243,7 +242,7 @@ output string test = testRes[3].prop|erties.rea|donly
 ",
                 '|');
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Uri);
@@ -277,7 +276,7 @@ output string test = testRes.prop|erties.rea|donly
 ",
                 '|');
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Uri);
@@ -319,7 +318,7 @@ resource test|Output string = 'str'
 ",
                 '|');
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Uri);
@@ -345,7 +344,7 @@ param constrainedSe|cureString string
 ",
                 '|');
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Uri);
@@ -387,10 +386,10 @@ output moduleOutput string = '${var|1}-${mod1.outputs.o|ut2}'
 ",
                 '|');
 
-            var moduleFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/mod.bicep"), modFile);
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/main.bicep"), file);
+            var moduleFile = new LanguageClientFile("file:///path/to/mod.bicep", modFile);
+            var bicepFile = new LanguageClientFile("file:///path/to/main.bicep", file);
 
-            var files = new Dictionary<Uri, string>
+            var files = new Dictionary<DocumentUri, string>
             {
                 [bicepFile.Uri] = file,
                 [moduleFile.Uri] = modFile
@@ -430,10 +429,10 @@ output o1 string = mod|1.name
 ",
                 '|');
 
-            var moduleFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/mod.bicep"), modFile);
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/main.bicep"), file);
+            var moduleFile = new LanguageClientFile("file:///path/to/mod.bicep", modFile);
+            var bicepFile = new LanguageClientFile("file:///path/to/main.bicep", file);
 
-            var files = new Dictionary<Uri, string>
+            var files = new Dictionary<DocumentUri, string>
             {
                 [bicepFile.Uri] = file,
                 [moduleFile.Uri] = modFile
@@ -478,10 +477,10 @@ output o1 string = mod|1.name
             template!.Should().NotBeNull();
             diags.Should().BeEmpty();
 
-            var moduleTemplateFile = SourceFileFactory.CreateArmTemplateFile(new Uri($"file:///path/to/mod.{extension}"), template!.ToString());
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/main.bicep"), file);
+            var moduleTemplateFile = new LanguageClientFile($"file:///path/to/mod.{extension}", template!.ToString());
+            var bicepFile = new LanguageClientFile("file:///path/to/main.bicep", file);
 
-            var files = new Dictionary<Uri, string>
+            var files = new Dictionary<DocumentUri, string>
             {
                 [bicepFile.Uri] = file,
                 [moduleTemplateFile.Uri] = template!.ToString()
@@ -611,10 +610,10 @@ output moduleOutput string = '${va|r1}-${mod1.outputs.ou|t2}'
             template!.Should().NotBeNull();
             diags.Should().BeEmpty();
 
-            var moduleTemplateFile = SourceFileFactory.CreateArmTemplateFile(new Uri("file:///path/to/mod.json"), template!.ToString());
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/main.bicep"), file);
+            var moduleTemplateFile = new LanguageClientFile("file:///path/to/mod.json", template!.ToString());
+            var bicepFile = new LanguageClientFile("file:///path/to/main.bicep", file);
 
-            var files = new Dictionary<Uri, string>
+            var files = new Dictionary<DocumentUri, string>
             {
                 [bicepFile.Uri] = file,
                 [moduleTemplateFile.Uri] = template!.ToString()
@@ -683,7 +682,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
 }
 ",
                 '|');
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Uri);
@@ -821,7 +820,7 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
                 repository,
                 digest,
                 tag);
-            var bicepFile = SourceFileFactory.CreateBicepFile(parentModuleUri, bicepFileContents);
+            var bicepFile = new LanguageClientFile(documentUri, bicepFileContents);
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
             hovers.Single()!.Contents.MarkupContent!.Value.Should().Be(expectedHoverContent);
@@ -864,10 +863,10 @@ param foo|bar = true
 
             var (bicepparamText, cursors) = ParserHelper.GetFileWithCursors(bicepparamTextWithCursor, '|');
 
-            var paramsFile = SourceFileFactory.CreateBicepParamFile(new Uri("file:///path/to/params.bicepparam"), bicepparamText);
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/main.bicep"), bicepText);
+            var paramsFile = new LanguageClientFile("file:///path/to/params.bicepparam", bicepparamText);
+            var bicepFile = new LanguageClientFile("file:///path/to/main.bicep", bicepText);
 
-            var files = new Dictionary<Uri, string>
+            var files = new Dictionary<DocumentUri, string>
             {
                 [paramsFile.Uri] = bicepparamText,
                 [bicepFile.Uri] = bicepText
@@ -904,10 +903,10 @@ param foo|bar = true
 
             var (mainText, cursors) = ParserHelper.GetFileWithCursors(mainTextWithCursor, '|');
 
-            var mainFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/main.bicep"), mainText);
-            var moduleFile = SourceFileFactory.CreateBicepFile(new Uri("file:///path/to/mod.bicep"), moduleText);
+            var mainFile = new LanguageClientFile("file:///path/to/main.bicep", mainText);
+            var moduleFile = new LanguageClientFile("file:///path/to/mod.bicep", moduleText);
 
-            var files = new Dictionary<Uri, string>
+            var files = new Dictionary<DocumentUri, string>
             {
                 [mainFile.Uri] = mainText,
                 [moduleFile.Uri] = moduleText
@@ -1052,7 +1051,7 @@ There might also be a link to something [link](www.google.com)
                 output b ing = foo.another|Property
                 """);
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), text);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", text);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, text, bicepFile.Uri);
@@ -1094,10 +1093,10 @@ param foo = {
 }
 """);
 
-            var jsonUri = new Uri("file:///path/to/main.json");
-            var paramsUri = new Uri("file:///path/to/params.bicepparam");
+            var jsonUri = "file:///path/to/main.json";
+            var paramsUri = "file:///path/to/params.bicepparam";
 
-            var files = new Dictionary<Uri, string>
+            var files = new Dictionary<DocumentUri, string>
             {
                 [jsonUri] = jsonContents.Template.ToJson(),
                 [paramsUri] = bicepparamText,
@@ -1106,7 +1105,7 @@ param foo = {
             using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, paramsUri, services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
             var client = helper.Client;
 
-            var hover = await RequestHover(client, SourceFileFactory.CreateBicepFile(paramsUri, bicepparamText), cursor);
+            var hover = await RequestHover(client, new LanguageClientFile(paramsUri, bicepparamText), cursor);
             hover!.Contents!.MarkupContent!.Value
                 .Should().BeEquivalentToIgnoringTrailingWhitespace("""
 ```bicep
@@ -1227,7 +1226,6 @@ AzureMetrics
             string? digest,
             string? tag)
         {
-            var file = SourceFileFactory.CreateBicepFile(parentModuleUri, bicepFileContents);
             var moduleDeclarationSyntax = programSyntax.Declarations.OfType<ModuleDeclarationSyntax>().Single();
 
             OciRegistryHelper.SaveManifestFileToModuleRegistryCache(
@@ -1370,32 +1368,22 @@ AzureMetrics
             return DataSets.NonStressDataSets.ToDynamicTestData();
         }
 
-        private static async Task<Hover?> RequestHover(ILanguageClient client, BicepFile bicepFile, int cursor)
+        private static async Task<Hover?> RequestHover(ILanguageClient client, LanguageClientFile bicepFile, int cursor)
         {
             var hovers = await RequestHovers(client, bicepFile, [cursor]);
 
             return hovers.Single();
         }
 
-        private static async Task<IEnumerable<Hover?>> RequestHovers(ILanguageClient client, BicepFile bicepFile, IEnumerable<int> cursors)
-        {
-            return await RequestHovers(client, bicepFile.Uri, bicepFile.LineStarts, cursors);
-        }
-
-        private static async Task<IEnumerable<Hover?>> RequestHovers(ILanguageClient client, BicepParamFile paramFile, IEnumerable<int> cursors)
-        {
-            return await RequestHovers(client, paramFile.Uri, paramFile.LineStarts, cursors);
-        }
-
-        private static async Task<IEnumerable<Hover?>> RequestHovers(ILanguageClient client, Uri fileUri, IReadOnlyList<int> lineStarts, IEnumerable<int> cursors)
+        private static async Task<IEnumerable<Hover?>> RequestHovers(ILanguageClient client, LanguageClientFile bicepFile, IEnumerable<int> cursors)
         {
             var hovers = new List<Hover?>();
             foreach (var cursor in cursors)
             {
                 var hover = await client.RequestHover(new HoverParams
                 {
-                    TextDocument = new TextDocumentIdentifier(fileUri),
-                    Position = TextCoordinateConverter.GetPosition(lineStarts, cursor),
+                    TextDocument = bicepFile.Uri,
+                    Position = bicepFile.GetPosition(cursor),
                 });
 
                 hovers.Add(hover);
@@ -1408,7 +1396,7 @@ AzureMetrics
         {
             var (file, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors, cursor);
 
-            var bicepFile = SourceFileFactory.CreateBicepFile(new Uri($"file:///{TestContext.TestName}-path/to/main.bicep"), file);
+            var bicepFile = new LanguageClientFile($"file:///{TestContext.TestName}-path/to/main.bicep", file);
 
             var helper = await ServerWithBuiltInTypes.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, file, bicepFile.Uri);

--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -8,6 +8,8 @@ using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.FileSystem;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.Core.Workspaces;
+using Bicep.LangServer.IntegrationTests.Assertions;
+using Bicep.LangServer.IntegrationTests.Helpers;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OmniSharp.Extensions.LanguageServer.Protocol;
@@ -120,9 +122,9 @@ new CompletionItemKind[] { CompletionItemKind.Field, CompletionItemKind.Field }
 ]
         public async Task Request_for_parameter_identifier_completions_should_return_correct_identifiers(string paramTextWithCursor, string bicepText, string[] completionLabels, CompletionItemKind[] completionItemKinds)
         {
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main.bicep")] = bicepText
+                ["/path/to/main.bicep"] = bicepText
             };
 
             var completions = await RunCompletionScenario(paramTextWithCursor, fileTextsByUri.ToImmutableDictionary(), '|');
@@ -163,9 +165,9 @@ param firstParam string", new[] { "'one'", "'two'" }, new[] { CompletionItemKind
         [DataTestMethod]
         public async Task Value_completions_should_be_based_on_type(string paramTextWithCursor, string bicepText, string[] expectedLabels, CompletionItemKind[] expectedKinds)
         {
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main.bicep")] = bicepText
+                ["/path/to/main.bicep"] = bicepText
             };
 
             var completions = await RunCompletionScenario(paramTextWithCursor, fileTextsByUri.ToImmutableDictionary(), '|');
@@ -176,14 +178,14 @@ param firstParam string", new[] { "'one'", "'two'" }, new[] { CompletionItemKind
         [TestMethod]
         public async Task Request_for_using_declaration_path_completions_should_return_correct_paths_for_file_directories()
         {
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main1.bicep")] = "param foo int",
-                [InMemoryFileResolver.GetFileUri("/path/to/main2.txt")] = "param bar int",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested1/main3.bicep")] = "param foo int",
-                [InMemoryFileResolver.GetFileUri("/path/to/module1.bicep")] = "param foo string",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested1/module2.bicep")] = "param bar bool",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested2/module3.bicep")] = "param bar string"
+                ["path/to/main1.bicep"] = "param foo int",
+                ["path/to/main2.txt"] = "param bar int",
+                ["path/to/nested1/main3.bicep"] = "param foo int",
+                ["path/to/module1.bicep"] = "param foo string",
+                ["path/to/nested1/module2.bicep"] = "param bar bool",
+                ["path/to/nested2/module3.bicep"] = "param bar string"
             };
 
             var completions = await RunCompletionScenario(@"
@@ -226,9 +228,9 @@ using |
                 """;
 
             var (text, cursors) = ParserHelper.GetFileWithCursors(mainContent, '|');
-            Uri mainUri = InMemoryFileResolver.GetFileUri("/path/to/main.bicepparam");
+            DocumentUri mainUri = "/path/to/main.bicepparam";
 
-            var bicepFile = SourceFileFactory.CreateBicepParamFile(mainUri, text);
+            var bicepFile = new LanguageClientFile(mainUri, text);
             using var helper = await LanguageServerHelper.StartServerWithText(
                 this.TestContext,
                 text,
@@ -247,20 +249,20 @@ using |
         [TestMethod]
         public async Task Request_for_extends_declaration_path_completions_should_return_correct_paths_for_file_directories()
         {
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main.bicepparam")] = "using none",
-                [InMemoryFileResolver.GetFileUri("/path/to/base.bicepparam")] = "using none",
-                [InMemoryFileResolver.GetFileUri("/path/to/main2.txt")] = "param bar int",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested1/main3.bicep")] = "param foo int",
-                [InMemoryFileResolver.GetFileUri("/path/to/module1.bicep")] = "param foo string",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested1/module2.bicep")] = "param bar bool",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested2/module3.bicep")] = "param bar string"
+                ["path/to/main.bicepparam"] = "using none",
+                ["path/to/base.bicepparam"] = "using none",
+                ["path/to/main2.txt"] = "param bar int",
+                ["path/to/nested1/main3.bicep"] = "param foo int",
+                ["path/to/module1.bicep"] = "param foo string",
+                ["path/to/nested1/module2.bicep"] = "param bar bool",
+                ["path/to/nested2/module3.bicep"] = "param bar string"
             };
 
-            var completions = await RunCompletionScenario(@"
-extends |
-", fileTextsByUri.ToImmutableDictionary(), '|');
+            var completions = await RunCompletionScenario("""
+                extends |
+                """, fileTextsByUri.ToImmutableDictionary(), '|');
 
             completions.Take(5).Should().SatisfyRespectively(
                 x =>
@@ -293,14 +295,14 @@ extends |
         [TestMethod]
         public async Task Request_for_using_declaration_path_completions_should_return_correct_partial_paths()
         {
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main1.bicep")] = "param foo int",
-                [InMemoryFileResolver.GetFileUri("/path/to/main2.txt")] = "param bar int",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested1/main3.bicep")] = "param foo int",
-                [InMemoryFileResolver.GetFileUri("/path/to/module1.bicep")] = "param foo string",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested1/module2.bicep")] = "param bar bool",
-                [InMemoryFileResolver.GetFileUri("/path/to/nested2/module3.bicep")] = "param bar string"
+                ["/path/to/main1.bicep"] = "param foo int",
+                ["/path/to/main2.txt"] = "param bar int",
+                ["/path/to/nested1/main3.bicep"] = "param foo int",
+                ["/path/to/module1.bicep"] = "param foo string",
+                ["/path/to/nested1/module2.bicep"] = "param bar bool",
+                ["/path/to/nested2/module3.bicep"] = "param bar string"
             };
 
             var completions = await RunCompletionScenario(@"
@@ -333,7 +335,7 @@ using './nested1/|'
         [DataTestMethod]
         public async Task Param_file_should_have_keyword_completions(string text)
         {
-            var completions = await RunCompletionScenario(text, ImmutableDictionary<Uri, string>.Empty, '|');
+            var completions = await RunCompletionScenario(text, ImmutableDictionary<DocumentUri, string>.Empty, '|');
 
             completions.Should().SatisfyRespectively(
                 x =>
@@ -358,7 +360,7 @@ using 'bar.bicep'
         [DataTestMethod]
         public async Task Using_completion_should_only_be_offered_once(string paramTextWithCursor)
         {
-            var completions = await RunCompletionScenario(paramTextWithCursor, ImmutableDictionary<Uri, string>.Empty, '|');
+            var completions = await RunCompletionScenario(paramTextWithCursor, ImmutableDictionary<DocumentUri, string>.Empty, '|');
 
             completions.Should().SatisfyRespectively(
                 x =>
@@ -401,9 +403,9 @@ param myBool bool
 
 param myArray array
 ";
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main.bicep")] = bicepText,
+                ["/path/to/main.bicep"] = bicepText,
             };
 
             var completions = await RunCompletionScenario(paramTextWithCursor, fileTextsByUri.ToImmutableDictionary(), '|');
@@ -454,9 +456,9 @@ type customType = {
 
 param customParam customType
 ";
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main.bicep")] = bicepText,
+                ["/path/to/main.bicep"] = bicepText,
             };
 
             var completions = await RunCompletionScenario(paramTextWithCursor, fileTextsByUri.ToImmutableDictionary(), '|');
@@ -495,9 +497,9 @@ type customType = {
 
 param customParam customType[]
 ";
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
-                [InMemoryFileResolver.GetFileUri("/path/to/main.bicep")] = bicepText,
+                ["/path/to/main.bicep"] = bicepText,
             };
 
             var completions = await RunCompletionScenario(paramTextWithCursor, fileTextsByUri.ToImmutableDictionary(), '|');
@@ -505,7 +507,7 @@ param customParam customType[]
             completions.Any(x => x.Label == "required-properties");
         }
 
-        private async Task<IEnumerable<CompletionItem>> RunCompletionScenario(string paramTextWithCursors, ImmutableDictionary<Uri, string> fileTextsByUri, char cursorInsertionMarker)
+        private async Task<IEnumerable<CompletionItem>> RunCompletionScenario(string paramTextWithCursors, ImmutableDictionary<DocumentUri, string> fileTextsByUri, char cursorInsertionMarker)
         {
             var paramUri = InMemoryFileResolver.GetFileUri("/path/to/param.bicepparam");
             var (paramFileTextNoCursor, cursor) = ParserHelper.GetFileWithSingleCursor(paramTextWithCursors, cursorInsertionMarker);
@@ -518,7 +520,7 @@ param customParam customType[]
                 paramUri,
                 services => services.WithNamespaceProvider(BuiltInTestTypes.Create()));
 
-            var paramFile = SourceFileFactory.CreateBicepParamFile(paramUri, paramFileTextNoCursor);
+            var paramFile = new LanguageClientFile(paramUri, paramFileTextNoCursor);
             var file = new FileRequestHelper(helper.Client, paramFile);
             var completions = await file.RequestCompletion(cursor);
             return completions.OrderBy(completion => completion.SortText);

--- a/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ReferencesTests.cs
@@ -53,7 +53,7 @@ var blah = '${test}'
         var locations = await file.RequestReferences(cursor, includeDeclaration: true);
 
         // all URIs should be the same in the results
-        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.Uri);
+        locations!.Select(r => r.Uri).Should().AllBeEquivalentTo(file.Source.Uri);
 
         AnnotateWithLocations(file, locations).Should().EqualIgnoringTrailingWhitespace(outputAnnotated);
     }
@@ -80,7 +80,7 @@ var blah = '${test}'
         var locations = await file.RequestReferences(cursor, includeDeclaration: false);
 
         // all URIs should be the same in the results
-        locations!.Select(r => r.Uri.ToUriEncoded()).Should().AllBeEquivalentTo(file.Source.Uri);
+        locations!.Select(r => r.Uri).Should().AllBeEquivalentTo(file.Source.Uri);
 
         AnnotateWithLocations(file, locations).Should().EqualIgnoringTrailingWhitespace(outputAnnotated);
     }
@@ -132,8 +132,9 @@ var dep2 = az.deploy|ment()
 
     private static string AnnotateWithLocations(FileRequestHelper file, LocationContainer? locations)
         => PrintHelper.PrintWithAnnotations(
-            file.Source,
-            locations!.Select(x => new PrintHelper.Annotation(Assertions.AssertionScopeExtensions.FromRange(file.Source, x.Range), "here")), 1, true);
+            file.Source.Text,
+            file.Source.LineStarts,
+            locations!.Select(x => new PrintHelper.Annotation(file.Source.GetSpan(x.Range), "here")), 1, true);
 
     private static async Task<IEnumerable<LocationContainer?>> RequestReferences(FileRequestHelper file, IEnumerable<int> cursors)
     {

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -46,7 +46,7 @@ var blah = '${NewIdentifier}'
 
         var edit = await file.RequestRename(cursor, "NewIdentifier");
 
-        var appliedEdit = file.ApplyWorkspaceEdit(edit).ProgramSyntax.ToString();
+        var appliedEdit = file.ApplyWorkspaceEdit(edit).Text;
 
         appliedEdit.Should().EqualIgnoringTrailingWhitespace(expectedOutput);
     }

--- a/src/Bicep.LangServer.IntegrationTests/SemanticTokenTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/SemanticTokenTests.cs
@@ -48,8 +48,8 @@ namespace Bicep.LangServer.IntegrationTests
         [DynamicData(nameof(GetData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(DataSet), DynamicDataDisplayName = nameof(DataSet.GetDisplayName))]
         public async Task Overlapping_tokens_are_not_returned(DataSet dataSet)
         {
-            var uri = DocumentUri.From($"/{dataSet.Name}");
-            var bicepFile = SourceFileFactory.CreateBicepFile(uri.ToUriEncoded(), dataSet.Bicep);
+            var uri = DocumentUri.From($"{dataSet.Name}");
+            var bicepFile = new LanguageClientFile(uri, dataSet.Bicep);
 
             var helper = await DefaultServer.GetAsync();
             await helper.OpenFileOnceAsync(TestContext, dataSet.Bicep, uri);
@@ -83,10 +83,10 @@ namespace Bicep.LangServer.IntegrationTests
         public async Task Correct_semantic_tokens_are_returned_for_params_file(string paramFileText, TextSpan[] spans, SemanticTokenType[] tokenType)
         {
             var baseFilePath = $"file:///{TestContext.TestName}_{Guid.NewGuid():D}";
-            var paramFileUri = new Uri($"{baseFilePath}/main.bicepparam");
-            var bicepFileUri = new Uri($"{baseFilePath}/main.bicep");
+            var paramFileUri = $"{baseFilePath}/main.bicepparam";
+            var bicepFileUri = $"{baseFilePath}/main.bicep";
 
-            var fileTextsByUri = new Dictionary<Uri, string>
+            var fileTextsByUri = new Dictionary<DocumentUri, string>
             {
                 [paramFileUri] = paramFileText,
                 [bicepFileUri] = ""

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
@@ -30,7 +30,7 @@ namespace Bicep.LangServer.UnitTests
         [TestMethod]
         public void Create_ShouldReturnValidCompilation()
         {
-            var fileUri = DocumentUri.Parse($"/{DataSets.Parameters_LF.Name}.bicep");
+            var fileUri = DocumentUri.From($"{DataSets.Parameters_LF.Name}.bicep");
             var provider = Create();
 
             var sourceFile = SourceFileFactory.CreateBicepFile(fileUri.ToUriEncoded(), DataSets.Parameters_LF.Bicep);

--- a/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompilationProviderTests.cs
@@ -33,7 +33,7 @@ namespace Bicep.LangServer.UnitTests
             var fileUri = DocumentUri.Parse($"/{DataSets.Parameters_LF.Name}.bicep");
             var provider = Create();
 
-            var sourceFile = SourceFileFactory.CreateSourceFile(fileUri.ToUriEncoded(), DataSets.Parameters_LF.Bicep);
+            var sourceFile = SourceFileFactory.CreateBicepFile(fileUri.ToUriEncoded(), DataSets.Parameters_LF.Bicep);
             var workspace = new Workspace();
             workspace.UpsertSourceFile(sourceFile);
 


### PR DESCRIPTION
Extracting more changes for my main file I/O migration branch...

This PR introduces two key improvements:

1. Simplifying `SourceFileFactory` – It merges multiple factory methods into one and refines the source file creation logic, allowing the removal of `BicepCompilationManager.CreateSourceFile`.

2. Reducing unnecessary `SourceFileFactory` usage – Many language server integration tests previously relied on SourceFileFactory to create source files, resulting in unnecessary parsing, even though they only needed the source file URI, contents, and line starts. This PR introduces a new helper test class, `LanguageClientFile`, eliminating the need to call `SourceFileFactory` and providing several benefits:

    - It improves test readability and maintainability.
    - Tests runs slightly faster as there is no unnecessary file parsing before making LSP requests.
    - References to `SourceFileFactory` get reduced from about 100 to 29. This is particularly important for narrowing the file I/O migration scope.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16242)