### PR TITLE
Local Deploy: Support deploying Azure modules

### DIFF
--- a/docs/experimental/local-deploy.md
+++ b/docs/experimental/local-deploy.md
@@ -98,7 +98,6 @@ Here's an example bicepconfig.json you can use to share your extension with othe
 
 
 ## Limitations
-1. Currently, it is not possible to mix and match Local and Azure resources in a single deployment. Please raise an issue if you would like to see this implemented.
 1. Code signing for the proof-of-concept extensions has not been implemented, meaning you may run into errors running the samples on a Mac.
 
 ## Raising bugs or feature requests

--- a/src/Bicep.Cli.E2eTests/src/examples/local-deploy/main.bicep
+++ b/src/Bicep.Cli.E2eTests/src/examples/local-deploy/main.bicep
@@ -1,3 +1,5 @@
+targetScope = 'local'
+
 extension mock
 
 param payload string

--- a/src/Bicep.Cli/Commands/LocalDeployCommand.cs
+++ b/src/Bicep.Cli/Commands/LocalDeployCommand.cs
@@ -6,9 +6,12 @@ using Bicep.Cli.Arguments;
 using Bicep.Cli.Helpers;
 using Bicep.Cli.Logging;
 using Bicep.Core;
+using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics;
+using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Types;
 using Bicep.Local.Deploy;
 using Bicep.Local.Deploy.Extensibility;
@@ -21,6 +24,8 @@ namespace Bicep.Cli.Commands;
 public class LocalDeployCommand : ICommand
 {
     private readonly IModuleDispatcher moduleDispatcher;
+    private readonly IConfigurationManager configurationManager;
+    private readonly ITokenCredentialFactory credentialFactory;
     private readonly IOContext io;
     private readonly ILogger logger;
     private readonly DiagnosticLogger diagnosticLogger;
@@ -28,12 +33,16 @@ public class LocalDeployCommand : ICommand
 
     public LocalDeployCommand(
         IModuleDispatcher moduleDispatcher,
+        IConfigurationManager configurationManager,
+        ITokenCredentialFactory credentialFactory,
         IOContext io,
         ILogger logger,
         DiagnosticLogger diagnosticLogger,
         BicepCompiler compiler)
     {
         this.moduleDispatcher = moduleDispatcher;
+        this.configurationManager = configurationManager;
+        this.credentialFactory = credentialFactory;
         this.io = io;
         this.logger = logger;
         this.diagnosticLogger = diagnosticLogger;
@@ -65,7 +74,14 @@ public class LocalDeployCommand : ICommand
             return 1;
         }
 
-        await using LocalExtensibilityHostManager extensibilityHandler = new(moduleDispatcher, GrpcBuiltInLocalExtension.Start);
+        if (compilation.GetEntrypointSemanticModel().Root.TryGetBicepFileSemanticModelViaUsing().IsSuccess(out var usingModel) &&
+            usingModel.TargetScope is not ResourceScope.Local)
+        {
+            logger.LogError($"The referenced .bicep file must have targetScope set to 'local'.");
+            return 1;
+        }
+
+        await using LocalExtensibilityHostManager extensibilityHandler = new(moduleDispatcher, configurationManager, credentialFactory, GrpcBuiltInLocalExtension.Start);
         await extensibilityHandler.InitializeExtensions(compilation);
 
         var result = await LocalDeployment.Deploy(extensibilityHandler, templateString, parametersString, cancellationToken);

--- a/src/Bicep.Core.IntegrationTests/ExtensionRegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensionRegistryTests.cs
@@ -413,6 +413,8 @@ output joke string = dadJoke.joke
         var services = await ExtensionTestHelper.GetServiceBuilderWithPublishedExtension(ThirdPartyTypeHelper.GetTestTypesTgzWithFallbackAndConfiguration(), AllFeaturesEnabledForLocalDeploy);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
+targetScope = 'local'
+
 extension 'br:example.azurecr.io/extensions/foo:1.2.3' with {
   namespace: 'ThirdPartyNamespace'
   config: 'Some path to config file'
@@ -449,6 +451,8 @@ output joke string = dadJoke.joke
         var services = await ExtensionTestHelper.GetServiceBuilderWithPublishedExtension(ThirdPartyTypeHelper.GetTestTypesTgzWithFallbackAndConfiguration(), AllFeaturesEnabledForLocalDeploy);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
+targetScope = 'local'
+
 extension 'br:example.azurecr.io/extensions/foo:1.2.3' with { }
 
 resource dadJoke 'fooType@v1' = {
@@ -470,6 +474,8 @@ output joke string = dadJoke.joke
         var services = await ExtensionTestHelper.GetServiceBuilderWithPublishedExtension(ThirdPartyTypeHelper.GetTestTypesTgz(), AllFeaturesEnabledForLocalDeploy);
 
         var result = await CompilationHelper.RestoreAndCompile(services, """
+targetScope = 'local'
+
 extension 'br:example.azurecr.io/extensions/foo:1.2.3' with {
   namespace: 'ThirdPartyNamespace'
   config: 'Some path to config file'

--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -41,6 +41,10 @@ namespace Bicep.Core.Emit
             {
                 supportedScopes |= ResourceScope.DesiredStateConfiguration;
             }
+            if (semanticModel.Configuration.ExperimentalFeaturesEnabled.LocalDeploy)
+            {
+                supportedScopes |= ResourceScope.Local;
+            }
 
             if (scopeValue is null)
             {

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -1630,7 +1630,8 @@ public class ExpressionBuilder
                 }
                 return;
             case ResourceScope.DesiredStateConfiguration:
-                // This scope just changes the schema so there are no properties to emit.
+            case ResourceScope.Local:
+                // These scopes just changes the schema so there are no properties to emit.
                 // We don't ever need to throw here because the feature is checked during scope validation.
                 return;
             default:

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -92,6 +92,7 @@ namespace Bicep.Core
         public const string TargetScopeTypeSubscription = "subscription";
         public const string TargetScopeTypeResourceGroup = "resourceGroup";
         public const string TargetScopeTypeDesiredStateConfiguration = "desiredStateConfiguration";
+        public const string TargetScopeTypeLocal = "local";
 
         public const string CopyLoopIdentifier = "copy";
 
@@ -313,6 +314,10 @@ namespace Bicep.Core
             if (resourceScope.HasFlag(ResourceScope.DesiredStateConfiguration))
             {
                 yield return "desiredStateConfiguration";
+            }
+            if (resourceScope.HasFlag(ResourceScope.Local))
+            {
+                yield return "local";
             }
         }
 

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
@@ -284,7 +284,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithDescription("Returns a named subscription scope.")
                     .WithRequiredParameter("subscriptionId", LanguageConstants.String, "The subscription ID")
                     .Build(),
-                ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup);
+                ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Local);
 
             const string resourceGroupGenericDescription = "Returns a resource group scope.";
             yield return (
@@ -310,7 +310,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("subscriptionId", LanguageConstants.String, "The subscription ID")
                     .WithRequiredParameter("resourceGroupName", LanguageConstants.String, "The resource group name")
                     .Build(),
-                ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup);
+                ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Local);
 
             yield return (
                 new FunctionOverloadBuilder("deployment")
@@ -521,15 +521,15 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithFlags(FunctionFlags.RequiresInlining)
                     .Build();
             }
-
+ 
             foreach (var overload in GetBicepFilePermittedOverloads())
             {
-                yield return new(overload, (_, sfk) => sfk == BicepSourceFileKind.BicepFile);
+                yield return new(overload, (targetScope, sfk) => sfk == BicepSourceFileKind.BicepFile && targetScope != ResourceScope.Local);
             }
 
             foreach (var overload in GetParamsFilePermittedOverloads())
             {
-                yield return new(overload, (_, sfk) => sfk == BicepSourceFileKind.ParamsFile);
+                yield return new(overload, (targetScope, sfk) => sfk == BicepSourceFileKind.ParamsFile && targetScope != ResourceScope.Local);
             }
 
             foreach (var (overload, allowedScopes) in GetScopeFunctions())

--- a/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/NamespaceProvider.cs
@@ -159,7 +159,13 @@ public class NamespaceProvider : INamespaceProvider
 
         if (LanguageConstants.IdentifierComparer.Equals(extensionName, AzNamespaceType.BuiltInName))
         {
-            return AzNamespaceType.Create(aliasName, targetScope, resourceTypeProviderFactory.GetBuiltInAzResourceTypesProvider(), sourceFile.FileKind);
+            var typeProvider = targetScope switch
+            {
+                ResourceScope.Local => new EmptyResourceTypeProvider(),
+                _ => resourceTypeProviderFactory.GetBuiltInAzResourceTypesProvider(),
+            };
+
+            return AzNamespaceType.Create(aliasName, targetScope, typeProvider, sourceFile.FileKind);
         }
 
         if (LanguageConstants.IdentifierComparer.Equals(extensionName, K8sNamespaceType.BuiltInName))

--- a/src/Bicep.Core/Syntax/SyntaxHelper.cs
+++ b/src/Bicep.Core/Syntax/SyntaxHelper.cs
@@ -76,6 +76,7 @@ namespace Bicep.Core.Syntax
                 LanguageConstants.TargetScopeTypeResourceGroup => ResourceScope.ResourceGroup,
                 // The feature flag is checked during scope validation, so just handle it here.
                 LanguageConstants.TargetScopeTypeDesiredStateConfiguration => ResourceScope.DesiredStateConfiguration,
+                LanguageConstants.TargetScopeTypeLocal => ResourceScope.Local,
                 _ => ResourceScope.None,
             };
         }

--- a/src/Bicep.Core/Syntax/TargetScopeSyntax.cs
+++ b/src/Bicep.Core/Syntax/TargetScopeSyntax.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Collections.Immutable;
+using Bicep.Core.Features;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Text;
@@ -44,14 +45,28 @@ namespace Bicep.Core.Syntax
 
         public override TextSpan Span => TextSpan.Between(this.LeadingNodes.FirstOrDefault() ?? this.Keyword, this.Value);
 
-        public TypeSymbol GetDeclaredType()
+        public static TypeSymbol GetDeclaredType(IFeatureProvider features)
         {
-            // TODO: Implement the ability to declare a file targeting multiple scopes
+            List<string> scopes = [
+                LanguageConstants.TargetScopeTypeTenant,
+                LanguageConstants.TargetScopeTypeManagementGroup,
+                LanguageConstants.TargetScopeTypeSubscription,
+                LanguageConstants.TargetScopeTypeResourceGroup,
+            ];
+
+            // We add the DSC constant here so we can have it as a completion when the feature is enabled.
+            if (features.DesiredStateConfigurationEnabled)
+            {
+                scopes.Add(LanguageConstants.TargetScopeTypeDesiredStateConfiguration);
+            }
+
+            if (features.LocalDeployEnabled)
+            {
+                scopes.Add(LanguageConstants.TargetScopeTypeLocal);
+            }
+
             return TypeHelper.CreateTypeUnion(
-                TypeFactory.CreateStringLiteralType(LanguageConstants.TargetScopeTypeTenant),
-                TypeFactory.CreateStringLiteralType(LanguageConstants.TargetScopeTypeManagementGroup),
-                TypeFactory.CreateStringLiteralType(LanguageConstants.TargetScopeTypeSubscription),
-                TypeFactory.CreateStringLiteralType(LanguageConstants.TargetScopeTypeResourceGroup));
+                scopes.Select(x => TypeFactory.CreateStringLiteralType(x)).ToImmutableArray());
         }
     }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -132,12 +132,10 @@ namespace Bicep.Core.TypeSystem
                     return new DeclaredTypeAssignment(TypeFactory.CreateBooleanType(), assert);
 
                 case TargetScopeSyntax targetScope:
-                    // We add the DSC constant here so we can have it as a completion when the feature is enabled.
-                    // TODO: When no longer experimental, add directly to 'TargetScopeSyntax.GetDeclaredType()' instead.
+                    var supportedScopes = TargetScopeSyntax.GetDeclaredType(features);
+
                     return new DeclaredTypeAssignment(
-                        features.DesiredStateConfigurationEnabled
-                            ? TypeHelper.CreateTypeUnion(targetScope.GetDeclaredType(), TypeFactory.CreateStringLiteralType(LanguageConstants.TargetScopeTypeDesiredStateConfiguration))
-                            : targetScope.GetDeclaredType(),
+                        supportedScopes,
                         targetScope, DeclaredTypeFlags.Constant);
 
                 case IfConditionSyntax ifCondition:

--- a/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ExtensibilityResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ExtensibilityResourceTypeFactory.cs
@@ -224,7 +224,7 @@ namespace Bicep.Core.TypeSystem.Providers.ThirdParty
         {
             if (input == Azure.Bicep.Types.Concrete.ScopeType.Unknown)
             {
-                return ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Resource;
+                return ResourceScope.Tenant | ResourceScope.ManagementGroup | ResourceScope.Subscription | ResourceScope.ResourceGroup | ResourceScope.Resource | ResourceScope.Local;
             }
 
             var output = ResourceScope.None;

--- a/src/Bicep.Core/TypeSystem/ResourceScope.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceScope.cs
@@ -21,5 +21,7 @@ namespace Bicep.Core.TypeSystem
         ResourceGroup = 1 << 5,
 
         DesiredStateConfiguration = 1 << 6,
+
+        Local = 1 << 7,
     }
 }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -2153,17 +2153,10 @@ namespace Bicep.Core.TypeSystem
                     diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Decorators.First().At).DecoratorsNotAllowed());
                 }
 
-                var declaredType = syntax.GetDeclaredType();
+                var declaredType = TargetScopeSyntax.GetDeclaredType(features);
                 if (declaredType is ErrorType)
                 {
                     return declaredType;
-                }
-
-                // We add the DSC constant here so we can error with BCP033 when the feature isn't enabled.
-                // TODO: When no longer experimental, add directly to 'TargetScopeSyntax.GetDeclaredType()' instead.
-                if (features.DesiredStateConfigurationEnabled)
-                {
-                    declaredType = TypeHelper.CreateTypeUnion(declaredType, TypeFactory.CreateStringLiteralType(LanguageConstants.TargetScopeTypeDesiredStateConfiguration));
                 }
 
                 TypeValidator.GetCompileTimeConstantViolation(syntax.Value, diagnostics);

--- a/src/Bicep.LangServer/Handlers/GetDeploymentDataHandler.cs
+++ b/src/Bicep.LangServer/Handlers/GetDeploymentDataHandler.cs
@@ -3,6 +3,7 @@
 
 using Bicep.Core.Semantics;
 using Bicep.Core.SourceGraph;
+using Bicep.Core.TypeSystem;
 using Bicep.LanguageServer.CompilationManager;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -38,7 +39,7 @@ namespace Bicep.LanguageServer.Handlers
             }
 
             var semanticModel = context.Compilation.GetEntrypointSemanticModel();
-            var localDeployEnabled = semanticModel.Features.LocalDeployEnabled;
+            var localDeployEnabled = false;
 
             string? paramsFile = null;
             string? templateFile = null;
@@ -46,24 +47,26 @@ namespace Bicep.LanguageServer.Handlers
             {
                 var result = context.Compilation.Emitter.Parameters();
 
-                if (result.Parameters is null ||
-                    result.Template?.Template is null)
-                {
-                    return new(ErrorMessage: $"Compilation failed. The Bicep parameters file contains errors.", LocalDeployEnabled: localDeployEnabled);
-                }
-
-                paramsFile = result.Parameters;
-                templateFile = result.Template.Template;
-
                 if (!semanticModel.Root.TryGetBicepFileSemanticModelViaUsing().IsSuccess(out var usingModel))
                 {
                     return new(ErrorMessage: $"Compilation failed. Failed to find a file referenced via 'using'.", LocalDeployEnabled: localDeployEnabled);
+                }
+
+                paramsFile = result.Parameters;
+                templateFile = result.Template?.Template;
+                localDeployEnabled = usingModel.TargetScope == ResourceScope.Local;
+
+                if (paramsFile is null ||
+                    templateFile is null)
+                {
+                    return new(ErrorMessage: $"Compilation failed. The Bicep parameters file contains errors.", LocalDeployEnabled: localDeployEnabled);
                 }
             }
             else if (semanticModel.Root.FileKind == BicepSourceFileKind.BicepFile)
             {
                 var result = context.Compilation.Emitter.Template();
                 templateFile = result.Template;
+                localDeployEnabled = context.Compilation.GetEntrypointSemanticModel().TargetScope == ResourceScope.Local;
 
                 if (result.Template is null)
                 {

--- a/src/Bicep.Local.Deploy.IntegrationTests/EndToEndDeploymentTests.cs
+++ b/src/Bicep.Local.Deploy.IntegrationTests/EndToEndDeploymentTests.cs
@@ -12,6 +12,7 @@ using Bicep.Core.Configuration;
 using Bicep.Core.Features;
 using Bicep.Core.FileSystem;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Auth;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Features;
@@ -50,6 +51,8 @@ public class EndToEndDeploymentTests : TestBase
 }
 """),
             ("main.bicep", """
+targetScope = 'local'
+
 extension http
 
 param coords {
@@ -152,7 +155,11 @@ param coords = {
             });
 
         var dispatcher = BicepTestConstants.CreateModuleDispatcher(services.Build().Construct<IServiceProvider>());
-        await using LocalExtensibilityHostManager extensibilityHandler = new(dispatcher, uri => Task.FromResult(extensionMock.Object));
+        await using LocalExtensibilityHostManager extensibilityHandler = new(
+            dispatcher,
+            StrictMock.Of<IConfigurationManager>().Object,
+            StrictMock.Of<ITokenCredentialFactory>().Object,
+            uri => Task.FromResult(extensionMock.Object));
         await extensibilityHandler.InitializeExtensions(result.Compilation);
 
         var localDeployResult = await LocalDeployment.Deploy(extensibilityHandler, templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
@@ -191,6 +198,8 @@ param coords = {
 }
 """),
             ("main.bicep", """
+targetScope = 'local'
+
 extension http
 
 param coords {
@@ -259,7 +268,11 @@ param coords = {
             });
 
         var dispatcher = BicepTestConstants.CreateModuleDispatcher(services.Build().Construct<IServiceProvider>());
-        await using LocalExtensibilityHostManager extensibilityHandler = new(dispatcher, uri => Task.FromResult(extensionMock.Object));
+        await using LocalExtensibilityHostManager extensibilityHandler = new(
+            dispatcher,
+            StrictMock.Of<IConfigurationManager>().Object,
+            StrictMock.Of<ITokenCredentialFactory>().Object,
+            uri => Task.FromResult(extensionMock.Object));
         await extensibilityHandler.InitializeExtensions(result.Compilation);
 
         var localDeployResult = await LocalDeployment.Deploy(extensibilityHandler, templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
@@ -291,6 +304,8 @@ param coords = {
 }
 """),
             ("main.bicep", """
+targetScope = 'local'
+
 extension http
 
 param coords {
@@ -359,7 +374,11 @@ param coords = {
             });
 
         var dispatcher = BicepTestConstants.CreateModuleDispatcher(services.Build().Construct<IServiceProvider>());
-        await using LocalExtensibilityHostManager extensibilityHandler = new(dispatcher, uri => Task.FromResult(extensionMock.Object));
+        await using LocalExtensibilityHostManager extensibilityHandler = new(
+            dispatcher,
+            StrictMock.Of<IConfigurationManager>().Object,
+            StrictMock.Of<ITokenCredentialFactory>().Object,
+            uri => Task.FromResult(extensionMock.Object));
         await extensibilityHandler.InitializeExtensions(result.Compilation);
 
         var localDeployResult = await LocalDeployment.Deploy(extensibilityHandler, templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
@@ -391,6 +410,8 @@ param coords = {
 }
 """),
             ("main.bicep", """
+targetScope = 'local'
+
 extension http
 
 param coords {
@@ -450,7 +471,11 @@ param coords = {
             });
 
         var dispatcher = BicepTestConstants.CreateModuleDispatcher(services.Build().Construct<IServiceProvider>());
-        await using LocalExtensibilityHostManager extensibilityHandler = new(dispatcher, uri => Task.FromResult(extensionMock.Object));
+        await using LocalExtensibilityHostManager extensibilityHandler = new(
+            dispatcher,
+            StrictMock.Of<IConfigurationManager>().Object,
+            StrictMock.Of<ITokenCredentialFactory>().Object,
+            uri => Task.FromResult(extensionMock.Object));
         await extensibilityHandler.InitializeExtensions(result.Compilation);
 
         var localDeployResult = await LocalDeployment.Deploy(extensibilityHandler, templateFile, parametersFile, TestContext.CancellationTokenSource.Token);

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensibilityHostManager.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensibilityHostManager.cs
@@ -11,8 +11,10 @@ using System.Threading;
 using Azure.Deployments.Engine.Host.Azure.ExtensibilityV2.Contract.Models;
 using Azure.Deployments.Extensibility.Core.V2.Json;
 using Azure.Deployments.Extensibility.Core.V2.Models;
+using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem.Types;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
@@ -31,12 +33,12 @@ public class LocalExtensibilityHostManager : IAsyncDisposable
     private readonly IModuleDispatcher moduleDispatcher;
     private readonly Func<Uri, Task<LocalExtensibilityHost>> extensionFactory;
 
-    public LocalExtensibilityHostManager(IModuleDispatcher moduleDispatcher, Func<Uri, Task<LocalExtensibilityHost>> extensionFactory)
+    public LocalExtensibilityHostManager(IModuleDispatcher moduleDispatcher, IConfigurationManager configurationManager, ITokenCredentialFactory credentialFactory, Func<Uri, Task<LocalExtensibilityHost>> extensionFactory)
     {
         this.moduleDispatcher = moduleDispatcher;
         this.extensionFactory = extensionFactory;
         // Built in extension for handling nested deployments
-        RegisteredExtensions[new("LocalNested", "0.0.0")] = new NestedDeploymentBuiltInLocalExtension(this);
+        RegisteredExtensions[new("LocalNested", "0.0.0")] = new NestedDeploymentBuiltInLocalExtension(configurationManager, credentialFactory, this);
     }
 
     public async Task<HttpResponseMessage> CallExtensibilityHost(

--- a/src/Bicep.Local.Deploy/LocalAzureDeployment.cs
+++ b/src/Bicep.Local.Deploy/LocalAzureDeployment.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Deployments.Core;
+using Azure.Deployments.Core.Definitions;
+using Azure.Deployments.Core.Interfaces;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Resources.Models;
+using Bicep.Core.Configuration;
+using Bicep.Core.Registry.Auth;
+using Bicep.Core.Tracing;
+using Bicep.Local.Deploy.Extensibility;
+using Microsoft.Azure.Deployments.Service.Shared.Jobs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+
+namespace Bicep.Local.Deploy;
+
+public static class LocalAzureDeployment
+{
+    public static async Task<LocalDeployment.Result> Deploy(RootConfiguration configuration, ITokenCredentialFactory credentialFactory, DeploymentLocator deploymentLocator, string templateString, string parametersString, CancellationToken cancellationToken)
+    {
+        var options = new ArmClientOptions();
+        options.Diagnostics.ApplySharedResourceManagerSettings();
+        options.Environment = new ArmEnvironment(configuration.Cloud.ResourceManagerEndpointUri, configuration.Cloud.AuthenticationScope);
+
+        var credential = credentialFactory.CreateChain(configuration.Cloud.CredentialPrecedence, configuration.Cloud.CredentialOptions, configuration.Cloud.ActiveDirectoryAuthorityUri);
+        var armClient = new ArmClient(credential, deploymentLocator.SubscriptionId, options);
+
+        if (deploymentLocator.SubscriptionId == null)
+        {
+            throw new NotImplementedException("Above-subscription scope is not supported yet.");
+        }
+
+        var deploymentCollection = deploymentLocator switch {
+            { SubscriptionId: {}, ResourceGroupName: null } => armClient.GetSubscriptionResource(new ResourceIdentifier($"/subscriptions/{deploymentLocator.SubscriptionId}")).GetArmDeployments(),
+            { SubscriptionId: {}, ResourceGroupName: {} } => armClient.GetResourceGroupResource(new ResourceIdentifier($"/subscriptions/{deploymentLocator.SubscriptionId}/resourceGroups/{deploymentLocator.ResourceGroupName}")).GetArmDeployments(),
+            _ => throw new NotImplementedException("Above-subscription scope is not supported yet."),
+        };
+
+        var deploymentProperties = new ArmDeploymentProperties(ArmDeploymentMode.Incremental)
+        {
+            Template = BinaryData.FromString(templateString),
+            Parameters = BinaryData.FromString(parametersString),
+        };
+        var armDeploymentContent = new ArmDeploymentContent(deploymentProperties);
+
+        if (deploymentLocator.ResourceGroupName == null)
+        {
+            // TODO avoid hardcoding this...
+            armDeploymentContent.Location = "West US 3";
+        }
+
+        var deploymentOperation = await deploymentCollection.CreateOrUpdateAsync(WaitUntil.Completed, deploymentLocator.DeploymentName, armDeploymentContent, cancellationToken);
+
+        var response = await deploymentOperation.WaitForCompletionAsync(cancellationToken);
+        var content = response.GetRawResponse().Content.ToString().FromDeploymentsJson<DeploymentContent>();
+
+        return new(content, []);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to annotate a .bicep file with `targetScope = 'local'` if the `localDeploy` feature is enabled. This now allows a mixture of "local" and "azure" Bicep files in a module hierarchy, and support has been added for deploying "azure" modules as part of a local deployment.

This introduces a **breaking change** to local-deploy, because it means that any `.bicep` file using the functionality will need to use the following:
```bicep
targetScope = 'local'
```
 
The reason for this is that currently we use the enablement of the experimental feature as a means of determining whether or not to support "local mode". This will not work if we want to make this functionality non-experimental - as it's the only way we can disambiguate "local" vs "azure".

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16752)