### PR TITLE
Add Notepad++ Bicep Syntax Highlighting Information

### DIFF
--- a/docs/highlighting.md
+++ b/docs/highlighting.md
@@ -91,3 +91,6 @@ npx http-server ./src/monarch/test/baselines
 
 ## Prism.js
 Bicep has a community-contributed [Prism.JS](https://prismjs.com/) highlighter available [here](https://github.com/PrismJS/prism/blob/master/components/prism-bicep.js).
+
+## Notepad++
+A community-contributed User Defined Language (UDL) file for Bicep syntax highlighting in [Notepad++](https://notepad-plus-plus.org/) is available [here](https://github.com/richardsondev/azure-bicep-udl).


### PR DESCRIPTION
Add Notepad++ Bicep Syntax Highlighting User Defined Language (UDL) link.

This documentation is only available on GitHub and not on the learn website so I'm only updating it in this repo.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16506)