### PR TITLE
Fix 13606, stuck in ext-src loop

### DIFF
--- a/src/Bicep.Core.UnitTests/Utils/SourceArchiveBuilder.cs
+++ b/src/Bicep.Core.UnitTests/Utils/SourceArchiveBuilder.cs
@@ -62,7 +62,7 @@ namespace Bicep.Core.UnitTests.Utils
             return SourceArchive.PackSourcesIntoStream(
                 EntrypointFile.Uri,
                 null,
-                SourceFiles.Select(x => new SourceFileWithArtifactReference(x, null)).ToArray());
+                [.. SourceFiles.Select(x => new SourceFileWithArtifactReference(x, null))]);
         }
 
         public BinaryData BuildBinaryData()

--- a/src/Bicep.Core/SourceCode/SourceCodePathHelper.cs
+++ b/src/Bicep.Core/SourceCode/SourceCodePathHelper.cs
@@ -70,7 +70,7 @@ namespace Bicep.Core.SourceCode
                 throw new ArgumentException($"Paths should be normalized before calling {nameof(MapPathsToDistinctRoots)}");
             }
 
-            string[] folders = filePaths.Select(path =>
+            string[] folders = [.. filePaths.Select(path =>
             {
                 if (!Path.IsPathFullyQualified(path) || Path.GetDirectoryName(path) is not string folder)
                 {
@@ -79,7 +79,7 @@ namespace Bicep.Core.SourceCode
 
                 return folder;
             })
-            .Select(NormalizeSlashes).ToArray();
+            .Select(NormalizeSlashes)];
 
             var distinctFolders = folders.Distinct(PathHelper.PathComparer).ToArray();
 

--- a/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CodeLensTests.cs
@@ -119,7 +119,7 @@ namespace Bicep.LangServer.IntegrationTests
             var lens = lenses.First();
             lens.Should().HaveRange(new Range(0, 0, 0, 0));
             lens.Should().HaveCommandName("bicep.internal.showModuleSourceFile");
-            lens.Should().HaveCommandTitle("Show compiled JSON for module module1 (br:myregistry.azurecr.io/myrepo/bicep/module1:v1)");
+            lens.Should().HaveCommandTitle("Show the compiled JSON for module \"module1\" (br:myregistry.azurecr.io/myrepo/bicep/module1:v1)");
             var target = new ExternalSourceReference(lens.CommandArguments().Single());
             target.IsRequestingCompiledJson.Should().BeTrue();
         }
@@ -141,7 +141,7 @@ namespace Bicep.LangServer.IntegrationTests
             var lens = lenses.First();
             lens.Should().HaveRange(new Range(0, 0, 0, 0));
             lens.Should().HaveCommandName("bicep.internal.showModuleSourceFile");
-            lens.Should().HaveCommandTitle("Show compiled JSON for module module1 (br:myregistry.azurecr.io/myrepo/bicep/module1:v1)");
+            lens.Should().HaveCommandTitle("Show the compiled JSON for module \"module1\" (br:myregistry.azurecr.io/myrepo/bicep/module1:v1)");
             var target = new ExternalSourceReference(lens.CommandArguments().Single());
             target.IsRequestingCompiledJson.Should().BeTrue();
         }
@@ -163,7 +163,7 @@ namespace Bicep.LangServer.IntegrationTests
             var lens = lenses.First();
             lens.Should().HaveRange(new Range(0, 0, 0, 0));
             lens.Should().HaveCommandName("bicep.internal.showModuleSourceFile");
-            lens.Should().HaveCommandTitle("Show compiled JSON for module module1 (br:myregistry.azurecr.io/myrepo/bicep/module1:v1)");
+            lens.Should().HaveCommandTitle("Show the compiled JSON for module \"module1\" (br:myregistry.azurecr.io/myrepo/bicep/module1:v1)");
             var target = new ExternalSourceReference(lens.CommandArguments().Single());
             target.IsRequestingCompiledJson.Should().BeTrue();
         }

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -24,6 +24,7 @@ using Bicep.LanguageServer.Telemetry;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using static Bicep.Core.UnitTests.Diagnostics.LinterRuleTests.UseRecentApiVersionRuleTests.GetAcceptableApiVersionsInvariantsTests;
 
 namespace Bicep.LangServer.UnitTests.Handlers
 {
@@ -31,9 +32,9 @@ namespace Bicep.LangServer.UnitTests.Handlers
     public class BicepExternalSourceRequestHandlerTests
     {
 #if WINDOWS_BUILD
-        private static string Root(string path) => $"c:\\{path}";
+        private static string Rooted(string path) => $"c:\\{path}";
 #else
-        private static string Root(string path) => $"/{path}";
+        private static string Rooted(string path) => $"/{path}";
 #endif
 
         private static readonly IFileExplorer FileExplorer = new FileSystemFileExplorer(new MockFileSystem(new Dictionary<string, MockFileData>()
@@ -143,7 +144,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(new SourceNotAvailableException()));
 
             var bicepSource = "metadata hi = 'This is the bicep source file'";
-            var bicepUri = PathHelper.FilePathToFileUrl(Root("foo/bar/entrypoint.bicep"));
+            var bicepUri = PathHelper.FilePathToFileUrl(Rooted("foo/bar/entrypoint.bicep"));
             var sourceArchive = new SourceArchiveBuilder(BicepTestConstants.SourceFileFactory).WithBicepFile(bicepUri, bicepSource).Build();
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(sourceArchive));
 
@@ -316,7 +317,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
             var bicepSource = "metadata hi = 'This is the bicep source file'";
-            var bicepUri = PathHelper.FilePathToFileUrl(Root("foo/bar/entrypoint.bicep"));
+            var bicepUri = PathHelper.FilePathToFileUrl(Rooted("foo/bar/entrypoint.bicep"));
             var sourceArchive = new SourceArchiveBuilder(BicepTestConstants.SourceFileFactory).WithBicepFile(bicepUri, bicepSource).Build();
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(sourceArchive));
 
@@ -368,7 +369,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             dispatcher.Setup(m => m.TryGetLocalArtifactEntryPointUri(moduleReference!)).Returns(ResultHelper.Create(compiledJsonUri, null));
 
             var bicepSource = "metadata hi = 'This is the bicep source file'";
-            var bicepUri = PathHelper.FilePathToFileUrl(Root("foo/bar/entrypoint.bicep"));
+            var bicepUri = PathHelper.FilePathToFileUrl(Rooted("foo/bar/entrypoint.bicep"));
             var sourceArchive = new SourceArchiveBuilder(BicepTestConstants.SourceFileFactory).WithBicepFile(bicepUri, bicepSource).Build();
             dispatcher.Setup(m => m.TryGetModuleSources(moduleReference!)).Returns(new ResultWithException<SourceArchive>(sourceArchive));
 
@@ -400,14 +401,24 @@ namespace Bicep.LangServer.UnitTests.Handlers
         public void GetExternalSourceLinkUri_FullLink_WithSource()
         {
             Uri result = GetExternalSourceLinkUri(new ExternalSourceLinkTestData());
-            result.Should().Be("bicep-extsrc:br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1%2Fentrypoint.bicep %28module1%3Av1%29?br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1#entrypoint.bicep");
+            //result.Should().Be("bicep-extsrc:br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1%2Fentrypoint.bicep %28module1%3Av1%29?br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1#entrypoint.bicep");
+            DecodeExternalSourceUri(result).FullTitle.Should().Be("br:myregistry.azurecr.io/myrepo/bicep/module1:v1 -> entrypoint.bicep");
         }
 
         [TestMethod]
         public void GetExternalSourceLinkUri_FullLink_WithoutSource()
         {
-            Uri result = GetExternalSourceLinkUri(new ExternalSourceLinkTestData(sourceEntrypoint: null));
-            result.Should().Be("bicep-extsrc:br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1%2Fmain.json %28module1%3Av1%29?br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1");
+            Uri result = GetExternalSourceLinkUri(new ExternalSourceLinkTestData(RelativeEntrypoint: null));
+            //result.Should().Be("bicep-extsrc:br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1%2Fmodule1%3Av1 -> main.json?br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1");
+            DecodeExternalSourceUri(result).FullTitle.Should().Be("br:myregistry.azurecr.io/myrepo/bicep/module1:v1 -> main.json");
+        }
+
+        [TestMethod]
+        public void GetExternalSourceLinkUri_FullLink_WithSource_NoModuleBasePath()
+        {
+            Uri result = GetExternalSourceLinkUri(new ExternalSourceLinkTestData(Repository: "module1"));
+            //result.Should().Be("bicep-extsrc:br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1%2Fentrypoint.bicep %28module1%3Av1%29?br%3Amyregistry.azurecr.io%2Fmyrepo%2Fbicep%2Fmodule1%3Av1#entrypoint.bicep");
+            DecodeExternalSourceUri(result).FullTitle.Should().Be("br:myregistry.azurecr.io/module1:v1 -> entrypoint.bicep");
         }
 
         [DataTestMethod]
@@ -417,22 +428,34 @@ namespace Bicep.LangServer.UnitTests.Handlers
             Uri result = GetExternalSourceLinkUri(testData);
 
             // Source archive entrypoints are always relative to the source root folder, so remove paths
-            var expectedEntrypointFilename = Path.GetFileName(testData.sourceEntrypoint ?? "main.json");
+            var expectedEntrypointFilename = Path.GetFileName(testData.SourceEntrypoint ?? "main.json");
 
-            DecodeExternalSourceUri(result).GetShortTitle().Should().Be($"{expectedEntrypointFilename} ({Path.GetFileName(testData.repository)}{testData.tagOrDigest})");
-            DecodeExternalSourceUri(result).FullTitle.Should().Be($"br:{testData.registry}/{testData.repository}{testData.tagOrDigest}/{expectedEntrypointFilename} ({Path.GetFileName(testData.repository)}{testData.tagOrDigest})");
+            DecodeExternalSourceUri(result).GetShortTitle().Should().Be($"{Path.GetFileName(testData.Repository)}{testData.TagOrDigest} -> {expectedEntrypointFilename}");
+            DecodeExternalSourceUri(result).FullTitle.Should().Be($"br:{testData.Registry}/{testData.Repository}{testData.TagOrDigest} -> {expectedEntrypointFilename}");
         }
 
         [TestMethod]
         public void GetExternalSourceLinkUri_WithExternalModuleFromCache_TitlesShouldBeCorrect()
         {
             var components = OciArtifactAddressComponents.TryParse("myregistry.azurecr.io/myrepo/bicep/module1:v1")
-            .Unwrap();
+                .Unwrap();
             var ext = new ExternalSourceReference(components, new SourceArchiveBuilder(BicepTestConstants.SourceFileFactory).Build())
                 .WithRequestForSourceFile("<cache>/br/mcr.microsoft.com/bicep$storage$storage-account/1.0.1$/main.json");
 
-            ext.GetShortTitle().Should().Be("main.json (module1:v1->storage-account:1.0.1)");
-            ext.FullTitle.Should().Be("br:myregistry.azurecr.io/myrepo/bicep/module1:v1/main.json (module1:v1->storage-account:1.0.1)");
+            ext.GetShortTitle().Should().Be("module1:v1 -> storage-account:1.0.1 -> main.json");
+            ext.FullTitle.Should().Be("br:myregistry.azurecr.io/myrepo/bicep/module1:v1 -> storage-account:1.0.1 -> main.json");
+        }
+
+        [TestMethod]
+        public void GetExternalSourceLinkUri_WithRequestedFileInSubfolder_TitlesShouldBeCorrect()
+        {
+            var components = OciArtifactAddressComponents.TryParse("myregistry.azurecr.io/myrepo/bicep/module1:v1")
+                .Unwrap();
+            var ext = new ExternalSourceReference(components, new SourceArchiveBuilder(BicepTestConstants.SourceFileFactory).Build())
+                .WithRequestForSourceFile("subfolder1/subfolder 2/my file.bicep");
+
+            ext.GetShortTitle().Should().Be("module1:v1 -> subfolder1>subfolder 2>my file.bicep");
+            ext.FullTitle.Should().Be("br:myregistry.azurecr.io/myrepo/bicep/module1:v1 -> subfolder1>subfolder 2>my file.bicep");
         }
 
         [DataTestMethod]
@@ -440,7 +463,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         public void GetExternalSourceLinkUri_ModuleReferenceShouldBeCorrect(ExternalSourceLinkTestData testData)
         {
             Uri result = GetExternalSourceLinkUri(testData);
-            DecodeExternalSourceUri(result).Components.ArtifactId.Should().Be($"{testData.registry}/{testData.repository}{testData.tagOrDigest}");
+            DecodeExternalSourceUri(result).Components.ArtifactId.Should().Be($"{testData.Registry}/{testData.Repository}{testData.TagOrDigest}");
         }
 
         [DataTestMethod]
@@ -448,7 +471,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
         public void GetExternalSourceLinkUri_RequestedFilenameShouldBeCorrect(ExternalSourceLinkTestData testData)
         {
             Uri result = GetExternalSourceLinkUri(testData);
-            var expectedRequestedFile = testData.sourceEntrypoint is null ? "main.json" : Path.GetFileName(testData.sourceEntrypoint);
+            var expectedRequestedFile = testData.SourceEntrypoint is null ? "main.json" : Path.GetFileName(testData.SourceEntrypoint);
             DecodeExternalSourceUri(result).RequestedFile.Should().Be(expectedRequestedFile);
         }
 
@@ -510,14 +533,14 @@ namespace Bicep.LangServer.UnitTests.Handlers
 
         private Uri GetExternalSourceLinkUri(ExternalSourceLinkTestData testData)
         {
-            Uri? entrypointUri = testData.sourceEntrypoint is { } ? PathHelper.FilePathToFileUrl(testData.sourceEntrypoint) : null;
+            Uri? entrypointUri = testData.SourceEntrypoint is { } ? PathHelper.FilePathToFileUrl(testData.SourceEntrypoint) : null;
             OciArtifactReference reference = new(
                 BicepTestConstants.DummyBicepFile,
                 ArtifactType.Module,
-                testData.registry,
-                testData.repository,
-                testData.tagOrDigest[0] == ':' ? testData.tagOrDigest[1..] : null,
-                testData.tagOrDigest[0] == '@' ? testData.tagOrDigest[1..] : null);
+                testData.Registry,
+                testData.Repository,
+                testData.TagOrDigest[0] == ':' ? testData.TagOrDigest[1..] : null,
+                testData.TagOrDigest[0] == '@' ? testData.TagOrDigest[1..] : null);
 
             SourceArchive? sourceArchive = entrypointUri is { } ?
                 new SourceArchiveBuilder(BicepTestConstants.SourceFileFactory).WithBicepFile(entrypointUri, "metadata description = 'bicep module'").Build()
@@ -547,16 +570,14 @@ namespace Bicep.LangServer.UnitTests.Handlers
         }
 
         public record ExternalSourceLinkTestData(
-            string? sourceEntrypoint =
-#if WINDOWS_BUILD
-                "c:\\entrypoint.bicep", // Use null to indicate no source code is available
-#else
-                        "/entrypoint.bicep", // Use null to indicate no source code is available
-#endif
-            string registry = "myregistry.azurecr.io",
-            string repository = "myrepo/bicep/module1",
-            string tagOrDigest = ":v1" // start with @ for digest
-            );
+            string? RelativeEntrypoint = "entrypoint.bicep", // Use null to indicate no source code is available
+            string Registry = "myregistry.azurecr.io",
+            string Repository = "myrepo/bicep/module1",
+            string TagOrDigest = ":v1" // start with @ for digest
+        )
+        {
+            public string? SourceEntrypoint => RelativeEntrypoint is null ? null : Rooted(RelativeEntrypoint);
+        }
 
         private static IEnumerable<object[]> GetExternalSourceLinkTestData()
         {
@@ -568,37 +589,37 @@ namespace Bicep.LangServer.UnitTests.Handlers
             static IEnumerable<ExternalSourceLinkTestData> GetData()
             {
                 // vary entrypoint (any valid file path character)
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("main.bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("my main.bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("my+main.bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("my$main.bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("my#main.bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("my(main).bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("my%main.bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("subfolder/main.bicep"));
-                yield return new ExternalSourceLinkTestData(sourceEntrypoint: Root("sub folder/my main.bicep"));
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "main.bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "my main.bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "my+main.bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "my$main.bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "my#main.bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "my(main).bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "my%main.bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "subfolder/main.bicep");
+                yield return new ExternalSourceLinkTestData(RelativeEntrypoint: "sub folder/my main.bicep");
 
                 // vary registry (can only be lower-case alphanumeric and '.', '_', '-')
-                yield return new ExternalSourceLinkTestData(registry: "myregistry.azurecr.io");
-                yield return new ExternalSourceLinkTestData(registry: "hello.my_registry.azurecr.io");
-                yield return new ExternalSourceLinkTestData(registry: "hello.my-registry.azurecr.io");
+                yield return new ExternalSourceLinkTestData(Registry: "myregistry.azurecr.io");
+                yield return new ExternalSourceLinkTestData(Registry: "hello.my_registry.azurecr.io");
+                yield return new ExternalSourceLinkTestData(Registry: "hello.my-registry.azurecr.io");
 
                 // vary repo (can only be lower-case alphanumeric and '.', '_', '-')
-                yield return new ExternalSourceLinkTestData(registry: "myrepo");
-                yield return new ExternalSourceLinkTestData(registry: "myrepo/bicep");
-                yield return new ExternalSourceLinkTestData(registry: "myrepo/bicep/module1");
-                yield return new ExternalSourceLinkTestData(registry: "myrepo/bicep/mod-ul-e1");
-                yield return new ExternalSourceLinkTestData(registry: "my-repo/bicep/mod.ul.e1");
-                yield return new ExternalSourceLinkTestData(registry: "my-repo/bicep/mod_ul_e1");
+                yield return new ExternalSourceLinkTestData(Registry: "myrepo");
+                yield return new ExternalSourceLinkTestData(Registry: "myrepo/bicep");
+                yield return new ExternalSourceLinkTestData(Registry: "myrepo/bicep/module1");
+                yield return new ExternalSourceLinkTestData(Registry: "myrepo/bicep/mod-ul-e1");
+                yield return new ExternalSourceLinkTestData(Registry: "my-repo/bicep/mod.ul.e1");
+                yield return new ExternalSourceLinkTestData(Registry: "my-repo/bicep/mod_ul_e1");
 
                 // vary tag/digest (valid tag characters are alphanumeric, ".", "_", or "-" but the tag cannot begin with ".", "_", or "-")
-                yield return new ExternalSourceLinkTestData(tagOrDigest: ":v1");
-                yield return new ExternalSourceLinkTestData(tagOrDigest: ":v1.2");
-                yield return new ExternalSourceLinkTestData(tagOrDigest: ":1.2.3");
-                yield return new ExternalSourceLinkTestData(tagOrDigest: ":v-1");
-                yield return new ExternalSourceLinkTestData(tagOrDigest: ":v_1");
-                yield return new ExternalSourceLinkTestData(tagOrDigest: ":whoa");
-                yield return new ExternalSourceLinkTestData(tagOrDigest: "@sha256:02345342df02345342df02345342df02345342df02345342df02345342df1234");
+                yield return new ExternalSourceLinkTestData(TagOrDigest: ":v1");
+                yield return new ExternalSourceLinkTestData(TagOrDigest: ":v1.2");
+                yield return new ExternalSourceLinkTestData(TagOrDigest: ":1.2.3");
+                yield return new ExternalSourceLinkTestData(TagOrDigest: ":v-1");
+                yield return new ExternalSourceLinkTestData(TagOrDigest: ":v_1");
+                yield return new ExternalSourceLinkTestData(TagOrDigest: ":whoa");
+                yield return new ExternalSourceLinkTestData(TagOrDigest: "@sha256:02345342df02345342df02345342df02345342df02345342df02345342df1234");
             }
         }
 

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepExternalSourceDocumentLinkHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepExternalSourceDocumentLinkHandlerTests.cs
@@ -231,7 +231,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             link.Range.Should().HaveRange((0, 10), (0, 46));
             link.Target.Should().NotBeNull();
             var target = new ExternalSourceReference(link.Target!);
-            target.FullTitle.Should().Be("br:mockregistry.io/test/module1:v1/main.bicep (module1:v1)");
+            target.FullTitle.Should().Be("br:mockregistry.io/test/module1:v1 -> main.bicep");
             target.RequestedFile.Should().Be("main.bicep");
             target.ToArtifactReference(BicepTestConstants.DummyBicepFile).Unwrap().FullyQualifiedReference.Should().Be("br:mockregistry.io/test/module1:v1");
         }
@@ -282,7 +282,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             link1.Range.Should().HaveRange((0, 10), (0, 46));
             link1.Target.Should().NotBeNull();
             var target1 = new ExternalSourceReference(link1.Target!);
-            target1.FullTitle.Should().Be("br:mockregistry.io/test/module1:v1/main.bicep (module1:v1)");
+            target1.FullTitle.Should().Be("br:mockregistry.io/test/module1:v1 -> main.bicep");
             target1.RequestedFile.Should().Be("main.bicep");
             target1.ToArtifactReference(BicepTestConstants.DummyBicepFile).Unwrap().FullyQualifiedReference.Should().Be("br:mockregistry.io/test/module1:v1");
 
@@ -290,7 +290,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             link2.Range.Should().HaveRange((6, 12), (6, 48));
             link2.Target.Should().NotBeNull();
             var target2 = new ExternalSourceReference(link2.Target!);
-            target2.FullTitle.Should().Be("br:mockregistry.io/test/module1:v2/main.bicep (module1:v2)");
+            target2.FullTitle.Should().Be("br:mockregistry.io/test/module1:v2 -> main.bicep");
             target2.RequestedFile.Should().Be("main.bicep");
             target2.ToArtifactReference(BicepTestConstants.DummyBicepFile).Unwrap().FullyQualifiedReference.Should().Be("br:mockregistry.io/test/module1:v2");
 

--- a/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceCodeLensProvider.cs
@@ -82,7 +82,7 @@ namespace Bicep.LanguageServer.Handlers
                                 var artifactId = externalReference.Components.ArtifactId;
                                 yield return CreateCodeLens(
                                     DocumentStart,
-                                    $"Show compiled JSON for module {moduleName} ({OciArtifactReferenceFacts.Scheme}:{artifactId})",
+                                    $"Show the compiled JSON for module \"{moduleName}\" ({OciArtifactReferenceFacts.Scheme}:{artifactId})",
                                     "bicep.internal.showModuleSourceFile",
                                     new ExternalSourceReference(request.TextDocument.Uri).WithRequestForCompiledJson().ToUri().ToString());
                             }

--- a/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
@@ -21,8 +21,16 @@ namespace Bicep.LanguageServer.Handlers
     [DebuggerDisplay("{ToUri()}")]
     public partial class ExternalSourceReference
     {
+        // Current real-life example:
+        //   module m 'br:mcr.microsoft.com/bicep/avm/ptn/aca-lza/hosting-environment:0.1.0' = ...
+        //     -> Press F12
+        //   a) To display a bicep source file other than main.bicep inside the module, CTRL+click on:
+        //     module spoke 'modules/spoke/deploy.spoke.bicep' = ...
+        //   b) To display a nested external reference to another module, CTRL+click on:
+        //     module spokeResourceGroup 'br/public:avm/res/resources/resource-group:0.2.3' = ...
+
         // The title to display for the document's tab,
-        //   e.g. "br:myregistry.azurecr.io/myrepo/module:v1/main.json (module:v1)" or something similar.
+        //   e.g. "br:myregistry.azurecr.io/myrepo/module:v1 -> main.json" or something similar.
         // VSCode will display everything after the last slash in the document's tab (interpreting it as
         //   a file path and name), and the full string on hover.
         public string FullTitle { get; init; }
@@ -124,10 +132,10 @@ namespace Bicep.LanguageServer.Handlers
             // Example:
             //
             //   source available (will be encoded):
-            //     bicep-extsrc:br:myregistry.azurecr.io/myrepo:main.bicep (v1)?br:myregistry.azurecr.io/myrepo:v1#main.bicep
+            //     bicep-extsrc:br:myregistry.azurecr.io/myrepo/module1:v1 -> subfolder>main.bicep?br:myregistry.azurecr.io/myrepo/module1:v1#subfolder/main.bicep
             //
             //   source not available, showing just JSON (will be encoded)
-            //     bicep-extsrc:br:myregistry.azurecr.io/myrepo:main.json (v1)?br:myregistry.azurecr.io/myrepo:v1
+            //     bicep-extsrc:br:myregistry.azurecr.io/myrepo/module1:v1 -> main.json?br:myregistry.azurecr.io/myrepo/module1:v1
             //
             var uri = new UriBuilder($"{LangServerConstants.ExternalSourceFileScheme}:{Uri.EscapeDataString(this.FullTitle)}")
             {
@@ -157,32 +165,37 @@ namespace Bicep.LanguageServer.Handlers
 
         private string GetFullTitle()
         {
-            var version = GetVersion();
             var shortTitle = GetShortTitle();
-            var fullDocumentTitle = $"{OciArtifactReferenceFacts.Scheme}:{Components.Registry}/{Components.Repository}{version}/{shortTitle}";
+            var repositoryBasePath = Path.GetDirectoryName(Components.Repository) ?? string.Empty;
+
+            // Example: br:mockregistry.io/test/modules/module1:v1 -> localpath>main.bicep
+            var fullDocumentTitle = $"{OciArtifactReferenceFacts.Scheme}:{Components.Registry}/{Path.Join(repositoryBasePath, shortTitle).Replace('\\', '/')}";
 
             return fullDocumentTitle;
         }
 
         // Includes the filename and the module reference (repo and tag/digest).
-        //  e.g. "main.json (myregistry.azurecr.io/myrepo:v1)"
+        //  e.g. "module1:v1 -> main.json"
         // This portion will be visible in the document's tab (minus any parent folders of the filename) without hover.
         public string GetShortTitle()
         {
-            string filename = RequestedFile ?? "main.json";
+            string filePath = RequestedFile ?? "main.json";
+            filePath = CharsToReplaceInFilePath().Replace(filePath, ">"); // \ or / will mess up the registry info in the title that vscode displays
             var version = GetVersion();
             var repoAndTag = $"{Path.GetFileName(Components.Repository)}{version}";
 
             string shortTitle;
             if (RequestedFile is not null && externalModulePathRegex.Match(RequestedFile) is Match match && match.Success)
             {
-                // We're display a nested external module's source. Show both its info and the info of the module that references it.
+                // We're displaying a nested external module's source. Show both its info and the info of the module that references it.
                 var externalRepoAndTag = $"{match.Groups["repoName"].Value}:{match.Groups["tag"].Value}";
-                shortTitle = $"{Path.GetFileName(filename)} ({repoAndTag}->{externalRepoAndTag})";
+                var fileNameInCache = match.Groups["filename"].Value;
+                fileNameInCache = CharsToReplaceInFilePath().Replace(fileNameInCache, ">");
+                shortTitle = $"{repoAndTag} -> {externalRepoAndTag} -> {fileNameInCache}";
             }
             else
             {
-                shortTitle = $"{filename} ({repoAndTag})";
+                shortTitle = $"{repoAndTag} -> {filePath}";
             }
 
             return shortTitle;
@@ -196,5 +209,8 @@ namespace Bicep.LanguageServer.Handlers
             \/(?<filename>[^\/]+)$            
             """, RegexOptions.IgnorePatternWhitespace)]
         private static partial Regex ExternalModulePathRegex();
+
+        [GeneratedRegex(@"[\/:?]")]
+        private static partial Regex CharsToReplaceInFilePath();
     }
 }

--- a/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
@@ -180,7 +180,11 @@ namespace Bicep.LanguageServer.Handlers
         public string GetShortTitle()
         {
             string filePath = RequestedFile ?? "main.json";
-            filePath = CharsToReplaceInFilePath().Replace(filePath, ">"); // \ or / will mess up the registry info in the title that vscode displays
+            // Our display of "module1:v1 -> <path>.bicep" in vscode depends on vscode interpreting that as the "filename" part of the uri,
+            //   since it's always displays the filename.
+            // If <path> contains / or \, vscode will interpret that as a folder structure and only display the last part of it.
+            filePath = CharsToReplaceInFilePath().Replace(filePath, ">");
+
             var version = GetVersion();
             var repoAndTag = $"{Path.GetFileName(Components.Repository)}{version}";
 

--- a/src/vscode-bicep/src/language/bicepExternalSourceContentProvider.ts
+++ b/src/vscode-bicep/src/language/bicepExternalSourceContentProvider.ts
@@ -1,29 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as path from "path";
 import * as vscode from "vscode";
-import { Uri } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { Disposable } from "../utils/disposable";
-import { BicepExternalSourceScheme, decodeExternalSourceUri } from "./decodeExternalSourceUri";
+import { decodeExternalSourceUri } from "./decodeExternalSourceUri";
 import { BicepExternalSourceParams, bicepExternalSourceRequestType } from "./protocol";
 
 export class BicepExternalSourceContentProvider extends Disposable implements vscode.TextDocumentContentProvider {
   constructor(private readonly languageClient: LanguageClient) {
     super();
-    this.register(
-      vscode.workspace.onDidOpenTextDocument((document) => {
-        /*
-         * Changing the language ID while the file is being opened causes one of the following problems:
-         * - getting a TextDocument and blocking on it causes a deadlock
-         * - doing the same in a fire/forget promise causes strange caching behavior in VS code where
-         *   the language server is called for a particular file only once
-         * Moving this to an event listener instead avoids these issues entirely.
-         */
-        this.trySetExternalSourceLanguage(document);
-      }),
-    );
   }
 
   onDidChange?: vscode.Event<vscode.Uri> | undefined;
@@ -45,57 +31,5 @@ export class BicepExternalSourceContentProvider extends Disposable implements vs
       target: moduleReference,
       requestedSourceFile,
     };
-  }
-
-  private getModuleReferenceScheme(uri: Uri): "br" | "ts" {
-    // e.g. 'br:registry.azurecr.io/module:v3' => 'br'
-    const { moduleReference } = decodeExternalSourceUri(uri);
-
-    const colonIndex = moduleReference.indexOf(":");
-    if (colonIndex >= 0) {
-      const scheme = moduleReference.substring(0, colonIndex);
-      if (scheme === "br" || scheme === "ts") {
-        return scheme;
-      }
-    }
-
-    throw new Error(`The document URI '${uri.toString()}' is in an unexpected format.`);
-  }
-
-  private trySetExternalSourceLanguage(document: vscode.TextDocument): void {
-    if (document.uri.scheme === BicepExternalSourceScheme && document.languageId === "plaintext") {
-      // The file is showing content from the bicep cache and the language is still set to plain text, so
-      // we should try to correct it
-
-      const scheme = this.getModuleReferenceScheme(document.uri);
-      const { requestedSourceFile } = decodeExternalSourceUri(document.uri);
-
-      // Not necessary to wait for this to finish
-      void vscode.languages.setTextDocumentLanguage(
-        document,
-        // If no requestedSourceFile, we're being asked for the compiled main.json file
-        this.getLanguageId(scheme, requestedSourceFile ?? "main.json"),
-      );
-    }
-  }
-
-  private getLanguageId(scheme: "br" | "ts", fileName: string) {
-    switch (scheme) {
-      case "ts":
-        return "json";
-      case "br": {
-        if (path.extname(fileName) === ".bicep") {
-          return "bicep";
-        }
-
-        const armToolsExtension = vscode.extensions.getExtension("msazurermtools.azurerm-vscode-tools");
-
-        // if ARM Tools extension is installed and active, use a more specific language ID
-        // otherwise, fall back to JSON
-        return armToolsExtension && armToolsExtension.isActive ? "arm-template" : "jsonc";
-      }
-      default:
-        return "plaintext";
-    }
   }
 }


### PR DESCRIPTION
Fixes #13606

The URI we use to show external bicep sources is encoded to contain the information necessary as query params.  vscode takes the portion before the query params as a file path and shows the filename in the title, so we're using that to control how it shows up in the title (not aware of a better way to do that).  Right now, it doesn't end with .bicep so we have some extension code to force it to bicep language id.  That's apparently flaky, best fix is to modify our title so that the actual filename is at the end of the path (e.g. main.bicep), then that extension code is no longer necessary at all.

Example current tab title:
![image](https://github.com/user-attachments/assets/9d740dfe-bda4-4d2d-b0cd-1fcd28bb762e)

Changed examples:
![image](https://github.com/user-attachments/assets/f5f6e639-b164-41c6-94ee-28c95d757bfb)
![image](https://github.com/user-attachments/assets/92eb4051-7b42-4320-a650-29091a57879a)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16381)