### PR TITLE
Support importing and declaring types in .bicepparam files

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -802,7 +802,7 @@ Hello from Bicep!"));
         [DataRow(
             "ParamsFile",
             "BCP337",
-            $"""This declaration type is not valid for a Bicep Parameters file. Specify a "{LanguageConstants.UsingKeyword}", "{LanguageConstants.ExtendsKeyword}", "{LanguageConstants.ParameterKeyword}" or "{LanguageConstants.VariableKeyword}" declaration.""")]
+            $"""This declaration type is not valid for a Bicep Parameters file. Supported declarations: "using", "extends", "param", "var".""")]
         [DataRow(
             "MainFile",
             "BCP037",

--- a/src/Bicep.Core.Samples/BaselineData_Bicepparam.cs
+++ b/src/Bicep.Core.Samples/BaselineData_Bicepparam.cs
@@ -108,6 +108,7 @@ namespace Bicep.Core.Samples
                 "Files/baselines_bicepparam/Invalid_Variables/parameters.bicepparam",
                 "Files/baselines_bicepparam/Invalid_MismatchedTypes/parameters.bicepparam",
                 "Files/baselines_bicepparam/Parameters/parameters.bicepparam",
+                "Files/baselines_bicepparam/TypedVariables/parameters.bicepparam",
                 "Files/baselines_bicepparam/Variables/parameters.bicepparam",
                 "Files/baselines_bicepparam/External_Inputs/parameters.bicepparam",
                 "Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.bicepparam");

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Parameters/parameters.diagnostics.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Parameters/parameters.diagnostics.bicepparam
@@ -7,10 +7,10 @@ param para1 = 'value
 //@[14:20) [BCP004 (Error)] The string at this location is not terminated due to an unexpected new line character. (bicep https://aka.ms/bicep/core-diagnostics#BCP004) |'value|
 
 para
-//@[00:04) [BCP337 (Error)] This declaration type is not valid for a Bicep Parameters file. Specify a "using", "extends", "param" or "var" declaration. (bicep https://aka.ms/bicep/core-diagnostics#BCP337) |para|
+//@[00:04) [BCP337 (Error)] This declaration type is not valid for a Bicep Parameters file. Supported declarations: "using", "extends", "param", "var", "type". (bicep https://aka.ms/bicep/core-diagnostics#BCP337) |para|
 
 para2
-//@[00:05) [BCP337 (Error)] This declaration type is not valid for a Bicep Parameters file. Specify a "using", "extends", "param" or "var" declaration. (bicep https://aka.ms/bicep/core-diagnostics#BCP337) |para2|
+//@[00:05) [BCP337 (Error)] This declaration type is not valid for a Bicep Parameters file. Supported declarations: "using", "extends", "param", "var", "type". (bicep https://aka.ms/bicep/core-diagnostics#BCP337) |para2|
 
 param expr = 1 + 2
 //@[00:18) [BCP259 (Error)] The parameter "expr" is assigned in the params file without being declared in the Bicep file. (bicep https://aka.ms/bicep/core-diagnostics#BCP259) |param expr = 1 + 2|

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+  "experimentalFeaturesEnabled": {
+    "typedVariables": true
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.bicepparam
@@ -1,0 +1,26 @@
+using 'main.bicep'
+
+import { FooType } from './types.bicep'
+
+var imported FooType = {
+  stringProp: 'adfadf'
+  intProp: 123
+}
+
+var inline {
+  stringProp: string
+  intProp: int
+} = {
+  stringProp: 'asdaosd'
+  intProp: 123
+}
+
+type InFileType = {
+  stringProp: string
+  intProp: int
+}
+
+var inFile InFileType = {
+  stringProp: 'asdaosd'
+  intProp: 123
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.diagnostics.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.diagnostics.bicepparam
@@ -1,0 +1,30 @@
+using 'main.bicep'
+
+import { FooType } from './types.bicep'
+
+var imported FooType = {
+//@[4:12) [no-unused-vars (Warning)] Variable "imported" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |imported|
+  stringProp: 'adfadf'
+  intProp: 123
+}
+
+var inline {
+//@[4:10) [no-unused-vars (Warning)] Variable "inline" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |inline|
+  stringProp: string
+  intProp: int
+} = {
+  stringProp: 'asdaosd'
+  intProp: 123
+}
+
+type InFileType = {
+  stringProp: string
+  intProp: int
+}
+
+var inFile InFileType = {
+//@[4:10) [no-unused-vars (Warning)] Variable "inFile" is declared but never used. (bicep core linter https://aka.ms/bicep/linter/no-unused-vars) |inFile|
+  stringProp: 'asdaosd'
+  intProp: 123
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.formatted.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.formatted.bicepparam
@@ -1,0 +1,26 @@
+using 'main.bicep'
+
+import { FooType } from './types.bicep'
+
+var imported FooType = {
+  stringProp: 'adfadf'
+  intProp: 123
+}
+
+var inline {
+  stringProp: string
+  intProp: int
+} = {
+  stringProp: 'asdaosd'
+  intProp: 123
+}
+
+type InFileType = {
+  stringProp: string
+  intProp: int
+}
+
+var inFile InFileType = {
+  stringProp: 'asdaosd'
+  intProp: 123
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.json
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {}
+}

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.symbols.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.symbols.bicepparam
@@ -1,0 +1,32 @@
+using 'main.bicep'
+
+import { FooType } from './types.bicep'
+//@[9:16) TypeAlias FooType. Type: Type<{ stringProp: string, intProp: int }>. Declaration start char: 9, length: 7
+
+var imported FooType = {
+//@[4:12) Variable imported. Type: { stringProp: string, intProp: int }. Declaration start char: 0, length: 64
+  stringProp: 'adfadf'
+  intProp: 123
+}
+
+var inline {
+//@[4:10) Variable inline. Type: { stringProp: string, intProp: int }. Declaration start char: 0, length: 95
+  stringProp: string
+  intProp: int
+} = {
+  stringProp: 'asdaosd'
+  intProp: 123
+}
+
+type InFileType = {
+//@[5:15) TypeAlias InFileType. Type: Type<{ stringProp: string, intProp: int }>. Declaration start char: 0, length: 57
+  stringProp: string
+  intProp: int
+}
+
+var inFile InFileType = {
+//@[4:10) Variable inFile. Type: { stringProp: string, intProp: int }. Declaration start char: 0, length: 66
+  stringProp: 'asdaosd'
+  intProp: 123
+}
+

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.syntax.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.syntax.bicepparam
@@ -1,0 +1,171 @@
+using 'main.bicep'
+//@[00:350) ProgramSyntax
+//@[00:018) ├─UsingDeclarationSyntax
+//@[00:005) | ├─Token(Identifier) |using|
+//@[06:018) | └─StringSyntax
+//@[06:018) |   └─Token(StringComplete) |'main.bicep'|
+//@[18:020) ├─Token(NewLine) |\n\n|
+
+import { FooType } from './types.bicep'
+//@[00:039) ├─CompileTimeImportDeclarationSyntax
+//@[00:006) | ├─Token(Identifier) |import|
+//@[07:018) | ├─ImportedSymbolsListSyntax
+//@[07:008) | | ├─Token(LeftBrace) |{|
+//@[09:016) | | ├─ImportedSymbolsListItemSyntax
+//@[09:016) | | | └─IdentifierSyntax
+//@[09:016) | | |   └─Token(Identifier) |FooType|
+//@[17:018) | | └─Token(RightBrace) |}|
+//@[19:039) | └─CompileTimeImportFromClauseSyntax
+//@[19:023) |   ├─Token(Identifier) |from|
+//@[24:039) |   └─StringSyntax
+//@[24:039) |     └─Token(StringComplete) |'./types.bicep'|
+//@[39:041) ├─Token(NewLine) |\n\n|
+
+var imported FooType = {
+//@[00:064) ├─VariableDeclarationSyntax
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:012) | ├─IdentifierSyntax
+//@[04:012) | | └─Token(Identifier) |imported|
+//@[13:020) | ├─TypeVariableAccessSyntax
+//@[13:020) | | └─IdentifierSyntax
+//@[13:020) | |   └─Token(Identifier) |FooType|
+//@[21:022) | ├─Token(Assignment) |=|
+//@[23:064) | └─ObjectSyntax
+//@[23:024) |   ├─Token(LeftBrace) |{|
+//@[24:025) |   ├─Token(NewLine) |\n|
+  stringProp: 'adfadf'
+//@[02:022) |   ├─ObjectPropertySyntax
+//@[02:012) |   | ├─IdentifierSyntax
+//@[02:012) |   | | └─Token(Identifier) |stringProp|
+//@[12:013) |   | ├─Token(Colon) |:|
+//@[14:022) |   | └─StringSyntax
+//@[14:022) |   |   └─Token(StringComplete) |'adfadf'|
+//@[22:023) |   ├─Token(NewLine) |\n|
+  intProp: 123
+//@[02:014) |   ├─ObjectPropertySyntax
+//@[02:009) |   | ├─IdentifierSyntax
+//@[02:009) |   | | └─Token(Identifier) |intProp|
+//@[09:010) |   | ├─Token(Colon) |:|
+//@[11:014) |   | └─IntegerLiteralSyntax
+//@[11:014) |   |   └─Token(Integer) |123|
+//@[14:015) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:003) ├─Token(NewLine) |\n\n|
+
+var inline {
+//@[00:095) ├─VariableDeclarationSyntax
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:010) | ├─IdentifierSyntax
+//@[04:010) | | └─Token(Identifier) |inline|
+//@[11:050) | ├─ObjectTypeSyntax
+//@[11:012) | | ├─Token(LeftBrace) |{|
+//@[12:013) | | ├─Token(NewLine) |\n|
+  stringProp: string
+//@[02:020) | | ├─ObjectTypePropertySyntax
+//@[02:012) | | | ├─IdentifierSyntax
+//@[02:012) | | | | └─Token(Identifier) |stringProp|
+//@[12:013) | | | ├─Token(Colon) |:|
+//@[14:020) | | | └─TypeVariableAccessSyntax
+//@[14:020) | | |   └─IdentifierSyntax
+//@[14:020) | | |     └─Token(Identifier) |string|
+//@[20:021) | | ├─Token(NewLine) |\n|
+  intProp: int
+//@[02:014) | | ├─ObjectTypePropertySyntax
+//@[02:009) | | | ├─IdentifierSyntax
+//@[02:009) | | | | └─Token(Identifier) |intProp|
+//@[09:010) | | | ├─Token(Colon) |:|
+//@[11:014) | | | └─TypeVariableAccessSyntax
+//@[11:014) | | |   └─IdentifierSyntax
+//@[11:014) | | |     └─Token(Identifier) |int|
+//@[14:015) | | ├─Token(NewLine) |\n|
+} = {
+//@[00:001) | | └─Token(RightBrace) |}|
+//@[02:003) | ├─Token(Assignment) |=|
+//@[04:046) | └─ObjectSyntax
+//@[04:005) |   ├─Token(LeftBrace) |{|
+//@[05:006) |   ├─Token(NewLine) |\n|
+  stringProp: 'asdaosd'
+//@[02:023) |   ├─ObjectPropertySyntax
+//@[02:012) |   | ├─IdentifierSyntax
+//@[02:012) |   | | └─Token(Identifier) |stringProp|
+//@[12:013) |   | ├─Token(Colon) |:|
+//@[14:023) |   | └─StringSyntax
+//@[14:023) |   |   └─Token(StringComplete) |'asdaosd'|
+//@[23:024) |   ├─Token(NewLine) |\n|
+  intProp: 123
+//@[02:014) |   ├─ObjectPropertySyntax
+//@[02:009) |   | ├─IdentifierSyntax
+//@[02:009) |   | | └─Token(Identifier) |intProp|
+//@[09:010) |   | ├─Token(Colon) |:|
+//@[11:014) |   | └─IntegerLiteralSyntax
+//@[11:014) |   |   └─Token(Integer) |123|
+//@[14:015) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:003) ├─Token(NewLine) |\n\n|
+
+type InFileType = {
+//@[00:057) ├─TypeDeclarationSyntax
+//@[00:004) | ├─Token(Identifier) |type|
+//@[05:015) | ├─IdentifierSyntax
+//@[05:015) | | └─Token(Identifier) |InFileType|
+//@[16:017) | ├─Token(Assignment) |=|
+//@[18:057) | └─ObjectTypeSyntax
+//@[18:019) |   ├─Token(LeftBrace) |{|
+//@[19:020) |   ├─Token(NewLine) |\n|
+  stringProp: string
+//@[02:020) |   ├─ObjectTypePropertySyntax
+//@[02:012) |   | ├─IdentifierSyntax
+//@[02:012) |   | | └─Token(Identifier) |stringProp|
+//@[12:013) |   | ├─Token(Colon) |:|
+//@[14:020) |   | └─TypeVariableAccessSyntax
+//@[14:020) |   |   └─IdentifierSyntax
+//@[14:020) |   |     └─Token(Identifier) |string|
+//@[20:021) |   ├─Token(NewLine) |\n|
+  intProp: int
+//@[02:014) |   ├─ObjectTypePropertySyntax
+//@[02:009) |   | ├─IdentifierSyntax
+//@[02:009) |   | | └─Token(Identifier) |intProp|
+//@[09:010) |   | ├─Token(Colon) |:|
+//@[11:014) |   | └─TypeVariableAccessSyntax
+//@[11:014) |   |   └─IdentifierSyntax
+//@[11:014) |   |     └─Token(Identifier) |int|
+//@[14:015) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:003) ├─Token(NewLine) |\n\n|
+
+var inFile InFileType = {
+//@[00:066) ├─VariableDeclarationSyntax
+//@[00:003) | ├─Token(Identifier) |var|
+//@[04:010) | ├─IdentifierSyntax
+//@[04:010) | | └─Token(Identifier) |inFile|
+//@[11:021) | ├─TypeVariableAccessSyntax
+//@[11:021) | | └─IdentifierSyntax
+//@[11:021) | |   └─Token(Identifier) |InFileType|
+//@[22:023) | ├─Token(Assignment) |=|
+//@[24:066) | └─ObjectSyntax
+//@[24:025) |   ├─Token(LeftBrace) |{|
+//@[25:026) |   ├─Token(NewLine) |\n|
+  stringProp: 'asdaosd'
+//@[02:023) |   ├─ObjectPropertySyntax
+//@[02:012) |   | ├─IdentifierSyntax
+//@[02:012) |   | | └─Token(Identifier) |stringProp|
+//@[12:013) |   | ├─Token(Colon) |:|
+//@[14:023) |   | └─StringSyntax
+//@[14:023) |   |   └─Token(StringComplete) |'asdaosd'|
+//@[23:024) |   ├─Token(NewLine) |\n|
+  intProp: 123
+//@[02:014) |   ├─ObjectPropertySyntax
+//@[02:009) |   | ├─IdentifierSyntax
+//@[02:009) |   | | └─Token(Identifier) |intProp|
+//@[09:010) |   | ├─Token(Colon) |:|
+//@[11:014) |   | └─IntegerLiteralSyntax
+//@[11:014) |   |   └─Token(Integer) |123|
+//@[14:015) |   ├─Token(NewLine) |\n|
+}
+//@[00:001) |   └─Token(RightBrace) |}|
+//@[01:002) ├─Token(NewLine) |\n|
+
+//@[00:000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.tokens.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/parameters.tokens.bicepparam
@@ -1,0 +1,111 @@
+using 'main.bicep'
+//@[00:05) Identifier |using|
+//@[06:18) StringComplete |'main.bicep'|
+//@[18:20) NewLine |\n\n|
+
+import { FooType } from './types.bicep'
+//@[00:06) Identifier |import|
+//@[07:08) LeftBrace |{|
+//@[09:16) Identifier |FooType|
+//@[17:18) RightBrace |}|
+//@[19:23) Identifier |from|
+//@[24:39) StringComplete |'./types.bicep'|
+//@[39:41) NewLine |\n\n|
+
+var imported FooType = {
+//@[00:03) Identifier |var|
+//@[04:12) Identifier |imported|
+//@[13:20) Identifier |FooType|
+//@[21:22) Assignment |=|
+//@[23:24) LeftBrace |{|
+//@[24:25) NewLine |\n|
+  stringProp: 'adfadf'
+//@[02:12) Identifier |stringProp|
+//@[12:13) Colon |:|
+//@[14:22) StringComplete |'adfadf'|
+//@[22:23) NewLine |\n|
+  intProp: 123
+//@[02:09) Identifier |intProp|
+//@[09:10) Colon |:|
+//@[11:14) Integer |123|
+//@[14:15) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:03) NewLine |\n\n|
+
+var inline {
+//@[00:03) Identifier |var|
+//@[04:10) Identifier |inline|
+//@[11:12) LeftBrace |{|
+//@[12:13) NewLine |\n|
+  stringProp: string
+//@[02:12) Identifier |stringProp|
+//@[12:13) Colon |:|
+//@[14:20) Identifier |string|
+//@[20:21) NewLine |\n|
+  intProp: int
+//@[02:09) Identifier |intProp|
+//@[09:10) Colon |:|
+//@[11:14) Identifier |int|
+//@[14:15) NewLine |\n|
+} = {
+//@[00:01) RightBrace |}|
+//@[02:03) Assignment |=|
+//@[04:05) LeftBrace |{|
+//@[05:06) NewLine |\n|
+  stringProp: 'asdaosd'
+//@[02:12) Identifier |stringProp|
+//@[12:13) Colon |:|
+//@[14:23) StringComplete |'asdaosd'|
+//@[23:24) NewLine |\n|
+  intProp: 123
+//@[02:09) Identifier |intProp|
+//@[09:10) Colon |:|
+//@[11:14) Integer |123|
+//@[14:15) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:03) NewLine |\n\n|
+
+type InFileType = {
+//@[00:04) Identifier |type|
+//@[05:15) Identifier |InFileType|
+//@[16:17) Assignment |=|
+//@[18:19) LeftBrace |{|
+//@[19:20) NewLine |\n|
+  stringProp: string
+//@[02:12) Identifier |stringProp|
+//@[12:13) Colon |:|
+//@[14:20) Identifier |string|
+//@[20:21) NewLine |\n|
+  intProp: int
+//@[02:09) Identifier |intProp|
+//@[09:10) Colon |:|
+//@[11:14) Identifier |int|
+//@[14:15) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:03) NewLine |\n\n|
+
+var inFile InFileType = {
+//@[00:03) Identifier |var|
+//@[04:10) Identifier |inFile|
+//@[11:21) Identifier |InFileType|
+//@[22:23) Assignment |=|
+//@[24:25) LeftBrace |{|
+//@[25:26) NewLine |\n|
+  stringProp: 'asdaosd'
+//@[02:12) Identifier |stringProp|
+//@[12:13) Colon |:|
+//@[14:23) StringComplete |'asdaosd'|
+//@[23:24) NewLine |\n|
+  intProp: 123
+//@[02:09) Identifier |intProp|
+//@[09:10) Colon |:|
+//@[11:14) Integer |123|
+//@[14:15) NewLine |\n|
+}
+//@[00:01) RightBrace |}|
+//@[01:02) NewLine |\n|
+
+//@[00:00) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/types.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/TypedVariables/types.bicep
@@ -1,0 +1,5 @@
+@export()
+type FooType = {
+  stringProp: string
+  intProp: int
+}

--- a/src/Bicep.Core.UnitTests/Assertions/DiagnosticAssertions.cs
+++ b/src/Bicep.Core.UnitTests/Assertions/DiagnosticAssertions.cs
@@ -25,6 +25,7 @@ namespace Bicep.Core.UnitTests.Assertions
         {
             public bool CanHandle(object value)
             {
+                
                 return value is Diagnostic;
             }
 

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -17,6 +17,7 @@ using Bicep.Core.Text;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Providers;
 using Bicep.IO.Abstraction;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 
 namespace Bicep.Core.Diagnostics
 {
@@ -1576,9 +1577,25 @@ namespace Bicep.Core.Diagnostics
                 "BCP335",
                 $"The provided value can have a length as large as {sourceMaxLength} and may be too long to assign to a target with a configured maximum length of {targetMaxLength}.");
 
-            public Diagnostic UnrecognizedParamsFileDeclaration() => CoreError(
-                "BCP337",
-                $@"This declaration type is not valid for a Bicep Parameters file. Specify a ""{LanguageConstants.UsingKeyword}"", ""{LanguageConstants.ExtendsKeyword}"", ""{LanguageConstants.ParameterKeyword}"" or ""{LanguageConstants.VariableKeyword}"" declaration.");
+            public Diagnostic UnrecognizedParamsFileDeclaration(bool supportsTypeDeclarations)
+            {
+                List<string> supportedDeclarations = [
+                    LanguageConstants.UsingKeyword,
+                    LanguageConstants.ExtendsKeyword,
+                    LanguageConstants.ParameterKeyword,
+                    LanguageConstants.VariableKeyword,
+                ];
+
+                // TODO make this unconditional when we release typed variables
+                if (supportsTypeDeclarations)
+                {
+                    supportedDeclarations.Add(LanguageConstants.TypeKeyword);
+                }
+
+                return CoreError(
+                    "BCP337",
+                    $@"This declaration type is not valid for a Bicep Parameters file. Supported declarations: {ToQuotedString(supportedDeclarations)}.");
+            }
 
             public Diagnostic FailedToEvaluateParameter(string parameterName, string message) => CoreError(
                 "BCP338",

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -51,6 +51,16 @@ namespace Bicep.Core.Parsing
             return new VariableDeclarationSyntax(leadingNodes, keyword, name, type, assignment, value);
         }
 
+        protected SyntaxBase TypeDeclaration(IEnumerable<SyntaxBase> leadingNodes)
+        {
+            var keyword = ExpectKeyword(LanguageConstants.TypeKeyword);
+            var name = this.IdentifierWithRecovery(b => b.ExpectedTypeIdentifier(), RecoveryFlags.None, TokenType.Assignment, TokenType.NewLine);
+            var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(name), TokenType.NewLine);
+            var value = this.WithRecovery(() => Type(allowOptionalResourceType: false), GetSuppressionFlag(name), TokenType.Assignment, TokenType.LeftBrace, TokenType.NewLine);
+
+            return new TypeDeclarationSyntax(leadingNodes, keyword, name, assignment, value);
+        }
+
         protected CompileTimeImportDeclarationSyntax CompileTimeImportDeclaration(Token keyword, IEnumerable<SyntaxBase> leadingNodes)
         {
             SyntaxBase importExpression = reader.Peek().Type switch

--- a/src/Bicep.Core/Parsing/ParamsParser.cs
+++ b/src/Bicep.Core/Parsing/ParamsParser.cs
@@ -62,10 +62,11 @@ namespace Bicep.Core.Parsing
                             LanguageConstants.VariableKeyword => this.VariableDeclaration(leadingNodes),
                             LanguageConstants.ImportKeyword => this.CompileTimeImportDeclaration(ExpectKeyword(LanguageConstants.ImportKeyword), leadingNodes),
                             LanguageConstants.ExtensionKeyword => this.ExtensionConfigAssignment(leadingNodes),
-                            _ => throw new ExpectedTokenException(current, b => b.UnrecognizedParamsFileDeclaration()),
+                            LanguageConstants.TypeKeyword => this.TypeDeclaration(leadingNodes),
+                            _ => throw new ExpectedTokenException(current, b => b.UnrecognizedParamsFileDeclaration(supportsTypeDeclarations: true)),
                         },
                         TokenType.NewLine => this.NewLine(),
-                        _ => throw new ExpectedTokenException(current, b => b.UnrecognizedParamsFileDeclaration()),
+                        _ => throw new ExpectedTokenException(current, b => b.UnrecognizedParamsFileDeclaration(supportsTypeDeclarations: true)),
                     };
 
                     string? ValidateKeyword(string keyword) =>

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -102,16 +102,6 @@ namespace Bicep.Core.Parsing
             return new MetadataDeclarationSyntax(leadingNodes, keyword, name, assignment, value);
         }
 
-        private SyntaxBase TypeDeclaration(IEnumerable<SyntaxBase> leadingNodes)
-        {
-            var keyword = ExpectKeyword(LanguageConstants.TypeKeyword);
-            var name = this.IdentifierWithRecovery(b => b.ExpectedTypeIdentifier(), RecoveryFlags.None, TokenType.Assignment, TokenType.NewLine);
-            var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(name), TokenType.NewLine);
-            var value = this.WithRecovery(() => Type(allowOptionalResourceType: false), GetSuppressionFlag(name), TokenType.Assignment, TokenType.LeftBrace, TokenType.NewLine);
-
-            return new TypeDeclarationSyntax(leadingNodes, keyword, name, assignment, value);
-        }
-
         private SyntaxBase ParameterDeclaration(IEnumerable<SyntaxBase> leadingNodes)
         {
             var keyword = ExpectKeyword(LanguageConstants.ParameterKeyword);

--- a/src/Bicep.Core/Semantics/ImportedSymbol.cs
+++ b/src/Bicep.Core/Semantics/ImportedSymbol.cs
@@ -65,6 +65,7 @@ public abstract class ImportedSymbol<T> : ImportedSymbol where T : ExportMetadat
         {
             ExportMetadataKind.Variable or
             ExportMetadataKind.Function => true,
+            ExportMetadataKind.Type when Context.SourceFile.Features.TypedVariablesEnabled => true,
             _ => false,
         },
         _ => false,

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -2173,7 +2173,12 @@ namespace Bicep.Core.Semantics.Namespaces
 
             }
 
-            foreach (var typeProp in GetArmPrimitiveTypes().Concat(GetResourceDerivedTypesTypeProperties()))
+            foreach (var typeProp in GetArmPrimitiveTypes())
+            {
+                yield return new(typeProp, (features, sfk) => true);
+            }
+
+            foreach (var typeProp in GetResourceDerivedTypesTypeProperties())
             {
                 yield return new(typeProp, (features, sfk) => sfk == BicepSourceFileKind.BicepFile);
             }


### PR DESCRIPTION
If the `typedVariables` experimental feature is enabled then:
* Allow usage of the `type` keyword in .bicepparam files
* Allow importing types from .bicep files in .bicepparam files
* Allow usage of inline types in .bicepparam files