### PR TITLE
Experimental support for typed variables

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -47,6 +47,9 @@ Allows the ARM template layer to use a new schema to represent resources as an o
 ### `testFramework`
 Should be enabled in tandem with `assertions` experimental feature flag for expected functionality. Allows you to author client-side, offline unit-test test blocks that reference Bicep files and mock deployment parameters in a separate `test.bicep` file using the new `test` keyword. Test blocks can be run with the command *bicep test <filepath_to_file_with_test_blocks>* which runs all `assert` statements in the Bicep files referenced by the test blocks. For more information, see [Bicep Experimental Test Framework](https://github.com/Azure/bicep/issues/11967).
 
+### `typedVariables`
+Permits optional usage of types on variable declarations.
+
 ### `waitAndRetry`
 The feature introduces waitUntil and retryOn decorators on resource data type. waitUnitl() decorator waits for the resource until its usable based on the desired property's state. retryOn() will retry the deployment if one if the listed exception codes are encountered.
 

--- a/src/Bicep.Core.IntegrationTests/TypedVariableTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypedVariableTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.IntegrationTests;
+
+[TestClass]
+public class TypedVariableTests : TestBase
+{
+    private ServiceBuilder Services => new ServiceBuilder().WithFeatureOverrides(new(TestContext, TypedVariablesEnabled: true));
+
+    [TestMethod]
+    public void Experimental_feature_is_blocked_unless_enabled()
+    {
+        var result = CompilationHelper.Compile(new ServiceBuilder(),
+            ("main.bicep", """
+var foo string = 'foo'
+""")
+        );
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics([
+            ("BCP413", DiagnosticLevel.Error, """Using typed variables requires enabling EXPERIMENTAL feature "TypedVariables"."""),
+        ]);
+    }
+
+    [TestMethod]
+    public void Simple_type_declarations_are_accepted()
+    {
+        var result = CompilationHelper.Compile(Services,
+            ("main.bicep", """
+var foo string = 'foo'
+""")
+        );
+
+        result.ExcludingLinterDiagnostics().Diagnostics.Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void Complex_type_declarations_are_accepted()
+    {
+        var result = CompilationHelper.Compile(Services,
+            ("main.bicep", """
+var foo {
+ abc: string
+ def: int
+ obj: {
+   prop1: string
+   prop2: int
+ }
+} = {
+  abc: 'abc'
+  def: 123
+  obj: {
+    prop1: 'prop1'
+    prop2: 456
+  }
+}
+""")
+        );
+
+        result.ExcludingLinterDiagnostics().Diagnostics.Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void Type_validation_runs_as_expected()
+    {
+        var result = CompilationHelper.Compile(Services,
+            ("main.bicep", """
+var foo object = 'invalidString'
+""")
+        );
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics([
+            ("BCP033", DiagnosticLevel.Error, """Expected a value of type "object" but the provided value is of type "'invalidString'"."""),
+        ]);
+    }
+
+    [TestMethod]
+    public void Invalid_type_reference_raises_an_error()
+    {
+        var result = CompilationHelper.Compile(Services,
+            ("main.bicep", """
+var foo invalid = 'foo'
+""")
+        );
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics([
+            ("BCP302", DiagnosticLevel.Error, """The name "invalid" is not a valid type. Please specify one of the following types: "array", "bool", "int", "object", "string"."""),
+        ]);
+    }
+}

--- a/src/Bicep.Core.Samples/DataSets.cs
+++ b/src/Bicep.Core.Samples/DataSets.cs
@@ -80,6 +80,8 @@ namespace Bicep.Core.Samples
 
         public static DataSet TypeDeclarations_LF => CreateDataSet();
 
+        public static DataSet TypedVariables_LF => CreateDataSet();
+
         public static DataSet Unicode_LF => CreateDataSet();
 
         public static DataSet Variables_LF => CreateDataSet();

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.diagnostics.bicep
@@ -49,11 +49,12 @@ var foo =
 // bad =
 var badEquals 2
 //@[04:13) [no-unused-vars (Warning)] Variable "badEquals" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |badEquals|
-//@[14:15) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) |2|
-//@[15:15) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP009) ||
+//@[14:15) [BCP413 (Error)] Using typed variables requires enabling EXPERIMENTAL feature "TypedVariables". (bicep https://aka.ms/bicep/core-diagnostics#BCP413) |2|
+//@[15:15) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) ||
 var badEquals2 3 true
 //@[04:14) [no-unused-vars (Warning)] Variable "badEquals2" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |badEquals2|
-//@[15:16) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) |3|
+//@[15:16) [BCP413 (Error)] Using typed variables requires enabling EXPERIMENTAL feature "TypedVariables". (bicep https://aka.ms/bicep/core-diagnostics#BCP413) |3|
+//@[17:21) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) |true|
 //@[21:21) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP009) ||
 
 // malformed identifier but type check should happen regardless
@@ -289,9 +290,9 @@ var ☕ = true
 //@[04:05) [BCP001 (Error)] The following token is not recognized: "☕". (bicep https://aka.ms/bicep/core-diagnostics#BCP001) |☕|
 var a☕ = true
 //@[04:05) [no-unused-vars (Warning)] Variable "a" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |a|
-//@[05:06) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) |☕|
+//@[05:06) [BCP279 (Error)] Expected a type at this location. Please specify a valid type expression or one of the following types: "array", "bool", "int", "object", "string". (bicep https://aka.ms/bicep/core-diagnostics#BCP279) |☕|
 //@[05:06) [BCP001 (Error)] The following token is not recognized: "☕". (bicep https://aka.ms/bicep/core-diagnostics#BCP001) |☕|
-//@[13:13) [BCP009 (Error)] Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP009) ||
+//@[05:06) [BCP413 (Error)] Using typed variables requires enabling EXPERIMENTAL feature "TypedVariables". (bicep https://aka.ms/bicep/core-diagnostics#BCP413) |☕|
 
 var missingArrayVariable = [for thing in stuff: 4]
 //@[04:24) [no-unused-vars (Warning)] Variable "missingArrayVariable" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |missingArrayVariable|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.diagnostics.bicep
@@ -36,9 +36,11 @@ var 2
 var $ = 23
 //@[04:05) [BCP015 (Error)] Expected a variable identifier at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP015) |$|
 //@[04:05) [BCP001 (Error)] The following token is not recognized: "$". (bicep https://aka.ms/bicep/core-diagnostics#BCP001) |$|
+//@[10:10) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) ||
 var # 33 = 43
 //@[04:05) [BCP015 (Error)] Expected a variable identifier at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP015) |#|
 //@[04:05) [BCP001 (Error)] The following token is not recognized: "#". (bicep https://aka.ms/bicep/core-diagnostics#BCP001) |#|
+//@[13:13) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) ||
 
 // no value assigned
 var foo =
@@ -60,7 +62,8 @@ var badEquals2 3 true
 // malformed identifier but type check should happen regardless
 var 2 = x
 //@[04:05) [BCP015 (Error)] Expected a variable identifier at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP015) |2|
-//@[08:09) [BCP062 (Error)] The referenced declaration with name "x" is not valid. (bicep https://aka.ms/bicep/core-diagnostics#BCP062) |x|
+//@[08:09) [BCP413 (Error)] Using typed variables requires enabling EXPERIMENTAL feature "TypedVariables". (bicep https://aka.ms/bicep/core-diagnostics#BCP413) |x|
+//@[09:09) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) ||
 
 // bad token value
 var foo = &
@@ -288,6 +291,7 @@ var anotherThing = true
 var ☕ = true
 //@[04:05) [BCP015 (Error)] Expected a variable identifier at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP015) |☕|
 //@[04:05) [BCP001 (Error)] The following token is not recognized: "☕". (bicep https://aka.ms/bicep/core-diagnostics#BCP001) |☕|
+//@[12:12) [BCP018 (Error)] Expected the "=" character at this location. (bicep https://aka.ms/bicep/core-diagnostics#BCP018) ||
 var a☕ = true
 //@[04:05) [no-unused-vars (Warning)] Variable "a" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |a|
 //@[05:06) [BCP279 (Error)] Expected a type at this location. Please specify a valid type expression or one of the following types: "array", "bool", "int", "object", "string". (bicep https://aka.ms/bicep/core-diagnostics#BCP279) |☕|

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.symbols.bicep
@@ -28,9 +28,9 @@ var missingValue =
 var 2 
 //@[04:05) Variable <error>. Type: error. Declaration start char: 0, length: 6
 var $ = 23
-//@[04:05) Variable <error>. Type: 23. Declaration start char: 0, length: 10
+//@[04:10) Variable <error>. Type: error. Declaration start char: 0, length: 10
 var # 33 = 43
-//@[04:08) Variable <error>. Type: 43. Declaration start char: 0, length: 13
+//@[04:13) Variable <error>. Type: error. Declaration start char: 0, length: 13
 
 // no value assigned
 var foo =
@@ -38,13 +38,13 @@ var foo =
 
 // bad =
 var badEquals 2
-//@[04:13) Variable badEquals. Type: 2. Declaration start char: 0, length: 15
+//@[04:13) Variable badEquals. Type: error. Declaration start char: 0, length: 15
 var badEquals2 3 true
-//@[04:14) Variable badEquals2. Type: 3. Declaration start char: 0, length: 21
+//@[04:14) Variable badEquals2. Type: error. Declaration start char: 0, length: 21
 
 // malformed identifier but type check should happen regardless
 var 2 = x
-//@[04:05) Variable <error>. Type: error. Declaration start char: 0, length: 9
+//@[04:07) Variable <error>. Type: error. Declaration start char: 0, length: 9
 
 // bad token value
 var foo = &
@@ -218,9 +218,9 @@ var anotherThing = true
 
 // invalid identifier character classes
 var ☕ = true
-//@[04:05) Variable <error>. Type: true. Declaration start char: 0, length: 12
+//@[04:12) Variable <error>. Type: error. Declaration start char: 0, length: 12
 var a☕ = true
-//@[04:05) Variable a. Type: any. Declaration start char: 0, length: 13
+//@[04:05) Variable a. Type: error. Declaration start char: 0, length: 13
 
 var missingArrayVariable = [for thing in stuff: 4]
 //@[32:37) Local thing. Type: any. Declaration start char: 32, length: 5

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.symbols.bicep
@@ -38,9 +38,9 @@ var foo =
 
 // bad =
 var badEquals 2
-//@[04:13) Variable badEquals. Type: error. Declaration start char: 0, length: 15
+//@[04:13) Variable badEquals. Type: 2. Declaration start char: 0, length: 15
 var badEquals2 3 true
-//@[04:14) Variable badEquals2. Type: error. Declaration start char: 0, length: 21
+//@[04:14) Variable badEquals2. Type: 3. Declaration start char: 0, length: 21
 
 // malformed identifier but type check should happen regardless
 var 2 = x
@@ -220,7 +220,7 @@ var anotherThing = true
 var ☕ = true
 //@[04:05) Variable <error>. Type: true. Declaration start char: 0, length: 12
 var a☕ = true
-//@[04:05) Variable a. Type: error. Declaration start char: 0, length: 13
+//@[04:05) Variable a. Type: any. Declaration start char: 0, length: 13
 
 var missingArrayVariable = [for thing in stuff: 4]
 //@[32:37) Local thing. Type: any. Declaration start char: 32, length: 5

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.syntax.bicep
@@ -81,23 +81,25 @@ var 2
 var $ = 23
 //@[00:0010) ├─VariableDeclarationSyntax
 //@[00:0003) | ├─Token(Identifier) |var|
-//@[04:0005) | ├─IdentifierSyntax
-//@[04:0005) | | └─SkippedTriviaSyntax
-//@[04:0005) | |   └─Token(Unrecognized) |$|
-//@[06:0007) | ├─Token(Assignment) |=|
-//@[08:0010) | └─IntegerLiteralSyntax
-//@[08:0010) |   └─Token(Integer) |23|
+//@[04:0010) | ├─IdentifierSyntax
+//@[04:0010) | | └─SkippedTriviaSyntax
+//@[04:0005) | |   ├─Token(Unrecognized) |$|
+//@[06:0007) | |   ├─Token(Assignment) |=|
+//@[08:0010) | |   └─Token(Integer) |23|
+//@[10:0010) | ├─SkippedTriviaSyntax
+//@[10:0010) | └─SkippedTriviaSyntax
 //@[10:0011) ├─Token(NewLine) |\n|
 var # 33 = 43
 //@[00:0013) ├─VariableDeclarationSyntax
 //@[00:0003) | ├─Token(Identifier) |var|
-//@[04:0008) | ├─IdentifierSyntax
-//@[04:0008) | | └─SkippedTriviaSyntax
+//@[04:0013) | ├─IdentifierSyntax
+//@[04:0013) | | └─SkippedTriviaSyntax
 //@[04:0005) | |   ├─Token(Unrecognized) |#|
-//@[06:0008) | |   └─Token(Integer) |33|
-//@[09:0010) | ├─Token(Assignment) |=|
-//@[11:0013) | └─IntegerLiteralSyntax
-//@[11:0013) |   └─Token(Integer) |43|
+//@[06:0008) | |   ├─Token(Integer) |33|
+//@[09:0010) | |   ├─Token(Assignment) |=|
+//@[11:0013) | |   └─Token(Integer) |43|
+//@[13:0013) | ├─SkippedTriviaSyntax
+//@[13:0013) | └─SkippedTriviaSyntax
 //@[13:0015) ├─Token(NewLine) |\n\n|
 
 // no value assigned
@@ -140,13 +142,15 @@ var badEquals2 3 true
 var 2 = x
 //@[00:0009) ├─VariableDeclarationSyntax
 //@[00:0003) | ├─Token(Identifier) |var|
-//@[04:0005) | ├─IdentifierSyntax
-//@[04:0005) | | └─SkippedTriviaSyntax
-//@[04:0005) | |   └─Token(Integer) |2|
-//@[06:0007) | ├─Token(Assignment) |=|
-//@[08:0009) | └─VariableAccessSyntax
-//@[08:0009) |   └─IdentifierSyntax
-//@[08:0009) |     └─Token(Identifier) |x|
+//@[04:0007) | ├─IdentifierSyntax
+//@[04:0007) | | └─SkippedTriviaSyntax
+//@[04:0005) | |   ├─Token(Integer) |2|
+//@[06:0007) | |   └─Token(Assignment) |=|
+//@[08:0009) | ├─TypeVariableAccessSyntax
+//@[08:0009) | | └─IdentifierSyntax
+//@[08:0009) | |   └─Token(Identifier) |x|
+//@[09:0009) | ├─SkippedTriviaSyntax
+//@[09:0009) | └─SkippedTriviaSyntax
 //@[09:0011) ├─Token(NewLine) |\n\n|
 
 // bad token value
@@ -1059,12 +1063,13 @@ var anotherThing = true
 var ☕ = true
 //@[00:0012) ├─VariableDeclarationSyntax
 //@[00:0003) | ├─Token(Identifier) |var|
-//@[04:0005) | ├─IdentifierSyntax
-//@[04:0005) | | └─SkippedTriviaSyntax
-//@[04:0005) | |   └─Token(Unrecognized) |☕|
-//@[06:0007) | ├─Token(Assignment) |=|
-//@[08:0012) | └─BooleanLiteralSyntax
-//@[08:0012) |   └─Token(TrueKeyword) |true|
+//@[04:0012) | ├─IdentifierSyntax
+//@[04:0012) | | └─SkippedTriviaSyntax
+//@[04:0005) | |   ├─Token(Unrecognized) |☕|
+//@[06:0007) | |   ├─Token(Assignment) |=|
+//@[08:0012) | |   └─Token(TrueKeyword) |true|
+//@[12:0012) | ├─SkippedTriviaSyntax
+//@[12:0012) | └─SkippedTriviaSyntax
 //@[12:0013) ├─Token(NewLine) |\n|
 var a☕ = true
 //@[00:0013) ├─VariableDeclarationSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.syntax.bicep
@@ -118,8 +118,9 @@ var badEquals 2
 //@[00:0003) | ├─Token(Identifier) |var|
 //@[04:0013) | ├─IdentifierSyntax
 //@[04:0013) | | └─Token(Identifier) |badEquals|
-//@[14:0015) | ├─SkippedTriviaSyntax
+//@[14:0015) | ├─IntegerTypeLiteralSyntax
 //@[14:0015) | | └─Token(Integer) |2|
+//@[15:0015) | ├─SkippedTriviaSyntax
 //@[15:0015) | └─SkippedTriviaSyntax
 //@[15:0016) ├─Token(NewLine) |\n|
 var badEquals2 3 true
@@ -127,8 +128,9 @@ var badEquals2 3 true
 //@[00:0003) | ├─Token(Identifier) |var|
 //@[04:0014) | ├─IdentifierSyntax
 //@[04:0014) | | └─Token(Identifier) |badEquals2|
-//@[15:0021) | ├─SkippedTriviaSyntax
-//@[15:0016) | | ├─Token(Integer) |3|
+//@[15:0016) | ├─IntegerTypeLiteralSyntax
+//@[15:0016) | | └─Token(Integer) |3|
+//@[17:0021) | ├─SkippedTriviaSyntax
 //@[17:0021) | | └─Token(TrueKeyword) |true|
 //@[21:0021) | └─SkippedTriviaSyntax
 //@[21:0023) ├─Token(NewLine) |\n\n|
@@ -1069,11 +1071,11 @@ var a☕ = true
 //@[00:0003) | ├─Token(Identifier) |var|
 //@[04:0005) | ├─IdentifierSyntax
 //@[04:0005) | | └─Token(Identifier) |a|
-//@[05:0013) | ├─SkippedTriviaSyntax
-//@[05:0006) | | ├─Token(Unrecognized) |☕|
-//@[07:0008) | | ├─Token(Assignment) |=|
-//@[09:0013) | | └─Token(TrueKeyword) |true|
-//@[13:0013) | └─SkippedTriviaSyntax
+//@[05:0006) | ├─SkippedTriviaSyntax
+//@[05:0006) | | └─Token(Unrecognized) |☕|
+//@[07:0008) | ├─Token(Assignment) |=|
+//@[09:0013) | └─BooleanLiteralSyntax
+//@[09:0013) |   └─Token(TrueKeyword) |true|
 //@[13:0015) ├─Token(NewLine) |\n\n|
 
 var missingArrayVariable = [for thing in stuff: 4]

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+    "experimentalFeaturesEnabled": {
+        "typedVariables": true
+    }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.bicep
@@ -1,0 +1,27 @@
+@export()
+var exportedString string = 'foo'
+
+@export()
+var exporteInlineType {
+  foo: string
+  bar: int
+} = {
+  foo: 'abc'
+  bar: 123
+}
+
+type FooType = {
+  foo: string
+  bar: int
+}
+
+@export()
+var exportedTypeRef FooType = {
+  foo: 'abc'
+  bar: 123
+}
+
+var unExported FooType = {
+  foo: 'abc'
+  bar: 123
+}

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.diagnostics.bicep
@@ -1,0 +1,29 @@
+@export()
+var exportedString string = 'foo'
+
+@export()
+var exporteInlineType {
+  foo: string
+  bar: int
+} = {
+  foo: 'abc'
+  bar: 123
+}
+
+type FooType = {
+  foo: string
+  bar: int
+}
+
+@export()
+var exportedTypeRef FooType = {
+  foo: 'abc'
+  bar: 123
+}
+
+var unExported FooType = {
+//@[4:14) [no-unused-vars (Warning)] Variable "unExported" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |unExported|
+  foo: 'abc'
+  bar: 123
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.formatted.bicep
@@ -1,0 +1,27 @@
+@export()
+var exportedString string = 'foo'
+
+@export()
+var exporteInlineType {
+  foo: string
+  bar: int
+} = {
+  foo: 'abc'
+  bar: 123
+}
+
+type FooType = {
+  foo: string
+  bar: int
+}
+
+@export()
+var exportedTypeRef FooType = {
+  foo: 'abc'
+  bar: 123
+}
+
+var unExported FooType = {
+  foo: 'abc'
+  bar: 123
+}

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.ir.bicep
@@ -1,0 +1,72 @@
+@export()
+//@[00:304) ProgramExpression
+//@[00:043) ├─DeclaredVariableExpression { Name = exportedString }
+//@[01:009) | ├─FunctionCallExpression { Name = export }
+var exportedString string = 'foo'
+//@[19:025) | ├─AmbientTypeReferenceExpression { Name = string }
+//@[28:033) | └─StringLiteralExpression { Value = foo }
+
+@export()
+//@[00:090) ├─DeclaredVariableExpression { Name = exporteInlineType }
+//@[01:009) | ├─FunctionCallExpression { Name = export }
+var exporteInlineType {
+//@[22:050) | ├─ObjectTypeExpression { Name = { foo: string, bar: int } }
+  foo: string
+//@[02:013) | | ├─ObjectTypePropertyExpression
+//@[07:013) | | | └─AmbientTypeReferenceExpression { Name = string }
+  bar: int
+//@[02:010) | | └─ObjectTypePropertyExpression
+//@[07:010) | |   └─AmbientTypeReferenceExpression { Name = int }
+} = {
+//@[04:031) | └─ObjectExpression
+  foo: 'abc'
+//@[02:012) |   ├─ObjectPropertyExpression
+//@[02:005) |   | ├─StringLiteralExpression { Value = foo }
+//@[07:012) |   | └─StringLiteralExpression { Value = abc }
+  bar: 123
+//@[02:010) |   └─ObjectPropertyExpression
+//@[02:005) |     ├─StringLiteralExpression { Value = bar }
+//@[07:010) |     └─IntegerLiteralExpression { Value = 123 }
+}
+
+type FooType = {
+//@[00:043) ├─DeclaredTypeExpression { Name = FooType }
+//@[15:043) | └─ObjectTypeExpression { Name = { foo: string, bar: int } }
+  foo: string
+//@[02:013) |   ├─ObjectTypePropertyExpression
+//@[07:013) |   | └─AmbientTypeReferenceExpression { Name = string }
+  bar: int
+//@[02:010) |   └─ObjectTypePropertyExpression
+//@[07:010) |     └─AmbientTypeReferenceExpression { Name = int }
+}
+
+@export()
+//@[00:067) ├─DeclaredVariableExpression { Name = exportedTypeRef }
+//@[01:009) | ├─FunctionCallExpression { Name = export }
+var exportedTypeRef FooType = {
+//@[20:027) | ├─TypeAliasReferenceExpression { Name = FooType }
+//@[30:057) | └─ObjectExpression
+  foo: 'abc'
+//@[02:012) |   ├─ObjectPropertyExpression
+//@[02:005) |   | ├─StringLiteralExpression { Value = foo }
+//@[07:012) |   | └─StringLiteralExpression { Value = abc }
+  bar: 123
+//@[02:010) |   └─ObjectPropertyExpression
+//@[02:005) |     ├─StringLiteralExpression { Value = bar }
+//@[07:010) |     └─IntegerLiteralExpression { Value = 123 }
+}
+
+var unExported FooType = {
+//@[00:052) └─DeclaredVariableExpression { Name = unExported }
+//@[15:022)   ├─TypeAliasReferenceExpression { Name = FooType }
+//@[25:052)   └─ObjectExpression
+  foo: 'abc'
+//@[02:012)     ├─ObjectPropertyExpression
+//@[02:005)     | ├─StringLiteralExpression { Value = foo }
+//@[07:012)     | └─StringLiteralExpression { Value = abc }
+  bar: 123
+//@[02:010)     └─ObjectPropertyExpression
+//@[02:005)       ├─StringLiteralExpression { Value = bar }
+//@[07:010)       └─IntegerLiteralExpression { Value = 123 }
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "6383359498761660162"
+    },
+    "__bicep_exported_variables!": [
+      {
+        "name": "exporteInlineType",
+        "type": {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "string"
+            },
+            "bar": {
+              "type": "int"
+            }
+          }
+        }
+      },
+      {
+        "name": "exportedString",
+        "type": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "exportedTypeRef",
+        "type": {
+          "$ref": "#/definitions/FooType"
+        }
+      }
+    ]
+  },
+  "definitions": {
+    "FooType": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "int"
+        }
+      }
+    }
+  },
+  "variables": {
+    "exportedString": "foo",
+    "exporteInlineType": {
+      "foo": "abc",
+      "bar": 123
+    },
+    "exportedTypeRef": {
+      "foo": "abc",
+      "bar": 123
+    },
+    "unExported": {
+      "foo": "abc",
+      "bar": 123
+    }
+  },
+  "resources": {}
+}

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.sourcemap.bicep
@@ -1,0 +1,69 @@
+@export()
+var exportedString string = 'foo'
+//@        "type": {
+//@          "type": "string"
+//@        }
+//@    "exportedString": "foo",
+
+@export()
+var exporteInlineType {
+//@        "type": {
+//@          "type": "object",
+//@          "properties": {
+//@          }
+//@        }
+  foo: string
+//@            "foo": {
+//@              "type": "string"
+//@            },
+  bar: int
+//@            "bar": {
+//@              "type": "int"
+//@            }
+} = {
+//@    "exporteInlineType": {
+//@    },
+  foo: 'abc'
+//@      "foo": "abc",
+  bar: 123
+//@      "bar": 123
+}
+
+type FooType = {
+//@    "FooType": {
+//@      "type": "object",
+//@      "properties": {
+//@      }
+//@    }
+  foo: string
+//@        "foo": {
+//@          "type": "string"
+//@        },
+  bar: int
+//@        "bar": {
+//@          "type": "int"
+//@        }
+}
+
+@export()
+var exportedTypeRef FooType = {
+//@        "type": {
+//@          "$ref": "#/definitions/FooType"
+//@        }
+//@    "exportedTypeRef": {
+//@    },
+  foo: 'abc'
+//@      "foo": "abc",
+  bar: 123
+//@      "bar": 123
+}
+
+var unExported FooType = {
+//@    "unExported": {
+//@    }
+  foo: 'abc'
+//@      "foo": "abc",
+  bar: 123
+//@      "bar": 123
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.symbolicnames.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "6383359498761660162"
+    },
+    "__bicep_exported_variables!": [
+      {
+        "name": "exporteInlineType",
+        "type": {
+          "type": "object",
+          "properties": {
+            "foo": {
+              "type": "string"
+            },
+            "bar": {
+              "type": "int"
+            }
+          }
+        }
+      },
+      {
+        "name": "exportedString",
+        "type": {
+          "type": "string"
+        }
+      },
+      {
+        "name": "exportedTypeRef",
+        "type": {
+          "$ref": "#/definitions/FooType"
+        }
+      }
+    ]
+  },
+  "definitions": {
+    "FooType": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "int"
+        }
+      }
+    }
+  },
+  "variables": {
+    "exportedString": "foo",
+    "exporteInlineType": {
+      "foo": "abc",
+      "bar": 123
+    },
+    "exportedTypeRef": {
+      "foo": "abc",
+      "bar": 123
+    },
+    "unExported": {
+      "foo": "abc",
+      "bar": 123
+    }
+  },
+  "resources": {}
+}

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.symbols.bicep
@@ -1,0 +1,33 @@
+@export()
+var exportedString string = 'foo'
+//@[4:18) Variable exportedString. Type: string. Declaration start char: 0, length: 43
+
+@export()
+var exporteInlineType {
+//@[4:21) Variable exporteInlineType. Type: { foo: string, bar: int }. Declaration start char: 0, length: 90
+  foo: string
+  bar: int
+} = {
+  foo: 'abc'
+  bar: 123
+}
+
+type FooType = {
+//@[5:12) TypeAlias FooType. Type: Type<{ foo: string, bar: int }>. Declaration start char: 0, length: 43
+  foo: string
+  bar: int
+}
+
+@export()
+var exportedTypeRef FooType = {
+//@[4:19) Variable exportedTypeRef. Type: { foo: string, bar: int }. Declaration start char: 0, length: 67
+  foo: 'abc'
+  bar: 123
+}
+
+var unExported FooType = {
+//@[4:14) Variable unExported. Type: { foo: string, bar: int }. Declaration start char: 0, length: 52
+  foo: 'abc'
+  bar: 123
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.syntax.bicep
@@ -1,0 +1,189 @@
+@export()
+//@[00:304) ProgramSyntax
+//@[00:043) ├─VariableDeclarationSyntax
+//@[00:009) | ├─DecoratorSyntax
+//@[00:001) | | ├─Token(At) |@|
+//@[01:009) | | └─FunctionCallSyntax
+//@[01:007) | |   ├─IdentifierSyntax
+//@[01:007) | |   | └─Token(Identifier) |export|
+//@[07:008) | |   ├─Token(LeftParen) |(|
+//@[08:009) | |   └─Token(RightParen) |)|
+//@[09:010) | ├─Token(NewLine) |\n|
+var exportedString string = 'foo'
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:018) | ├─IdentifierSyntax
+//@[04:018) | | └─Token(Identifier) |exportedString|
+//@[19:025) | ├─TypeVariableAccessSyntax
+//@[19:025) | | └─IdentifierSyntax
+//@[19:025) | |   └─Token(Identifier) |string|
+//@[26:027) | ├─Token(Assignment) |=|
+//@[28:033) | └─StringSyntax
+//@[28:033) |   └─Token(StringComplete) |'foo'|
+//@[33:035) ├─Token(NewLine) |\n\n|
+
+@export()
+//@[00:090) ├─VariableDeclarationSyntax
+//@[00:009) | ├─DecoratorSyntax
+//@[00:001) | | ├─Token(At) |@|
+//@[01:009) | | └─FunctionCallSyntax
+//@[01:007) | |   ├─IdentifierSyntax
+//@[01:007) | |   | └─Token(Identifier) |export|
+//@[07:008) | |   ├─Token(LeftParen) |(|
+//@[08:009) | |   └─Token(RightParen) |)|
+//@[09:010) | ├─Token(NewLine) |\n|
+var exporteInlineType {
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:021) | ├─IdentifierSyntax
+//@[04:021) | | └─Token(Identifier) |exporteInlineType|
+//@[22:050) | ├─ObjectTypeSyntax
+//@[22:023) | | ├─Token(LeftBrace) |{|
+//@[23:024) | | ├─Token(NewLine) |\n|
+  foo: string
+//@[02:013) | | ├─ObjectTypePropertySyntax
+//@[02:005) | | | ├─IdentifierSyntax
+//@[02:005) | | | | └─Token(Identifier) |foo|
+//@[05:006) | | | ├─Token(Colon) |:|
+//@[07:013) | | | └─TypeVariableAccessSyntax
+//@[07:013) | | |   └─IdentifierSyntax
+//@[07:013) | | |     └─Token(Identifier) |string|
+//@[13:014) | | ├─Token(NewLine) |\n|
+  bar: int
+//@[02:010) | | ├─ObjectTypePropertySyntax
+//@[02:005) | | | ├─IdentifierSyntax
+//@[02:005) | | | | └─Token(Identifier) |bar|
+//@[05:006) | | | ├─Token(Colon) |:|
+//@[07:010) | | | └─TypeVariableAccessSyntax
+//@[07:010) | | |   └─IdentifierSyntax
+//@[07:010) | | |     └─Token(Identifier) |int|
+//@[10:011) | | ├─Token(NewLine) |\n|
+} = {
+//@[00:001) | | └─Token(RightBrace) |}|
+//@[02:003) | ├─Token(Assignment) |=|
+//@[04:031) | └─ObjectSyntax
+//@[04:005) |   ├─Token(LeftBrace) |{|
+//@[05:006) |   ├─Token(NewLine) |\n|
+  foo: 'abc'
+//@[02:012) |   ├─ObjectPropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |foo|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:012) |   | └─StringSyntax
+//@[07:012) |   |   └─Token(StringComplete) |'abc'|
+//@[12:013) |   ├─Token(NewLine) |\n|
+  bar: 123
+//@[02:010) |   ├─ObjectPropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |bar|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:010) |   | └─IntegerLiteralSyntax
+//@[07:010) |   |   └─Token(Integer) |123|
+//@[10:011) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:003) ├─Token(NewLine) |\n\n|
+
+type FooType = {
+//@[00:043) ├─TypeDeclarationSyntax
+//@[00:004) | ├─Token(Identifier) |type|
+//@[05:012) | ├─IdentifierSyntax
+//@[05:012) | | └─Token(Identifier) |FooType|
+//@[13:014) | ├─Token(Assignment) |=|
+//@[15:043) | └─ObjectTypeSyntax
+//@[15:016) |   ├─Token(LeftBrace) |{|
+//@[16:017) |   ├─Token(NewLine) |\n|
+  foo: string
+//@[02:013) |   ├─ObjectTypePropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |foo|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:013) |   | └─TypeVariableAccessSyntax
+//@[07:013) |   |   └─IdentifierSyntax
+//@[07:013) |   |     └─Token(Identifier) |string|
+//@[13:014) |   ├─Token(NewLine) |\n|
+  bar: int
+//@[02:010) |   ├─ObjectTypePropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |bar|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:010) |   | └─TypeVariableAccessSyntax
+//@[07:010) |   |   └─IdentifierSyntax
+//@[07:010) |   |     └─Token(Identifier) |int|
+//@[10:011) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:003) ├─Token(NewLine) |\n\n|
+
+@export()
+//@[00:067) ├─VariableDeclarationSyntax
+//@[00:009) | ├─DecoratorSyntax
+//@[00:001) | | ├─Token(At) |@|
+//@[01:009) | | └─FunctionCallSyntax
+//@[01:007) | |   ├─IdentifierSyntax
+//@[01:007) | |   | └─Token(Identifier) |export|
+//@[07:008) | |   ├─Token(LeftParen) |(|
+//@[08:009) | |   └─Token(RightParen) |)|
+//@[09:010) | ├─Token(NewLine) |\n|
+var exportedTypeRef FooType = {
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:019) | ├─IdentifierSyntax
+//@[04:019) | | └─Token(Identifier) |exportedTypeRef|
+//@[20:027) | ├─TypeVariableAccessSyntax
+//@[20:027) | | └─IdentifierSyntax
+//@[20:027) | |   └─Token(Identifier) |FooType|
+//@[28:029) | ├─Token(Assignment) |=|
+//@[30:057) | └─ObjectSyntax
+//@[30:031) |   ├─Token(LeftBrace) |{|
+//@[31:032) |   ├─Token(NewLine) |\n|
+  foo: 'abc'
+//@[02:012) |   ├─ObjectPropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |foo|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:012) |   | └─StringSyntax
+//@[07:012) |   |   └─Token(StringComplete) |'abc'|
+//@[12:013) |   ├─Token(NewLine) |\n|
+  bar: 123
+//@[02:010) |   ├─ObjectPropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |bar|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:010) |   | └─IntegerLiteralSyntax
+//@[07:010) |   |   └─Token(Integer) |123|
+//@[10:011) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:003) ├─Token(NewLine) |\n\n|
+
+var unExported FooType = {
+//@[00:052) ├─VariableDeclarationSyntax
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:014) | ├─IdentifierSyntax
+//@[04:014) | | └─Token(Identifier) |unExported|
+//@[15:022) | ├─TypeVariableAccessSyntax
+//@[15:022) | | └─IdentifierSyntax
+//@[15:022) | |   └─Token(Identifier) |FooType|
+//@[23:024) | ├─Token(Assignment) |=|
+//@[25:052) | └─ObjectSyntax
+//@[25:026) |   ├─Token(LeftBrace) |{|
+//@[26:027) |   ├─Token(NewLine) |\n|
+  foo: 'abc'
+//@[02:012) |   ├─ObjectPropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |foo|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:012) |   | └─StringSyntax
+//@[07:012) |   |   └─Token(StringComplete) |'abc'|
+//@[12:013) |   ├─Token(NewLine) |\n|
+  bar: 123
+//@[02:010) |   ├─ObjectPropertySyntax
+//@[02:005) |   | ├─IdentifierSyntax
+//@[02:005) |   | | └─Token(Identifier) |bar|
+//@[05:006) |   | ├─Token(Colon) |:|
+//@[07:010) |   | └─IntegerLiteralSyntax
+//@[07:010) |   |   └─Token(Integer) |123|
+//@[10:011) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:002) ├─Token(NewLine) |\n|
+
+//@[00:000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypedVariables_LF/main.tokens.bicep
@@ -1,0 +1,123 @@
+@export()
+//@[00:01) At |@|
+//@[01:07) Identifier |export|
+//@[07:08) LeftParen |(|
+//@[08:09) RightParen |)|
+//@[09:10) NewLine |\n|
+var exportedString string = 'foo'
+//@[00:03) Identifier |var|
+//@[04:18) Identifier |exportedString|
+//@[19:25) Identifier |string|
+//@[26:27) Assignment |=|
+//@[28:33) StringComplete |'foo'|
+//@[33:35) NewLine |\n\n|
+
+@export()
+//@[00:01) At |@|
+//@[01:07) Identifier |export|
+//@[07:08) LeftParen |(|
+//@[08:09) RightParen |)|
+//@[09:10) NewLine |\n|
+var exporteInlineType {
+//@[00:03) Identifier |var|
+//@[04:21) Identifier |exporteInlineType|
+//@[22:23) LeftBrace |{|
+//@[23:24) NewLine |\n|
+  foo: string
+//@[02:05) Identifier |foo|
+//@[05:06) Colon |:|
+//@[07:13) Identifier |string|
+//@[13:14) NewLine |\n|
+  bar: int
+//@[02:05) Identifier |bar|
+//@[05:06) Colon |:|
+//@[07:10) Identifier |int|
+//@[10:11) NewLine |\n|
+} = {
+//@[00:01) RightBrace |}|
+//@[02:03) Assignment |=|
+//@[04:05) LeftBrace |{|
+//@[05:06) NewLine |\n|
+  foo: 'abc'
+//@[02:05) Identifier |foo|
+//@[05:06) Colon |:|
+//@[07:12) StringComplete |'abc'|
+//@[12:13) NewLine |\n|
+  bar: 123
+//@[02:05) Identifier |bar|
+//@[05:06) Colon |:|
+//@[07:10) Integer |123|
+//@[10:11) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:03) NewLine |\n\n|
+
+type FooType = {
+//@[00:04) Identifier |type|
+//@[05:12) Identifier |FooType|
+//@[13:14) Assignment |=|
+//@[15:16) LeftBrace |{|
+//@[16:17) NewLine |\n|
+  foo: string
+//@[02:05) Identifier |foo|
+//@[05:06) Colon |:|
+//@[07:13) Identifier |string|
+//@[13:14) NewLine |\n|
+  bar: int
+//@[02:05) Identifier |bar|
+//@[05:06) Colon |:|
+//@[07:10) Identifier |int|
+//@[10:11) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:03) NewLine |\n\n|
+
+@export()
+//@[00:01) At |@|
+//@[01:07) Identifier |export|
+//@[07:08) LeftParen |(|
+//@[08:09) RightParen |)|
+//@[09:10) NewLine |\n|
+var exportedTypeRef FooType = {
+//@[00:03) Identifier |var|
+//@[04:19) Identifier |exportedTypeRef|
+//@[20:27) Identifier |FooType|
+//@[28:29) Assignment |=|
+//@[30:31) LeftBrace |{|
+//@[31:32) NewLine |\n|
+  foo: 'abc'
+//@[02:05) Identifier |foo|
+//@[05:06) Colon |:|
+//@[07:12) StringComplete |'abc'|
+//@[12:13) NewLine |\n|
+  bar: 123
+//@[02:05) Identifier |bar|
+//@[05:06) Colon |:|
+//@[07:10) Integer |123|
+//@[10:11) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:03) NewLine |\n\n|
+
+var unExported FooType = {
+//@[00:03) Identifier |var|
+//@[04:14) Identifier |unExported|
+//@[15:22) Identifier |FooType|
+//@[23:24) Assignment |=|
+//@[25:26) LeftBrace |{|
+//@[26:27) NewLine |\n|
+  foo: 'abc'
+//@[02:05) Identifier |foo|
+//@[05:06) Colon |:|
+//@[07:12) StringComplete |'abc'|
+//@[12:13) NewLine |\n|
+  bar: 123
+//@[02:05) Identifier |bar|
+//@[05:06) Colon |:|
+//@[07:10) Integer |123|
+//@[10:11) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:02) NewLine |\n|
+
+//@[00:00) EndOfFile ||

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -112,7 +112,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "localDeploy": false,
           "resourceDerivedTypes": false,
           "secureOutputs": false,
-          "resourceInfoCodegen": false
+          "resourceInfoCodegen": false,
+          "typedVariables": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -194,7 +195,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "localDeploy": false,
           "resourceDerivedTypes": false,
           "secureOutputs": false,
-          "resourceInfoCodegen": false
+          "resourceInfoCodegen": false,
+          "typedVariables": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -301,7 +303,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "localDeploy": false,
           "resourceDerivedTypes": false,
           "secureOutputs": false,
-          "resourceInfoCodegen": false
+          "resourceInfoCodegen": false,
+          "typedVariables": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -394,7 +397,8 @@ namespace Bicep.Core.UnitTests.Configuration
                 LocalDeploy: false,
                 ResourceDerivedTypes: false,
                 SecureOutputs: false,
-                ResourceInfoCodegen: false);
+                ResourceInfoCodegen: false,
+                TypedVariables: false);
 
             configuration.WithExperimentalFeaturesEnabled(experimentalFeaturesEnabled).Should().HaveContents(/*lang=json,strict*/ """
             {
@@ -480,7 +484,8 @@ namespace Bicep.Core.UnitTests.Configuration
                 "localDeploy": false,
                 "resourceDerivedTypes": false,
                 "secureOutputs": false,
-                "resourceInfoCodegen": false
+                "resourceInfoCodegen": false,
+                "typedVariables": false
             },
             "formatting": {
                 "indentKind": "Space",
@@ -852,7 +857,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "localDeploy": false,
           "resourceDerivedTypes": false,
           "secureOutputs": false,
-          "resourceInfoCodegen": false
+          "resourceInfoCodegen": false,
+          "typedVariables": false
         },
         "formatting": {
           "indentKind": "Space",

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoLocationExprOutsideParamsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoLocationExprOutsideParamsRuleTests.cs
@@ -107,29 +107,29 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 
         [DataRow(@"
             targetScope = 'managementGroup'
-            var notLocation object = deployment2().location
+            param notLocation object = deployment2().location
           ",
             OnCompileErrors.Ignore)]
         [DataRow(@"
             targetScope = 'managementGroup'
-            var notLocation  string = sys.deployment().location
+            param notLocation  string = sys.deployment().location
           ",
             OnCompileErrors.Ignore)]
         [DataRow(@"
             targetScope = 'managementGroup'
-            var notLocation  string = DEPLOYMENT().location
+            param notLocation  string = DEPLOYMENT().location
           ",
             OnCompileErrors.Ignore)]
         [DataRow(@"
-            var notLocation  object = myresourceGroup().location
+            param notLocation  object = myresourceGroup().location
           ",
             OnCompileErrors.Ignore)]
         [DataRow(@"
-            var notLocation  string = sys.resourceGroup().location
+            param notLocation  string = sys.resourceGroup().location
           ",
             OnCompileErrors.Ignore)]
         [DataRow(@"
-            var notLocation string = ResourceGroup().location
+            param notLocation string = ResourceGroup().location
           ",
             OnCompileErrors.Ignore)]
         [DataTestMethod]

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -26,7 +26,8 @@ public record FeatureProviderOverrides(
     bool? ResourceInfoCodegenEnabled = default,
     bool? ExtendableParamFilesEnabled = default,
     string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
-    bool? ExtensibilityV2EmittingEnabled = default)
+    bool? ExtensibilityV2EmittingEnabled = default,
+    bool? TypedVariablesEnabled = default)
 {
     public FeatureProviderOverrides(
         TestContext testContext,
@@ -47,7 +48,8 @@ public record FeatureProviderOverrides(
         bool? ResourceInfoCodegenEnabled = default,
         bool? ExtendableParamFilesEnabled = default,
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
-        bool? ExtensibilityV2EmittingEnabled = default
+        bool? ExtensibilityV2EmittingEnabled = default,
+        bool? TypedVariablesEnabled = default
     ) : this(
         FileHelper.GetCacheRootDirectory(testContext),
         RegistryEnabled,
@@ -67,6 +69,7 @@ public record FeatureProviderOverrides(
         ResourceInfoCodegenEnabled,
         ExtendableParamFilesEnabled,
         AssemblyVersion,
-        ExtensibilityV2EmittingEnabled)
+        ExtensibilityV2EmittingEnabled,
+        TypedVariablesEnabled)
     { }
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -50,5 +50,7 @@ public class OverriddenFeatureProvider : IFeatureProvider
 
     public bool ExtendableParamFilesEnabled => overrides.ExtendableParamFilesEnabled ?? features.ExtendableParamFilesEnabled;
 
+    public bool TypedVariablesEnabled => overrides.TypedVariablesEnabled ?? features.TypedVariablesEnabled;
+
     public bool ExtensibilityV2EmittingEnabled => overrides.ExtensibilityV2EmittingEnabled ?? features.ExtensibilityV2EmittingEnabled;
 }

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -21,7 +21,8 @@ public record ExperimentalFeaturesEnabled(
     bool LocalDeploy,
     bool ResourceDerivedTypes,
     bool SecureOutputs,
-    bool ResourceInfoCodegen)
+    bool ResourceInfoCodegen,
+    bool TypedVariables)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
         => element.ToNonNullObject<ExperimentalFeaturesEnabled>();

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1872,6 +1872,14 @@ namespace Bicep.Core.Diagnostics
             public Diagnostic TypeExpressionResolvesToUnassignableType(TypeSymbol type) => CoreError(
                 "BCP411",
                 $"The type \"{type}\" cannot be used in a type assignment because it does not fit within one of ARM's primitive type categories (string, int, bool, array, object).{TypeInaccuracyClause}");
+
+            public Diagnostic InvalidVariableType(IEnumerable<string> validTypes) => CoreError(
+                "BCP412",
+                $"The variable type is not valid. Please specify one of the following types: {ToQuotedString(validTypes)}.");
+
+            public Diagnostic TypedVariablesUnsupported() => CoreError(
+                "BCP413",
+                $"""Using typed variables requires enabling EXPERIMENTAL feature "{nameof(ExperimentalFeaturesEnabled.TypedVariables)}".""");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
@@ -66,7 +66,6 @@ internal class ArmDeclarationToExpressionConverter
     internal DeclaredVariableExpression CreateDeclaredVariableExpressionFor(string originalName)
         => new(sourceSyntax,
             armIdentifierToSymbolNameMapping[new(ArmSymbolType.Variable, originalName)],
-            // TODO do we need to support type here?
             Type: null,
             ConvertToVariableValue(originalName),
             // Variables cannot have descriptions in an ARM template -- this is only supported in Bicep

--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
@@ -66,6 +66,8 @@ internal class ArmDeclarationToExpressionConverter
     internal DeclaredVariableExpression CreateDeclaredVariableExpressionFor(string originalName)
         => new(sourceSyntax,
             armIdentifierToSymbolNameMapping[new(ArmSymbolType.Variable, originalName)],
+            // TODO do we need to support type here?
+            Type: null,
             ConvertToVariableValue(originalName),
             // Variables cannot have descriptions in an ARM template -- this is only supported in Bicep
             Description: null,

--- a/src/Bicep.Core/Emit/CompileTimeImports/ImportClosureInfo.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ImportClosureInfo.cs
@@ -115,7 +115,7 @@ public record ImportClosureInfo(ImmutableArray<DeclaredTypeExpression> ImportedT
                     }
                     break;
                 case BicepSynthesizedVariableReference synthesizedVariableRef:
-                    importedVariables.Add(name, new(closure.SymbolsInImportClosure[synthesizedVariableRef], name, synthesizedVariableRef.Value));
+                    importedVariables.Add(name, new(closure.SymbolsInImportClosure[synthesizedVariableRef], name, null, synthesizedVariableRef.Value));
                     break;
                 default:
                     throw new UnreachableException($"This switch was expected to exhaustively process all kinds of {nameof(IntraTemplateSymbolicReference)} but did not handle an instance of type {symbol.GetType().Name}");

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -57,6 +57,7 @@ namespace Bicep.Core.Emit
             BlockResourceDerivedTypesThatDoNotDereferenceProperties(model, diagnostics);
             BlockSpreadInUnsupportedLocations(model, diagnostics);
             BlockExtendsWithoutFeatureFlagEnabled(model, diagnostics);
+            BlockTypedVariablesWithoutExperimentalFeaure(model, diagnostics);
 
             var paramAssignments = CalculateParameterAssignments(model, diagnostics);
 
@@ -755,6 +756,18 @@ namespace Bicep.Core.Emit
                 foreach (var spread in body.Children.OfType<SpreadExpressionSyntax>())
                 {
                     diagnostics.Write(spread, x => x.SpreadOperatorUnsupportedInLocation(spread));
+                }
+            }
+        }
+
+        private static void BlockTypedVariablesWithoutExperimentalFeaure(SemanticModel model, IDiagnosticWriter diagnostics)
+        {
+            foreach (var variable in model.Root.VariableDeclarations)
+            {
+                if (variable.DeclaringVariable.Type is {} &&
+                    !model.Features.TypedVariablesEnabled)
+                {
+                    diagnostics.Write(variable.DeclaringVariable.Type, x => x.TypedVariablesUnsupported());
                 }
             }
         }

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -57,7 +57,6 @@ namespace Bicep.Core.Emit
             BlockResourceDerivedTypesThatDoNotDereferenceProperties(model, diagnostics);
             BlockSpreadInUnsupportedLocations(model, diagnostics);
             BlockExtendsWithoutFeatureFlagEnabled(model, diagnostics);
-            BlockTypedVariablesWithoutExperimentalFeaure(model, diagnostics);
 
             var paramAssignments = CalculateParameterAssignments(model, diagnostics);
 
@@ -756,18 +755,6 @@ namespace Bicep.Core.Emit
                 foreach (var spread in body.Children.OfType<SpreadExpressionSyntax>())
                 {
                     diagnostics.Write(spread, x => x.SpreadOperatorUnsupportedInLocation(spread));
-                }
-            }
-        }
-
-        private static void BlockTypedVariablesWithoutExperimentalFeaure(SemanticModel model, IDiagnosticWriter diagnostics)
-        {
-            foreach (var variable in model.Root.VariableDeclarations)
-            {
-                if (variable.DeclaringVariable.Type is {} &&
-                    !model.Features.TypedVariablesEnabled)
-                {
-                    diagnostics.Write(variable.DeclaringVariable.Type, x => x.TypedVariablesUnsupported());
                 }
             }
         }

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -22,6 +22,7 @@ namespace Bicep.Core.Emit
                 model.Features.SymbolicNameCodegenEnabled ||
                 // resourceinfo codegen has been enabled
                 model.Features.ResourceInfoCodegenEnabled ||
+                model.Features.TypedVariablesEnabled ||
                 // there are any user-defined type declarations
                 model.Root.TypeDeclarations.Any() ||
                 // there are any user-defined function declarations

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -55,6 +55,8 @@ namespace Bicep.Core.Features
 
         public bool ResourceInfoCodegenEnabled => this.configuration.ExperimentalFeaturesEnabled.ResourceInfoCodegen;
 
+        public bool TypedVariablesEnabled => configuration.ExperimentalFeaturesEnabled.TypedVariables;
+
         public bool ExtensibilityV2EmittingEnabled => ReadBooleanEnvVar("BICEP_EXTENSIBILITY_V2_EMITTING_ENABLED", defaultValue: false);
 
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -38,6 +38,8 @@ public interface IFeatureProvider
     bool SecureOutputsEnabled { get; }
 
     bool ResourceInfoCodegenEnabled { get; }
+    
+    bool TypedVariablesEnabled { get; }
 
     bool ExtensibilityV2EmittingEnabled { get; }
 
@@ -61,6 +63,7 @@ public interface IFeatureProvider
                 (LocalDeployEnabled, "Enable local deploy", false, false),
                 (ResourceDerivedTypesEnabled, CoreResources.ExperimentalFeatureNames_ResourceDerivedTypes, true, false),
                 (SecureOutputsEnabled, CoreResources.ExperimentalFeatureNames_SecureOutputs, true, false),
+                (TypedVariablesEnabled, "Typed variables", true, false),
                 (ExtendableParamFilesEnabled, "Enable extendable parameters", true, false),
             })
             {

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -439,6 +439,7 @@ public record DeclaredParameterExpression(
 public record DeclaredVariableExpression(
     SyntaxBase? SourceSyntax,
     string Name,
+    TypeExpression? Type,
     Expression Value,
     Expression? Description = null,
     Expression? Exported = null

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -186,6 +186,7 @@ public class ExpressionBuilder
                 return EvaluateDecorators(variable, new DeclaredVariableExpression(
                     variable,
                     variable.Name.IdentifierName,
+                    variable.Type != null ? ConvertTypeWithoutLowering(variable.Type) : null,
                     ConvertWithoutLowering(variable.Value)));
 
             case FunctionDeclarationSyntax function:
@@ -475,7 +476,7 @@ public class ExpressionBuilder
 
         var functionVariables = Context.FunctionVariables
             .OrderBy(x => x.Value.Name, LanguageConstants.IdentifierComparer)
-            .Select(x => new DeclaredVariableExpression(x.Key, x.Value.Name, x.Value.Value))
+            .Select(x => new DeclaredVariableExpression(x.Key, x.Value.Name, null, x.Value.Value))
             .ToImmutableArray();
 
         var variables = Context.SemanticModel.Root.VariableDeclarations

--- a/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
@@ -288,10 +288,11 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
     {
         var hasChanges =
             TryRewrite(expression.Value, out var value) |
+            TryRewriteStrict(expression.Type, out var type) |
             TryRewriteDescription(expression, out var description) |
             TryRewrite(expression.Exported, out var exported);
 
-        return hasChanges ? expression with { Value = value, Description = description, Exported = exported } : expression;
+        return hasChanges ? expression with { Value = value, Type = type, Description = description, Exported = exported } : expression;
     }
 
     void IExpressionVisitor.VisitDeclaredFunctionExpression(DeclaredFunctionExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredFunctionExpression);

--- a/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
@@ -186,6 +186,7 @@ public abstract class ExpressionVisitor : IExpressionVisitor
     {
         VisitDescribableExpression(expression);
         Visit(expression.Exported);
+        Visit(expression.Type);
         Visit(expression.Value);
     }
 

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -36,7 +36,7 @@ namespace Bicep.Core.Parsing
         protected SyntaxBase VariableDeclaration(IEnumerable<SyntaxBase> leadingNodes)
         {
             var keyword = ExpectKeyword(LanguageConstants.VariableKeyword);
-            var name = this.IdentifierWithRecovery(b => b.ExpectedVariableIdentifier(), RecoveryFlags.None, TokenType.Identifier, TokenType.Assignment, TokenType.NewLine);
+            var name = this.IdentifierWithRecovery(b => b.ExpectedVariableIdentifier(), RecoveryFlags.None, TokenType.Identifier, TokenType.NewLine);
             var type = WithRecoveryNullable(() => reader.Peek().Type switch
             {
                 TokenType.EndOfFile or

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -36,11 +36,18 @@ namespace Bicep.Core.Parsing
         protected SyntaxBase VariableDeclaration(IEnumerable<SyntaxBase> leadingNodes)
         {
             var keyword = ExpectKeyword(LanguageConstants.VariableKeyword);
-            var name = this.IdentifierWithRecovery(b => b.ExpectedVariableIdentifier(), RecoveryFlags.None, TokenType.Assignment, TokenType.NewLine);
-            var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(name), TokenType.NewLine);
+            var name = this.IdentifierWithRecovery(b => b.ExpectedVariableIdentifier(), RecoveryFlags.None, TokenType.Identifier, TokenType.Assignment, TokenType.NewLine);
+            var type = WithRecoveryNullable(() => reader.Peek().Type switch
+            {
+                TokenType.EndOfFile or
+                TokenType.NewLine or
+                TokenType.Assignment => null,
+                _ => Type(allowOptionalResourceType: false),
+            }, GetSuppressionFlag(name), TokenType.Assignment, TokenType.NewLine);
+            var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(type ?? name), TokenType.NewLine);
             var value = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(assignment), TokenType.NewLine);
 
-            return new VariableDeclarationSyntax(leadingNodes, keyword, name, assignment, value);
+            return new VariableDeclarationSyntax(leadingNodes, keyword, name, type, assignment, value);
         }
 
         protected CompileTimeImportDeclarationSyntax CompileTimeImportDeclaration(Token keyword, IEnumerable<SyntaxBase> leadingNodes)

--- a/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
+++ b/src/Bicep.Core/PrettyPrint/DocumentBuildVisitor.cs
@@ -153,6 +153,7 @@ namespace Bicep.Core.PrettyPrint
                 this.Visit(syntax.Keyword);
                 this.documentStack.Push(Nil);
                 this.Visit(syntax.Name);
+                this.Visit(syntax.Type);
                 this.Visit(syntax.Assignment);
                 this.Visit(syntax.Value);
             });

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
@@ -477,11 +477,9 @@ namespace Bicep.Core.PrettyPrintV2
 
         private IEnumerable<Document> LayoutVariableDeclarationSyntax(VariableDeclarationSyntax syntax) =>
             this.LayoutLeadingNodes(syntax.LeadingNodes)
-                .Concat(this.Spread(
-                    syntax.Keyword,
-                    syntax.Name,
-                    syntax.Assignment,
-                    syntax.Value));
+                .Concat(syntax.Type is not null
+                    ? Spread(syntax.Keyword, syntax.Name, syntax.Type, syntax.Assignment, syntax.Value)
+                    : Spread(syntax.Keyword, syntax.Name, syntax.Assignment, syntax.Value));
 
         private IEnumerable<Document> LayoutAssertDeclarationSyntax(AssertDeclarationSyntax syntax) =>
             this.LayoutLeadingNodes(syntax.LeadingNodes)

--- a/src/Bicep.Core/Semantics/Metadata/ExportMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ExportMetadata.cs
@@ -19,7 +19,7 @@ public abstract record ExportMetadata(ExportMetadataKind Kind, string Name, ITyp
 public record ExportedTypeMetadata(string Name, ITypeReference TypeReference, string? Description)
     : ExportMetadata(ExportMetadataKind.Type, Name, TypeReference, Description);
 
-public record ExportedVariableMetadata(string Name, ITypeReference TypeReference, string? Description)
+public record ExportedVariableMetadata(string Name, ITypeReference TypeReference, string? Description, ITypeReference? DeclaredType)
     : ExportMetadata(ExportMetadataKind.Variable, Name, TypeReference, Description);
 
 public record ExportedFunctionParameterMetadata(string Name, ITypeReference TypeReference, string? Description);

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -191,6 +191,9 @@ namespace Bicep.Core.Semantics
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
             this.Visit(syntax.Name);
+            allowedFlags = FunctionFlags.TypeDecorator;
+            this.Visit(syntax.Type);
+            allowedFlags = FunctionFlags.VariableDecorator;
             this.Visit(syntax.Assignment);
             allowedFlags = FunctionFlags.RequiresInlining;
             this.Visit(syntax.Value);

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1961,6 +1961,7 @@ namespace Bicep.Core.Semantics.Namespaces
         {
             ParameterDeclarationSyntax parameterDeclaration => parameterDeclaration.Type,
             OutputDeclarationSyntax outputDeclaration => outputDeclaration.Type,
+            VariableDeclarationSyntax variableDeclaration => variableDeclaration.Type,
             TypeDeclarationSyntax typeDeclaration => typeDeclaration.Value,
             ObjectTypePropertySyntax objectTypeProperty => objectTypeProperty.Value,
             _ => null,

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -171,7 +171,11 @@ namespace Bicep.Core.Semantics
 
         private IEnumerable<ExportMetadata> FindExportedVariables() => Root.VariableDeclarations
             .Where(v => v.IsExported(this))
-            .Select(v => new ExportedVariableMetadata(v.Name, v.Type, DescriptionHelper.TryGetFromDecorator(this, v.DeclaringVariable)));
+            .Select(v => new ExportedVariableMetadata(
+                v.Name,
+                v.Type,
+                DescriptionHelper.TryGetFromDecorator(this, v.DeclaringVariable),
+                DeclaredType: GetDeclaredType(v.DeclaringVariable)));
 
         private IEnumerable<ExportMetadata> FindExportedFunctions() => Root.FunctionDeclarations
             .Where(f => f.IsExported(this))

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -73,6 +73,7 @@ namespace Bicep.Core.Syntax
         {
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Name);
+            this.Visit(syntax.Type);
             this.Visit(syntax.Value);
         }
 

--- a/src/Bicep.Core/Syntax/CstVisitor.cs
+++ b/src/Bicep.Core/Syntax/CstVisitor.cs
@@ -65,6 +65,7 @@ namespace Bicep.Core.Syntax
             this.VisitNodes(syntax.LeadingNodes);
             this.Visit(syntax.Keyword);
             this.Visit(syntax.Name);
+            this.Visit(syntax.Type);
             this.Visit(syntax.Assignment);
             this.Visit(syntax.Value);
         }

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -412,11 +412,12 @@ namespace Bicep.Core.Syntax
         public static ParenthesizedExpressionSyntax CreateParenthesized(SyntaxBase inner)
             => new(LeftParenToken, inner, RightParenToken);
 
-        public static VariableDeclarationSyntax CreateVariableDeclaration(string name, SyntaxBase value, IEnumerable<SyntaxBase>? leadingNodes = null)
+        public static VariableDeclarationSyntax CreateVariableDeclaration(string name, SyntaxBase value, SyntaxBase? type = null, IEnumerable<SyntaxBase>? leadingNodes = null)
             => new(
                 leadingNodes ?? [],
                 VariableKeywordToken,
                 CreateIdentifierWithTrailingSpace(name),
+                type,
                 AssignmentToken,
                 value);
 

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -213,6 +213,7 @@ namespace Bicep.Core.Syntax
             var hasChanges = TryRewrite(syntax.LeadingNodes, out var leadingNodes);
             hasChanges |= TryRewriteStrict(syntax.Keyword, out var keyword);
             hasChanges |= TryRewriteStrict(syntax.Name, out var name);
+            hasChanges |= TryRewriteStrict(syntax.Type, out var type);
             hasChanges |= TryRewrite(syntax.Assignment, out var assignment);
             hasChanges |= TryRewrite(syntax.Value, out var value);
 
@@ -221,7 +222,7 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new VariableDeclarationSyntax(leadingNodes, keyword, name, assignment, value);
+            return new VariableDeclarationSyntax(leadingNodes, keyword, name, type, assignment, value);
         }
         void ISyntaxVisitor.VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax) => ReplaceCurrent(syntax, ReplaceVariableDeclarationSyntax);
 

--- a/src/Bicep.Core/Syntax/VariableDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/VariableDeclarationSyntax.cs
@@ -7,7 +7,7 @@ namespace Bicep.Core.Syntax
 {
     public class VariableDeclarationSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
     {
-        public VariableDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase assignment, SyntaxBase value)
+        public VariableDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase? type, SyntaxBase assignment, SyntaxBase value)
             : base(leadingNodes)
         {
             AssertKeyword(keyword, nameof(keyword), LanguageConstants.VariableKeyword);
@@ -17,6 +17,7 @@ namespace Bicep.Core.Syntax
 
             this.Keyword = keyword;
             this.Name = name;
+            this.Type = type;
             this.Assignment = assignment;
             this.Value = value;
         }
@@ -24,6 +25,8 @@ namespace Bicep.Core.Syntax
         public Token Keyword { get; }
 
         public IdentifierSyntax Name { get; }
+
+        public SyntaxBase? Type { get; }
 
         public SyntaxBase Assignment { get; }
 

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -179,6 +179,9 @@ namespace Bicep.Core.TypeSystem
 
                 case TypedLambdaSyntax typedLambda:
                     return GetTypedLambdaType(typedLambda);
+
+                case VariableDeclarationSyntax variableDeclaration:
+                    return GetVariableTypeIfDefined(variableDeclaration);
             }
 
             return null;
@@ -471,6 +474,19 @@ namespace Bicep.Core.TypeSystem
             return new(ApplyTypeModifyingDecorators(DisallowNamespaceTypes(declaredType.Type, syntax.Type), syntax), syntax);
         }
 
+        private DeclaredTypeAssignment? GetVariableTypeIfDefined(VariableDeclarationSyntax syntax)
+        {
+            if (syntax.Type is null)
+            {
+                return null;
+            }
+
+            var declaredType = TryGetTypeFromTypeSyntax(syntax.Type) ??
+                ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).InvalidVariableType(GetValidTypeNames()));
+
+            return new(ApplyTypeModifyingDecorators(DisallowNamespaceTypes(declaredType.Type, syntax.Type), syntax), syntax);
+        }
+
         private ITypeReference GetTypeFromTypeSyntax(SyntaxBase syntax) => TryGetTypeFromTypeSyntax(syntax)
             ?? ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).InvalidTypeDefinition());
 
@@ -513,9 +529,6 @@ namespace Bicep.Core.TypeSystem
 
             return declaredType is not null ? new(declaredType, syntax, DeclaredTypeFlags.None) : null;
         });
-
-        private DeclaredTypeAssignment GetResourceTypeType(ResourceTypeSyntax syntax)
-            => new(GetTypeReferenceForResourceType(syntax), syntax);
 
         private TypeSymbol GetTypeReferenceForResourceType(ResourceTypeSyntax syntax)
         {
@@ -1134,12 +1147,6 @@ namespace Bicep.Core.TypeSystem
             _ => type,
         };
 
-        private static ITypeReference UnwrapType(ITypeReference typeReference) => typeReference switch
-        {
-            DeferredTypeReference => new DeferredTypeReference(() => UnwrapType(typeReference.Type)),
-            _ => UnwrapType(typeReference.Type),
-        };
-
         private ITypeReference ConvertTypeExpressionToType(NullableTypeSyntax syntax)
         {
             var baseExpressionType = DisallowNamespaceTypes(GetTypeFromTypeSyntax(syntax.Base), syntax.Base);
@@ -1227,7 +1234,7 @@ namespace Bicep.Core.TypeSystem
                     var innerModuleBody = moduleSymbol.DeclaringModule.Value;
                     return this.GetDeclaredTypeAssignment(innerModuleBody);
 
-                case VariableSymbol variableSymbol when IsCycleFree(variableSymbol):
+                case VariableSymbol variableSymbol when variableSymbol.DeclaringVariable.Type is null && IsCycleFree(variableSymbol):
                     var variableType = this.typeManager.GetTypeInfo(variableSymbol.DeclaringVariable.Value);
                     return new DeclaredTypeAssignment(variableType, variableSymbol.DeclaringVariable);
 
@@ -1755,6 +1762,7 @@ namespace Bicep.Core.TypeSystem
                     return TryCreateAssignment(ResolveDiscriminatedObjects(namespaceType.ConfigurationType.Type, syntax), syntax, extensionAssignment.Flags);
                 case FunctionArgumentSyntax:
                 case OutputDeclarationSyntax parentOutput when syntax == parentOutput.Value:
+                case VariableDeclarationSyntax parentVariable when syntax == parentVariable.Value:
                     if (GetNonNullableTypeAssignment(parent) is not { } parentAssignment)
                     {
                         return null;

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1020,6 +1020,14 @@ namespace Bicep.Core.TypeSystem
         public override void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
             => AssignTypeWithDiagnostics(syntax, diagnostics =>
             {
+                if (syntax.Type is {})
+                {
+                    var declaredType = GetDeclaredTypeAndValidateDecorators(syntax, syntax.Type, diagnostics);
+                    diagnostics.WriteMultiple(GetDeclarationAssignmentDiagnostics(declaredType, syntax.Value));
+
+                    return declaredType;
+                }
+
                 var errors = new List<IDiagnostic>();
 
                 var valueType = typeManager.GetTypeInfo(syntax.Value);
@@ -1062,7 +1070,7 @@ namespace Bicep.Core.TypeSystem
             => AssignTypeWithDiagnostics(syntax, diagnostics =>
             {
                 var declaredType = GetDeclaredTypeAndValidateDecorators(syntax, syntax.Type, diagnostics);
-                diagnostics.WriteMultiple(GetOutputDeclarationDiagnostics(declaredType, syntax));
+                diagnostics.WriteMultiple(GetDeclarationAssignmentDiagnostics(declaredType, syntax.Value));
 
                 base.VisitOutputDeclarationSyntax(syntax);
 
@@ -2355,9 +2363,9 @@ namespace Bicep.Core.TypeSystem
         private IEnumerable<TypeSymbol> GetRecoveredArgumentTypes(IEnumerable<FunctionArgumentSyntax> argumentSyntaxes) =>
             this.GetArgumentTypes(argumentSyntaxes).Select(argumentType => argumentType.TypeKind == TypeKind.Error ? LanguageConstants.Any : argumentType);
 
-        private IEnumerable<IDiagnostic> GetOutputDeclarationDiagnostics(TypeSymbol assignedType, OutputDeclarationSyntax syntax)
+        private IEnumerable<IDiagnostic> GetDeclarationAssignmentDiagnostics(TypeSymbol declaredType, SyntaxBase value)
         {
-            var valueType = typeManager.GetTypeInfo(syntax.Value);
+            var valueType = typeManager.GetTypeInfo(value);
 
             // this type is not a property in a symbol so the semantic error visitor won't collect the errors automatically
             if (valueType is ErrorType)
@@ -2365,7 +2373,7 @@ namespace Bicep.Core.TypeSystem
                 return valueType.GetDiagnostics();
             }
 
-            if (assignedType is ErrorType)
+            if (declaredType is ErrorType)
             {
                 // no point in checking that the value is assignable to the declared output type if no valid declared type could be discerned
                 return [];
@@ -2373,7 +2381,7 @@ namespace Bicep.Core.TypeSystem
 
             var diagnosticWriter = ToListDiagnosticWriter.Create();
 
-            TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, parsingErrorLookup, diagnosticWriter, syntax.Value, assignedType);
+            TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, parsingErrorLookup, diagnosticWriter, value, declaredType);
 
             return diagnosticWriter.GetDiagnostics();
         }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1022,6 +1022,11 @@ namespace Bicep.Core.TypeSystem
             {
                 if (syntax.Type is {})
                 {
+                    if (!model.Features.TypedVariablesEnabled)
+                    {
+                        return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax.Type).TypedVariablesUnsupported());
+                    }
+
                     var declaredType = GetDeclaredTypeAndValidateDecorators(syntax, syntax.Type, diagnostics);
                     diagnostics.WriteMultiple(GetDeclarationAssignmentDiagnostics(declaredType, syntax.Value));
 

--- a/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
@@ -110,12 +110,12 @@ namespace Bicep.LangServer.IntegrationTests
         public LanguageClientFile ApplyCompletion(CompletionItem completion, params string[] tabStops)
             => LspRefactoringHelper.ApplyCompletion(bicepFile, completion, tabStops);
 
-        public async Task<LanguageClientFile> RequestAndApplyCompletion(int cursor, string label)
+        public async Task<LanguageClientFile> RequestAndApplyCompletion(int cursor, string label, string[]? tabStops = null)
         {
             var completionList = await RequestCompletion(cursor);
             var completion = completionList.Should().ContainSingle(x => x.Label == label).Subject;
 
-            return ApplyCompletion(completion);
+            return ApplyCompletion(completion, tabStops ?? []);
         }
 
         public LanguageClientFile ApplyWorkspaceEdit(WorkspaceEdit? edit)

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -198,44 +198,45 @@ namespace Bicep.LanguageServer.Completions
             var typeArgumentContext = TryGetTypeArgumentContext(matchingNodes, offset);
 
             var kind = ConvertFlag(IsTopLevelDeclarationStartContext(matchingNodes, offset), BicepCompletionContextKind.TopLevelDeclarationStart) |
-                       ConvertFlag(IsNestedResourceStartContext(matchingNodes, topLevelDeclarationInfo, objectInfo, offset), BicepCompletionContextKind.NestedResourceDeclarationStart) |
-                       GetDeclarationTypeFlags(matchingNodes, offset) |
-                       ConvertFlag(IsResourceTypeFollowerContext(matchingNodes, offset), BicepCompletionContextKind.ResourceTypeFollower) |
-                       GetObjectPropertyNameFlags(matchingNodes, objectInfo, offset) |
-                       ConvertFlag(IsMemberAccessContext(matchingNodes, propertyAccessInfo, offset), BicepCompletionContextKind.MemberAccess) |
-                       ConvertFlag(IsResourceAccessContext(matchingNodes, resourceAccessInfo, offset), BicepCompletionContextKind.ResourceAccess) |
-                       ConvertFlag(IsArrayIndexContext(matchingNodes, arrayAccessInfo), BicepCompletionContextKind.ArrayIndex | BicepCompletionContextKind.Expression) |
-                       GetPropertyValueFlags(matchingNodes, propertyInfo, offset) |
-                       ConvertFlag(IsArrayItemContext(matchingNodes, arrayInfo, offset), BicepCompletionContextKind.ArrayItem | BicepCompletionContextKind.Expression) |
-                       ConvertFlag(IsResourceBodyContext(matchingNodes, offset), BicepCompletionContextKind.ResourceBody) |
-                       ConvertFlag(IsModuleBodyContext(matchingNodes, offset), BicepCompletionContextKind.ModuleBody) |
-                       ConvertFlag(IsTestBodyContext(matchingNodes, offset), BicepCompletionContextKind.TestBody) |
-                       ConvertFlag(IsParameterDefaultValueContext(matchingNodes, offset), BicepCompletionContextKind.ParameterDefaultValue | BicepCompletionContextKind.Expression) |
-                       ConvertFlag(IsVariableValueContext(matchingNodes, offset), BicepCompletionContextKind.VariableValue | BicepCompletionContextKind.Expression) |
-                       ConvertFlag(IsOutputValueContext(matchingNodes, offset), BicepCompletionContextKind.OutputValue | BicepCompletionContextKind.Expression) |
-                       ConvertFlag(IsOutputTypeFollowerContext(matchingNodes, offset), BicepCompletionContextKind.OutputTypeFollower) |
-                       ConvertFlag(IsOuterExpressionContext(matchingNodes, offset), BicepCompletionContextKind.Expression) |
-                       ConvertFlag(IsTargetScopeContext(matchingNodes, offset), BicepCompletionContextKind.TargetScope) |
-                       ConvertFlag(IsDecoratorNameContext(matchingNodes, offset), BicepCompletionContextKind.DecoratorName) |
-                       ConvertFlag(functionArgumentContext is not null, BicepCompletionContextKind.FunctionArgument | BicepCompletionContextKind.Expression) |
-                       ConvertFlag(IsUsingPathContext(matchingNodes, offset), BicepCompletionContextKind.UsingFilePath) |
-                       ConvertFlag(IsExtendsPathContext(matchingNodes, offset), BicepCompletionContextKind.ExtendsFilePath) |
-                       ConvertFlag(IsTestPathContext(matchingNodes, offset), BicepCompletionContextKind.TestPath) |
-                       ConvertFlag(IsModulePathContext(matchingNodes, offset), BicepCompletionContextKind.ModulePath) |
-                       ConvertFlag(IsImportPathContext(matchingNodes, offset), BicepCompletionContextKind.ModulePath) |
-                       ConvertFlag(IsParameterIdentifierContext(matchingNodes, offset), BicepCompletionContextKind.ParamIdentifier) |
-                       ConvertFlag(IsParameterValueContext(matchingNodes, offset), BicepCompletionContextKind.ParamValue) |
-                       ConvertFlag(IsObjectTypePropertyValueContext(matchingNodes, offset), BicepCompletionContextKind.ObjectTypePropertyValue) |
-                       ConvertFlag(IsUnionTypeMemberContext(matchingNodes, offset), BicepCompletionContextKind.UnionTypeMember) |
-                       ConvertFlag(IsTypedLocalVariableTypeContext(matchingNodes, offset), BicepCompletionContextKind.TypedLocalVariableType) |
-                       ConvertFlag(IsTypedLambdaOutputTypeContext(matchingNodes, offset), BicepCompletionContextKind.TypedLambdaOutputType) |
-                       ConvertFlag(typeArgumentContext is not null, BicepCompletionContextKind.TypeArgument) |
-                       ConvertFlag(IsTypeMemberAccessContext(matchingNodes, typePropertyAccessInfo, offset), BicepCompletionContextKind.TypeMemberAccess) |
-                       ConvertFlag(IsImportIdentifierContext(matchingNodes, offset), BicepCompletionContextKind.ImportIdentifier) |
-                       ConvertFlag(IsImportedSymbolListItemContext(matchingNodes, offset), BicepCompletionContextKind.ImportedSymbolIdentifier) |
-                       ConvertFlag(ExpectingContextualAsKeyword(matchingNodes, offset), BicepCompletionContextKind.ExpectingExtensionAsKeyword) |
-                       ConvertFlag(ExpectingContextualFromKeyword(matchingNodes, offset), BicepCompletionContextKind.ExpectingImportFromKeyword) |
-                       ConvertFlag(IsAfterSpreadTokenContext(matchingNodes, offset), BicepCompletionContextKind.Expression);
+                ConvertFlag(IsNestedResourceStartContext(matchingNodes, topLevelDeclarationInfo, objectInfo, offset), BicepCompletionContextKind.NestedResourceDeclarationStart) |
+                GetDeclarationTypeFlags(matchingNodes, offset) |
+                ConvertFlag(IsResourceTypeFollowerContext(matchingNodes, offset), BicepCompletionContextKind.ResourceTypeFollower) |
+                GetObjectPropertyNameFlags(matchingNodes, objectInfo, offset) |
+                ConvertFlag(IsMemberAccessContext(matchingNodes, propertyAccessInfo, offset), BicepCompletionContextKind.MemberAccess) |
+                ConvertFlag(IsResourceAccessContext(matchingNodes, resourceAccessInfo, offset), BicepCompletionContextKind.ResourceAccess) |
+                ConvertFlag(IsArrayIndexContext(matchingNodes, arrayAccessInfo), BicepCompletionContextKind.ArrayIndex | BicepCompletionContextKind.Expression) |
+                GetPropertyValueFlags(matchingNodes, propertyInfo, offset) |
+                ConvertFlag(IsArrayItemContext(matchingNodes, arrayInfo, offset), BicepCompletionContextKind.ArrayItem | BicepCompletionContextKind.Expression) |
+                ConvertFlag(IsResourceBodyContext(matchingNodes, offset), BicepCompletionContextKind.ResourceBody) |
+                ConvertFlag(IsModuleBodyContext(matchingNodes, offset), BicepCompletionContextKind.ModuleBody) |
+                ConvertFlag(IsTestBodyContext(matchingNodes, offset), BicepCompletionContextKind.TestBody) |
+                ConvertFlag(IsParameterDefaultValueContext(matchingNodes, offset), BicepCompletionContextKind.ParameterDefaultValue | BicepCompletionContextKind.Expression) |
+                ConvertFlag(IsVariableValueContext(matchingNodes, offset), BicepCompletionContextKind.VariableValue | BicepCompletionContextKind.Expression) |
+                ConvertFlag(IsOutputValueContext(matchingNodes, offset), BicepCompletionContextKind.OutputValue | BicepCompletionContextKind.Expression) |
+                ConvertFlag(IsOutputTypeFollowerContext(matchingNodes, offset), BicepCompletionContextKind.OutputTypeFollower) |
+                ConvertFlag(IsOuterExpressionContext(matchingNodes, offset), BicepCompletionContextKind.Expression) |
+                ConvertFlag(IsTargetScopeContext(matchingNodes, offset), BicepCompletionContextKind.TargetScope) |
+                ConvertFlag(IsDecoratorNameContext(matchingNodes, offset), BicepCompletionContextKind.DecoratorName) |
+                ConvertFlag(functionArgumentContext is not null, BicepCompletionContextKind.FunctionArgument | BicepCompletionContextKind.Expression) |
+                ConvertFlag(IsUsingPathContext(matchingNodes, offset), BicepCompletionContextKind.UsingFilePath) |
+                ConvertFlag(IsExtendsPathContext(matchingNodes, offset), BicepCompletionContextKind.ExtendsFilePath) |
+                ConvertFlag(IsTestPathContext(matchingNodes, offset), BicepCompletionContextKind.TestPath) |
+                ConvertFlag(IsModulePathContext(matchingNodes, offset), BicepCompletionContextKind.ModulePath) |
+                ConvertFlag(IsImportPathContext(matchingNodes, offset), BicepCompletionContextKind.ModulePath) |
+                ConvertFlag(IsParameterIdentifierContext(matchingNodes, offset), BicepCompletionContextKind.ParamIdentifier) |
+                ConvertFlag(IsParameterValueContext(matchingNodes, offset), BicepCompletionContextKind.ParamValue) |
+                ConvertFlag(IsObjectTypePropertyValueContext(matchingNodes, offset), BicepCompletionContextKind.ObjectTypePropertyValue) |
+                ConvertFlag(IsUnionTypeMemberContext(matchingNodes, offset), BicepCompletionContextKind.UnionTypeMember) |
+                ConvertFlag(IsTypedLocalVariableTypeContext(matchingNodes, offset), BicepCompletionContextKind.TypedLocalVariableType) |
+                ConvertFlag(IsTypedLambdaOutputTypeContext(matchingNodes, offset), BicepCompletionContextKind.TypedLambdaOutputType) |
+                ConvertFlag(typeArgumentContext is not null, BicepCompletionContextKind.TypeArgument) |
+                ConvertFlag(IsTypeMemberAccessContext(matchingNodes, typePropertyAccessInfo, offset), BicepCompletionContextKind.TypeMemberAccess) |
+                ConvertFlag(IsImportIdentifierContext(matchingNodes, offset), BicepCompletionContextKind.ImportIdentifier) |
+                ConvertFlag(IsImportedSymbolListItemContext(matchingNodes, offset), BicepCompletionContextKind.ImportedSymbolIdentifier) |
+                ConvertFlag(ExpectingContextualAsKeyword(matchingNodes, offset), BicepCompletionContextKind.ExpectingExtensionAsKeyword) |
+                ConvertFlag(ExpectingContextualFromKeyword(matchingNodes, offset), BicepCompletionContextKind.ExpectingImportFromKeyword) |
+                ConvertFlag(IsAfterSpreadTokenContext(matchingNodes, offset), BicepCompletionContextKind.Expression) |
+                ConvertFlag(IsVariableNameFollowerContext(matchingNodes, offset), BicepCompletionContextKind.VariableNameFollower);
 
             if (bicepFile.Features.ExtensibilityEnabled)
             {
@@ -442,6 +443,14 @@ namespace Bicep.LanguageServer.Completions
             SyntaxMatcher.IsTailMatch<ResourceDeclarationSyntax, SkippedTriviaSyntax, Token>(matchingNodes, (resource, skipped, token) => resource.Assignment == skipped && token.Type == TokenType.Identifier) ||
             // resource foo '...' |=
             SyntaxMatcher.IsTailMatch<ResourceDeclarationSyntax, Token>(matchingNodes, (resource, token) => resource.Assignment == token && token.Type == TokenType.Assignment && offset == token.Span.Position);
+
+        private static bool IsVariableNameFollowerContext(List<SyntaxBase> matchingNodes, int offset) =>
+            // var foo |
+            SyntaxMatcher.IsTailMatch<VariableDeclarationSyntax>(matchingNodes, variable => 
+                offset > variable.Name.GetEndPosition() && 
+                variable.Type is null &&
+                variable.Assignment is SkippedTriviaSyntax && 
+                offset <= variable.Assignment.Span.Position);
 
         private static bool IsTargetScopeContext(List<SyntaxBase> matchingNodes, int offset) =>
             SyntaxMatcher.IsTailMatch<TargetScopeSyntax>(matchingNodes, targetScope =>
@@ -1058,6 +1067,7 @@ namespace Bicep.LanguageServer.Completions
                 case VariableDeclarationSyntax variable:
                     // is the cursor after the equals sign in the variable?
                     return !variable.Name.Span.ContainsInclusive(offset) &&
+                           variable.Type?.Span.ContainsInclusive(offset) != true &&
                            !variable.Assignment.Span.ContainsInclusive(offset) &&
                            variable.Value is SkippedTriviaSyntax && offset == variable.Value.Span.Position;
 

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -258,5 +258,10 @@ namespace Bicep.LanguageServer.Completions
         /// The current location needs a bicepparam file path completion for extends declaration
         /// </summary>
         ExtendsFilePath = 1UL << 47,
+
+        /// <summary>
+        /// The location immediately after a name in a variable declaration.
+        /// </summary>
+        VariableNameFollower = 1UL << 48,
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -79,9 +79,10 @@ namespace Bicep.LanguageServer.Completions
                 .Concat(GetTestBodyCompletions(model, context))
                 .Concat(GetResourceBodyCompletions(model, context))
                 .Concat(GetParameterDefaultValueCompletions(model, context))
-                .Concat(GetVariableValueCompletions(context))
+                .Concat(GetVariableValueCompletions(model, context))
                 .Concat(GetOutputValueCompletions(model, context))
                 .Concat(GetOutputTypeFollowerCompletions(context))
+                .Concat(GetVariableNameFollowerCompletions(context))
                 .Concat(GetTargetScopeCompletions(model, context))
                 .Concat(GetExtensionCompletions(model, context))
                 .Concat(GetCompileTimeImportCompletions(model, context))
@@ -311,6 +312,12 @@ namespace Bicep.LanguageServer.Completions
 
             if (context.Kind.HasFlag(BicepCompletionContextKind.TypedLocalVariableType) ||
                 context.Kind.HasFlag(BicepCompletionContextKind.TypedLambdaOutputType))
+            {
+                return GetTypeCompletions(model, context);
+            }
+
+            if (context.Kind.HasFlag(BicepCompletionContextKind.VariableNameFollower) &&
+                model.Features.TypedVariablesEnabled)
             {
                 return GetTypeCompletions(model, context);
             }
@@ -763,13 +770,18 @@ namespace Bicep.LanguageServer.Completions
             return GetValueCompletionsForType(model, context, declaredType, (parameter.Modifier as ParameterDefaultValueSyntax)?.DefaultValue, loopsAllowed: false);
         }
 
-        private IEnumerable<CompletionItem> GetVariableValueCompletions(BicepCompletionContext context)
+        private IEnumerable<CompletionItem> GetVariableValueCompletions(SemanticModel model, BicepCompletionContext context)
         {
-            if (!context.Kind.HasFlag(BicepCompletionContextKind.VariableValue))
+            if (!context.Kind.HasFlag(BicepCompletionContextKind.VariableValue) || context.EnclosingDeclaration is not VariableDeclarationSyntax variable)
             {
                 return [];
             }
 
+            if (model.GetDeclaredType(variable) is {} declaredType)
+            {
+                return GetValueCompletionsForType(model, context, declaredType, variable.Value, loopsAllowed: true);
+            }
+    
             // we don't know what the variable type is, so assume "any"
             return CreateLoopCompletions(context.ReplacementRange, LanguageConstants.Any, filtersAllowed: false);
         }
@@ -789,6 +801,15 @@ namespace Bicep.LanguageServer.Completions
         private IEnumerable<CompletionItem> GetOutputTypeFollowerCompletions(BicepCompletionContext context)
         {
             if (context.Kind.HasFlag(BicepCompletionContextKind.OutputTypeFollower))
+            {
+                const string equals = "=";
+                yield return CreateOperatorCompletion(equals, context.ReplacementRange, preselect: true);
+            }
+        }
+
+        private IEnumerable<CompletionItem> GetVariableNameFollowerCompletions(BicepCompletionContext context)
+        {
+            if (context.Kind.HasFlag(BicepCompletionContextKind.VariableNameFollower))
             {
                 const string equals = "=";
                 yield return CreateOperatorCompletion(equals, context.ReplacementRange, preselect: true);

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -839,6 +839,10 @@
         "resourceInfoCodegen": {
             "type": "boolean",
             "description": "Enables the 'resourceInfo' function for simplified code generation. See https://aka.ms/bicep/experimental-features#resourceinfocodegen"
+        },
+        "typedVariables": {
+          "type": "boolean",
+          "description": "If enabled, you can optionally add a type to variable declarations. See https://aka.ms/bicep/experimental-features#typedvariables"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Adds a new experimental feature "typedVariables".

If the feature is enabled, then an optional type can be added to a variable declaration statement.
```bicep
// current syntax
var foo = 'hello'

// with optional type
var foo string = 'hello'
```

Closes #9364