### PR TITLE
Emit an info-level diagnostic on safe access of undeclared property

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -2014,7 +2014,10 @@ var chosenOne = which ? input : default
 
 var p = chosenOne.?foo
 ");
-        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP187", DiagnosticLevel.Info, "The property \"foo\" does not exist in the resource or type definition, although it might still be valid. If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."),
+        });
     }
 
     [TestMethod]
@@ -6284,7 +6287,10 @@ output foo string[] = [for item in items: item.foo]
             output foo string[] = [for item in items: item.?foo]
             """);
 
-        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP187", DiagnosticLevel.Info, "The property \"foo\" does not exist in the resource or type definition, although it might still be valid. If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."),
+        });
     }
 
     [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -1862,4 +1862,22 @@ param myParam string
             ("BCP411", DiagnosticLevel.Error, """The type "any" cannot be used in a type assignment because it does not fit within one of ARM's primitive type categories (string, int, bool, array, object). If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."""),
         });
     }
+
+    [TestMethod]
+    public void Diagnostic_should_be_emitted_for_safe_access_of_non_existent_property()
+    {
+        var result = CompilationHelper.Compile("""
+            param unsealed {
+              requiredProperty: string
+            }
+
+            output x string = unsealed.?undeclaredProperty
+            """);
+
+        result.Should().NotHaveAnyCompilationBlockingDiagnostics();
+        result.Should().HaveDiagnostics(new[]
+        {
+            ("BCP187", DiagnosticLevel.Info, "The property \"undeclaredProperty\" does not exist in the resource or type definition, although it might still be valid. If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."),
+        });
+    }
 }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSafeAccessRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSafeAccessRuleTests.cs
@@ -240,4 +240,13 @@ output bar string? = foo.outputs[?'bar']
 supportingFiles: [new("module.bicep", """
 output bar string? = null
 """)]);
+
+    [TestMethod]
+    public void Rule_ignores_access_with_null_forgiving_operator() => AssertNoDiagnostics("""
+        param foo {
+          optionalProperty: string?
+        }
+
+        output bar string = foo.optionalProperty!
+        """);
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseSafeAccessRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseSafeAccessRule.cs
@@ -73,7 +73,7 @@ public sealed class UseSafeAccessRule : LinterRuleBase
 
         foreach (var access in SyntaxAggregator.AggregateByType<AccessExpressionSyntax>(model.Root.Syntax))
         {
-            if (access.IsSafeAccess)
+            if (access.IsSafeAccess || model.Binder.GetParent(access) is NonNullAssertionSyntax)
             {
                 continue;
             }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -979,7 +979,8 @@ namespace Bicep.Core.Diagnostics
                 "BCP186",
                 $"Unable to parse literal JSON value. Please ensure that it is well-formed.");
 
-            public Diagnostic FallbackPropertyUsed(string property) => CoreWarning(
+            public Diagnostic FallbackPropertyUsed(bool shouldDowngrade, string property) => CoreDiagnostic(
+                shouldDowngrade ? DiagnosticLevel.Info : DiagnosticLevel.Warning,
                 "BCP187",
                 $"The property \"{property}\" does not exist in the resource or type definition, although it might still be valid.{TypeInaccuracyClause}");
 

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -261,9 +261,10 @@ namespace Bicep.Core.TypeSystem
                 }
             }
 
-            if (!isSafeAccess && flags.HasFlag(TypePropertyFlags.FallbackProperty))
+            if (flags.HasFlag(TypePropertyFlags.FallbackProperty))
             {
-                diagnostics.Write(DiagnosticBuilder.ForPosition(propertyExpressionPositionable).FallbackPropertyUsed(propertyName));
+                diagnostics.Write(DiagnosticBuilder.ForPosition(propertyExpressionPositionable)
+                    .FallbackPropertyUsed(shouldDowngrade: isSafeAccess, propertyName));
             }
 
             return null;

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -1128,7 +1128,8 @@ namespace Bicep.Core.TypeSystem
 
                         if (declaredProperty.Flags.HasFlag(TypePropertyFlags.FallbackProperty))
                         {
-                            diagnosticWriter.Write(config.OriginSyntax ?? declaredPropertySyntax?.Key ?? expression, x => x.FallbackPropertyUsed(declaredProperty.Name));
+                            diagnosticWriter.Write(config.OriginSyntax ?? declaredPropertySyntax?.Key ?? expression,
+                                x => x.FallbackPropertyUsed(shouldDowngrade: false, declaredProperty.Name));
                         }
 
                         var newConfig = new TypeValidatorConfig(


### PR DESCRIPTION
Resolves #16239

This PR updates the logic that checks for access to undeclared properties to emit an info-level diagnostic when an undeclared property is accessed using the `.?` operator. Previously, this check would emit a warning-level diagnostic for non-safe access and no diagnostic for safe access.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16327)