### PR TITLE
Use symbolic name for list function calls

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -530,7 +530,7 @@ Hello from Bicep!"));
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8414774091366329766"
+      "templateHash": "5753469770830927723"
     }
   },
   "parameters": {
@@ -560,7 +560,7 @@ Hello from Bicep!"));
         "mode": "Incremental",
         "parameters": {
           "connectionString": {
-            "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', toLower(parameters('accountName')), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', toLower(parameters('accountName'))), '2019-06-01').keys[0].value)]"
+            "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', toLower(parameters('accountName')), environment().suffixes.storage, listKeys('stgAccount', '2019-06-01').keys[0].value)]"
           }
         },
         "template": {

--- a/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/main.json
+++ b/src/Bicep.Core.IntegrationTests/Files/SymbolicNameTests/ResourceInfo/sql-database-with-management/main.json
@@ -10,7 +10,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12257213075107815581"
+      "templateHash": "2218153118927665716"
     }
   },
   "parameters": {
@@ -67,7 +67,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "15472057974476185533"
+              "templateHash": "11760589400102001951"
             }
           },
           "parameters": {
@@ -184,7 +184,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "8317946402947078880"
+                      "templateHash": "9783543878755843654"
                     }
                   },
                   "parameters": {
@@ -326,7 +326,7 @@
                           "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
                         },
                         "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
                       },
                       "dependsOn": [
                         "azureDefender",
@@ -548,7 +548,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "8745376269234083579"
+                              "templateHash": "15987064923562259504"
                             }
                           },
                           "parameters": {
@@ -638,7 +638,7 @@
                                   "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
                                 },
                                 "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(resourceInfo('storageAccountVulnerabilityAssessments').id, '2021-04-01').keys[0].value, '')]"
+                                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
                               },
                               "dependsOn": [
                                 "azureDefender",

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -2402,8 +2402,8 @@ output deployedTopics array = [for (topicName, i) in topics: {
         result.Template!.Should().HaveValueAtPath("$.outputs.deployedTopics.copy.input", new JObject
         {
             ["name"] = "[variables('topics')[copyIndex()]]",
-            ["accessKey1"] = "[listKeys(resourceId('Microsoft.EventGrid/topics', 'myExistingEventGridTopic'), '2021-06-01-preview').key1]",
-            ["accessKey2"] = "[listKeys(resourceId('Microsoft.EventGrid/topics', format('{0}-ZZZ', variables('topics')[copyIndex()])), '2021-06-01-preview').key1]"
+            ["accessKey1"] = "[listKeys('testR', '2021-06-01-preview').key1]",
+            ["accessKey2"] = "[listKeys(format('eventGridTopics[{0}]', copyIndex()), '2021-06-01-preview').key1]"
         });
     }
 
@@ -2954,7 +2954,7 @@ output badResult object = {
 
         result.Template.Should().HaveValueAtPath("$.outputs['badResult'].value", new JObject
         {
-            ["value"] = "[listAnything(resourceId('Microsoft.Storage/storageAccounts', parameters('storageName')), '2021-04-01').keys[0].value]",
+            ["value"] = "[listAnything('stg', '2021-04-01').keys[0].value]",
         });
     }
 
@@ -7146,6 +7146,27 @@ var subnetId = vNet::subnets[0].id
 
         var uri = buildUri(components)
 """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void List_functions_should_use_symbolic_name()
+    {
+        var result = CompilationHelper.Compile(Services.WithFeatureOverrides(new(SymbolicNameCodegenEnabled: true)), """
+            resource storageaccount 'Microsoft.Storage/storageAccounts@2021-02-01' = {
+              name: 'acct'
+              location: resourceGroup().location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }
+
+            output secret string = storageaccount.listKeys().keys[0].value
+            """);
+
+        result.Template.Should().HaveValueAtPath("$.outputs['secret'].value", "[listKeys('storageaccount', '2021-02-01').keys[0].value]", "the listKeys() function call should use a symbolic name value");
 
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }

--- a/src/Bicep.Core.IntegrationTests/Scenarios/ResourceListFunctionTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/ResourceListFunctionTests.cs
@@ -38,9 +38,9 @@ output pkMethodPayload string = stg.listKeys(stg.apiVersion, {
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
             result.Template.Should().HaveValueAtPath("$.outputs['pkStandard'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
-            result.Template.Should().HaveValueAtPath("$.outputs['pkMethod'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
-            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodVersionOverride'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2021-01-01').keys[0].value]");
-            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodPayload'].value", "[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01', createObject('key1', 'val1'))]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethod'].value", "[listKeys('stg', '2019-06-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodVersionOverride'].value", "[listKeys('stg', '2021-01-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodPayload'].value", "[listKeys('stg', '2019-06-01', createObject('key1', 'val1'))]");
         }
 
         [TestMethod]
@@ -66,9 +66,9 @@ output pkMethodPayload string = stg.listKeys(stg.apiVersion, {
 
             result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
             result.Template.Should().HaveValueAtPath("$.outputs['pkStandard'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
-            result.Template.Should().HaveValueAtPath("$.outputs['pkMethod'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01').keys[0].value]");
-            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodVersionOverride'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2021-01-01').keys[0].value]");
-            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodPayload'].value", "[listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'other'), 'Microsoft.Storage/storageAccounts', 'testacc'), '2019-06-01', createObject('key1', 'val1'))]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethod'].value", "[listKeys('stg', '2019-06-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodVersionOverride'].value", "[listKeys('stg', '2021-01-01').keys[0].value]");
+            result.Template.Should().HaveValueAtPath("$.outputs['pkMethodPayload'].value", "[listKeys('stg', '2019-06-01', createObject('key1', 'val1'))]");
         }
 
         [TestMethod]

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-webapp/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/cosmosdb-webapp/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "39478038817515390"
+      "templateHash": "14650989739404175409"
     }
   },
   "parameters": {
@@ -135,7 +135,7 @@
             },
             {
               "name": "CosmosDb:Key",
-              "value": "[listKeys(resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosAccountName')), '2021-04-15').primaryMasterKey]"
+              "value": "[listKeys('cosmosAccount', '2021-04-15').primaryMasterKey]"
             },
             {
               "name": "CosmosDb:DatabaseName",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/data-factory-v2-blob-to-blob-copy/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/data-factory-v2-blob-to-blob-copy/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1828620419650743269"
+      "templateHash": "15424787848331863337"
     }
   },
   "parameters": {
@@ -80,7 +80,7 @@
       "properties": {
         "type": "AzureBlobStorage",
         "typeProperties": {
-          "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1}', parameters('storageAccountName'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value)]"
+          "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1}', parameters('storageAccountName'), listKeys('storageAccount', '2021-04-01').keys[0].value)]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/deployment-script-with-storage/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/deployment-script-with-storage/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2337670687143365993"
+      "templateHash": "4008548470292567255"
     }
   },
   "parameters": {
@@ -65,7 +65,7 @@
         "azCliVersion": "2.0.80",
         "storageAccountSettings": {
           "storageAccountName": "[format('dscript{0}', uniqueString(resourceGroup().id))]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', format('dscript{0}', uniqueString(resourceGroup().id))), '2019-06-01').keys[0].value]"
+          "storageAccountKey": "[listKeys('stg', '2019-06-01').keys[0].value]"
         },
         "scriptContent": "[parameters('scriptToExecute')]",
         "cleanupPreference": "OnSuccess",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/function-app-create/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/function-app-create/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1130720585865187562"
+      "templateHash": "15662154353272946598"
     }
   },
   "parameters": {
@@ -149,11 +149,11 @@
           "appSettings": [
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys('storageAccount', '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys('storageAccount', '2019-06-01').keys[0].value)]"
             },
             {
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/function-http-trigger/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/function-http-trigger/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8292737599368142901"
+      "templateHash": "5996778647356391117"
     }
   },
   "parameters": {
@@ -96,11 +96,11 @@
           "appSettings": [
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys('storageAccount', '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys('storageAccount', '2019-06-01').keys[0].value)]"
             },
             {
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/function-premium-vnet-integration/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/function-premium-vnet-integration/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "746252077949181675"
+      "templateHash": "1552598901444162445"
     }
   },
   "parameters": {
@@ -179,11 +179,11 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix= {1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix= {1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys('storageAccount', '2021-04-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2};', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2};', variables('storageAccountName'), environment().suffixes.storage, listKeys('storageAccount', '2021-04-01').keys[0].value)]"
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/hdinsight-spark-linux/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11743606657506036861"
+      "templateHash": "13773349477514106252"
     }
   },
   "parameters": {
@@ -126,7 +126,7 @@
               "name": "[replace(replace(reference('defaultStorageAccount').primaryEndpoints.blob, 'https://', ''), '/', '')]",
               "isDefault": true,
               "container": "[parameters('clusterName')]",
-              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', format('storage{0}', uniqueString(resourceGroup().id))), '2021-04-01').keys[0].value]"
+              "key": "[listKeys('defaultStorageAccount', '2021-04-01').keys[0].value]"
             }
           ]
         },

--- a/src/Bicep.Core.Samples/Files/user_submitted/101/website-with-container/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/101/website-with-container/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15571119746721048953"
+      "templateHash": "11276468194288266874"
     }
   },
   "parameters": {
@@ -70,7 +70,7 @@
             },
             {
               "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
-              "value": "[listCredentials(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('acrSubscription'), parameters('acrResourceGroup')), 'Microsoft.ContainerRegistry/registries', parameters('acrName')), '2019-05-01').passwords[0].value]"
+              "value": "[listCredentials('containerRegistry', '2019-05-01').passwords[0].value]"
             },
             {
               "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-sftp-files/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "6574878384061361538"
+      "templateHash": "4588876734589341088"
     }
   },
   "parameters": {
@@ -155,7 +155,7 @@
               "readOnly": false,
               "shareName": "[parameters('fileShareName')]",
               "storageAccountName": "[variables('storageAccountName')]",
-              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2020-08-01-preview').keys[0].value]"
+              "storageAccountKey": "[listKeys('storageAccount', '2020-08-01-preview').keys[0].value]"
             }
           }
         ]

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/aci-wordpress/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "15092152355211734820"
+      "templateHash": "1874808718678481912"
     }
   },
   "parameters": {
@@ -96,7 +96,7 @@
         "azPowerShellVersion": "3.0",
         "storageAccountSettings": {
           "storageAccountName": "[parameters('storageAccountName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]"
+          "storageAccountKey": "[listKeys('stg', '2019-06-01').keys[0].value]"
         },
         "scriptContent": "[variables('wpScriptToExecute')]",
         "cleanupPreference": "OnSuccess",
@@ -124,7 +124,7 @@
         "azPowerShellVersion": "3.0",
         "storageAccountSettings": {
           "storageAccountName": "[parameters('storageAccountName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]"
+          "storageAccountKey": "[listKeys('stg', '2019-06-01').keys[0].value]"
         },
         "scriptContent": "[variables('sqlScriptToExecute')]",
         "cleanupPreference": "OnSuccess",
@@ -212,7 +212,7 @@
           {
             "azureFile": {
               "shareName": "[variables('wpShareName')]",
-              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]",
+              "storageAccountKey": "[listKeys('stg', '2019-06-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "wordpressfile"
@@ -220,7 +220,7 @@
           {
             "azureFile": {
               "shareName": "[variables('sqlShareName')]",
-              "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]",
+              "storageAccountKey": "[listKeys('stg', '2019-06-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "mysqlfile"

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/iot-with-storage/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/iot-with-storage/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "12727316593788848374"
+      "templateHash": "6762298828630915836"
     }
   },
   "parameters": {
@@ -82,7 +82,7 @@
           "endpoints": {
             "storageContainers": [
               {
-                "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]",
+                "connectionString": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', variables('storageAccountName'), environment().suffixes.storage, listKeys('stg', '2019-06-01').keys[0].value)]",
                 "containerName": "[variables('storageContainerName')]",
                 "fileNameFormat": "{iothub}/{partition}/{YYYY}/{MM}/{DD}/{HH}/{mm}",
                 "batchFrequencyInSeconds": 100,

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/jumpbox.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "5882546700845036639"
+      "templateHash": "6693041172534413310"
     }
   },
   "parameters": {
@@ -279,7 +279,7 @@
           "stopOnMultipleConnections": false
         },
         "protectedSettings": {
-          "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2020-10-01').primarySharedKey]"
+          "workspaceKey": "[listKeys('logAnalyticsWorkspace', '2020-10-01').primarySharedKey]"
         }
       },
       "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/private-aks-cluster/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "7099217802857967896"
+      "templateHash": "11478743218766629590"
     }
   },
   "parameters": {
@@ -1110,7 +1110,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "5882546700845036639"
+              "templateHash": "6693041172534413310"
             }
           },
           "parameters": {
@@ -1383,7 +1383,7 @@
                   "stopOnMultipleConnections": false
                 },
                 "protectedSettings": {
-                  "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2020-10-01').primarySharedKey]"
+                  "workspaceKey": "[listKeys('logAnalyticsWorkspace', '2020-10-01').primarySharedKey]"
                 }
               },
               "dependsOn": [

--- a/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/201/redis-premium-persistence/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "4242983551703296912"
+      "templateHash": "5964134893459816940"
     }
   },
   "parameters": {
@@ -113,7 +113,7 @@
           "rdb-backup-enabled": "true",
           "rdb-backup-frequency": "60",
           "rdb-backup-max-snapshot-count": "1",
-          "rdb-storage-connection-string": "[format('DefaultEndpointsProtocol=https;BlobEndpoint=https://{0}.blob.{1};AccountName={2};AccountKey={3}', parameters('storageAccountName'), environment().suffixes.storage, parameters('storageAccountName'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value)]"
+          "rdb-storage-connection-string": "[format('DefaultEndpointsProtocol=https;BlobEndpoint=https://{0}.blob.{1};AccountName={2};AccountKey={3}', parameters('storageAccountName'), environment().suffixes.storage, parameters('storageAccountName'), listKeys('storageAccount', '2021-04-01').keys[0].value)]"
         }
       }
     },

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/function-app-with-custom-domain-managed-certificate/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "11676306796050547526"
+      "templateHash": "14018630185797880413"
     }
   },
   "parameters": {
@@ -99,11 +99,11 @@
             },
             {
               "name": "AzureWebJobsStorage",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', format('{0}st', replace(variables('componentBase'), '-', '')), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', format('{0}st', replace(variables('componentBase'), '-', ''))), '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', format('{0}st', replace(variables('componentBase'), '-', '')), environment().suffixes.storage, listKeys('storage', '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', format('{0}st', replace(variables('componentBase'), '-', '')), environment().suffixes.storage, listKeys(resourceId('Microsoft.Storage/storageAccounts', format('{0}st', replace(variables('componentBase'), '-', ''))), '2019-06-01').keys[0].value)]"
+              "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};EndpointSuffix={1};AccountKey={2}', format('{0}st', replace(variables('componentBase'), '-', '')), environment().suffixes.storage, listKeys('storage', '2019-06-01').keys[0].value)]"
             },
             {
               "name": "WEBSITE_CONTENTSHARE",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9057535916510324216"
+      "templateHash": "5491712624423386996"
     }
   },
   "parameters": {
@@ -59,7 +59,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1068286565697285392"
+              "templateHash": "250853418754530153"
             }
           },
           "parameters": {
@@ -172,7 +172,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "1258101679779122937"
+                      "templateHash": "16716795212938447812"
                     }
                   },
                   "parameters": {
@@ -314,7 +314,7 @@
                           "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
                         },
                         "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
+                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
                       },
                       "dependsOn": [
                         "azureDefender",
@@ -528,7 +528,7 @@
                             "_generator": {
                               "name": "bicep",
                               "version": "dev",
-                              "templateHash": "2831038909335126258"
+                              "templateHash": "11469233179948538129"
                             }
                           },
                           "parameters": {
@@ -618,7 +618,7 @@
                                   "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
                                 },
                                 "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
+                                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
                               },
                               "dependsOn": [
                                 "azureDefender",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-database.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "2831038909335126258"
+      "templateHash": "11469233179948538129"
     }
   },
   "parameters": {
@@ -96,7 +96,7 @@
           "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
         },
         "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
+        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
       },
       "dependsOn": [
         "azureDefender",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-server.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1258101679779122937"
+      "templateHash": "16716795212938447812"
     }
   },
   "parameters": {
@@ -148,7 +148,7 @@
           "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
         },
         "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
+        "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
       },
       "dependsOn": [
         "azureDefender",
@@ -362,7 +362,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "2831038909335126258"
+              "templateHash": "11469233179948538129"
             }
           },
           "parameters": {
@@ -452,7 +452,7 @@
                   "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
                 },
                 "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
+                "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
               },
               "dependsOn": [
                 "azureDefender",

--- a/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/301/sql-database-with-management/modules/sql-logical-servers.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "1068286565697285392"
+      "templateHash": "250853418754530153"
     }
   },
   "parameters": {
@@ -119,7 +119,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "1258101679779122937"
+              "templateHash": "16716795212938447812"
             }
           },
           "parameters": {
@@ -261,7 +261,7 @@
                   "emails": "[parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.emails]"
                 },
                 "storageContainerPath": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
+                "storageAccountAccessKey": "[if(not(empty(parameters('sqlLogicalServer').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
               },
               "dependsOn": [
                 "azureDefender",
@@ -475,7 +475,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "dev",
-                      "templateHash": "2831038909335126258"
+                      "templateHash": "11469233179948538129"
                     }
                   },
                   "parameters": {
@@ -565,7 +565,7 @@
                           "emails": "[parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.emails]"
                         },
                         "storageContainerPath": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), format('{0}{1}', reference('storageAccountVulnerabilityAssessments').primaryEndpoints.blob, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.containerName), '')]",
-                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.resourceGroupName), 'Microsoft.Storage/storageAccounts', parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name), '2021-04-01').keys[0].value, '')]"
+                        "storageAccountAccessKey": "[if(not(empty(parameters('sqlDatabase').azureDefender.vulnerabilityAssessments.storageAccount.name)), listKeys('storageAccountVulnerabilityAssessments', '2021-04-01').keys[0].value, '')]"
                       },
                       "dependsOn": [
                         "azureDefender",

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/main.json
@@ -10,7 +10,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "14160766691322920806"
+      "templateHash": "12215227315513211084"
     }
   },
   "parameters": {
@@ -70,7 +70,7 @@
             "_generator": {
               "name": "bicep",
               "version": "dev",
-              "templateHash": "9852798249945125896"
+              "templateHash": "6074732564892661550"
             }
           },
           "parameters": {
@@ -137,7 +137,7 @@
             },
             "kubeConfig": {
               "type": "string",
-              "value": "[listClusterAdminCredential(resourceId('Microsoft.ContainerService/managedClusters', parameters('baseName')), '2020-09-01').kubeconfigs[0].value]"
+              "value": "[listClusterAdminCredential('aks', '2020-09-01').kubeconfigs[0].value]"
             }
           }
         }

--- a/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/aks.json
+++ b/src/Bicep.Core.Samples/Files/user_submitted/extensibility/aks/modules/aks.json
@@ -10,7 +10,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "9852798249945125896"
+      "templateHash": "6074732564892661550"
     }
   },
   "parameters": {
@@ -77,7 +77,7 @@
     },
     "kubeConfig": {
       "type": "string",
-      "value": "[listClusterAdminCredential(resourceId('Microsoft.ContainerService/managedClusters', parameters('baseName')), '2020-09-01').kubeconfigs[0].value]"
+      "value": "[listClusterAdminCredential('aks', '2020-09-01').kubeconfigs[0].value]"
     }
   }
 }

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -5,6 +5,7 @@ using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using Azure.Deployments.Expression.Expressions;
 using Bicep.Core.Analyzers.Linter.Common;
 using Bicep.Core.Extensions;
@@ -130,24 +131,26 @@ namespace Bicep.Core.Emit
                 case ResourceFunctionCallExpression listFunction when listFunction.Name.StartsWithOrdinalInsensitively(LanguageConstants.ListFunctionPrefix):
                     {
                         var resource = listFunction.Resource.Metadata;
-                        var resourceIdExpression = new PropertyAccessExpression(
-                            listFunction.Resource.SourceSyntax,
-                            listFunction.Resource,
-                            "id",
-                            AccessExpressionFlags.None);
+
+                        var functionTargetExpression =
+                            context.Settings.EnableSymbolicNames && resource is DeclaredResourceMetadata declared
+                                ? GenerateSymbolicReference(declared, listFunction.Resource.IndexContext)
+                                : ConvertExpression(new PropertyAccessExpression(
+                                    listFunction.Resource.SourceSyntax,
+                                    listFunction.Resource,
+                                    "id",
+                                    AccessExpressionFlags.None));
 
                         var apiVersion = resource.TypeReference.ApiVersion ?? throw new InvalidOperationException($"Expected resource type {resource.TypeReference.FormatName()} to contain version");
-                        var apiVersionExpression = new StringLiteralExpression(listFunction.Resource.SourceSyntax, apiVersion);
+                        var apiVersionExpression = new JTokenExpression(apiVersion);
 
                         var listArgs = listFunction.Parameters.Length switch
                         {
-                            0 => new Expression[] { resourceIdExpression, apiVersionExpression, },
-                            _ => new Expression[] { resourceIdExpression, }.Concat(listFunction.Parameters),
+                            0 => new LanguageExpression[] { functionTargetExpression, apiVersionExpression, },
+                            _ => new LanguageExpression[] { functionTargetExpression, }.Concat(listFunction.Parameters.Select(ConvertExpression)),
                         };
 
-                        return CreateFunction(
-                            listFunction.Name,
-                            listArgs.Select(p => ConvertExpression(p)));
+                        return CreateFunction(listFunction.Name, listArgs);
                     }
 
                 case PropertyAccessExpression exp:


### PR DESCRIPTION
I noticed that we use resource IDs instead of symbolic names for `list*()` function calls even though the backend supports both. I find the symbolic names easier to read, but this change shouldn't have any observable impact.