### PR TITLE
Fix naming for externalInput definition property

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -286,7 +286,7 @@ param foo = externalInput('sys.cli', 'foo')
         externalInputs["sys_cli_0"].Should().DeepEqual(new JObject
         {
             ["kind"] = "sys.cli",
-            ["options"] = "foo",
+            ["config"] = "foo",
         });
     }
 
@@ -311,12 +311,12 @@ param foo3 = foo2
         externalInputs["sys_cli_0"].Should().DeepEqual(new JObject
         {
             ["kind"] = "sys.cli",
-            ["options"] = "foo",
+            ["config"] = "foo",
         });
         externalInputs["sys_cli_1"].Should().DeepEqual(new JObject
         {
             ["kind"] = "sys.cli",
-            ["options"] = "foo2",
+            ["config"] = "foo2",
         });
     }
 
@@ -365,7 +365,7 @@ param foo3 = foo2
         externalInputs["sys_cli_0"].Should().DeepEqual(new JObject
         {
             ["kind"] = "sys.cli",
-            ["options"] = "foo",
+            ["config"] = "foo",
         });
     }
 

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/External_Inputs/parameters.json
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/External_Inputs/parameters.json
@@ -52,62 +52,62 @@
     }
   },
   "externalInputDefinitions": {
+    "custom_binding_4": {
+      "kind": "custom.binding",
+      "config": "__BINDING__"
+    },
+    "sys_cli_1": {
+      "kind": "sys.cli",
+      "config": "foo"
+    },
+    "sys_cli_9": {
+      "kind": "sys.cli",
+      "config": "myParam"
+    },
+    "custom_tool_5": {
+      "kind": "custom.tool",
+      "config": {
+        "path": "/path/to/file",
+        "isSecure": true
+      }
+    },
+    "sys_cli_11": {
+      "kind": "sys.cli",
+      "config": "myVar"
+    },
     "sys_envVar_3": {
       "kind": "sys.envVar",
-      "options": "bar"
+      "config": "bar"
+    },
+    "sys_cli_12": {
+      "kind": "sys.cli",
+      "config": "a"
+    },
+    "custom_binding_8": {
+      "kind": "custom.binding",
+      "config": {
+        "path": "/path/to/file",
+        "isSecure": true
+      }
     },
     "sys_sons_cool_param_provider_10": {
       "kind": "sys&sons.cool#param provider"
     },
-    "sys_cli_11": {
+    "sys_cli_6": {
       "kind": "sys.cli",
-      "options": "myVar"
+      "config": "a"
     },
     "custom_binding_7": {
       "kind": "custom.binding",
-      "options": "__BINDING__"
-    },
-    "sys_cli_9": {
-      "kind": "sys.cli",
-      "options": "myParam"
-    },
-    "sys_cli_1": {
-      "kind": "sys.cli",
-      "options": "foo"
-    },
-    "sys_cli_2": {
-      "kind": "sys.cli",
-      "options": "foo"
-    },
-    "sys_cli_6": {
-      "kind": "sys.cli",
-      "options": "a"
-    },
-    "custom_binding_8": {
-      "kind": "custom.binding",
-      "options": {
-        "path": "/path/to/file",
-        "isSecure": true
-      }
-    },
-    "custom_binding_4": {
-      "kind": "custom.binding",
-      "options": "__BINDING__"
-    },
-    "custom_tool_5": {
-      "kind": "custom.tool",
-      "options": {
-        "path": "/path/to/file",
-        "isSecure": true
-      }
+      "config": "__BINDING__"
     },
     "sys_cli_0": {
       "kind": "sys.cli",
-      "options": "foo"
+      "config": "foo"
     },
-    "sys_cli_12": {
+    "sys_cli_2": {
       "kind": "sys.cli",
-      "options": "a"
+      "config": "foo"
     }
   }
 }

--- a/src/Bicep.Core/Emit/ParametersJsonWriter.cs
+++ b/src/Bicep.Core/Emit/ParametersJsonWriter.cs
@@ -90,7 +90,7 @@ public class ParametersJsonWriter
                     emitter.EmitProperty("kind", expression.Parameters[0]);
                     if (expression.Parameters.Length > 1)
                     {
-                        emitter.EmitProperty("options", expression.Parameters[1]);
+                        emitter.EmitProperty("config", expression.Parameters[1]);
                     }
                 });
             }


### PR DESCRIPTION
Fix naming mistake: `options` -> `config`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16809)