### PR TITLE
Fix SourceArchive.FindDocumentLinks

### DIFF
--- a/src/Bicep.Core/SourceLink/SourceArchive.cs
+++ b/src/Bicep.Core/SourceLink/SourceArchive.cs
@@ -219,7 +219,8 @@ namespace Bicep.Core.SourceLink
             return new SourceArchive(metadata, fileEntries.ToImmutableDictionary());
         }
 
-        public ImmutableArray<SourceCodeDocumentPathLink> FindDocumentLinks(string path) => this.metadata.DocumentLinks[path];
+        public ImmutableArray<SourceCodeDocumentPathLink> FindDocumentLinks(string path) =>
+            this.metadata.DocumentLinks.TryGetValue(path, out var documentLinks) ? documentLinks : [];
 
         public LinkedSourceFile FindSourceFile(string path)
         {


### PR DESCRIPTION
`SourceArchive.FindDocumentLinks` should return an empty array instead of throwing an exception if no document links are found.

Closes #16935.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/16939)