### PR TITLE
Generate deterministic dependsOn

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7127796614903415778"
+      "templateHash": "4287109754528407984"
     }
   },
   "parameters": {
@@ -35,8 +35,8 @@
         "style": "[reference(resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild'), '2020-12-01').style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')]",
-        "[resourceId('My.Rp/parentType', 'basicParent')]"
+        "[resourceId('My.Rp/parentType', 'basicParent')]",
+        "[resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')]"
       ]
     },
     {
@@ -60,8 +60,8 @@
         "style": "[reference(resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild'), '2020-12-01').style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild')]",
-        "[resourceId('My.Rp/parentType', 'basicParent')]"
+        "[resourceId('My.Rp/parentType', 'basicParent')]",
+        "[resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild')]"
       ]
     },
     {
@@ -83,8 +83,8 @@
         "style": "[reference(resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild'), '2020-12-01').style]"
       },
       "dependsOn": [
-        "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]",
-        "[resourceId('My.Rp/parentType', 'conditionParent')]"
+        "[resourceId('My.Rp/parentType', 'conditionParent')]",
+        "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]"
       ]
     },
     {

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.sourcemap.bicep
@@ -37,8 +37,8 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@      "apiVersion": "2020-12-01",
 //@      "name": "[format('{0}/{1}/{2}', 'basicParent', 'basicChild', 'basicGrandchild')]",
 //@      "dependsOn": [
-//@        "[resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')]",
-//@        "[resourceId('My.Rp/parentType', 'basicParent')]"
+//@        "[resourceId('My.Rp/parentType', 'basicParent')]",
+//@        "[resourceId('My.Rp/parentType/childType', 'basicParent', 'basicChild')]"
 //@      ]
 //@    },
       name: 'basicGrandchild'
@@ -59,8 +59,8 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
 //@      "apiVersion": "2020-12-01",
 //@      "name": "[format('{0}/{1}', 'basicParent', 'basicSibling')]",
 //@      "dependsOn": [
-//@        "[resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild')]",
-//@        "[resourceId('My.Rp/parentType', 'basicParent')]"
+//@        "[resourceId('My.Rp/parentType', 'basicParent')]",
+//@        "[resourceId('My.Rp/parentType/childType/grandchildType', 'basicParent', 'basicChild', 'basicGrandchild')]"
 //@      ]
 //@    },
     name: 'basicSibling'
@@ -152,8 +152,8 @@ resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
 //@      "apiVersion": "2020-12-01",
 //@      "name": "[format('{0}/{1}/{2}', 'conditionParent', 'conditionChild', 'conditionGrandchild')]",
 //@      "dependsOn": [
-//@        "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]",
-//@        "[resourceId('My.Rp/parentType', 'conditionParent')]"
+//@        "[resourceId('My.Rp/parentType', 'conditionParent')]",
+//@        "[resourceId('My.Rp/parentType/childType', 'conditionParent', 'conditionChild')]"
 //@      ]
 //@    },
       name: 'conditionGrandchild'

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1582162446949403796"
+      "templateHash": "10234740426243815159"
     }
   },
   "parameters": {
@@ -36,8 +36,8 @@
         "style": "[reference('basicParent::basicChild').style]"
       },
       "dependsOn": [
-        "basicParent::basicChild",
-        "basicParent"
+        "basicParent",
+        "basicParent::basicChild"
       ]
     },
     "basicParent::basicChild": {
@@ -61,8 +61,8 @@
         "style": "[reference('basicParent::basicChild::basicGrandchild').style]"
       },
       "dependsOn": [
-        "basicParent::basicChild::basicGrandchild",
-        "basicParent"
+        "basicParent",
+        "basicParent::basicChild::basicGrandchild"
       ]
     },
     "existingParent::existingChild::existingGrandchild": {
@@ -74,8 +74,8 @@
         "style": "[reference('existingParent::existingChild').style]"
       },
       "dependsOn": [
-        "existingParent::existingChild",
-        "existingParent"
+        "existingParent",
+        "existingParent::existingChild"
       ]
     },
     "existingParent::existingChild": {
@@ -94,8 +94,8 @@
         "style": "[reference('conditionParent::conditionChild').style]"
       },
       "dependsOn": [
-        "conditionParent::conditionChild",
-        "conditionParent"
+        "conditionParent",
+        "conditionParent::conditionChild"
       ]
     },
     "conditionParent::conditionChild": {

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -601,7 +601,7 @@ public class ExpressionBuilder
             .SelectMany(g => g.FirstOrDefault(t => t.Target.IndexExpression is null) is { } dependencyOnCollection
                 ? dependencyOnCollection.AsEnumerable()
                 : g.Distinct(t => t.Target))
-            .OrderBy(t => t.Target.Resource.Name)  // order to generate a deterministic template
+            .OrderBy(t => t.TargetKey)  // order to generate a deterministic template
             .Select(t => t.Expression)
             .ToImmutableArray();
 
@@ -1275,6 +1275,7 @@ public class ExpressionBuilder
     }
 
     private record DependencyExpression(
+        string TargetKey, // Used for sorting.
         ResourceDependency Target,
         ResourceDependencyExpression Expression);
 
@@ -1287,6 +1288,7 @@ public class ExpressionBuilder
         {
             Expression reference;
             ResourceDependency target;
+            string targetKey;
             var localReplacements = this.localReplacements;
             var allNodesInPathAccessCopyIndex = true;
 
@@ -1294,6 +1296,7 @@ public class ExpressionBuilder
             do
             {
                 target = path[i];
+                targetKey = target.Resource.Name;
                 var targetContext = i == 0 ? newContext : path[i - 1].Resource.DeclaringSyntax;
                 IndexReplacementContext? indexContext = null;
 
@@ -1304,6 +1307,7 @@ public class ExpressionBuilder
                             var metadata = Context.SemanticModel.ResourceMetadata.TryLookup(resource.DeclaringSyntax) as DeclaredResourceMetadata
                                 ?? throw new InvalidOperationException("Failed to find resource in cache");
 
+                            targetKey = ExpressionConverter.GetSymbolicName(Context.SemanticModel.ResourceAncestors, metadata);
                             indexContext = (resource.IsCollection && target.IndexExpression is null)
                                 ? null
                                 : new ExpressionBuilder(Context, localReplacements)
@@ -1352,7 +1356,7 @@ public class ExpressionBuilder
                 allNodesInPathAccessCopyIndex = allNodesInPathAccessCopyIndex && copyIndexAccesses.Length > 0;
             } while (++i < path.Length);
 
-            yield return new(target, new(null, reference));
+            yield return new(targetKey, target, new(null, reference));
         }
     }
 


### PR DESCRIPTION
The dependsOn items are currently ordered by resource/module symbol names. However, this ordering is not deterministic when two nested resources share the same symbol name but have different parents (e.g., parentOne::child and parentTwo::child). This PR resolves the issue by sorting dependsOn based on fully qualified symbol names.

Closes #16332.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16668)