### PR TITLE
Add foundation for extension config assignment syntax.

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -6,7 +6,6 @@ using Azure.Containers.ContainerRegistry;
 using Bicep.Cli.Models;
 using Bicep.Cli.UnitTests.Assertions;
 using Bicep.Core.Configuration;
-using Bicep.Core.Extensions;
 using Bicep.Core.Registry;
 using Bicep.Core.Samples;
 using Bicep.Core.UnitTests;
@@ -291,6 +290,7 @@ output foo string = foo
                 AssertNoErrors(error);
             }
 
+            data.Compiled.Should().NotBeNull();
             data.Compiled!.ShouldHaveExpectedJsonValue();
         }
 
@@ -309,6 +309,7 @@ output foo string = foo
                 AssertNoErrors(error);
             }
 
+            data.Compiled.Should().NotBeNull();
             data.Compiled!.ReadFromOutputFolder().Should().OnlyContainLFNewline();
             data.Compiled!.ShouldHaveExpectedJsonValue();
         }
@@ -332,6 +333,7 @@ output foo string = foo
             var parametersStdout = output.FromJson<BuildParamsStdout>();
             parametersStdout.parametersJson.Should().OnlyContainLFNewline();
 
+            data.Compiled.Should().NotBeNull();
             data.Compiled!.WriteToOutputFolder(parametersStdout.parametersJson);
             data.Compiled.ShouldHaveExpectedJsonValue();
         }
@@ -562,7 +564,7 @@ using 'main.bicep'
 param intParam = 42
 """;
 
-            
+
             var fileResults = new[]
             {
                 (input: "file1.bicepparam", expectOutput: true),

--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core.CodeAction;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.IntegrationTests.Extensibility;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
-using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 
@@ -28,6 +26,8 @@ namespace Bicep.Core.IntegrationTests
             }
             """))
             .WithNamespaceProvider(TestExtensibilityNamespaceProvider.CreateWithDefaults());
+
+        private static ServiceBuilder ServicesWithModuleExtensionConfigs => Services.WithFeatureOverrides(new(ExtensibilityEnabled: true, ModuleExtensionConfigsEnabled: true));
 
         [TestMethod]
         public void Bar_import_bad_config_is_blocked()
@@ -655,6 +655,150 @@ Hello from Bicep!"));
             result.Template.Should().HaveValueAtPath("$.languageVersion", "2.2-experimental");
             result.Template.Should().HaveValueAtPath("$.extensions.foo.name", "Foo");
             result.Template.Should().HaveValueAtPath("$.resources.myApp.extension", "foo");
+        }
+
+        [TestMethod]
+        public void Module_with_required_extension_config_can_be_compiled_successfully()
+        {
+            var paramsUri = new Uri("file:///main.bicepparam");
+            var mainUri = new Uri("file:///main.bicep");
+            var moduleAUri = new Uri("file:///modulea.bicep");
+
+            // TODO(kylealbert): Remove 'with' clause in template when that's removed
+            var files = new Dictionary<Uri, string>
+            {
+                [paramsUri] =
+                    """
+                    using 'main.bicep'
+
+                    param inputa = 'abc'
+
+                    extension k8s with {
+                      kubeConfig: 'abc'
+                      namespace: 'other'
+                    }
+                    """,
+                [mainUri] =
+                    """
+                    param inputa string
+
+                    extension kubernetes with {
+                      kubeConfig: 'DELETE'
+                      namespace: 'DELETE'
+                    } as k8s
+
+                    extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview'
+
+                    module modulea 'modulea.bicep' = {
+                      name: 'modulea'
+                      params: {
+                        inputa: inputa
+                      }
+                      extensionConfigs: {
+                        kubernetes: {
+                          kubeConfig: 'fromModule'
+                          namespace: 'other'
+                        }
+                      }
+                    }
+
+                    output outputa string = modulea.outputs.outputa
+                    """,
+                [moduleAUri] =
+                    """
+                    param inputa string
+
+                    extension kubernetes with {
+                      kubeConfig: 'DELETE'
+                      namespace: 'DELETE'
+                    }
+
+                    extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+
+                    output outputa string = inputa
+                    """
+            };
+
+            var compilation = ServicesWithModuleExtensionConfigs.BuildCompilation(files, paramsUri);
+
+            compilation.Should().NotHaveAnyDiagnostics_WithAssertionScoping(d => d.IsError());
+        }
+
+        [DataTestMethod]
+        [DataRow("MissingExtensionConfigsDeclaration")]
+        [DataRow("MissingRequiredExtensionConfig")]
+        [DataRow("MissingRequiredConfigProperty")]
+        [DataRow("PropertyIsNotDefinedInSchema")]
+        [DataRow("ConfigProvidedForExtensionThatDoesNotAcceptConfig")]
+        public void Module_with_invalid_extension_config_produces_diagnostic(string scenario)
+        {
+            var mainUri = new Uri("file:///main.bicep");
+            var moduleAUri = new Uri("file:///modulea.bicep");
+
+            var extensionConfigsStr = scenario switch
+            {
+                "MissingExtensionConfigsDeclaration" => "",
+                "MissingRequiredExtensionConfig" => "extensionConfigs: {}",
+                "MissingRequiredConfigProperty" => "extensionConfigs: { kubernetes: { namespace: 'other' } }",
+                "PropertyIsNotDefinedInSchema" => "extensionConfigs: { kubernetes: { kubeConfig: 'test', namespace: 'other', extra: 'extra' } }",
+                "ConfigProvidedForExtensionThatDoesNotAcceptConfig" => "extensionConfigs: { kubernetes: { kubeConfig: 'test', namespace: 'other' }, graph: { } }",
+                _ => throw new NotImplementedException()
+            };
+
+            // TODO(kylealbert): Remove 'with' clause in template when that's removed
+            var files = new Dictionary<Uri, string>
+            {
+                [mainUri] =
+                    $$"""
+                      param inputa string
+
+                      module modulea 'modulea.bicep' = {
+                        name: 'modulea'
+                        params: {
+                          inputa: inputa
+                        }
+                        {{extensionConfigsStr}}
+                      }
+
+                      output outputa string = modulea.outputs.outputa
+                      """,
+                [moduleAUri] =
+                    """
+                    param inputa string
+
+                    extension kubernetes with {
+                      kubeConfig: ''
+                      namespace: 'default'
+                    }
+
+                    extension microsoftGraph as graph
+
+                    output outputa string = inputa
+                    """
+            };
+
+            var compilation = ServicesWithModuleExtensionConfigs.BuildCompilation(files, mainUri);
+
+            if (scenario is "MissingExtensionConfigsDeclaration")
+            {
+                compilation.Should().ContainSingleDiagnostic("BCP035", DiagnosticLevel.Error, """The specified "module" declaration is missing the following required properties: "extensionConfigs".""");
+            }
+            else if (scenario is "MissingRequiredExtensionConfig")
+            {
+                compilation.Should().ContainSingleDiagnostic("BCP035", DiagnosticLevel.Error, """The specified "object" declaration is missing the following required properties: "kubernetes".""");
+            }
+            else if (scenario is "MissingRequiredConfigProperty")
+            {
+                compilation.Should().ContainSingleDiagnostic("BCP035", DiagnosticLevel.Error, """The specified "object" declaration is missing the following required properties: "kubeConfig".""");
+            }
+            else if (scenario is "PropertyIsNotDefinedInSchema")
+            {
+                compilation.Should().ContainSingleDiagnostic("BCP037", DiagnosticLevel.Error, """The property "extra" is not allowed on objects of type "configuration". Permissible properties include "context".""");
+            }
+            else if (scenario is "ConfigProvidedForExtensionThatDoesNotAcceptConfig")
+            {
+                compilation.Should().ContainSingleDiagnostic("BCP037", DiagnosticLevel.Error, """The property "graph" is not allowed on objects of type "extensionConfigs". No other properties are allowed.""");
+            }
         }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Immutable;
+
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
-using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.Emit;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Extensions;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.FileSystem;
 using Bicep.Core.UnitTests.Utils;
@@ -83,10 +81,10 @@ output outputb string = '${inputa}-${inputb}'
 
             var compilation = Services.BuildCompilation(files, mainUri);
 
-            var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
+            var (success, diagnosticsByFile) = compilation.GetSuccessAndDiagnosticsByBicepFile();
             diagnosticsByFile.Values.SelectMany(x => x).Should().BeEmpty();
             success.Should().BeTrue();
-            GetTemplate(compilation).Should().NotBeEmpty();
+            compilation.GetTestTemplate().Should().NotBeEmpty();
         }
 
         [TestMethod]
@@ -112,7 +110,7 @@ module mainRecursive 'main.bicep' = {
 
             var compilation = Services.BuildCompilation(files, mainUri);
 
-            var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
+            var (success, diagnosticsByFile) = compilation.GetSuccessAndDiagnosticsByBicepFile();
             diagnosticsByFile[mainUri].Should().HaveDiagnostics(new[] {
                 ("BCP094", DiagnosticLevel.Error, "This module references itself, which is not allowed."),
             });
@@ -166,7 +164,7 @@ module main 'main.bicep' = {
 
             var compilation = Services.BuildCompilation(files, mainUri);
 
-            var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
+            var (success, diagnosticsByFile) = compilation.GetSuccessAndDiagnosticsByBicepFile();
             diagnosticsByFile[mainUri].Should().HaveDiagnostics(new[] {
                 ("BCP095", DiagnosticLevel.Error, "The file is involved in a cycle (\"/modulea.bicep\" -> \"/moduleb.bicep\" -> \"/main.bicep\")."),
             });
@@ -224,7 +222,7 @@ module modulea 'modulea.bicep' = {
             var compiler = ServiceBuilder.Create(s => s.WithFileResolver(mockFileResolver.Object).WithDisabledAnalyzersConfiguration()).GetCompiler();
             var compilation = await compiler.CreateCompilation(mainFileUri);
 
-            var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
+            var (success, diagnosticsByFile) = compilation.GetSuccessAndDiagnosticsByBicepFile();
             diagnosticsByFile[mainFileUri].Should().HaveDiagnostics(new[] {
                 ("BCP093", DiagnosticLevel.Error, "File path \"modulea.bicep\" could not be resolved relative to \"/path/to/main.bicep\"."),
             });
@@ -296,11 +294,11 @@ output outputc2 int = inputb + 1
 
             var compilation = Services.BuildCompilation(files, mainUri);
 
-            var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
+            var (success, diagnosticsByFile) = compilation.GetSuccessAndDiagnosticsByBicepFile();
             diagnosticsByFile.Values.SelectMany(x => x).Should().BeEmpty();
             success.Should().BeTrue();
 
-            var templateString = GetTemplate(compilation);
+            var templateString = compilation.GetTestTemplate();
             var template = JToken.Parse(templateString);
             template.Should().NotBeNull();
 
@@ -366,7 +364,7 @@ module modulea 'modulea.bicep' = {
             var compiler = ServiceBuilder.Create(s => s.WithFileResolver(mockFileResolver.Object).WithDisabledAnalyzersConfiguration()).GetCompiler();
             var compilation = await compiler.CreateCompilation(mainUri);
 
-            var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
+            var (success, diagnosticsByFile) = compilation.GetSuccessAndDiagnosticsByBicepFile();
             diagnosticsByFile[mainUri].Should().HaveDiagnostics(new[] {
                 ("BCP091", DiagnosticLevel.Error, "An error occurred reading file. Mock read failure!"),
             });
@@ -802,31 +800,12 @@ module {symbolicName} 'mod.bicep' = [for x in []: {{
             result.Template.Should().HaveValueAtPath("$.outputs.allModNames.copy.input", $"[format('{symbolicNamePrefix}-{{0}}-{{1}}', range(0, 10)[copyIndex()], uniqueString('{symbolicName}', deployment().name))]");
         }
 
-        private static string GetTemplate(Compilation compilation)
-        {
-            var stringBuilder = new StringBuilder();
-            var stringWriter = new StringWriter(stringBuilder);
-
-            var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel());
-            emitter.Emit(stringWriter);
-
-            return stringBuilder.ToString();
-        }
-
-        private static (bool success, IDictionary<Uri, ImmutableArray<IDiagnostic>> diagnosticsByFile) GetSuccessAndDiagnosticsByFile(Compilation compilation)
-        {
-            var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.Uri, kvp => kvp.Value);
-            var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => !d.IsError());
-
-            return (success, diagnosticsByFile);
-        }
-
         private static void ModuleTemplateHashValidator(Compilation compilation, string expectedTemplateHash)
         {
-            var (success, diagnosticsByFile) = GetSuccessAndDiagnosticsByFile(compilation);
+            var (success, diagnosticsByFile) = compilation.GetSuccessAndDiagnosticsByBicepFile();
             diagnosticsByFile.Values.SelectMany(x => x).Should().BeEmpty();
             success.Should().BeTrue();
-            var templateString = GetTemplate(compilation);
+            var templateString = compilation.GetTestTemplate();
             var template = JToken.Parse(templateString);
             template.Should().NotBeNull();
             template.SelectToken(BicepTestConstants.GeneratorTemplateHashPath)?.ToString().Should().Be(expectedTemplateHash);

--- a/src/Bicep.Core.Samples/BaselineData_Bicepparam.cs
+++ b/src/Bicep.Core.Samples/BaselineData_Bicepparam.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.Reflection;
 using Bicep.Core.UnitTests.Baselines;
 using FluentAssertions;
@@ -98,6 +99,7 @@ namespace Bicep.Core.Samples
             // ensure this list is kept up-to-date to validate that we're picking all of the baseline tests
             embeddedFiles.Select(x => x.StreamPath).Should().BeEquivalentTo(
                 "Files/baselines_bicepparam/Expressions/parameters.bicepparam",
+                "Files/baselines_bicepparam/Extensions/parameters.bicepparam",
                 "Files/baselines_bicepparam/Imports/parameters.bicepparam",
                 "Files/baselines_bicepparam/Extends/parameters.bicepparam",
                 "Files/baselines_bicepparam/Invalid_Expressions/parameters.bicepparam",

--- a/src/Bicep.Core.Samples/DataSets.cs
+++ b/src/Bicep.Core.Samples/DataSets.cs
@@ -18,6 +18,8 @@ namespace Bicep.Core.Samples
 
         public static DataSet Empty => CreateDataSet();
 
+        public static DataSet Extensions_CRLF => CreateDataSet();
+
         public static DataSet Functions_LF => CreateDataSet();
 
         public static DataSet Imports_LF => CreateDataSet();

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/bicepconfig.json
@@ -1,0 +1,6 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true,
+    "moduleExtensionConfigs": true
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/child/hasConfigurableExtensionsWithAlias.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/child/hasConfigurableExtensionsWithAlias.bicep
@@ -1,0 +1,6 @@
+extension kubernetes with {
+  kubeConfig: 'DELETE'
+  namespace: 'DELETE'
+} as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/child/hasConfigurableExtensionsWithoutAlias.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/child/hasConfigurableExtensionsWithoutAlias.bicep
@@ -1,0 +1,6 @@
+extension kubernetes with {
+  kubeConfig: 'DELETE'
+  namespace: 'DELETE'
+}
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview'

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.bicep
@@ -1,0 +1,34 @@
+// BEGIN: Extension declarations
+
+// extension kubernetes with {
+//   kubeConfig: 'DELETE'
+//   namespace: 'DELETE'
+// } as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+
+// END: Extension declarations
+
+// BEGIN: Extension configs for modules
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+  name: 'moduleWithExtsWithAliases'
+  extensionConfigs: {
+    k8s: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+  name: 'moduleWithExtsWithoutAlaises'
+  extensionConfigs: {
+    kubernetes: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+// END: Extension configs for modules

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.diagnostics.bicep
@@ -1,0 +1,35 @@
+// BEGIN: Extension declarations
+
+// extension kubernetes with {
+//   kubeConfig: 'DELETE'
+//   namespace: 'DELETE'
+// } as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+
+// END: Extension declarations
+
+// BEGIN: Extension configs for modules
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+  name: 'moduleWithExtsWithAliases'
+  extensionConfigs: {
+    k8s: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+  name: 'moduleWithExtsWithoutAlaises'
+  extensionConfigs: {
+    kubernetes: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+// END: Extension configs for modules
+

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.formatted.bicep
@@ -1,0 +1,34 @@
+// BEGIN: Extension declarations
+
+// extension kubernetes with {
+//   kubeConfig: 'DELETE'
+//   namespace: 'DELETE'
+// } as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+
+// END: Extension declarations
+
+// BEGIN: Extension configs for modules
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+  name: 'moduleWithExtsWithAliases'
+  extensionConfigs: {
+    k8s: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+  name: 'moduleWithExtsWithoutAlaises'
+  extensionConfigs: {
+    kubernetes: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+// END: Extension configs for modules

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.ir.bicep
@@ -1,0 +1,66 @@
+// BEGIN: Extension declarations
+//@[00:872) ProgramExpression
+
+// extension kubernetes with {
+//   kubeConfig: 'DELETE'
+//   namespace: 'DELETE'
+// } as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+
+// END: Extension declarations
+
+// BEGIN: Extension configs for modules
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+//@[00:249) ├─DeclaredModuleExpression
+//@[84:249) | ├─ObjectExpression
+  name: 'moduleWithExtsWithAliases'
+//@[02:035) | | └─ObjectPropertyExpression
+//@[02:006) | |   ├─StringLiteralExpression { Value = name }
+//@[08:035) | |   └─StringLiteralExpression { Value = moduleWithExtsWithAliases }
+  extensionConfigs: {
+//@[20:122) | └─ObjectExpression
+    k8s: {
+//@[04:094) |   └─ObjectPropertyExpression
+//@[04:007) |     ├─StringLiteralExpression { Value = k8s }
+//@[09:094) |     └─ObjectExpression
+      kubeConfig: 'kubeConfig2FromModule'
+//@[06:041) |       ├─ObjectPropertyExpression
+//@[06:016) |       | ├─StringLiteralExpression { Value = kubeConfig }
+//@[18:041) |       | └─StringLiteralExpression { Value = kubeConfig2FromModule }
+      namespace: 'ns2FromModule'
+//@[06:032) |       └─ObjectPropertyExpression
+//@[06:015) |         ├─StringLiteralExpression { Value = namespace }
+//@[17:032) |         └─StringLiteralExpression { Value = ns2FromModule }
+    }
+  }
+}
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+//@[00:265) └─DeclaredModuleExpression
+//@[90:265)   ├─ObjectExpression
+  name: 'moduleWithExtsWithoutAlaises'
+//@[02:038)   | └─ObjectPropertyExpression
+//@[02:006)   |   ├─StringLiteralExpression { Value = name }
+//@[08:038)   |   └─StringLiteralExpression { Value = moduleWithExtsWithoutAlaises }
+  extensionConfigs: {
+//@[20:129)   └─ObjectExpression
+    kubernetes: {
+//@[04:101)     └─ObjectPropertyExpression
+//@[04:014)       ├─StringLiteralExpression { Value = kubernetes }
+//@[16:101)       └─ObjectExpression
+      kubeConfig: 'kubeConfig2FromModule'
+//@[06:041)         ├─ObjectPropertyExpression
+//@[06:016)         | ├─StringLiteralExpression { Value = kubeConfig }
+//@[18:041)         | └─StringLiteralExpression { Value = kubeConfig2FromModule }
+      namespace: 'ns2FromModule'
+//@[06:032)         └─ObjectPropertyExpression
+//@[06:015)           ├─StringLiteralExpression { Value = namespace }
+//@[17:032)           └─StringLiteralExpression { Value = ns2FromModule }
+    }
+  }
+}
+
+// END: Extension configs for modules
+

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.2-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Extensibility",
+      "Enables defining extension configs for modules"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "14801463368454451945"
+    }
+  },
+  "resources": {
+    "moduleWithExtsWithAliases": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "moduleWithExtsWithAliases",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "extensionConfigs": {
+          "k8s": {
+            "kubeConfig": {
+              "value": "kubeConfig2FromModule"
+            },
+            "namespace": {
+              "value": "ns2FromModule"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.2-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+            "_EXPERIMENTAL_FEATURES_ENABLED": [
+              "Extensibility",
+              "Enables defining extension configs for modules"
+            ],
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "6761252660116907708"
+            }
+          },
+          "extensions": {
+            "k8s": {
+              "name": "Kubernetes",
+              "version": "1.0.0",
+              "config": {
+                "kubeConfig": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                },
+                "namespace": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                }
+              }
+            }
+          },
+          "resources": {}
+        }
+      }
+    },
+    "moduleWithExtsWithoutAliases": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "moduleWithExtsWithoutAlaises",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "extensionConfigs": {
+          "kubernetes": {
+            "kubeConfig": {
+              "value": "kubeConfig2FromModule"
+            },
+            "namespace": {
+              "value": "ns2FromModule"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.2-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+            "_EXPERIMENTAL_FEATURES_ENABLED": [
+              "Extensibility",
+              "Enables defining extension configs for modules"
+            ],
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "718382094432436506"
+            }
+          },
+          "extensions": {
+            "kubernetes": {
+              "name": "Kubernetes",
+              "version": "1.0.0",
+              "config": {
+                "kubeConfig": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                },
+                "namespace": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                }
+              }
+            }
+          },
+          "resources": {}
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.sourcemap.bicep
@@ -1,0 +1,145 @@
+// BEGIN: Extension declarations
+
+// extension kubernetes with {
+//   kubeConfig: 'DELETE'
+//   namespace: 'DELETE'
+// } as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+
+// END: Extension declarations
+
+// BEGIN: Extension configs for modules
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+//@    "moduleWithExtsWithAliases": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2022-09-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "template": {
+//@          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+//@          "languageVersion": "2.2-experimental",
+//@          "contentVersion": "1.0.0.0",
+//@          "metadata": {
+//@            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+//@            "_EXPERIMENTAL_FEATURES_ENABLED": [
+//@              "Extensibility",
+//@              "Enables defining extension configs for modules"
+//@            ],
+//@            "_generator": {
+//@              "name": "bicep",
+//@              "version": "dev",
+//@              "templateHash": "6761252660116907708"
+//@            }
+//@          },
+//@          "extensions": {
+//@            "k8s": {
+//@              "name": "Kubernetes",
+//@              "version": "1.0.0",
+//@              "config": {
+//@                "kubeConfig": {
+//@                  "type": "string",
+//@                  "defaultValue": "DELETE"
+//@                },
+//@                "namespace": {
+//@                  "type": "string",
+//@                  "defaultValue": "DELETE"
+//@                }
+//@              }
+//@            }
+//@          },
+//@          "resources": {}
+//@        }
+//@      }
+//@    },
+  name: 'moduleWithExtsWithAliases'
+//@      "name": "moduleWithExtsWithAliases",
+  extensionConfigs: {
+//@        "extensionConfigs": {
+//@        },
+    k8s: {
+//@          "k8s": {
+//@          }
+      kubeConfig: 'kubeConfig2FromModule'
+//@            "kubeConfig": {
+//@              "value": "kubeConfig2FromModule"
+//@            },
+      namespace: 'ns2FromModule'
+//@            "namespace": {
+//@              "value": "ns2FromModule"
+//@            }
+    }
+  }
+}
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+//@    "moduleWithExtsWithoutAliases": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2022-09-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "template": {
+//@          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+//@          "languageVersion": "2.2-experimental",
+//@          "contentVersion": "1.0.0.0",
+//@          "metadata": {
+//@            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+//@            "_EXPERIMENTAL_FEATURES_ENABLED": [
+//@              "Extensibility",
+//@              "Enables defining extension configs for modules"
+//@            ],
+//@            "_generator": {
+//@              "name": "bicep",
+//@              "version": "dev",
+//@              "templateHash": "718382094432436506"
+//@            }
+//@          },
+//@          "extensions": {
+//@            "kubernetes": {
+//@              "name": "Kubernetes",
+//@              "version": "1.0.0",
+//@              "config": {
+//@                "kubeConfig": {
+//@                  "type": "string",
+//@                  "defaultValue": "DELETE"
+//@                },
+//@                "namespace": {
+//@                  "type": "string",
+//@                  "defaultValue": "DELETE"
+//@                }
+//@              }
+//@            }
+//@          },
+//@          "resources": {}
+//@        }
+//@      }
+//@    }
+  name: 'moduleWithExtsWithoutAlaises'
+//@      "name": "moduleWithExtsWithoutAlaises",
+  extensionConfigs: {
+//@        "extensionConfigs": {
+//@        },
+    kubernetes: {
+//@          "kubernetes": {
+//@          }
+      kubeConfig: 'kubeConfig2FromModule'
+//@            "kubeConfig": {
+//@              "value": "kubeConfig2FromModule"
+//@            },
+      namespace: 'ns2FromModule'
+//@            "namespace": {
+//@              "value": "ns2FromModule"
+//@            }
+    }
+  }
+}
+
+// END: Extension configs for modules
+

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbolicnames.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.2-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Extensibility",
+      "Enables defining extension configs for modules"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "14801463368454451945"
+    }
+  },
+  "resources": {
+    "moduleWithExtsWithAliases": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "moduleWithExtsWithAliases",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "extensionConfigs": {
+          "k8s": {
+            "kubeConfig": {
+              "value": "kubeConfig2FromModule"
+            },
+            "namespace": {
+              "value": "ns2FromModule"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.2-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+            "_EXPERIMENTAL_FEATURES_ENABLED": [
+              "Extensibility",
+              "Enables defining extension configs for modules"
+            ],
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "6761252660116907708"
+            }
+          },
+          "extensions": {
+            "k8s": {
+              "name": "Kubernetes",
+              "version": "1.0.0",
+              "config": {
+                "kubeConfig": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                },
+                "namespace": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                }
+              }
+            }
+          },
+          "resources": {}
+        }
+      }
+    },
+    "moduleWithExtsWithoutAliases": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "moduleWithExtsWithoutAlaises",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "extensionConfigs": {
+          "kubernetes": {
+            "kubeConfig": {
+              "value": "kubeConfig2FromModule"
+            },
+            "namespace": {
+              "value": "ns2FromModule"
+            }
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.2-experimental",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+            "_EXPERIMENTAL_FEATURES_ENABLED": [
+              "Extensibility",
+              "Enables defining extension configs for modules"
+            ],
+            "_generator": {
+              "name": "bicep",
+              "version": "dev",
+              "templateHash": "718382094432436506"
+            }
+          },
+          "extensions": {
+            "kubernetes": {
+              "name": "Kubernetes",
+              "version": "1.0.0",
+              "config": {
+                "kubeConfig": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                },
+                "namespace": {
+                  "type": "string",
+                  "defaultValue": "DELETE"
+                }
+              }
+            }
+          },
+          "resources": {}
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbols.bicep
@@ -1,0 +1,37 @@
+// BEGIN: Extension declarations
+
+// extension kubernetes with {
+//   kubeConfig: 'DELETE'
+//   namespace: 'DELETE'
+// } as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+
+// END: Extension declarations
+
+// BEGIN: Extension configs for modules
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+//@[7:32) Module moduleWithExtsWithAliases. Type: module. Declaration start char: 0, length: 249
+  name: 'moduleWithExtsWithAliases'
+  extensionConfigs: {
+    k8s: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+//@[7:35) Module moduleWithExtsWithoutAliases. Type: module. Declaration start char: 0, length: 265
+  name: 'moduleWithExtsWithoutAlaises'
+  extensionConfigs: {
+    kubernetes: {
+      kubeConfig: 'kubeConfig2FromModule'
+      namespace: 'ns2FromModule'
+    }
+  }
+}
+
+// END: Extension configs for modules
+

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.syntax.bicep
@@ -1,0 +1,148 @@
+// BEGIN: Extension declarations
+//@[00:872) ProgramSyntax
+//@[32:036) ├─Token(NewLine) |\r\n\r\n|
+
+// extension kubernetes with {
+//@[30:032) ├─Token(NewLine) |\r\n|
+//   kubeConfig: 'DELETE'
+//@[25:027) ├─Token(NewLine) |\r\n|
+//   namespace: 'DELETE'
+//@[24:026) ├─Token(NewLine) |\r\n|
+// } as k8s
+//@[11:015) ├─Token(NewLine) |\r\n\r\n|
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+//@[94:098) ├─Token(NewLine) |\r\n\r\n|
+
+// END: Extension declarations
+//@[30:034) ├─Token(NewLine) |\r\n\r\n|
+
+// BEGIN: Extension configs for modules
+//@[39:043) ├─Token(NewLine) |\r\n\r\n|
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+//@[00:249) ├─ModuleDeclarationSyntax
+//@[00:006) | ├─Token(Identifier) |module|
+//@[07:032) | ├─IdentifierSyntax
+//@[07:032) | | └─Token(Identifier) |moduleWithExtsWithAliases|
+//@[33:081) | ├─StringSyntax
+//@[33:081) | | └─Token(StringComplete) |'child/hasConfigurableExtensionsWithAlias.bicep'|
+//@[82:083) | ├─Token(Assignment) |=|
+//@[84:249) | └─ObjectSyntax
+//@[84:085) |   ├─Token(LeftBrace) |{|
+//@[85:087) |   ├─Token(NewLine) |\r\n|
+  name: 'moduleWithExtsWithAliases'
+//@[02:035) |   ├─ObjectPropertySyntax
+//@[02:006) |   | ├─IdentifierSyntax
+//@[02:006) |   | | └─Token(Identifier) |name|
+//@[06:007) |   | ├─Token(Colon) |:|
+//@[08:035) |   | └─StringSyntax
+//@[08:035) |   |   └─Token(StringComplete) |'moduleWithExtsWithAliases'|
+//@[35:037) |   ├─Token(NewLine) |\r\n|
+  extensionConfigs: {
+//@[02:122) |   ├─ObjectPropertySyntax
+//@[02:018) |   | ├─IdentifierSyntax
+//@[02:018) |   | | └─Token(Identifier) |extensionConfigs|
+//@[18:019) |   | ├─Token(Colon) |:|
+//@[20:122) |   | └─ObjectSyntax
+//@[20:021) |   |   ├─Token(LeftBrace) |{|
+//@[21:023) |   |   ├─Token(NewLine) |\r\n|
+    k8s: {
+//@[04:094) |   |   ├─ObjectPropertySyntax
+//@[04:007) |   |   | ├─IdentifierSyntax
+//@[04:007) |   |   | | └─Token(Identifier) |k8s|
+//@[07:008) |   |   | ├─Token(Colon) |:|
+//@[09:094) |   |   | └─ObjectSyntax
+//@[09:010) |   |   |   ├─Token(LeftBrace) |{|
+//@[10:012) |   |   |   ├─Token(NewLine) |\r\n|
+      kubeConfig: 'kubeConfig2FromModule'
+//@[06:041) |   |   |   ├─ObjectPropertySyntax
+//@[06:016) |   |   |   | ├─IdentifierSyntax
+//@[06:016) |   |   |   | | └─Token(Identifier) |kubeConfig|
+//@[16:017) |   |   |   | ├─Token(Colon) |:|
+//@[18:041) |   |   |   | └─StringSyntax
+//@[18:041) |   |   |   |   └─Token(StringComplete) |'kubeConfig2FromModule'|
+//@[41:043) |   |   |   ├─Token(NewLine) |\r\n|
+      namespace: 'ns2FromModule'
+//@[06:032) |   |   |   ├─ObjectPropertySyntax
+//@[06:015) |   |   |   | ├─IdentifierSyntax
+//@[06:015) |   |   |   | | └─Token(Identifier) |namespace|
+//@[15:016) |   |   |   | ├─Token(Colon) |:|
+//@[17:032) |   |   |   | └─StringSyntax
+//@[17:032) |   |   |   |   └─Token(StringComplete) |'ns2FromModule'|
+//@[32:034) |   |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[04:005) |   |   |   └─Token(RightBrace) |}|
+//@[05:007) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[02:003) |   |   └─Token(RightBrace) |}|
+//@[03:005) |   ├─Token(NewLine) |\r\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:005) ├─Token(NewLine) |\r\n\r\n|
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+//@[00:265) ├─ModuleDeclarationSyntax
+//@[00:006) | ├─Token(Identifier) |module|
+//@[07:035) | ├─IdentifierSyntax
+//@[07:035) | | └─Token(Identifier) |moduleWithExtsWithoutAliases|
+//@[36:087) | ├─StringSyntax
+//@[36:087) | | └─Token(StringComplete) |'child/hasConfigurableExtensionsWithoutAlias.bicep'|
+//@[88:089) | ├─Token(Assignment) |=|
+//@[90:265) | └─ObjectSyntax
+//@[90:091) |   ├─Token(LeftBrace) |{|
+//@[91:093) |   ├─Token(NewLine) |\r\n|
+  name: 'moduleWithExtsWithoutAlaises'
+//@[02:038) |   ├─ObjectPropertySyntax
+//@[02:006) |   | ├─IdentifierSyntax
+//@[02:006) |   | | └─Token(Identifier) |name|
+//@[06:007) |   | ├─Token(Colon) |:|
+//@[08:038) |   | └─StringSyntax
+//@[08:038) |   |   └─Token(StringComplete) |'moduleWithExtsWithoutAlaises'|
+//@[38:040) |   ├─Token(NewLine) |\r\n|
+  extensionConfigs: {
+//@[02:129) |   ├─ObjectPropertySyntax
+//@[02:018) |   | ├─IdentifierSyntax
+//@[02:018) |   | | └─Token(Identifier) |extensionConfigs|
+//@[18:019) |   | ├─Token(Colon) |:|
+//@[20:129) |   | └─ObjectSyntax
+//@[20:021) |   |   ├─Token(LeftBrace) |{|
+//@[21:023) |   |   ├─Token(NewLine) |\r\n|
+    kubernetes: {
+//@[04:101) |   |   ├─ObjectPropertySyntax
+//@[04:014) |   |   | ├─IdentifierSyntax
+//@[04:014) |   |   | | └─Token(Identifier) |kubernetes|
+//@[14:015) |   |   | ├─Token(Colon) |:|
+//@[16:101) |   |   | └─ObjectSyntax
+//@[16:017) |   |   |   ├─Token(LeftBrace) |{|
+//@[17:019) |   |   |   ├─Token(NewLine) |\r\n|
+      kubeConfig: 'kubeConfig2FromModule'
+//@[06:041) |   |   |   ├─ObjectPropertySyntax
+//@[06:016) |   |   |   | ├─IdentifierSyntax
+//@[06:016) |   |   |   | | └─Token(Identifier) |kubeConfig|
+//@[16:017) |   |   |   | ├─Token(Colon) |:|
+//@[18:041) |   |   |   | └─StringSyntax
+//@[18:041) |   |   |   |   └─Token(StringComplete) |'kubeConfig2FromModule'|
+//@[41:043) |   |   |   ├─Token(NewLine) |\r\n|
+      namespace: 'ns2FromModule'
+//@[06:032) |   |   |   ├─ObjectPropertySyntax
+//@[06:015) |   |   |   | ├─IdentifierSyntax
+//@[06:015) |   |   |   | | └─Token(Identifier) |namespace|
+//@[15:016) |   |   |   | ├─Token(Colon) |:|
+//@[17:032) |   |   |   | └─StringSyntax
+//@[17:032) |   |   |   |   └─Token(StringComplete) |'ns2FromModule'|
+//@[32:034) |   |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[04:005) |   |   |   └─Token(RightBrace) |}|
+//@[05:007) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[02:003) |   |   └─Token(RightBrace) |}|
+//@[03:005) |   ├─Token(NewLine) |\r\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:005) ├─Token(NewLine) |\r\n\r\n|
+
+// END: Extension configs for modules
+//@[37:039) ├─Token(NewLine) |\r\n|
+
+//@[00:000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.tokens.bicep
@@ -1,0 +1,109 @@
+// BEGIN: Extension declarations
+//@[32:36) NewLine |\r\n\r\n|
+
+// extension kubernetes with {
+//@[30:32) NewLine |\r\n|
+//   kubeConfig: 'DELETE'
+//@[25:27) NewLine |\r\n|
+//   namespace: 'DELETE'
+//@[24:26) NewLine |\r\n|
+// } as k8s
+//@[11:15) NewLine |\r\n\r\n|
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview' as graph
+//@[94:98) NewLine |\r\n\r\n|
+
+// END: Extension declarations
+//@[30:34) NewLine |\r\n\r\n|
+
+// BEGIN: Extension configs for modules
+//@[39:43) NewLine |\r\n\r\n|
+
+module moduleWithExtsWithAliases 'child/hasConfigurableExtensionsWithAlias.bicep' = {
+//@[00:06) Identifier |module|
+//@[07:32) Identifier |moduleWithExtsWithAliases|
+//@[33:81) StringComplete |'child/hasConfigurableExtensionsWithAlias.bicep'|
+//@[82:83) Assignment |=|
+//@[84:85) LeftBrace |{|
+//@[85:87) NewLine |\r\n|
+  name: 'moduleWithExtsWithAliases'
+//@[02:06) Identifier |name|
+//@[06:07) Colon |:|
+//@[08:35) StringComplete |'moduleWithExtsWithAliases'|
+//@[35:37) NewLine |\r\n|
+  extensionConfigs: {
+//@[02:18) Identifier |extensionConfigs|
+//@[18:19) Colon |:|
+//@[20:21) LeftBrace |{|
+//@[21:23) NewLine |\r\n|
+    k8s: {
+//@[04:07) Identifier |k8s|
+//@[07:08) Colon |:|
+//@[09:10) LeftBrace |{|
+//@[10:12) NewLine |\r\n|
+      kubeConfig: 'kubeConfig2FromModule'
+//@[06:16) Identifier |kubeConfig|
+//@[16:17) Colon |:|
+//@[18:41) StringComplete |'kubeConfig2FromModule'|
+//@[41:43) NewLine |\r\n|
+      namespace: 'ns2FromModule'
+//@[06:15) Identifier |namespace|
+//@[15:16) Colon |:|
+//@[17:32) StringComplete |'ns2FromModule'|
+//@[32:34) NewLine |\r\n|
+    }
+//@[04:05) RightBrace |}|
+//@[05:07) NewLine |\r\n|
+  }
+//@[02:03) RightBrace |}|
+//@[03:05) NewLine |\r\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:05) NewLine |\r\n\r\n|
+
+module moduleWithExtsWithoutAliases 'child/hasConfigurableExtensionsWithoutAlias.bicep' = {
+//@[00:06) Identifier |module|
+//@[07:35) Identifier |moduleWithExtsWithoutAliases|
+//@[36:87) StringComplete |'child/hasConfigurableExtensionsWithoutAlias.bicep'|
+//@[88:89) Assignment |=|
+//@[90:91) LeftBrace |{|
+//@[91:93) NewLine |\r\n|
+  name: 'moduleWithExtsWithoutAlaises'
+//@[02:06) Identifier |name|
+//@[06:07) Colon |:|
+//@[08:38) StringComplete |'moduleWithExtsWithoutAlaises'|
+//@[38:40) NewLine |\r\n|
+  extensionConfigs: {
+//@[02:18) Identifier |extensionConfigs|
+//@[18:19) Colon |:|
+//@[20:21) LeftBrace |{|
+//@[21:23) NewLine |\r\n|
+    kubernetes: {
+//@[04:14) Identifier |kubernetes|
+//@[14:15) Colon |:|
+//@[16:17) LeftBrace |{|
+//@[17:19) NewLine |\r\n|
+      kubeConfig: 'kubeConfig2FromModule'
+//@[06:16) Identifier |kubeConfig|
+//@[16:17) Colon |:|
+//@[18:41) StringComplete |'kubeConfig2FromModule'|
+//@[41:43) NewLine |\r\n|
+      namespace: 'ns2FromModule'
+//@[06:15) Identifier |namespace|
+//@[15:16) Colon |:|
+//@[17:32) StringComplete |'ns2FromModule'|
+//@[32:34) NewLine |\r\n|
+    }
+//@[04:05) RightBrace |}|
+//@[05:07) NewLine |\r\n|
+  }
+//@[02:03) RightBrace |}|
+//@[03:05) NewLine |\r\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:05) NewLine |\r\n\r\n|
+
+// END: Extension configs for modules
+//@[37:39) NewLine |\r\n|
+
+//@[00:00) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/bicepconfig.json
@@ -1,0 +1,6 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true,
+    "moduleExtensionConfigs": true
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/main.bicep
@@ -1,0 +1,6 @@
+extension kubernetes with {
+  kubeConfig: '1'
+  namespace: 'default'
+} as k8s
+
+//extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview'

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.bicepparam
@@ -1,0 +1,6 @@
+using 'main.bicep'
+
+extension k8s with {
+  kubeConfig: 'configFromParamFile'
+  namespace: 'nsFromParamFile'
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.diagnostics.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.diagnostics.bicepparam
@@ -1,0 +1,7 @@
+using 'main.bicep'
+
+extension k8s with {
+  kubeConfig: 'configFromParamFile'
+  namespace: 'nsFromParamFile'
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.formatted.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.formatted.bicepparam
@@ -1,0 +1,6 @@
+using 'main.bicep'
+
+extension k8s with {
+  kubeConfig: 'configFromParamFile'
+  namespace: 'nsFromParamFile'
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.json
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "extensionConfigs": {
+    "k8s": {}
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.symbols.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.symbols.bicepparam
@@ -1,0 +1,7 @@
+using 'main.bicep'
+
+extension k8s with {
+  kubeConfig: 'configFromParamFile'
+  namespace: 'nsFromParamFile'
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.syntax.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.syntax.bicepparam
@@ -1,0 +1,39 @@
+using 'main.bicep'
+//@[00:110) ProgramSyntax
+//@[00:018) ├─UsingDeclarationSyntax
+//@[00:005) | ├─Token(Identifier) |using|
+//@[06:018) | └─StringSyntax
+//@[06:018) |   └─Token(StringComplete) |'main.bicep'|
+//@[18:020) ├─Token(NewLine) |\n\n|
+
+extension k8s with {
+//@[00:089) ├─ExtensionConfigAssignmentSyntax
+//@[00:009) | ├─Token(Identifier) |extension|
+//@[10:013) | ├─IdentifierSyntax
+//@[10:013) | | └─Token(Identifier) |k8s|
+//@[14:089) | └─ExtensionWithClauseSyntax
+//@[14:018) |   ├─Token(Identifier) |with|
+//@[19:089) |   └─ObjectSyntax
+//@[19:020) |     ├─Token(LeftBrace) |{|
+//@[20:021) |     ├─Token(NewLine) |\n|
+  kubeConfig: 'configFromParamFile'
+//@[02:035) |     ├─ObjectPropertySyntax
+//@[02:012) |     | ├─IdentifierSyntax
+//@[02:012) |     | | └─Token(Identifier) |kubeConfig|
+//@[12:013) |     | ├─Token(Colon) |:|
+//@[14:035) |     | └─StringSyntax
+//@[14:035) |     |   └─Token(StringComplete) |'configFromParamFile'|
+//@[35:036) |     ├─Token(NewLine) |\n|
+  namespace: 'nsFromParamFile'
+//@[02:030) |     ├─ObjectPropertySyntax
+//@[02:011) |     | ├─IdentifierSyntax
+//@[02:011) |     | | └─Token(Identifier) |namespace|
+//@[11:012) |     | ├─Token(Colon) |:|
+//@[13:030) |     | └─StringSyntax
+//@[13:030) |     |   └─Token(StringComplete) |'nsFromParamFile'|
+//@[30:031) |     ├─Token(NewLine) |\n|
+}
+//@[00:001) |     └─Token(RightBrace) |}|
+//@[01:002) ├─Token(NewLine) |\n|
+
+//@[00:000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.tokens.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Extensions/parameters.tokens.bicepparam
@@ -1,0 +1,26 @@
+using 'main.bicep'
+//@[00:05) Identifier |using|
+//@[06:18) StringComplete |'main.bicep'|
+//@[18:20) NewLine |\n\n|
+
+extension k8s with {
+//@[00:09) Identifier |extension|
+//@[10:13) Identifier |k8s|
+//@[14:18) Identifier |with|
+//@[19:20) LeftBrace |{|
+//@[20:21) NewLine |\n|
+  kubeConfig: 'configFromParamFile'
+//@[02:12) Identifier |kubeConfig|
+//@[12:13) Colon |:|
+//@[14:35) StringComplete |'configFromParamFile'|
+//@[35:36) NewLine |\n|
+  namespace: 'nsFromParamFile'
+//@[02:11) Identifier |namespace|
+//@[11:12) Colon |:|
+//@[13:30) StringComplete |'nsFromParamFile'|
+//@[30:31) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:02) NewLine |\n|
+
+//@[00:00) EndOfFile ||

--- a/src/Bicep.Core.UnitTests/Assertions/IDiagnosticCollectionExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/IDiagnosticCollectionExtensions.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Linq;
+
 using Bicep.Core.Diagnostics;
 using FluentAssertions;
 using FluentAssertions.Collections;
@@ -34,6 +34,13 @@ namespace Bicep.Core.UnitTests.Assertions
             AssertionExtensions.Should(Subject).Contain(x => x.Code == code && x.Level == level && DiagnosticAssertions.DiagnosticMessageMatches(x.Message, message), because, becauseArgs);
 
             return new AndConstraint<IDiagnosticCollectionAssertions>(this);
+        }
+
+        public AndConstraint<IDiagnosticCollectionAssertions> ContainDiagnostic(Func<DiagnosticBuilder.DiagnosticBuilderInternal, Diagnostic> diagnosticFactory, string because = "", params object[] becauseArgs)
+        {
+            var diagnostic = diagnosticFactory(DiagnosticBuilder.ForDocumentStart());
+
+            return ContainDiagnostic(diagnostic.Code, diagnostic.Level, diagnostic.Message, because, becauseArgs);
         }
 
         public AndConstraint<IDiagnosticCollectionAssertions> NotContainDiagnostic(string code, string because = "", params object[] becauseArgs)

--- a/src/Bicep.Core.UnitTests/Extensions/CompilationTestExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Extensions/CompilationTestExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Text;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Emit;
+using Bicep.Core.Semantics;
+
+namespace Bicep.Core.UnitTests.Extensions;
+
+public static class CompilationTestExtensions
+{
+    public static (bool success, IDictionary<Uri, ImmutableArray<IDiagnostic>> diagnosticsByFile) GetSuccessAndDiagnosticsByBicepFile(this Compilation compilation)
+    {
+        var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile().ToDictionary(kvp => kvp.Key.Uri, kvp => kvp.Value);
+        var success = diagnosticsByFile.Values.SelectMany(x => x).All(d => !d.IsError());
+
+        return (success, diagnosticsByFile);
+    }
+
+    public static string GetTestTemplate(this Compilation compilation)
+    {
+        var stringBuilder = new StringBuilder();
+        var stringWriter = new StringWriter(stringBuilder);
+
+        var emitter = new TemplateEmitter(compilation.GetEntrypointSemanticModel());
+        emitter.Emit(stringWriter);
+
+        return stringBuilder.ToString();
+    }
+}

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -184,6 +184,9 @@ namespace Bicep.Core.Emit
                 case ParametersAssignmentReferenceExpression exp:
                     return CreateFunction("parameters", new JTokenExpression(exp.Parameter.Name));
 
+                case ExtensionConfigAssignmentExpression exp:
+                    return CreateFunction("extensionConfigs", new JTokenExpression(exp.ExtensionConfigAssignment.Name));
+
                 case LambdaExpression exp:
                     var variableNames = exp.Parameters.Select(x => new JTokenExpression(x));
                     var body = ConvertExpression(exp.Body);

--- a/src/Bicep.Core/Emit/ExpressionEmitter.cs
+++ b/src/Bicep.Core/Emit/ExpressionEmitter.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.Collections.Immutable;
+
 using Azure.Deployments.Expression.Configuration;
 using Azure.Deployments.Expression.Expressions;
 using Azure.Deployments.Expression.Serializers;
@@ -325,7 +325,9 @@ namespace Bicep.Core.Emit
             {
                 case ResourceFunctionCallExpression functionCall when
                     LanguageConstants.IdentifierComparer.Equals(functionCall.Name, AzResourceTypeProvider.GetSecretFunctionName):
-                    return ConvertModuleParameterGetSecret(functionCall);
+                    return ExpressionFactory.CreateObject(
+                        [ExpressionFactory.CreateObjectProperty("reference", ConvertToKeyVaultReference(functionCall))],
+                        functionCall.SourceSyntax);
                 case TernaryExpression ternary:
                     return new TernaryExpression(ternary.SourceSyntax, ternary.Condition, ConvertModuleParameter(ternary.True), ConvertModuleParameter(ternary.False));
                 default:
@@ -335,21 +337,41 @@ namespace Bicep.Core.Emit
             }
         }
 
-        private static Expression ConvertModuleParameterGetSecret(ResourceFunctionCallExpression functionCall)
+        public static Expression ConvertModuleExtensionConfig(Expression extensionConfigValueExpr) =>
+            extensionConfigValueExpr switch
+            {
+                // TODO(kylealbert): "extensionConfigs" function handling.
+                ResourceFunctionCallExpression functionCall when LanguageConstants.IdentifierComparer.Equals(functionCall.Name, AzResourceTypeProvider.GetSecretFunctionName)
+                    => ExpressionFactory.CreateObject(
+                        [ExpressionFactory.CreateObjectProperty("keyVaultReference", ConvertToKeyVaultReference(functionCall))],
+                        functionCall.SourceSyntax),
+                TernaryExpression ternary => new TernaryExpression(ternary.SourceSyntax, ternary.Condition, ConvertModuleExtensionConfig(ternary.True), ConvertModuleExtensionConfig(ternary.False)),
+                _ => ExpressionFactory.CreateObject(
+                    [ExpressionFactory.CreateObjectProperty("value", extensionConfigValueExpr)],
+                    extensionConfigValueExpr.SourceSyntax)
+            };
+
+        private static ObjectExpression ConvertToKeyVaultReference(ResourceFunctionCallExpression functionCall)
         {
-            var properties = new List<ObjectPropertyExpression>();
-            properties.Add(ExpressionFactory.CreateObjectProperty("keyVault", ExpressionFactory.CreateObject(new[] {
-                ExpressionFactory.CreateObjectProperty("id", new PropertyAccessExpression(functionCall.Resource.SourceSyntax, functionCall.Resource, "id", AccessExpressionFlags.None)),
-            }, functionCall.SourceSyntax)));
-            properties.Add(ExpressionFactory.CreateObjectProperty("secretName", functionCall.Parameters[0]));
+            var properties = new List<ObjectPropertyExpression>
+            {
+                ExpressionFactory.CreateObjectProperty(
+                    "keyVault",
+                    ExpressionFactory.CreateObject(
+                        [
+                            ExpressionFactory.CreateObjectProperty(
+                                "id", new PropertyAccessExpression(functionCall.Resource.SourceSyntax, functionCall.Resource, "id", AccessExpressionFlags.None))
+                        ],
+                        functionCall.SourceSyntax)),
+                ExpressionFactory.CreateObjectProperty("secretName", functionCall.Parameters[0])
+            };
+
             if (functionCall.Parameters.Length > 1)
             {
                 properties.Add(ExpressionFactory.CreateObjectProperty("secretVersion", functionCall.Parameters[1]));
             }
 
-            return ExpressionFactory.CreateObject(new[] {
-                ExpressionFactory.CreateObjectProperty("reference", ExpressionFactory.CreateObject(properties))
-            }, functionCall.SourceSyntax);
+            return ExpressionFactory.CreateObject(properties);
         }
 
         public void EmitProperty(ObjectPropertyExpression property)

--- a/src/Bicep.Core/Emit/ParametersJsonWriter.cs
+++ b/src/Bicep.Core/Emit/ParametersJsonWriter.cs
@@ -55,6 +55,29 @@ public class ParametersJsonWriter
 
         jsonWriter.WriteEndObject();
 
+        if (model.Features is { ExtensibilityEnabled: true, ModuleExtensionConfigsEnabled: true })
+        {
+            WriteExtensionConfigs(jsonWriter);
+        }
+
+        jsonWriter.WriteEndObject();
+    }
+
+    private void WriteExtensionConfigs(JsonTextWriter jsonWriter)
+    {
+        jsonWriter.WritePropertyName("extensionConfigs");
+        jsonWriter.WriteStartObject();
+
+        foreach (var extension in model.Root.ExtensionConfigAssignments)
+        {
+            jsonWriter.WritePropertyName(extension.Name);
+            jsonWriter.WriteStartObject();
+
+            // TODO(kylealbert): write config properties
+
+            jsonWriter.WriteEndObject();
+        }
+
         jsonWriter.WriteEndObject();
     }
 

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -1256,7 +1256,7 @@ namespace Bicep.Core.Emit
                     }
                 }
 
-                // Emit the options property 
+                // Emit the options property
                 if (resource.RetryOn is not null || resource.WaitUntil is not null)
                 {
                     emitter.EmitObjectProperty("options", () =>
@@ -1398,6 +1398,73 @@ namespace Bicep.Core.Emit
             }, paramsObject.SourceSyntax);
         }
 
+        private void EmitModuleExtensionConfigs(ExpressionEmitter emitter, DeclaredModuleExpression module)
+        {
+            if (module.ExtensionConfigs is not ObjectExpression extConfigsObjExpr)
+            {
+                // 'extensionConfigs' is optional if the module has no required extension configurations
+                return;
+            }
+
+            emitter.EmitObjectProperty(
+                "extensionConfigs", () =>
+                {
+                    foreach (var extAliasPropertyExpr in extConfigsObjExpr.Properties)
+                    {
+                        if (extAliasPropertyExpr.TryGetKeyText() is not { } extAlias)
+                        {
+                            // should have been caught by earlier validation
+                            throw new ArgumentException("Disallowed interpolation in module extension config alias key");
+                        }
+
+                        if (extAliasPropertyExpr.Value is ObjectExpression extConfigObjExpr)
+                        {
+                            emitter.EmitObjectProperty(
+                                extAlias, () =>
+                                {
+                                    foreach (var extConfigPropertyExpr in extConfigObjExpr.Properties)
+                                    {
+                                        if (extConfigPropertyExpr.TryGetKeyText() is not { } extConfigPropertyName)
+                                        {
+                                            // should have been caught by earlier validation
+                                            throw new ArgumentException("Disallowed interpolation in module extension config property key");
+                                        }
+
+                                        // we can't just call EmitObjectProperties here because the ObjectSyntax is flatter than the structure we're generating
+                                        // because nested deployment extension configs are objects with a single value property
+                                        if (extConfigPropertyExpr.Value is ForLoopExpression @for)
+                                        {
+                                            // the value is a for-expression
+                                            // write a single property copy loop
+                                            emitter.EmitObjectProperty(extConfigPropertyName, () => { emitter.EmitCopyProperty(() => { emitter.EmitArray(() => { emitter.EmitCopyObject("value", @for.Expression, @for.Body, "value"); }, @for.SourceSyntax); }); });
+                                        }
+                                        else if (extConfigPropertyExpr.Value is ResourceReferenceExpression resource &&
+                                            module.Symbol.TryGetModuleType() is ModuleType moduleType &&
+                                            moduleType.TryGetExtensionConfigPropertyType(extAlias, extConfigPropertyName) is ResourceParameterType)
+                                        {
+                                            // TODO(kylealbert): verify this
+                                            // This is a resource being passed into a module, we actually want to pass in its id
+                                            // rather than the whole resource.
+                                            var idExpression = new PropertyAccessExpression(resource.SourceSyntax, resource, "id", AccessExpressionFlags.None);
+                                            emitter.EmitProperty(extConfigPropertyName, ExpressionEmitter.ConvertModuleExtensionConfig(idExpression));
+                                        }
+                                        else
+                                        {
+                                            // the value is not a for-expression - can emit normally
+                                            emitter.EmitProperty(extConfigPropertyName, ExpressionEmitter.ConvertModuleExtensionConfig(extConfigPropertyExpr.Value));
+                                        }
+                                    }
+                                });
+                        }
+                        else
+                        {
+                            // TODO(kylealbert): ternaries, extension symbols
+                            throw new NotImplementedException($"Expression emit is not handled for {extAliasPropertyExpr.Value.GetType().Name}");
+                        }
+                    }
+                }, extConfigsObjExpr.SourceSyntax);
+        }
+
         private void EmitModuleForLocalDeploy(PositionTrackingJsonTextWriter jsonWriter, DeclaredModuleExpression module, ExpressionEmitter emitter)
         {
             emitter.EmitObject(() =>
@@ -1421,6 +1488,11 @@ namespace Bicep.Core.Emit
                 emitter.EmitObjectProperty("properties", () =>
                 {
                     EmitModuleParameters(emitter, module);
+
+                    if (this.Context.SemanticModel.Features is { ExtensibilityEnabled: true, ModuleExtensionConfigsEnabled: true })
+                    {
+                        EmitModuleExtensionConfigs(emitter, module);
+                    }
 
                     var moduleSemanticModel = GetModuleSemanticModel(module.Symbol);
 
@@ -1510,6 +1582,11 @@ namespace Bicep.Core.Emit
                     emitter.EmitProperty("mode", "Incremental");
 
                     EmitModuleParameters(emitter, module);
+
+                    if (Context.SemanticModel.Features is { ExtensibilityEnabled: true, ModuleExtensionConfigsEnabled: true })
+                    {
+                        EmitModuleExtensionConfigs(emitter, module);
+                    }
 
                     var moduleSemanticModel = GetModuleSemanticModel(moduleSymbol);
 

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -1454,7 +1454,7 @@ namespace Bicep.Core.Emit
                                             emitter.EmitProperty(extConfigPropertyName, ExpressionEmitter.ConvertModuleExtensionConfig(extConfigPropertyExpr.Value));
                                         }
                                     }
-                                });
+                                }, extConfigObjExpr.SourceSyntax);
                         }
                         else
                         {

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -401,6 +401,16 @@ public record ExtensionExpression(
     protected override object? GetDebugAttributes() => new { Name };
 }
 
+public record ExtensionConfigAssignmentExpression(
+    SyntaxBase? SourceSyntax,
+    ExtensionConfigAssignmentSymbol ExtensionConfigAssignment) : Expression(SourceSyntax)
+{
+    public override void Accept(IExpressionVisitor visitor)
+        => visitor.VisitExtensionConfigAssignmentExpression(this);
+
+    protected override object? GetDebugAttributes() => new { ExtensionAlias = ExtensionConfigAssignment.Name };
+}
+
 public abstract record TypeDeclaringExpression(
     SyntaxBase? SourceSyntax,
     Expression? Description,

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -508,6 +508,7 @@ public record DeclaredModuleExpression(
     SyntaxBase BodySyntax,
     Expression Body,
     Expression? Parameters,
+    Expression? ExtensionConfigs,
     ImmutableArray<ResourceDependencyExpression> DependsOn,
     Expression? Description = null
 ) : DescribableExpression(SourceSyntax, Description)

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -36,6 +36,7 @@ public class ExpressionBuilder
     private static readonly ImmutableHashSet<string> ModulePropertiesToOmit = [
         AzResourceTypeProvider.ResourceNamePropertyName,
         LanguageConstants.ModuleParamsPropertyName,
+        LanguageConstants.ModuleExtensionConfigsPropertyName,
         LanguageConstants.ResourceScopePropertyName,
         LanguageConstants.ResourceDependsOnPropertyName,
     ];
@@ -567,7 +568,9 @@ public class ExpressionBuilder
             .Select(ConvertObjectProperty)
             .Append(CreateModuleNameExpression(symbol, objectBody));
         Expression bodyExpression = new ObjectExpression(body, properties.ToImmutableArray());
+
         var parameters = objectBody.TryGetPropertyByName(LanguageConstants.ModuleParamsPropertyName);
+        var extensionConfigs = objectBody.TryGetPropertyByName(LanguageConstants.ModuleExtensionConfigsPropertyName);
 
         if (condition is not null)
         {
@@ -591,6 +594,7 @@ public class ExpressionBuilder
             body,
             bodyExpression,
             parameters is not null ? ConvertWithoutLowering(parameters.Value) : null,
+            extensionConfigs is not null ? ConvertWithoutLowering(extensionConfigs.Value) : null,
             BuildDependencyExpressions(symbol, body));
     }
 

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -1082,6 +1082,9 @@ public class ExpressionBuilder
             case ParameterAssignmentSymbol parameterSymbol:
                 return new ParametersAssignmentReferenceExpression(variableAccessSyntax, parameterSymbol);
 
+            case ExtensionConfigAssignmentSymbol extensionConfigAssignmentSymbol:
+                return new ExtensionConfigAssignmentExpression(variableAccessSyntax, extensionConfigAssignmentSymbol);
+
             case VariableSymbol variableSymbol:
                 if (Context.VariablesToInline.Contains(variableSymbol))
                 {

--- a/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionRewriteVisitor.cs
@@ -256,6 +256,13 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         return hasChanges ? expression with { Config = config, Description = description } : expression;
     }
 
+    void IExpressionVisitor.VisitExtensionConfigAssignmentExpression(ExtensionConfigAssignmentExpression expression) => ReplaceCurrent(expression, ReplaceExtensionConfigAssignmentExpression);
+
+    public virtual Expression ReplaceExtensionConfigAssignmentExpression(ExtensionConfigAssignmentExpression expression)
+    {
+        return expression;
+    }
+
     void IExpressionVisitor.VisitDeclaredParameterExpression(DeclaredParameterExpression expression) => ReplaceCurrent(expression, ReplaceDeclaredParameterExpression);
     public virtual Expression ReplaceDeclaredParameterExpression(DeclaredParameterExpression expression)
     {
@@ -394,10 +401,11 @@ public abstract class ExpressionRewriteVisitor : IExpressionVisitor
         var hasChanges =
             TryRewrite(expression.Body, out var body) |
             TryRewrite(expression.Parameters, out var parameters) |
+            TryRewrite(expression.ExtensionConfigs, out var extensionConfigs) |
             TryRewriteStrict(expression.DependsOn, out var dependsOn) |
             TryRewriteDescription(expression, out var description);
 
-        return hasChanges ? expression with { Body = body, Parameters = parameters, DependsOn = dependsOn, Description = description } : expression;
+        return hasChanges ? expression with { Body = body, Parameters = parameters, ExtensionConfigs = extensionConfigs, DependsOn = dependsOn, Description = description } : expression;
     }
 
     void IExpressionVisitor.VisitResourceDependencyExpression(ResourceDependencyExpression expression) => ReplaceCurrent(expression, ReplaceResourceDependencyExpression);

--- a/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionVisitor.cs
@@ -163,6 +163,12 @@ public abstract class ExpressionVisitor : IExpressionVisitor
         Visit(expression.Config);
     }
 
+    public void VisitExtensionConfigAssignmentExpression(ExtensionConfigAssignmentExpression expression)
+    {
+        // TODO(kylealbert): Is this needed?
+        //Visit(expression.Config);
+    }
+
     public virtual void VisitDeclaredParameterExpression(DeclaredParameterExpression expression)
     {
         VisitTypeDeclaringExpression(expression);
@@ -216,6 +222,7 @@ public abstract class ExpressionVisitor : IExpressionVisitor
         Visit(expression.Body);
         Visit(expression.Parameters);
         Visit(expression.DependsOn);
+        Visit(expression.ExtensionConfigs);
     }
 
     public virtual void VisitResourceDependencyExpression(ResourceDependencyExpression expression)

--- a/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
+++ b/src/Bicep.Core/Intermediate/IExpressionVisitor.cs
@@ -63,6 +63,8 @@ public interface IExpressionVisitor
 
     void VisitExtensionExpression(ExtensionExpression expression);
 
+    void VisitExtensionConfigAssignmentExpression(ExtensionConfigAssignmentExpression expression);
+
     void VisitDeclaredParameterExpression(DeclaredParameterExpression expression);
 
     void VisitDeclaredVariableExpression(DeclaredVariableExpression expression);

--- a/src/Bicep.Core/Parsing/ParamsParser.cs
+++ b/src/Bicep.Core/Parsing/ParamsParser.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.Collections.Immutable;
 using Bicep.Core.Syntax;
 
@@ -60,6 +61,7 @@ namespace Bicep.Core.Parsing
                             LanguageConstants.ParameterKeyword => this.ParameterAssignment(),
                             LanguageConstants.VariableKeyword => this.VariableDeclaration(leadingNodes),
                             LanguageConstants.ImportKeyword => this.CompileTimeImportDeclaration(ExpectKeyword(LanguageConstants.ImportKeyword), leadingNodes),
+                            LanguageConstants.ExtensionKeyword => this.ExtensionConfigAssignment(leadingNodes),
                             _ => throw new ExpectedTokenException(current, b => b.UnrecognizedParamsFileDeclaration()),
                         },
                         TokenType.NewLine => this.NewLine(),
@@ -105,6 +107,32 @@ namespace Bicep.Core.Parsing
             var value = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(assignment), TokenType.NewLine);
 
             return new ParameterAssignmentSyntax(keyword, name, assignment, value);
+        }
+
+        private ExtensionConfigAssignmentSyntax ExtensionConfigAssignment(IEnumerable<SyntaxBase> leadingNodes)
+        {
+            var extKeyword = ExpectKeyword(LanguageConstants.ExtensionKeyword);
+
+            var specificationSyntax = reader.Peek().Type switch
+            {
+                TokenType.Identifier => new IdentifierSyntax(reader.Read()),
+                _ => this.WithRecovery(
+                    () => ThrowIfSkipped(this.InterpolableString, b => b.ExpectedExtensionSpecification()),
+                    RecoveryFlags.None,
+                    TokenType.NewLine)
+            };
+
+            var withClause = this.WithRecovery(this.ExtensionWithClause, GetSuppressionFlag(specificationSyntax), TokenType.NewLine);
+
+            return new(leadingNodes, extKeyword, specificationSyntax, withClause);
+        }
+
+        private ExtensionWithClauseSyntax ExtensionWithClause()
+        {
+            var keyword = this.ExpectKeyword(LanguageConstants.WithKeyword);
+            var config = this.WithRecovery(() => this.Object(ExpressionFlags.AllowComplexLiterals), RecoveryFlags.None, TokenType.NewLine);
+
+            return new(keyword, config);
         }
     }
 }

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.SyntaxVisitor.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.SyntaxVisitor.cs
@@ -52,6 +52,8 @@ namespace Bicep.Core.PrettyPrintV2
 
         public void VisitExtensionDeclarationSyntax(ExtensionDeclarationSyntax syntax) => this.Apply(syntax, this.LayoutExtensionDeclarationSyntax);
 
+        public void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax) => this.Apply(syntax, this.LayoutExtensionConfigAssignmentSyntax);
+
         public void VisitExtensionWithClauseSyntax(ExtensionWithClauseSyntax syntax) => this.Apply(syntax, this.LayoutExtensionWithClauseSyntax);
 
         public void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax) => this.Apply(syntax, this.LayoutInstanceFunctionCallSyntax);

--- a/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
+++ b/src/Bicep.Core/PrettyPrintV2/SyntaxLayouts.cs
@@ -6,7 +6,6 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrintV2.Documents;
 using Bicep.Core.Syntax;
-using Microsoft.Extensions.Primitives;
 using static Bicep.Core.PrettyPrintV2.Documents.DocumentOperators;
 
 namespace Bicep.Core.PrettyPrintV2
@@ -117,6 +116,14 @@ namespace Bicep.Core.PrettyPrintV2
                     syntax.SpecificationString,
                     syntax.WithClause,
                     syntax.AsClause));
+
+        private IEnumerable<Document> LayoutExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax) =>
+            this.LayoutLeadingNodes(syntax.LeadingNodes)
+                .Concat(
+                    this.Spread(
+                        syntax.Keyword,
+                        syntax.SpecificationString,
+                        syntax.WithClause));
 
         private IEnumerable<Document> LayoutExtensionWithClauseSyntax(ExtensionWithClauseSyntax syntax) =>
             this.Spread(

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -8,11 +8,9 @@ using Azure.Deployments.Core.Definitions.Schema;
 using Azure.Deployments.Core.Entities;
 using Azure.Deployments.Templates.Engines;
 using Azure.Deployments.Templates.Exceptions;
-using Azure.Deployments.Templates.Export;
 using Bicep.Core.ArmHelpers;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
-using Bicep.Core.Extensions;
 using Bicep.Core.Resources;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Semantics.Namespaces;
@@ -29,6 +27,7 @@ namespace Bicep.Core.Semantics
     {
         private readonly Lazy<ResourceScope> targetScopeLazy;
         private readonly Lazy<ImmutableSortedDictionary<string, ParameterMetadata>> parametersLazy;
+        private readonly Lazy<ImmutableSortedDictionary<string, ExtensionMetadata>> extensionsLazy;
         private readonly Lazy<ImmutableSortedDictionary<string, ExportMetadata>> exportsLazy;
         private readonly Lazy<ImmutableArray<OutputMetadata>> outputsLazy;
 
@@ -91,6 +90,8 @@ namespace Bicep.Core.Semantics
                         LanguageConstants.IdentifierComparer);
             });
 
+            this.extensionsLazy = new(FindExtensions);
+
             this.exportsLazy = new(FindExports);
 
             this.outputsLazy = new(() =>
@@ -116,6 +117,8 @@ namespace Bicep.Core.Semantics
             : this.targetScopeLazy.Value;
 
         public ImmutableSortedDictionary<string, ParameterMetadata> Parameters => this.parametersLazy.Value;
+
+        public ImmutableSortedDictionary<string, ExtensionMetadata> Extensions => this.extensionsLazy.Value;
 
         public ImmutableSortedDictionary<string, ExportMetadata> Exports => exportsLazy.Value;
 
@@ -214,6 +217,23 @@ namespace Bicep.Core.Semantics
 
                 _ => GetType((ITemplateSchemaNode)output),
             };
+        }
+
+        private ImmutableSortedDictionary<string, ExtensionMetadata> FindExtensions()
+        {
+            if (this.SourceFile.FeatureProvider is not { ExtensibilityEnabled: true, ModuleExtensionConfigsEnabled: true } || this.SourceFile.Template?.Extensions is null)
+            {
+                return ImmutableSortedDictionary<string, ExtensionMetadata>.Empty;
+            }
+
+            return this.SourceFile.Template.Extensions
+                .ToImmutableSortedDictionary(
+                    ext => ext.Key,
+                    ext =>
+                    {
+                        // TODO(kylealbert): Get namespace type.
+                        return new ExtensionMetadata(ext.Key, ext.Value.Name.Value, ext.Value.Version.Value, null);
+                    });
         }
 
         private ImmutableSortedDictionary<string, ExportMetadata> FindExports()

--- a/src/Bicep.Core/Semantics/Compilation.cs
+++ b/src/Bicep.Core/Semantics/Compilation.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.Collections.Immutable;
 using Bicep.Core.Analyzers.Interfaces;
-using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
-using Bicep.Core.Extensions;
-using Bicep.Core.Features;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Utils;
@@ -81,6 +79,9 @@ namespace Bicep.Core.Semantics
             => SourceFileGrouping.SourceFiles.OfType<BicepSourceFile>().ToImmutableDictionary(
                 bicepFile => bicepFile,
                 bicepFile => this.GetSemanticModel(bicepFile) is SemanticModel semanticModel ? semanticModel.GetAllDiagnostics() : []);
+
+        public ImmutableDictionary<Uri, ImmutableArray<IDiagnostic>> GetAllDiagnosticsByBicepFileUri()
+            => GetAllDiagnosticsByBicepFile().ToImmutableDictionary(kvp => kvp.Key.Uri, bicepFile => bicepFile.Value);
 
         private T GetSemanticModel<T>(ISourceFile sourceFile) where T : class, ISemanticModel =>
             this.GetSemanticModel(sourceFile) as T ??

--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -1,20 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.Collections.Immutable;
-using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
-using Bicep.Core.Features;
 using Bicep.Core.Navigation;
-using Bicep.Core.Registry.Oci;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
-using Bicep.Core.Syntax.Visitors;
-using Bicep.Core.TypeSystem;
-using Bicep.Core.TypeSystem.Providers;
-using Bicep.Core.TypeSystem.Types;
-using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.Semantics
@@ -178,6 +171,20 @@ namespace Bicep.Core.Semantics
             base.VisitParameterAssignmentSyntax(syntax);
 
             var symbol = new ParameterAssignmentSymbol(this.context, syntax.Name.IdentifierName, syntax);
+            DeclareSymbol(symbol);
+        }
+
+        public override void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax)
+        {
+            base.VisitExtensionConfigAssignmentSyntax(syntax);
+
+            if (syntax.TryGetSymbolName() is not { } extAlias)
+            {
+                // TODO(kylealbert): Figure out specifics for spec strings vs alias.
+                return;
+            }
+
+            var symbol = new ExtensionConfigAssignmentSymbol(this.context, extAlias, syntax);
             DeclareSymbol(symbol);
         }
 

--- a/src/Bicep.Core/Semantics/EmptySemanticModel.cs
+++ b/src/Bicep.Core/Semantics/EmptySemanticModel.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
-using Bicep.Core.Diagnostics;
-using Bicep.Core.Emit;
-using Bicep.Core.Parsing;
 using Bicep.Core.Semantics.Metadata;
-using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.Workspaces;
 
@@ -19,6 +15,8 @@ namespace Bicep.Core.Semantics
         public ResourceScope TargetScope => ResourceScope.None;
 
         public ImmutableSortedDictionary<string, ParameterMetadata> Parameters => ImmutableSortedDictionary<string, ParameterMetadata>.Empty;
+
+        public ImmutableSortedDictionary<string, ExtensionMetadata> Extensions => ImmutableSortedDictionary<string, ExtensionMetadata>.Empty;
 
         public ImmutableSortedDictionary<string, ExportMetadata> Exports => ImmutableSortedDictionary<string, ExportMetadata>.Empty;
 

--- a/src/Bicep.Core/Semantics/ExtensionConfigAssignmentSymbol.cs
+++ b/src/Bicep.Core/Semantics/ExtensionConfigAssignmentSymbol.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Parsing;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.Semantics
+{
+    public class ExtensionConfigAssignmentSymbol : DeclaredSymbol
+    {
+        private sealed class ExtensionConfigAssignmentNameSource : ISymbolNameSource
+        {
+            public ExtensionConfigAssignmentNameSource(ExtensionConfigAssignmentSyntax syntax)
+            {
+                // TODO(kylealbert): is this right?
+                this.Span = syntax.SpecificationString.Span;
+            }
+
+            public TextSpan Span { get; }
+
+            public bool IsValid => true;
+        }
+
+        public ExtensionConfigAssignmentSymbol(ISymbolContext context, string name, ExtensionConfigAssignmentSyntax declaringSyntax)
+            : base(context, name, declaringSyntax, new ExtensionConfigAssignmentNameSource(declaringSyntax))
+        {
+        }
+
+        /// <summary>
+        /// Gets the syntax node that declared this symbol.
+        /// </summary>
+        public ExtensionConfigAssignmentSyntax DeclaringExtensionConfigAssignment => (ExtensionConfigAssignmentSyntax)this.DeclaringSyntax;
+
+        public override SymbolKind Kind => SymbolKind.ExtensionConfigAssignment;
+
+        public override IEnumerable<Symbol> Descendants
+        {
+            get { yield return this.Type; }
+        }
+
+        public override void Accept(SymbolVisitor visitor) => visitor.VisitExtensionConfigAssignmentSymbol(this);
+    }
+}

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
@@ -7,7 +8,6 @@ using Bicep.Core.Navigation;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem.Types;
-using Bicep.Core.Utils;
 using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.Semantics
@@ -33,6 +33,7 @@ namespace Bicep.Core.Semantics
 
             var declarationsBySyntax = ImmutableDictionary.CreateBuilder<SyntaxBase, DeclaredSymbol>();
             var extensionDeclarations = ImmutableArray.CreateBuilder<ExtensionNamespaceSymbol>();
+            var extensionConfigAssignments = ImmutableArray.CreateBuilder<ExtensionConfigAssignmentSymbol>();
             var metadataDeclarations = ImmutableArray.CreateBuilder<MetadataSymbol>();
             var parameterDeclarations = ImmutableArray.CreateBuilder<ParameterSymbol>();
             var typeDeclarations = ImmutableArray.CreateBuilder<TypeAliasSymbol>();
@@ -58,6 +59,11 @@ namespace Bicep.Core.Semantics
                 {
                     case ExtensionNamespaceSymbol extensionNamespace:
                         extensionDeclarations.Add(extensionNamespace);
+
+                        break;
+                    case ExtensionConfigAssignmentSymbol extensionConfigAssignment:
+                        extensionConfigAssignments.Add(extensionConfigAssignment);
+
                         break;
                     case MetadataSymbol metadata:
                         metadataDeclarations.Add(metadata);
@@ -112,6 +118,7 @@ namespace Bicep.Core.Semantics
 
             DeclarationsBySyntax = declarationsBySyntax.ToImmutable();
             ExtensionDeclarations = extensionDeclarations.ToImmutable();
+            ExtensionConfigAssignments = extensionConfigAssignments.ToImmutable();
             MetadataDeclarations = metadataDeclarations.ToImmutable();
             ParameterDeclarations = parameterDeclarations.ToImmutable();
             TypeDeclarations = typeDeclarations.ToImmutable();
@@ -137,6 +144,7 @@ namespace Bicep.Core.Semantics
         public override IEnumerable<Symbol> Descendants =>
             this.NamespaceResolver.ImplicitNamespaces.Values
             .Concat<Symbol>(this.ExtensionDeclarations)
+            .Concat(this.ExtensionConfigAssignments)
             .Concat(this.LocalScopes)
             .Concat(this.MetadataDeclarations)
             .Concat(this.ParameterDeclarations)
@@ -196,6 +204,8 @@ namespace Bicep.Core.Semantics
         public ImmutableArray<TestSymbol> TestDeclarations { get; }
 
         public ImmutableArray<ParameterAssignmentSymbol> ParameterAssignments { get; }
+
+        public ImmutableArray<ExtensionConfigAssignmentSymbol> ExtensionConfigAssignments { get; }
 
         public ImmutableArray<ImportedTypeSymbol> ImportedTypes { get; }
 

--- a/src/Bicep.Core/Semantics/ISemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ISemanticModel.cs
@@ -13,6 +13,8 @@ namespace Bicep.Core.Semantics
 
         ImmutableSortedDictionary<string, ParameterMetadata> Parameters { get; }
 
+        ImmutableSortedDictionary<string, ExtensionMetadata> Extensions { get; }
+
         ImmutableSortedDictionary<string, ExportMetadata> Exports { get; }
 
         ImmutableArray<OutputMetadata> Outputs { get; }

--- a/src/Bicep.Core/Semantics/Metadata/ExtensionMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ExtensionMetadata.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.TypeSystem.Types;
+
+namespace Bicep.Core.Semantics.Metadata
+{
+    public record ExtensionMetadata(
+        string Alias,
+        string Name,
+        string Version,
+        NamespaceType? NamespaceType);
+}

--- a/src/Bicep.Core/Semantics/Metadata/ExtensionMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ExtensionMetadata.cs
@@ -9,5 +9,6 @@ namespace Bicep.Core.Semantics.Metadata
         string Alias,
         string Name,
         string Version,
+        // TODO(kylealbert): this should be non-nullable
         NamespaceType? NamespaceType);
 }

--- a/src/Bicep.Core/Semantics/SymbolKind.cs
+++ b/src/Bicep.Core/Semantics/SymbolKind.cs
@@ -23,5 +23,6 @@ namespace Bicep.Core.Semantics
         ParameterAssignment,
         Metadata,
         TypeAlias,
+        ExtensionConfigAssignment
     }
 }

--- a/src/Bicep.Core/Semantics/SymbolVisitor.cs
+++ b/src/Bicep.Core/Semantics/SymbolVisitor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Bicep.Core.TypeSystem;
 
 namespace Bicep.Core.Semantics
@@ -92,6 +93,11 @@ namespace Bicep.Core.Semantics
         }
 
         public virtual void VisitExtensionNamespaceSymbol(ExtensionNamespaceSymbol symbol)
+        {
+            VisitDescendants(symbol);
+        }
+
+        public virtual void VisitExtensionConfigAssignmentSymbol(ExtensionConfigAssignmentSymbol symbol)
         {
             VisitDescendants(symbol);
         }

--- a/src/Bicep.Core/Semantics/TemplateSpecSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/TemplateSpecSemanticModel.cs
@@ -24,6 +24,8 @@ namespace Bicep.Core.Semantics
 
         public ImmutableSortedDictionary<string, ParameterMetadata> Parameters => this.mainTemplateSemanticModel.Parameters;
 
+        public ImmutableSortedDictionary<string, ExtensionMetadata> Extensions => this.mainTemplateSemanticModel.Extensions;
+
         public ImmutableSortedDictionary<string, ExportMetadata> Exports => this.mainTemplateSemanticModel.Exports;
 
         public ImmutableArray<OutputMetadata> Outputs => this.mainTemplateSemanticModel.Outputs;

--- a/src/Bicep.Core/SourceGraph/ArmTemplateFile.cs
+++ b/src/Bicep.Core/SourceGraph/ArmTemplateFile.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Deployments.Core.Definitions.Schema;
+using Bicep.Core.Features;
 using Bicep.IO.Abstraction;
 using Newtonsoft.Json.Linq;
 
@@ -9,7 +10,7 @@ namespace Bicep.Core.Workspaces
 {
     public class ArmTemplateFile : ISourceFile
     {
-        public ArmTemplateFile(Uri fileUri, IFileHandle fileHandle, string text, Template? template, JObject? templateObject)
+        public ArmTemplateFile(Uri fileUri, IFileHandle fileHandle, string text, Template? template, JObject? templateObject, IFeatureProvider featureProvider)
         {
             if ((template is null && templateObject is not null) ||
                 (template is not null && templateObject is null))
@@ -22,6 +23,7 @@ namespace Bicep.Core.Workspaces
             this.Text = text;
             this.Template = template;
             this.TemplateObject = templateObject;
+            this.FeatureProvider = featureProvider;
         }
 
         public Uri Uri { get; }
@@ -33,6 +35,8 @@ namespace Bicep.Core.Workspaces
         public Template? Template { get; }
 
         public JObject? TemplateObject { get; }
+
+        public IFeatureProvider FeatureProvider { get; }
 
         public bool HasErrors() => this.Template is null;
     }

--- a/src/Bicep.Core/SourceGraph/SourceFileFactory.cs
+++ b/src/Bicep.Core/SourceGraph/SourceFileFactory.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.CodeDom;
 using Azure.Deployments.Core.Configuration;
 using Azure.Deployments.Core.Constants;
 using Azure.Deployments.Core.Definitions.Schema;
@@ -10,9 +9,7 @@ using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
-using Bicep.Core.Modules;
 using Bicep.Core.Parsing;
-using Bicep.Core.Registry;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.Text;
 using Bicep.IO.Abstraction;
@@ -110,7 +107,12 @@ namespace Bicep.Core.Workspaces
             return new(fileUri, fileHandle, lineStarts, parser.Program(), this.configurationManager, this.featureProviderFactory, this.auxiliaryFileCache, parser.LexingErrorLookup, parser.ParsingErrorLookup);
         }
 
-        public ArmTemplateFile CreateArmTemplateFile(Uri fileUri, string fileContents) => CreateArmTemplateFile(fileUri, fileUri.IsFile ? this.fileExplorer.GetFile(fileUri.ToIOUri()) : DummyFileHandle.Instance, fileContents);
+        public ArmTemplateFile CreateArmTemplateFile(Uri fileUri, string fileContents) =>
+            CreateArmTemplateFile(
+                fileUri,
+                fileUri.IsFile ? this.fileExplorer.GetFile(fileUri.ToIOUri()) : DummyFileHandle.Instance,
+                fileContents,
+                this.featureProviderFactory);
 
         public TemplateSpecFile CreateTemplateSpecFile(Uri fileUri, string fileContents)
         {
@@ -136,7 +138,8 @@ namespace Bicep.Core.Workspaces
                 return CreateErrorFile();
             }
         }
-        private static ArmTemplateFile CreateArmTemplateFile(Uri fileUri, IFileHandle fileHandle, string fileContents)
+
+        private static ArmTemplateFile CreateArmTemplateFile(Uri fileUri, IFileHandle fileHandle, string fileContents, IFeatureProviderFactory featureProviderFactory)
         {
             try
             {
@@ -146,15 +149,15 @@ namespace Bicep.Core.Workspaces
 
                 var templateObject = ParseObject(fileContents);
 
-                return new(fileUri, fileHandle, fileContents, template, templateObject);
+                return new(fileUri, fileHandle, fileContents, template, templateObject, featureProviderFactory.GetFeatureProvider(fileUri));
             }
             catch (Exception)
             {
-                return new(fileUri, fileHandle, fileContents, null, null);
+                return new(fileUri, fileHandle, fileContents, null, null, featureProviderFactory.GetFeatureProvider(fileUri));
             }
         }
 
-        private static ArmTemplateFile CreateDummyArmTemplateFile(string content) => CreateArmTemplateFile(InMemoryMainTemplateUri, DummyFileHandle.Instance, content);
+        private ArmTemplateFile CreateDummyArmTemplateFile(string content) => CreateArmTemplateFile(InMemoryMainTemplateUri, DummyFileHandle.Instance, content, this.featureProviderFactory);
 
         private static void ValidateTemplate(Template template)
         {

--- a/src/Bicep.Core/Syntax/AstVisitor.cs
+++ b/src/Bicep.Core/Syntax/AstVisitor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
@@ -331,6 +332,13 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.SpecificationString);
             this.Visit(syntax.WithClause);
             this.Visit(syntax.AsClause);
+        }
+
+        public override void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax)
+        {
+            this.VisitNodes(syntax.LeadingNodes);
+            this.Visit(syntax.SpecificationString);
+            this.Visit(syntax.WithClause);
         }
 
         public override void VisitExtensionWithClauseSyntax(ExtensionWithClauseSyntax syntax)

--- a/src/Bicep.Core/Syntax/CstVisitor.cs
+++ b/src/Bicep.Core/Syntax/CstVisitor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
@@ -417,6 +418,14 @@ namespace Bicep.Core.Syntax
             this.Visit(syntax.SpecificationString);
             this.Visit(syntax.WithClause);
             this.Visit(syntax.AsClause);
+        }
+
+        public override void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax)
+        {
+            this.VisitNodes(syntax.LeadingNodes);
+            this.Visit(syntax.Keyword);
+            this.Visit(syntax.SpecificationString);
+            this.Visit(syntax.WithClause);
         }
 
         public override void VisitExtensionWithClauseSyntax(ExtensionWithClauseSyntax syntax)

--- a/src/Bicep.Core/Syntax/ExtensionConfigAssignmentSyntax.cs
+++ b/src/Bicep.Core/Syntax/ExtensionConfigAssignmentSyntax.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Navigation;
+using Bicep.Core.Parsing;
+
+namespace Bicep.Core.Syntax
+{
+    public class ExtensionConfigAssignmentSyntax : StatementSyntax, ITopLevelDeclarationSyntax
+    {
+        public ExtensionConfigAssignmentSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, SyntaxBase specificationString, SyntaxBase withClause)
+            : base(leadingNodes)
+        {
+            AssertKeyword(keyword, nameof(keyword), LanguageConstants.ExtensionKeyword);
+            AssertSyntaxType(specificationString, nameof(specificationString), typeof(StringSyntax), typeof(SkippedTriviaSyntax), typeof(IdentifierSyntax));
+
+            this.Keyword = keyword;
+            this.SpecificationString = specificationString;
+            this.WithClause = withClause;
+        }
+
+        public Token Keyword { get; }
+
+        public SyntaxBase SpecificationString { get; }
+
+        public SyntaxBase WithClause { get; }
+
+        public ObjectSyntax? Config => (this.WithClause as ExtensionWithClauseSyntax)?.Config as ObjectSyntax;
+
+        public string? TryGetSymbolName() => this.SpecificationString switch
+        {
+            IdentifierSyntax value => value.IdentifierName,
+            _ => null,
+        };
+
+        public override TextSpan Span => TextSpan.Between(this.Keyword, TextSpan.LastNonNull(this.SpecificationString, this.WithClause));
+
+        public override void Accept(ISyntaxVisitor visitor) => visitor.VisitExtensionConfigAssignmentSyntax(this);
+    }
+}

--- a/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxVisitor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Bicep.Core.Parsing;
 
 namespace Bicep.Core.Syntax
@@ -115,6 +116,8 @@ namespace Bicep.Core.Syntax
         void VisitMissingDeclarationSyntax(MissingDeclarationSyntax syntax);
 
         void VisitExtensionDeclarationSyntax(ExtensionDeclarationSyntax syntax);
+
+        void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax);
 
         void VisitExtensionWithClauseSyntax(ExtensionWithClauseSyntax syntax);
 

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.Parsing;
@@ -362,6 +363,23 @@ namespace Bicep.Core.Syntax
             return new ExtensionDeclarationSyntax(leadingNodes, keyword, specification, withClause, asClause);
         }
         void ISyntaxVisitor.VisitExtensionDeclarationSyntax(ExtensionDeclarationSyntax syntax) => ReplaceCurrent(syntax, ReplaceExtensionDeclarationSyntax);
+
+        protected virtual SyntaxBase ReplaceExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax)
+        {
+            var hasChanges = TryRewrite(syntax.LeadingNodes, out var leadingNodes);
+            hasChanges |= TryRewriteStrict(syntax.Keyword, out var keyword);
+            hasChanges |= TryRewriteStrict(syntax.SpecificationString, out var specification);
+            hasChanges |= TryRewriteStrict(syntax.WithClause, out var withClause);
+
+            if (!hasChanges)
+            {
+                return syntax;
+            }
+
+            return new ExtensionConfigAssignmentSyntax(leadingNodes, keyword, specification, withClause);
+        }
+
+        void ISyntaxVisitor.VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax) => ReplaceCurrent(syntax, ReplaceExtensionConfigAssignmentSyntax);
 
         protected virtual SyntaxBase ReplaceExtensionWithClauseSyntax(ExtensionWithClauseSyntax syntax)
         {

--- a/src/Bicep.Core/Syntax/SyntaxVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxVisitor.cs
@@ -40,6 +40,8 @@ namespace Bicep.Core.Syntax
 
         public abstract void VisitExtensionDeclarationSyntax(ExtensionDeclarationSyntax syntax);
 
+        public abstract void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax);
+
         public abstract void VisitExtensionWithClauseSyntax(ExtensionWithClauseSyntax syntax);
 
         public abstract void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax);

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -1213,15 +1213,12 @@ namespace Bicep.Core.TypeSystem
             // TODO(kylealbert): this needs some thought with spec strings, ext names, and aliases
             if (syntax.TryGetSymbolName() is not { } symbolName)
             {
-                return null;
+                throw new NotImplementedException();
             }
 
             if (semanticModel.Extensions.TryGetValue(symbolName, out var extensionMetadata))
             {
-                // TODO(kylealbert): This needs some thought. It doesn't seem to make sense to use a NamespaceType because this syntax
-                //  is configuraing a namespace, not defining it. It might make sense to create a custom type symbol to wrap the
-                //  Namespace's config type or simply return the config type.
-                return null;
+                return extensionMetadata.NamespaceType?.ConfigurationType;
             }
 
             return null;

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -931,6 +931,11 @@ namespace Bicep.Core.TypeSystem
             => AssignTypeWithDiagnostics(
                 syntax, diagnostics =>
                 {
+                    if (features is not { ExtensibilityEnabled: true, ModuleExtensionConfigsEnabled: true })
+                    {
+                        return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).UnrecognizedParamsFileDeclaration());
+                    }
+
                     if (binder.GetSymbolInfo(syntax) is not ExtensionConfigAssignmentSymbol configAssignmentSymbol)
                     {
                         // We have syntax or binding errors, which should have already been handled.

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -3,14 +3,11 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
-using Azure.Deployments.Core.Diagnostics;
-using Azure.Deployments.Templates.Export;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
 using Bicep.Core.Extensions;
 using Bicep.Core.Features;
 using Bicep.Core.Intermediate;
-using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
@@ -19,7 +16,6 @@ using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.TypeSystem.Providers;
 using Bicep.Core.TypeSystem.Types;
-using Bicep.Core.Workspaces;
 
 namespace Bicep.Core.TypeSystem
 {
@@ -930,6 +926,50 @@ namespace Bicep.Core.TypeSystem
 
                 return namespaceType;
             });
+
+        public override void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax)
+            => AssignTypeWithDiagnostics(
+                syntax, diagnostics =>
+                {
+                    if (binder.GetSymbolInfo(syntax) is not ExtensionConfigAssignmentSymbol configAssignmentSymbol)
+                    {
+                        // We have syntax or binding errors, which should have already been handled.
+                        return ErrorType.Empty();
+                    }
+
+                    var declaredType = typeManager.GetDeclaredType(syntax); // this is the config type
+
+                    if (declaredType is ErrorType)
+                    {
+                        return declaredType;
+                    }
+                    else if (declaredType is not null && declaredType.GetType() != typeof(ObjectType))
+                    {
+                        return ErrorType.Empty();
+                    }
+
+                    base.VisitExtensionConfigAssignmentSyntax(syntax);
+
+                    var configType = (ObjectType?)declaredType;
+
+                    if (configType is null) // Ext does not support configuration
+                    {
+                        diagnostics.Write(syntax.SpecificationString, x => x.ExtensionDoesNotSupportConfiguration(configAssignmentSymbol.Name));
+
+                        return ErrorType.Empty();
+                    }
+
+                    if (syntax.Config is not null)
+                    {
+                        TypeValidator.NarrowTypeAndCollectDiagnostics(typeManager, binder, this.parsingErrorLookup, diagnostics, syntax.Config, configType, false);
+                    }
+                    else if (syntax.WithClause.IsSkipped && configType.Properties.Any(p => p.Value.Flags.HasFlag(TypePropertyFlags.Required)))
+                    {
+                        diagnostics.Write(syntax, x => x.ExtensionRequiresConfiguration(configAssignmentSymbol.Name));
+                    }
+
+                    return configType;
+                });
 
         private void ValidateDecorators(IEnumerable<DecoratorSyntax> decoratorSyntaxes, TypeSymbol targetType, IDiagnosticWriter diagnostics)
         {

--- a/src/Bicep.Core/TypeSystem/Types/ModuleType.cs
+++ b/src/Bicep.Core/TypeSystem/Types/ModuleType.cs
@@ -44,5 +44,20 @@ namespace Bicep.Core.TypeSystem.Types
 
             return null;
         }
+
+        public TypeSymbol? TryGetExtensionConfigPropertyType(string extAlias, string configPropertyName)
+        {
+            if (Body is ObjectType objectType &&
+                objectType.Properties.TryGetValue(LanguageConstants.ModuleExtensionConfigsPropertyName, out var extensionConfigsProperty) &&
+                extensionConfigsProperty.TypeReference.Type is ObjectType extConfigObjectType &&
+                extConfigObjectType.Properties.TryGetValue(extAlias, out var extAliasProperty) &&
+                extAliasProperty.TypeReference.Type is NamespaceType { ConfigurationType: { } extConfigType } &&
+                extConfigType.Properties.TryGetValue(configPropertyName, out var configProperty))
+            {
+                return configProperty.TypeReference.Type;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/Types/NamespaceType.cs
+++ b/src/Bicep.Core/TypeSystem/Types/NamespaceType.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Bicep.Core.Registry;
-using Bicep.Core.Registry.Oci;
 using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem.Providers;
 
@@ -45,6 +45,10 @@ namespace Bicep.Core.TypeSystem.Types
 
         public string ExtensionName => Settings.BicepExtensionName;
 
+        public string ExtensionVersion => Settings.TemplateExtensionVersion;
+
         public ObjectType? ConfigurationType => Settings.ConfigurationType;
+
+        public bool IsConfigurationRequired => ConfigurationType?.Properties.Values.Any(p => p.Flags.HasFlag(TypePropertyFlags.Required)) is true;
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepDocumentSymbolHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDocumentSymbolHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using System.Collections.Immutable;
-using System.DirectoryServices.AccountManagement;
 using Bicep.Core.Semantics;
 using Bicep.Core.Syntax;
 using Bicep.LanguageServer.CompilationManager;
@@ -87,6 +87,7 @@ namespace Bicep.LanguageServer.Handlers
             ModuleSymbol => SymbolKind.Module,
             OutputSymbol => SymbolKind.Interface,
             ParameterAssignmentSymbol => SymbolKind.Constant,
+            ExtensionConfigAssignmentSymbol => SymbolKind.Constant,
             AssertSymbol => SymbolKind.Boolean,
             _ => SymbolKind.Key,
         };
@@ -101,6 +102,7 @@ namespace Bicep.LanguageServer.Handlers
             ModuleSymbol module => module.Type.Name,
             OutputSymbol output => output.Type.Name,
             ParameterAssignmentSymbol paramAssignment => paramAssignment.Type.Name,
+            ExtensionConfigAssignmentSymbol extConfigAssignment => extConfigAssignment.Type.Name,
             AssertSymbol assert => assert.Type.Name,
             _ => string.Empty,
         };

--- a/src/Bicep.LangServer/SemanticTokenVisitor.cs
+++ b/src/Bicep.LangServer/SemanticTokenVisitor.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
 using Bicep.Core;
 using Bicep.Core.Parsing;
 using Bicep.Core.Semantics;
@@ -362,6 +363,13 @@ namespace Bicep.LanguageServer
         {
             AddTokenType(syntax.Keyword, SemanticTokenType.Keyword);
             AddTokenType(syntax.Alias, SemanticTokenType.Namespace);
+        }
+
+        public override void VisitExtensionConfigAssignmentSyntax(ExtensionConfigAssignmentSyntax syntax)
+        {
+            AddTokenType(syntax.Keyword, SemanticTokenType.Keyword);
+            this.Visit(syntax.SpecificationString);
+            this.Visit(syntax.WithClause);
         }
 
         public override void VisitCompileTimeImportDeclarationSyntax(CompileTimeImportDeclarationSyntax syntax)


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented: Foundation for https://github.com/Azure/bicep-reps/pull/6
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature
* [ ] I have a resource name property equal to "name"
* [ ] If applicable, I have set the `location` property to `location: /*${<id>:location}*/'location'` (not `resourceGroup().location`) where `<id>` is a placeholder id, and added `param location string` to the test's main.bicep file so that the resulting main.combined.bicep file used in the tests compiles without errors
* [ ] I have verified that the snippet deploys correctly when used in the context of an actual bicep file

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
