### PR TITLE
Retire built-in Microsoft Graph extension

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CentralizedProviderVersionManagementTests.cs
@@ -44,7 +44,7 @@ namespace Bicep.Core.IntegrationTests
                     "microsoftGraph",
                     false,
                     new (string, DiagnosticLevel, string)[] {
-                     ("BCP407", DiagnosticLevel.Warning, "Built-in extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes" ) } };
+                     ("BCP407", DiagnosticLevel.Error, "Built-in extension \"microsoftGraph\" is retired. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes" ) } };
                 yield return new object[] {
                     "az",
                     true,

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -23,7 +23,6 @@ namespace Bicep.Core.IntegrationTests
             {
               "az": "builtin:",
               "kubernetes": "builtin:",
-              "microsoftGraph": "builtin:",
               "foo": "builtin:",
               "bar": "builtin:"
             }

--- a/src/Bicep.Core.IntegrationTests/Files/ExtensionRegistryTests/microsoftgraph/index.json
+++ b/src/Bicep.Core.IntegrationTests/Files/ExtensionRegistryTests/microsoftgraph/index.json
@@ -1,0 +1,19 @@
+{
+  "resources": {
+    "Microsoft.Graph/groups@v1.0": {
+      "$ref": "types.json#/7"
+    },
+    "Microsoft.Graph/applications@v1.0": {
+      "$ref": "types.json#/11"
+    },
+    "Microsoft.Graph/servicePrincipals@v1.0": {
+      "$ref": "types.json#/15"
+    }
+  },
+  "resourceFunctions": {},
+  "settings": {
+    "name": "MicrosoftGraph",
+    "version": "1.2.3",
+    "isSingleton": false
+  }
+}

--- a/src/Bicep.Core.IntegrationTests/Files/ExtensionRegistryTests/microsoftgraph/types.json
+++ b/src/Bicep.Core.IntegrationTests/Files/ExtensionRegistryTests/microsoftgraph/types.json
@@ -1,0 +1,210 @@
+[
+  {
+    "$type": "StringType"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Microsoft.Graph/groups"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "v1.0"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Microsoft.Graph/groups",
+    "properties": {
+      "type": {
+        "type": {
+          "$ref": "#/1"
+        },
+        "flags": 10
+      },
+      "apiVersion": {
+        "type": {
+          "$ref": "#/2"
+        },
+        "flags": 10
+      },
+      "displayName": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0
+      },
+      "mailEnabled": {
+        "type": {
+          "$ref": "#/4"
+        },
+        "flags": 0
+      },
+      "mailNickname": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0
+      },
+      "securityEnabled": {
+        "type": {
+          "$ref": "#/4"
+        },
+        "flags": 0
+      },
+      "uniqueName": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 25
+      },
+      "members": {
+        "type": {
+          "$ref": "#/5"
+        },
+        "flags": 0
+      },
+      "owners": {
+        "type": {
+          "$ref": "#/6"
+        },
+        "flags": 0
+      },
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0,
+        "description": "The unique identifier for an entity. Read-only."
+      }
+    }
+  },
+  {
+    "$type": "BooleanType"
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
+    "$type": "ResourceType",
+    "name": "Microsoft.Graph/groups@v1.0",
+    "scopeType": 0,
+    "body": {
+      "$ref": "#/3"
+    },
+    "flags": 0
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Microsoft.Graph/applications"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "v1.0"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Microsoft.Graph/applications",
+    "properties": {
+      "type": {
+        "type": {
+          "$ref": "#/8"
+        },
+        "flags": 10
+      },
+      "apiVersion": {
+        "type": {
+          "$ref": "#/9"
+        },
+        "flags": 10
+      },
+      "displayName": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0
+      },
+      "appId": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0
+      },
+      "uniqueName": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 25
+      },
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0
+      }
+    }
+  },
+  {
+    "$type": "ResourceType",
+    "name": "Microsoft.Graph/applications@v1.0",
+    "scopeType": 0,
+    "body": {
+      "$ref": "#/10"
+    },
+    "flags": 0
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "Microsoft.Graph/servicePrincipals"
+  },
+  {
+    "$type": "StringLiteralType",
+    "value": "v1.0"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "Microsoft.Graph/servicePrincipals",
+    "properties": {
+      "type": {
+        "type": {
+          "$ref": "#/12"
+        },
+        "flags": 10
+      },
+      "apiVersion": {
+        "type": {
+          "$ref": "#/13"
+        },
+        "flags": 10
+      },
+      "appId": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 17
+      },
+      "id": {
+        "type": {
+          "$ref": "#/0"
+        },
+        "flags": 0
+      }
+    }
+  },
+  {
+    "$type": "ResourceType",
+    "name": "Microsoft.Graph/servicePrincipals@v1.0",
+    "scopeType": 0,
+    "body": {
+      "$ref": "#/14"
+    },
+    "flags": 0
+  }
+]

--- a/src/Bicep.Core.IntegrationTests/OutputsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/OutputsTests.cs
@@ -30,7 +30,6 @@ namespace Bicep.Core.IntegrationTests
             {
               "az": "builtin:",
               "kubernetes": "builtin:",
-              "microsoftGraph": "builtin:",
               "foo": "builtin:",
               "bar": "builtin:"
             }

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -31,7 +31,6 @@ namespace Bicep.Core.IntegrationTests
             {
               "az": "builtin:",
               "kubernetes": "builtin:",
-              "microsoftGraph": "builtin:",
               "foo": "builtin:",
               "bar": "builtin:"
             }

--- a/src/Bicep.Core.IntegrationTests/ProviderImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ProviderImportTests.cs
@@ -381,7 +381,10 @@ extension madeUpNamespace
         {
             var result = await CompilationHelper.RestoreAndCompile(await GetServices(), @"extension microsoftGraph as graph");
 
-            result.Should().NotHaveAnyDiagnostics();
+            result.Should().NotGenerateATemplate();
+            result.Should().HaveDiagnostics(new[] {
+                ("BCP407", DiagnosticLevel.Error, """Built-in extension "microsoftGraph" is retired. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes"""),
+            });
         }
     }
 }

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -64,8 +64,7 @@ namespace Bicep.Core.UnitTests.Configuration
         },
         "extensions": {
           "az": "builtin:",
-          "kubernetes": "builtin:",
-          "microsoftGraph": "builtin:"
+          "kubernetes": "builtin:"
         },
         "implicitExtensions": ["az"],
         "analyzers": {
@@ -175,8 +174,7 @@ namespace Bicep.Core.UnitTests.Configuration
         },
         "extensions": {
             "az": "builtin:",
-            "kubernetes": "builtin:",
-            "microsoftGraph": "builtin:"
+            "kubernetes": "builtin:"
         },
         "implicitExtensions": [
             "az"
@@ -250,8 +248,7 @@ namespace Bicep.Core.UnitTests.Configuration
         },
         "extensions": {
             "az": "builtin:",
-            "kubernetes": "builtin:",
-            "microsoftGraph": "builtin:"
+            "kubernetes": "builtin:"
         },
         "implicitExtensions": [
             "az"
@@ -432,7 +429,6 @@ namespace Bicep.Core.UnitTests.Configuration
                 }
             },
             "extensions": {
-                "microsoftGraph": "builtin:",
                 "kubernetes": "builtin:",
                 "az": "builtin:"
             },
@@ -812,8 +808,7 @@ namespace Bicep.Core.UnitTests.Configuration
         },
         "extensions": {
             "az": "builtin:",
-            "kubernetes": "builtin:",
-            "microsoftGraph": "builtin:"
+            "kubernetes": "builtin:"
         },
         "implicitExtensions": [
             "az"

--- a/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
@@ -53,7 +53,7 @@ public class ExtensionsConfigurationTests
         config.Should().NotBeNull();
         config!.Extensions.Should().NotBeNull();
 
-        foreach (var extensionName in new[] { "az", "kubernetes", "microsoftGraph" })
+        foreach (var extensionName in new[] { "az", "kubernetes" })
         {
             config.Extensions!.TryGetExtensionSource(extensionName).IsSuccess(out var extension).Should().BeTrue();
             extension!.Value.Should().Be("builtin:");

--- a/src/Bicep.Core/Configuration/ExtensionsConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ExtensionsConfiguration.cs
@@ -40,6 +40,11 @@ public partial class ExtensionsConfiguration : ConfigurationSection<ImmutableDic
     {
         if (!this.Data.TryGetValue(extensionName, out var extensionConfigEntry))
         {
+            if (extensionName == MicrosoftGraphNamespaceType.BuiltInName)
+            {
+                return new(x => x.MicrosoftGraphBuiltinRetired(null));
+            }
+
             return new(x => x.UnrecognizedExtension(extensionName));
         }
         return new(extensionConfigEntry);

--- a/src/Bicep.Core/Configuration/bicepconfig.json
+++ b/src/Bicep.Core/Configuration/bicepconfig.json
@@ -31,8 +31,7 @@
   },
   "extensions": {
     "az": "builtin:",
-    "kubernetes": "builtin:",
-    "microsoftGraph": "builtin:"
+    "kubernetes": "builtin:"
   },
   "implicitExtensions": ["az"],
   "analyzers": {

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1823,18 +1823,18 @@ namespace Bicep.Core.Diagnostics
                 "BCP406",
                 $"The \"{LanguageConstants.ExtendsKeyword}\" keyword is not supported");
 
-            public Diagnostic MicrosoftGraphBuiltinDeprecatedSoon(ExtensionDeclarationSyntax syntax)
+            public Diagnostic MicrosoftGraphBuiltinRetired(ExtensionDeclarationSyntax? syntax)
             {
-                var msGraphRegistryPath = "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview";
+                var msGraphRegistryPath = "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.9-preview";
                 var codeFix = new CodeFix(
                     $"Replace built-in extension \'microsoftGraph\' with dynamic types registry path",
                     true,
                     CodeFixKind.QuickFix,
-                    new CodeReplacement(syntax.SpecificationString.Span, $"\'{msGraphRegistryPath}\'"));
+                    new CodeReplacement(syntax?.SpecificationString.Span ?? TextSpan, $"\'{msGraphRegistryPath}\'"));
 
-                return CoreWarning(
+                return CoreError(
                 "BCP407",
-                $"Built-in extension \"microsoftGraph\" is deprecated. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes")
+                $"Built-in extension \"microsoftGraph\" is retired. Use dynamic types instead. See https://aka.ms/graphBicepDynamicTypes")
                 with
                 {
                     Fixes = [codeFix]

--- a/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
@@ -162,14 +162,15 @@ public class NamespaceProvider : INamespaceProvider
             return AzNamespaceType.Create(aliasName, targetScope, resourceTypeProviderFactory.GetBuiltInAzResourceTypesProvider(), sourceFile.FileKind);
         }
 
-        if (LanguageConstants.IdentifierComparer.Equals(extensionName, MicrosoftGraphNamespaceType.BuiltInName))
-        {
-            return MicrosoftGraphNamespaceType.Create(aliasName);
-        }
-
         if (LanguageConstants.IdentifierComparer.Equals(extensionName, K8sNamespaceType.BuiltInName))
         {
             return K8sNamespaceType.Create(aliasName);
+        }
+
+        // microsoftGraph built-in extension is no longer supported.
+        if (LanguageConstants.IdentifierComparer.Equals(extensionName, MicrosoftGraphNamespaceType.BuiltInName))
+        {
+            return ErrorType.Create(diagBuilder.MicrosoftGraphBuiltinRetired(syntax));
         }
 
         return ErrorType.Create(diagBuilder.InvalidExtension_NotABuiltInExtension(sourceFile.Configuration.ConfigFileUri, extensionName));

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -928,11 +928,6 @@ namespace Bicep.Core.TypeSystem
                     }
                 }
 
-                if (LanguageConstants.IdentifierComparer.Equals(namespaceType.Name, MicrosoftGraphNamespaceType.BuiltInName))
-                {
-                    diagnostics.Write(syntax.SpecificationString, x => x.MicrosoftGraphBuiltinDeprecatedSoon(syntax));
-                }
-
                 return namespaceType;
             });
 

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1891,8 +1891,8 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' 
                     c => c!.Select(x => x.Label).Should().Equal("with", "as"),
                     c => c!.Select(x => x.Label).Should().Equal("with", "as"),
                     c => c!.Select(x => x.Label).Should().BeEmpty(),
-                    c => c!.Select(x => x.Label).Should().Equal($"az", "kubernetes", "microsoftGraph", "sys"),
-                    c => c!.Select(x => x.Label).Should().Equal($"az", "kubernetes", "microsoftGraph", "sys")
+                    c => c!.Select(x => x.Label).Should().Equal($"az", "kubernetes", "sys"),
+                    c => c!.Select(x => x.Label).Should().Equal($"az", "kubernetes", "sys")
                 ),
                 '|');
 

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -415,7 +415,7 @@ output length int =
         }
 
         [TestMethod]
-        public async Task CompletionsShouldContainMicrosoftGraphWhenPreviewFeatureEnabled()
+        public async Task CompletionsShouldContainMicrosoftGraphWhenExtensibilityEnabled()
         {
             var (contents, cursor) = ParserHelper.GetFileWithSingleCursor("extension m| as graph");
 
@@ -426,7 +426,7 @@ output length int =
             var compilationWithMSGraph = serviceWithGraph.BuildCompilation(contents);
             var completionsWithMSGraph = await completionProvider.GetFilteredCompletions(compilationWithMSGraph, BicepCompletionContext.Create(compilationWithMSGraph, cursor), CancellationToken.None);
 
-            completionsWithMSGraph.Should().Contain(c => c.Label.Contains("microsoftGraph"));
+            completionsWithMSGraph.Should().NotContain(c => c.Label.Contains("microsoftGraph"));
         }
 
         private static void AssertExpectedDeclarationTypeCompletions(List<CompletionItem> completions)

--- a/src/Bicep.Local.Extension/packages.lock.json
+++ b/src/Bicep.Local.Extension/packages.lock.json
@@ -42,6 +42,12 @@
         "resolved": "3.3.4",
         "contentHash": "0k2Jwpc8eq0hjOtX6TxRkHm9clkJ2PAQ3heEHgqIJZcsfdFosC/iyz18nsgTVDDWpID80rC7aiYK7ripx+Qndg=="
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.12, )",
+        "resolved": "8.0.12",
+        "contentHash": "FV4HnQ3JI15PHnJ5PGTbz+rYvrih42oLi/7UMIshNwCwUZhTq13UzrggtXk4ygrcMcN+4jsS6hhshx2p/Zd0ig=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -286,8 +286,7 @@
       "additionalProperties": false,
       "default": {
         "az": "builtin:",
-        "kubernetes": "builtin:",
-        "microsoftGraph": "builtin:"
+        "kubernetes": "builtin:"
       }
     },
     "implicitExtensions": {


### PR DESCRIPTION
# Contributing a Pull Request

The built-in extension for Microsoft Graph is retired. Microsoft Graph Bicep extension is moving to dynamic types, where artifacts are pulled from MCR. See https://aka.ms/graphBicepDynamicTypes for more details.
