### PR TITLE
`secure-secrets-in-params`: Flag insecure references to secure params

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecretsInParamsMustBeSecureTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecretsInParamsMustBeSecureTests.cs
@@ -14,6 +14,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
     [TestClass]
     public class SecretsInParamsMustBeSecureTests : LinterRuleTestsBase
     {
+        private void AssertCodeFix(string inputFile, string resultFile)
+            => AssertCodeFix(SecretsInParamsMustBeSecureRule.Code, "Mark parameter as secure", inputFile, resultFile);
+
         [TestMethod]
         public void ParameterNameInFormattedMessage()
         {
@@ -156,5 +159,21 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             ";
             CompileAndTest(bicep, 0);
         }
+
+        [TestMethod]
+        // https://github.com/Azure/bicep/issues/15835
+        public void Default_value_reference_to_insecure_param_is_flagged()
+            => AssertCodeFix("""
+@secure()
+param secureParam string
+
+param insecurePa|ram string = secureParam
+""", """
+@secure()
+param secureParam string
+
+@secure()
+param insecureParam string = secureParam
+""");
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecretsInParamsMustBeSecureRule.cs
@@ -59,7 +59,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private Diagnostic? AnalyzeUnsecuredParameter(SemanticModel model, DiagnosticLevel diagnosticLevel, ParameterSymbol parameterSymbol)
+        private IDiagnostic? AnalyzeUnsecuredParameter(SemanticModel model, DiagnosticLevel diagnosticLevel, ParameterSymbol parameterSymbol)
         {
             string name = parameterSymbol.Name;
             TypeSymbol type = parameterSymbol.Type;
@@ -69,23 +69,36 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 {
                     if (!AllowedRegex.IsMatch(name))
                     {
-                        // Create fix
-                        var decorator = SyntaxFactory.CreateDecorator("secure");
-                        var newline = model.Configuration.Formatting.Data.NewlineKind.ToEscapeSequence();
-                        var decoratorText = $"{decorator}{newline}";
-                        var fixSpan = new TextSpan(parameterSymbol.DeclaringSyntax.Span.Position, 0);
-                        var codeReplacement = new CodeReplacement(fixSpan, decoratorText);
-
-                        return CreateFixableDiagnosticForSpan(
-                            diagnosticLevel,
-                            parameterSymbol.NameSource.Span,
-                            new CodeFix("Mark parameter as secure", isPreferred: true, CodeFixKind.QuickFix, codeReplacement),
-                            name);
+                        return CreateDiagnostic(model, parameterSymbol, diagnosticLevel);
                     }
                 }
             }
 
+            foreach (var referencedSymbol in model.Binder.GetSymbolsReferencedInDeclarationOf(parameterSymbol))
+            {
+                if (referencedSymbol is ParameterSymbol referencedParameter && referencedParameter.IsSecure())
+                {
+                    // The default vlaue has a reference to a parameter marked as secure
+                    return CreateDiagnostic(model, parameterSymbol, diagnosticLevel);
+                }
+            }
+
             return null;
+        }
+
+        private IDiagnostic CreateDiagnostic(SemanticModel model, ParameterSymbol parameterSymbol, DiagnosticLevel diagnosticLevel)
+        {
+            var decorator = SyntaxFactory.CreateDecorator("secure");
+            var newline = model.Configuration.Formatting.Data.NewlineKind.ToEscapeSequence();
+            var decoratorText = $"{decorator}{newline}";
+            var fixSpan = new TextSpan(parameterSymbol.DeclaringSyntax.Span.Position, 0);
+            var codeReplacement = new CodeReplacement(fixSpan, decoratorText);
+
+            return CreateFixableDiagnosticForSpan(
+                diagnosticLevel,
+                parameterSymbol.NameSource.Span,
+                new CodeFix("Mark parameter as secure", isPreferred: true, CodeFixKind.QuickFix, codeReplacement),
+                parameterSymbol.Name);
         }
     }
 }


### PR DESCRIPTION
Ensure insecure param default value references to secure parameters are flagged in `secure-secrets-in-params` linter rule.

Example bicep code that would be flagged by this change:
```bicep
@secure()
param secureParam string

param insecurePa|ram string = secureParam
```

Closes #15835