### PR TITLE
Local deploy: ensure languageversion 2.2-experimental emitting is enabled

### DIFF
--- a/src/Bicep.Cli/Commands/LocalDeployCommand.cs
+++ b/src/Bicep.Cli/Commands/LocalDeployCommand.cs
@@ -13,6 +13,7 @@ using Bicep.Core.Registry.Auth;
 using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Types;
+using Bicep.IO.Abstraction;
 using Bicep.Local.Deploy;
 using Bicep.Local.Deploy.Extensibility;
 using Bicep.Local.Extension.Rpc;
@@ -23,6 +24,7 @@ namespace Bicep.Cli.Commands;
 
 public class LocalDeployCommand : ICommand
 {
+    private readonly IFileExplorer fileExplorer;
     private readonly IModuleDispatcher moduleDispatcher;
     private readonly IConfigurationManager configurationManager;
     private readonly ITokenCredentialFactory credentialFactory;
@@ -32,6 +34,7 @@ public class LocalDeployCommand : ICommand
     private readonly BicepCompiler compiler;
 
     public LocalDeployCommand(
+        IFileExplorer fileExplorer,
         IModuleDispatcher moduleDispatcher,
         IConfigurationManager configurationManager,
         ITokenCredentialFactory credentialFactory,
@@ -40,6 +43,7 @@ public class LocalDeployCommand : ICommand
         DiagnosticLogger diagnosticLogger,
         BicepCompiler compiler)
     {
+        this.fileExplorer = fileExplorer;
         this.moduleDispatcher = moduleDispatcher;
         this.configurationManager = configurationManager;
         this.credentialFactory = credentialFactory;
@@ -81,7 +85,7 @@ public class LocalDeployCommand : ICommand
             return 1;
         }
 
-        await using LocalExtensibilityHostManager extensibilityHandler = new(moduleDispatcher, configurationManager, credentialFactory, GrpcBuiltInLocalExtension.Start);
+        await using LocalExtensibilityHostManager extensibilityHandler = new(fileExplorer, moduleDispatcher, configurationManager, credentialFactory, GrpcBuiltInLocalExtension.Start);
         await extensibilityHandler.InitializeExtensions(compilation);
         var result = await extensibilityHandler.Deploy(templateString, parametersString, cancellationToken);
 

--- a/src/Bicep.Core.UnitTests/Utils/ExtensionTestHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ExtensionTestHelper.cs
@@ -29,16 +29,19 @@ public static class ExtensionTestHelper
     }
 
     public static Task<ServiceBuilder> GetServiceBuilderWithPublishedExtension(BinaryData tgzData, FeatureProviderOverrides features, IFileSystem? fileSystem = null)
-        => GetServiceBuilderWithPublishedExtension(tgzData, "example.azurecr.io/extensions/foo:1.2.3", features, fileSystem);
+        => GetServiceBuilderWithPublishedExtension(new ExtensionPackage(tgzData, false, []), "example.azurecr.io/extensions/foo:1.2.3", features, fileSystem);
 
-    public static async Task<ServiceBuilder> GetServiceBuilderWithPublishedExtension(BinaryData tgzData, string target, FeatureProviderOverrides features, IFileSystem? fileSystem = null)
+    public static Task<ServiceBuilder> GetServiceBuilderWithPublishedExtension(ExtensionPackage package, FeatureProviderOverrides features, IFileSystem? fileSystem = null)
+        => GetServiceBuilderWithPublishedExtension(package, "example.azurecr.io/extensions/foo:1.2.3", features, fileSystem);
+
+    public static async Task<ServiceBuilder> GetServiceBuilderWithPublishedExtension(ExtensionPackage package, string target, FeatureProviderOverrides features, IFileSystem? fileSystem = null)
     {
         var reference = OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile, ArtifactType.Module, null, target).Unwrap();
 
         fileSystem ??= new MockFileSystem();
         var services = GetServiceBuilder(fileSystem, reference.Registry, reference.Repository, features);
 
-        await RegistryHelper.PublishExtensionToRegistryAsync(services.Build(), reference.FullyQualifiedReference, tgzData);
+        await RegistryHelper.PublishExtensionToRegistryAsync(services.Build(), reference.FullyQualifiedReference, package);
 
         return services;
     }

--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -22,6 +22,7 @@ using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Registry;
 using Bicep.IO.FileSystem;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 using static Bicep.Core.UnitTests.Registry.FakeContainerRegistryClient;
@@ -201,6 +202,9 @@ public static class RegistryHelper
     }
 
     public static async Task PublishExtensionToRegistryAsync(IDependencyHelper services, string target, BinaryData tgzData, Uri? bicepFileUri = null)
+        => await PublishExtensionToRegistryAsync(services, target, new ExtensionPackage(tgzData, false, []), bicepFileUri);
+
+    public static async Task PublishExtensionToRegistryAsync(IDependencyHelper services, string target, ExtensionPackage package, Uri? bicepFileUri = null)
     {
         var dispatcher = services.Construct<IModuleDispatcher>();
 
@@ -219,7 +223,7 @@ public static class RegistryHelper
             throw new InvalidOperationException($"Failed to get reference '{errorBuilder(DiagnosticBuilder.ForDocumentStart()).Message}'.");
         }
 
-        await dispatcher.PublishExtension(targetReference, new(tgzData, false, []));
+        await dispatcher.PublishExtension(targetReference, package);
     }
 
     private static List<RepoTagDescriptor> ToTagDescriptors(IEnumerable<string> tags)

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -62,7 +62,7 @@ public interface IFeatureProvider
                 (AssertsEnabled, CoreResources.ExperimentalFeatureNames_Asserts, true, true),
                 (WaitAndRetryEnabled, CoreResources.ExperimentalFeatureNames_WaitAndRetry, true, true),
                 (OnlyIfNotExistsEnabled, CoreResources.ExperimentalFeatureNames_OnlyIfNotExists, true, true),
-                (LocalDeployEnabled, "Enable local deploy", false, false),
+                (LocalDeployEnabled, "Enable local deploy", true, true),
                 (TypedVariablesEnabled, "Typed variables", true, false),
                 (ExtendableParamFilesEnabled, "Enable extendable parameters", true, false),
                 (ModuleExtensionConfigsEnabled, "Enable defining extension configs for modules", true, true),

--- a/src/Bicep.Local.Deploy.IntegrationTests/KestrelProviderExtension.cs
+++ b/src/Bicep.Local.Deploy.IntegrationTests/KestrelProviderExtension.cs
@@ -12,7 +12,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Local.Deploy.IntegrationTests;
 
-[TestClass]
 public class KestrelProviderExtension : ProviderExtension
 {
     protected override async Task RunServer(ConnectionOptions connectionOptions, ResourceDispatcher dispatcher, CancellationToken cancellationToken)

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -95,11 +95,6 @@
           "description": "When completing 'br:' module references, query Azure for all container registries accessible to the user (may be slow). If this option is off, only registries configured under moduleAliases in bicepconfig.json will be listed.",
           "default": false
         },
-        "bicep.experimental.disableDeploymentPane": {
-          "type": "boolean",
-          "description": "Disable the experimental Bicep Deployment Pane.",
-          "default": false
-        },
         "bicep.trace.server": {
           "type": "string",
           "enum": [
@@ -182,14 +177,12 @@
     "commands": [
       {
         "command": "bicep.showDeployPane",
-        "when": "!config.bicep.experimental.disableDeploymentPane",
         "title": "Show Deployment Pane",
         "category": "Bicep",
         "icon": "$(cloud-upload)"
       },
       {
         "command": "bicep.showDeployPaneToSide",
-        "when": "!config.bicep.experimental.disableDeploymentPane",
         "title": "Show Deployment Pane to the Side",
         "category": "Bicep",
         "icon": "$(cloud-upload)"
@@ -345,7 +338,7 @@
       "editor/title": [
         {
           "command": "bicep.showDeployPaneToSide",
-          "when": "!config.bicep.experimental.disableDeploymentPane && (editorLangId == bicep || editorLangId == bicep-params)",
+          "when": "editorLangId == bicep || editorLangId == bicep-params",
           "alt": "bicep.showDeployPane",
           "group": "navigation"
         },
@@ -404,12 +397,12 @@
         },
         {
           "command": "bicep.showDeployPane",
-          "when": "!config.bicep.experimental.disableDeploymentPane && (resourceLangId == bicep || resourceLangId == bicep-params)",
+          "when": "resourceLangId == bicep || resourceLangId == bicep-params",
           "group": "2_bicep_2_deploy"
         },
         {
           "command": "bicep.showDeployPaneToSide",
-          "when": "!config.bicep.experimental.disableDeploymentPane && (resourceLangId == bicep || resourceLangId == bicep-params)",
+          "when": "resourceLangId == bicep || resourceLangId == bicep-params",
           "group": "2_bicep_2_deploy"
         },
         {
@@ -466,12 +459,12 @@
         },
         {
           "command": "bicep.showDeployPane",
-          "when": "!config.bicep.experimental.disableDeploymentPane && (resourceLangId == bicep || resourceLangId == bicep-params)",
+          "when": "resourceLangId == bicep || resourceLangId == bicep-params",
           "group": "2_bicep_2_deploy"
         },
         {
           "command": "bicep.showDeployPaneToSide",
-          "when": "!config.bicep.experimental.disableDeploymentPane && (resourceLangId == bicep || resourceLangId == bicep-params)",
+          "when": "resourceLangId == bicep || resourceLangId == bicep-params",
           "group": "2_bicep_2_deploy"
         },
         {
@@ -533,12 +526,12 @@
         },
         {
           "command": "bicep.showDeployPane",
-          "when": "!config.bicep.experimental.disableDeploymentPane && (resourceLangId == bicep || resourceLangId == bicep-params)",
+          "when": "resourceLangId == bicep || resourceLangId == bicep-params",
           "group": "2_bicep_2_deploy"
         },
         {
           "command": "bicep.showDeployPaneToSide",
-          "when": "!config.bicep.experimental.disableDeploymentPane && (resourceLangId == bicep || resourceLangId == bicep-params)",
+          "when": "resourceLangId == bicep || resourceLangId == bicep-params",
           "group": "2_bicep_2_deploy"
         },
         {
@@ -590,12 +583,10 @@
         },
         {
           "command": "bicep.showDeployPane",
-          "when": "!config.bicep.experimental.disableDeploymentPane",
           "group": "0_bicep"
         },
         {
           "command": "bicep.showDeployPaneToSide",
-          "when": "!config.bicep.experimental.disableDeploymentPane",
           "group": "0_bicep"
         },
         {


### PR DESCRIPTION
1. Ensure languageversion 2.2-experimental emitting is enabled
2. Remove usage of `config.bicep.experimental.disableDeploymentPane` (used while this feature was in experimental mode)
3. Fix to avoid accidentally trying to start non-local extensions