### PR TITLE
Emit 2.1-experimental language version for onlyIfNotExists and waitAndRetry Decorators

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Decorators/OnlyIfNotExistsDecoratorTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Decorators/OnlyIfNotExistsDecoratorTests.cs
@@ -68,7 +68,7 @@ namespace Bicep.Core.IntegrationTests.Decorators
             {
                 diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
 
-                template.Should().NotBeNull().And.HaveValueAtPath("$.languageVersion", "2.2-experimental");
+                template.Should().NotBeNull().And.HaveValueAtPath("$.languageVersion", "2.1-experimental");
                 template.Should().NotBeNull()
                     .And.HaveValueAtPath("$.resources['sqlServer'].@options.onlyIfNotExists", onlyIfNotExistsJObject);
                 template.Should().NotBeNull()

--- a/src/Bicep.Core.IntegrationTests/Decorators/RetryOnDecoratorTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Decorators/RetryOnDecoratorTests.cs
@@ -63,7 +63,7 @@ namespace Bicep.Core.IntegrationTests.Decorators
             using (new AssertionScope())
             {
                 diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
-                template.Should().NotBeNull().And.HaveValueAtPath("$.languageVersion", "2.2-experimental");
+                template.Should().NotBeNull().And.HaveValueAtPath("$.languageVersion", "2.1-experimental");
                 template.Should().NotBeNull()
                     .And.HaveValueAtPath("$.resources['sqlServer'].@options.retryOn", retryOnJObject);
             }

--- a/src/Bicep.Core.IntegrationTests/Decorators/WaitUntilDecoratorTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Decorators/WaitUntilDecoratorTests.cs
@@ -44,7 +44,7 @@ namespace Bicep.Core.IntegrationTests.Decorators
             using (new AssertionScope())
             {
                 diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
-                template.Should().NotBeNull().And.HaveValueAtPath("$.languageVersion", "2.2-experimental");
+                template.Should().NotBeNull().And.HaveValueAtPath("$.languageVersion", "2.1-experimental");
                 template.Should().NotBeNull()
                     .And.HaveValueAtPath("$.resources['sqlServer'].@options.waitUntil", waitUntilObject);
             }

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -113,10 +113,9 @@ namespace Bicep.Core.Emit
 
             if (Context.Settings.UseExperimentalTemplateLanguageVersion)
             {
+                // Note (tasmalligan): 2.2 epxerimental is being used for extensibility migration and local deploy
                 if (Context.SemanticModel.TargetScope == ResourceScope.Local ||
-                    Context.SemanticModel.Features.ExtensibilityV2EmittingEnabled ||
-                    Context.SemanticModel.Features.OnlyIfNotExistsEnabled ||
-                    Context.SemanticModel.Features.WaitAndRetryEnabled)
+                    Context.SemanticModel.Features.ExtensibilityV2EmittingEnabled)
                 {
                     emitter.EmitProperty(LanguageVersionPropertyName, "2.2-experimental");
                 }


### PR DESCRIPTION
Update TemplateWriter to emit 2.1-experimental for onlyIfNotExists and waitAndRetry Decorators since 2.2-experimental is used for extensibility migration and local deploy.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16798)