### PR TITLE
clearer message when experimental feature for extendableparamfiles is not enabled

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -412,7 +412,7 @@ output foo string = foo
 
             var result = await Bicep(settings, "build-params", mainBicepParamPath, "--stdout");
 
-            result.Should().Fail().And.HaveStderrMatch($"*Error BCP406: Using \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\".");
+            result.Should().Fail().And.HaveStderrMatch($"*Error BCP406: Using \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\".*");
         }
 
         [TestMethod]

--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -412,7 +412,7 @@ output foo string = foo
 
             var result = await Bicep(settings, "build-params", mainBicepParamPath, "--stdout");
 
-            result.Should().Fail().And.HaveStderrMatch($"*Error BCP406: The \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\".");
+            result.Should().Fail().And.HaveStderrMatch($"*Error BCP406: Using \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\".");
         }
 
         [TestMethod]

--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -412,7 +412,7 @@ output foo string = foo
 
             var result = await Bicep(settings, "build-params", mainBicepParamPath, "--stdout");
 
-            result.Should().Fail().And.HaveStderrMatch($"*Error BCP406: The \"extends\" keyword is not supported*");
+            result.Should().Fail().And.HaveStderrMatch($"*Error BCP406: The \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\".");
         }
 
         [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -502,10 +502,10 @@ param stringParam =  /*TODO*/
 
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
                 ("BCP405", DiagnosticLevel.Error, "More than one \"extends\" declaration are present"),
-                ("BCP406", DiagnosticLevel.Error, "The \"extends\" keyword is not supported"),
+                ("BCP406", DiagnosticLevel.Error, "The \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\"."),
                 ("BCP404", DiagnosticLevel.Error, "The \"extends\" declaration is missing a bicepparam file path reference"),
                 ("BCP405", DiagnosticLevel.Error, "More than one \"extends\" declaration are present"),
-                ("BCP406", DiagnosticLevel.Error, "The \"extends\" keyword is not supported"),
+                ("BCP406", DiagnosticLevel.Error, "The \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\"."),
             });
         }
 

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -502,10 +502,10 @@ param stringParam =  /*TODO*/
 
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[] {
                 ("BCP405", DiagnosticLevel.Error, "More than one \"extends\" declaration are present"),
-                ("BCP406", DiagnosticLevel.Error, "The \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\"."),
+                ("BCP406", DiagnosticLevel.Error, "Using \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\"."),
                 ("BCP404", DiagnosticLevel.Error, "The \"extends\" declaration is missing a bicepparam file path reference"),
                 ("BCP405", DiagnosticLevel.Error, "More than one \"extends\" declaration are present"),
-                ("BCP406", DiagnosticLevel.Error, "The \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\"."),
+                ("BCP406", DiagnosticLevel.Error, "Using \"extends\" keyword requires enabling EXPERIMENTAL feature \"ExtendableParamFiles\"."),
             });
         }
 

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1817,7 +1817,7 @@ namespace Bicep.Core.Diagnostics
 
             public Diagnostic ExtendsNotSupported() => CoreError(
                 "BCP406",
-                $"The \"{LanguageConstants.ExtendsKeyword}\" keyword is not supported");
+                $"Using \"{LanguageConstants.ExtendsKeyword}\" keyword requires enabling EXPERIMENTAL feature \"{nameof(ExperimentalFeaturesEnabled.ExtendableParamFiles)}\".");
 
             public Diagnostic MicrosoftGraphBuiltinRetired(ExtensionDeclarationSyntax? syntax)
             {


### PR DESCRIPTION
Fixes #16733 

## Contributing a feature

* [x] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [x] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [x] I have appropriate test coverage of my new feature

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16744)