### PR TITLE
Handle synchronous deployment failures in deploy pane

### DIFF
--- a/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -1,5 +1,294 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`App > handles synchronous deployment failures correctly 1`] = `
+<div>
+  <main
+    id="webview-body"
+  >
+    <section
+      class="form-section"
+    >
+      <vscode-divider
+        role="separator"
+      />
+      <div
+        class="form-title"
+      >
+        <div
+          aria-hidden="true"
+          class="sc-gtLWhw cXkuWu codicon codicon-chevron-up"
+          data-testid="chevron-up-codicon"
+        />
+        <h3>
+          Deployment Scope
+        </h3>
+      </div>
+      <div
+        class="form-content"
+      >
+        <vscode-table
+          role="table"
+        >
+          <vscode-table-body
+            role="rowgroup"
+          >
+            <vscode-table-row
+              role="row"
+            >
+              <vscode-table-cell
+                role="cell"
+              >
+                Subscription Id
+              </vscode-table-cell>
+              <vscode-table-cell
+                role="cell"
+              >
+                <vscode-badge
+                  variant="default"
+                >
+                  a790367f-228f-43fd-a660-ed9abb7258ef
+                </vscode-badge>
+              </vscode-table-cell>
+            </vscode-table-row>
+            <vscode-table-row
+              role="row"
+            >
+              <vscode-table-cell
+                role="cell"
+              >
+                Resource Group
+              </vscode-table-cell>
+              <vscode-table-cell
+                role="cell"
+              >
+                <vscode-badge
+                  variant="default"
+                >
+                  mockRg
+                </vscode-badge>
+              </vscode-table-cell>
+            </vscode-table-row>
+          </vscode-table-body>
+        </vscode-table>
+        <div
+          class="controls"
+        >
+          <vscode-button
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            Change Scope
+          </vscode-button>
+        </div>
+      </div>
+    </section>
+    <section
+      class="form-section"
+    >
+      <vscode-divider
+        role="separator"
+      />
+      <div
+        class="form-title"
+      >
+        <div
+          aria-hidden="true"
+          class="sc-gtLWhw cXkuWu codicon codicon-chevron-up"
+          data-testid="chevron-up-codicon"
+        />
+        <h3>
+          Parameters
+        </h3>
+      </div>
+      <div
+        class="form-content"
+      >
+        <vscode-button
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          Pick JSON Parameters File
+        </vscode-button>
+        <span
+          class="input-row"
+        >
+          <vscode-label
+            for=""
+            id="vscode-label-3"
+          >
+            fooParam
+          </vscode-label>
+          <vscode-textfield
+            aria-invalid="false"
+            internals-valid=""
+            type="text"
+          />
+        </span>
+      </div>
+    </section>
+    <section
+      class="form-section"
+    >
+      <vscode-divider
+        role="separator"
+      />
+      <div
+        class="form-title"
+      >
+        <div
+          aria-hidden="true"
+          class="sc-gtLWhw cXkuWu codicon codicon-chevron-up"
+          data-testid="chevron-up-codicon"
+        />
+        <h3>
+          Actions
+        </h3>
+      </div>
+      <div
+        class="form-content"
+      >
+        <div
+          class="controls"
+        >
+          <vscode-button
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            Deploy
+          </vscode-button>
+          <vscode-button
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            Validate
+          </vscode-button>
+          <vscode-button
+            role="button"
+            tabindex="0"
+            type="button"
+          >
+            What-If
+          </vscode-button>
+        </div>
+      </div>
+    </section>
+    <section
+      class="form-section"
+    >
+      <vscode-divider
+        role="separator"
+      />
+      <div
+        class="form-title"
+      >
+        <div
+          aria-hidden="true"
+          class="sc-gtLWhw cXkuWu codicon codicon-chevron-up"
+          data-testid="chevron-up-codicon"
+        />
+        <h3>
+          Result
+        </h3>
+      </div>
+      <div
+        class="form-content"
+      >
+        <vscode-table
+          role="table"
+        >
+          <vscode-table-body
+            role="rowgroup"
+          >
+            <vscode-table-row
+              role="row"
+            >
+              <vscode-table-cell
+                role="cell"
+              >
+                Deployment Name
+              </vscode-table-cell>
+              <vscode-table-cell
+                role="cell"
+              >
+                <vscode-badge
+                  variant="default"
+                >
+                  bicep-deploy-1737601964200
+                  <a
+                    href="https://portal.azure.com/#@9eeeb42f-40a5-4229-849f-a71fae26c89f/blade/HubsExtension/DeploymentDetailsBlade/overview/id/%2Fsubscriptions%2Fa790367f-228f-43fd-a660-ed9abb7258ef%2FresourceGroups%2FmockRg%2Fproviders%2FMicrosoft.Resources%2Fdeployments%2Fbicep-deploy-1737601964200"
+                    style="vertical-align: middle;"
+                    title="Open in Portal"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="sc-gtLWhw dxZIxj codicon codicon-globe"
+                      data-testid="globe-codicon"
+                    />
+                  </a>
+                </vscode-badge>
+              </vscode-table-cell>
+            </vscode-table-row>
+            <vscode-table-row
+              role="row"
+            >
+              <vscode-table-cell
+                role="cell"
+              >
+                Status
+              </vscode-table-cell>
+              <vscode-table-cell
+                role="cell"
+              >
+                <vscode-badge
+                  variant="default"
+                >
+                  Failed
+                </vscode-badge>
+              </vscode-table-cell>
+            </vscode-table-row>
+          </vscode-table-body>
+        </vscode-table>
+        <vscode-checkbox
+          aria-checked="false"
+          aria-invalid="false"
+          aria-label="Show JSON?"
+          internals-valid=""
+          role="checkbox"
+        >
+          Show JSON?
+        </vscode-checkbox>
+        <vscode-table
+          role="table"
+        >
+          <vscode-table-body
+            role="rowgroup"
+          >
+            <vscode-table-row
+              role="row"
+            >
+              <vscode-table-cell
+                role="cell"
+              >
+                Message
+              </vscode-table-cell>
+              <vscode-table-cell
+                role="cell"
+              >
+                Error: Deployment failed
+              </vscode-table-cell>
+            </vscode-table-row>
+          </vscode-table-body>
+        </vscode-table>
+      </div>
+    </section>
+  </main>
+</div>
+`;
+
 exports[`App > renders the App component with deployment state 1`] = `
 <div>
   <main
@@ -725,7 +1014,7 @@ exports[`App > supports the scope picker 1`] = `
         >
           <vscode-label
             for=""
-            id="vscode-label-5"
+            id="vscode-label-6"
           >
             fooParam
           </vscode-label>
@@ -905,7 +1194,7 @@ exports[`App > validates a deployment 1`] = `
         >
           <vscode-label
             for=""
-            id="vscode-label-3"
+            id="vscode-label-4"
           >
             fooParam
           </vscode-label>
@@ -1179,7 +1468,7 @@ exports[`App > what-ifs a deployment 1`] = `
         >
           <vscode-label
             for=""
-            id="vscode-label-4"
+            id="vscode-label-5"
           >
             fooParam
           </vscode-label>

--- a/src/vscode-bicep-ui/apps/deploy-pane/src/components/hooks/useAzure.ts
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/components/hooks/useAzure.ts
@@ -94,7 +94,7 @@ export function useAzure(props: UseAzureProps) {
         }
         setOperations(operations);
       };
-
+      
       let poller;
       try {
         poller = await client.deployments.beginCreateOrUpdateAtScope(getScopeId(scope), deploymentName, deployment);
@@ -107,7 +107,11 @@ export function useAzure(props: UseAzureProps) {
       } catch (e) {
         return { success: false, error: parseError(e) };
       } finally {
-        await updateOperations();
+        if (poller) {
+          // only attempt to fetch operations if the deployment ran asynchronously.
+          // if it failed synchronously, then the operations API will return 404.
+          await updateOperations();
+        }
       }
 
       const finalResult = poller.getResult();


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] All documentation contributions should be made directly in the [Bicep documentation on Microsoft Docs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/).

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://docs.microsoft.com/azure/azure-resource-manager/bicep/child-resource-name-type)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Files/SnippetTemplates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16257)