### PR TITLE
Prevent infinite recursion during type narrowing

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -7211,4 +7211,23 @@ var subnetId = vNet::subnets[0].id
 
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
+
+    [TestMethod]
+    public void Test_Issue16727()
+    {
+        var result = CompilationHelper.Compile("""
+            resource nsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+              name: 'example'
+              location: 'location'
+              properties: {
+                securityRules: []
+              }
+              tags: {}
+            }
+
+            output properties resourceOutput<'Microsoft.Network/networkSecurityGroups@2024-05-01'>.properties = nsg.properties
+            """);
+
+        result.Should().NotHaveAnyDiagnostics();
+    }
 }

--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -1873,4 +1873,20 @@ param myParam string
             ("BCP033", DiagnosticLevel.Error, "Expected a value of type \"int | null\" but the provided value is of type \"null | string\"."),
         });
     }
+
+    [TestMethod]
+    public void Narrowing_a_recursive_type_against_itself_does_not_recur_infinitely()
+    {
+        var result = CompilationHelper.Compile("""
+            type recursiveType = {
+              recursion: recursiveType?
+            }
+
+            param p recursiveType
+
+            output o recursiveType = p
+            """);
+
+        result.Should().NotHaveAnyDiagnostics();
+    }
 }

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -1003,7 +1003,7 @@ namespace Bicep.Core.TypeSystem
                 return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).AccessExpressionForbiddenBase());
             }
 
-            return EnsureNonParameterizedType(propertyNameSyntax, GetTypePropertyType(baseExpressionType, propertyName, propertyNameSyntax));
+            return EnsureNonParameterizedType(propertyNameSyntax, typePropertyType);
         }
 
         private static TypeSymbol GetTypePropertyType(ITypeReference baseExpressionType, string propertyName, SyntaxBase propertyNameSyntax)

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -32,7 +32,8 @@ namespace Bicep.Core.TypeSystem
             bool DisallowAny,
             SyntaxBase? OriginSyntax,
             TypeMismatchDiagnosticWriter? OnTypeMismatch,
-            bool IsResourceDeclaration);
+            bool IsResourceDeclaration,
+            HashSet<(SyntaxBase expression, TypeSymbol expressionType, TypeSymbol targetType)> currentlyProcessing);
 
         private TypeValidator(ITypeManager typeManager, IBinder binder, IDiagnosticLookup parsingErrorLookup, IDiagnosticWriter diagnosticWriter)
         {
@@ -218,7 +219,8 @@ namespace Bicep.Core.TypeSystem
                 DisallowAny: false,
                 OriginSyntax: null,
                 OnTypeMismatch: null,
-                IsResourceDeclaration: isResourceDeclaration);
+                IsResourceDeclaration: isResourceDeclaration,
+                currentlyProcessing: new());
 
             var validator = new TypeValidator(typeManager, binder, parsingErrorLookup, diagnosticWriter);
 
@@ -1139,7 +1141,7 @@ namespace Bicep.Core.TypeSystem
                                 diagnosticWriter.Write(diagnosticTarget, x => x.CannotAssignToReadOnlyProperty(resourceTypeInaccuracy || ShouldWarnForPropertyMismatch(targetType), declaredProperty.Name, resourceTypeInaccuracy));
                             }
 
-                            narrowedProperties.Add(new NamedTypeProperty(declaredProperty.Name, declaredProperty.TypeReference.Type, declaredProperty.Flags));
+                            narrowedProperties.Add(declaredProperty);
                             continue;
                         }
 
@@ -1149,25 +1151,40 @@ namespace Bicep.Core.TypeSystem
                                 x => x.FallbackPropertyUsed(shouldDowngrade: false, declaredProperty.Name));
                         }
 
-                        var newConfig = new TypeValidatorConfig(
-                            SkipConstantCheck: skipConstantCheckForProperty,
-                            SkipTypeErrors: true,
-                            DisallowAny: declaredProperty.Flags.HasFlag(TypePropertyFlags.DisallowAny),
-                            OriginSyntax: config.OriginSyntax,
-                            OnTypeMismatch: GetPropertyMismatchDiagnosticWriter(
+                        var newConfig = config with
+                        {
+                            SkipConstantCheck = skipConstantCheckForProperty,
+                            SkipTypeErrors = true,
+                            DisallowAny = declaredProperty.Flags.HasFlag(TypePropertyFlags.DisallowAny),
+                            OnTypeMismatch = GetPropertyMismatchDiagnosticWriter(
                                 config: config,
                                 shouldWarn: (config.IsResourceDeclaration && !declaredProperty.Flags.HasFlag(TypePropertyFlags.SystemProperty)) || ShouldWarn(declaredProperty.TypeReference.Type),
                                 propertyName: declaredProperty.Name,
                                 showTypeInaccuracyClause: config.IsResourceDeclaration && !declaredProperty.Flags.HasFlag(TypePropertyFlags.SystemProperty)),
-                            IsResourceDeclaration: config.IsResourceDeclaration);
+                        };
 
-                        // append "| null" to the property type for non-required properties
-                        var (propertyAssignmentType, typeWasPreserved) = AddImplicitNull(declaredProperty.TypeReference.Type, declaredProperty.Flags);
+                        var propertyExpression = declaredPropertySyntax?.Value ?? expression;
+                        TypeSymbol propertyTargetType = declaredProperty.TypeReference.Type;
+                        TypeSymbol propertyExpressionType = expressionTypeProperty.TypeReference.Type;
 
-                        var narrowedType = NarrowType(newConfig, declaredPropertySyntax?.Value ?? expression, expressionTypeProperty.TypeReference.Type, propertyAssignmentType);
-                        narrowedType = RemoveImplicitNull(narrowedType, typeWasPreserved);
+                        TypeSymbol GetNarrowedPropertyType()
+                        {
+                            // append "| null" to the property type for non-required properties
+                            var (propertyAssignmentType, typeWasPreserved) = AddImplicitNull(propertyTargetType, declaredProperty.Flags);
 
-                        narrowedProperties.Add(new NamedTypeProperty(declaredProperty.Name, narrowedType, declaredProperty.Flags));
+                            var narrowedType = NarrowType(newConfig, propertyExpression, propertyExpressionType, propertyAssignmentType);
+                            return RemoveImplicitNull(narrowedType, typeWasPreserved);
+                        }
+
+                        // In the case of a recursive type, eager narrowing can lead to infinite recursion. If we've
+                        // already narrowed this (expressionSyntax, expressionType, targetType) triple, then all
+                        // relevant diagnostics have already been raised. Use a deferred type reference to stop eagerly
+                        // comparing and narrowing types from this point forward.
+                        ITypeReference narrowedPropertyType = config.currentlyProcessing.Add((propertyExpression, propertyExpressionType, propertyTargetType))
+                            ? GetNarrowedPropertyType()
+                            : new DeferredTypeReference(GetNarrowedPropertyType);
+
+                        narrowedProperties.Add(new NamedTypeProperty(declaredProperty.Name, narrowedPropertyType, declaredProperty.Flags));
                     }
                     else
                     {
@@ -1236,19 +1253,22 @@ namespace Bicep.Core.TypeSystem
                             skipConstantCheckForProperty = true;
                         }
 
-                        var newConfig = new TypeValidatorConfig(
-                            SkipConstantCheck: skipConstantCheckForProperty,
-                            SkipTypeErrors: true,
-                            DisallowAny: targetType.AdditionalProperties.Flags.HasFlag(TypePropertyFlags.DisallowAny),
-                            OriginSyntax: config.OriginSyntax,
-                            OnTypeMismatch: GetPropertyMismatchDiagnosticWriter(config, ShouldWarn(targetType.AdditionalProperties.TypeReference.Type), extraProperty.Key, false),
-                            IsResourceDeclaration: config.IsResourceDeclaration);
+                        var newConfig = config with
+                        {
+                            SkipConstantCheck = skipConstantCheckForProperty,
+                            SkipTypeErrors = true,
+                            DisallowAny = targetType.AdditionalProperties.Flags.HasFlag(TypePropertyFlags.DisallowAny),
+                            OnTypeMismatch = GetPropertyMismatchDiagnosticWriter(config, ShouldWarn(targetType.AdditionalProperties.TypeReference.Type), extraProperty.Key, false),
+                        };
 
                         // append "| null" to the type on non-required properties
                         var (additionalPropertiesAssignmentType, _) = AddImplicitNull(targetType.AdditionalProperties.TypeReference.Type, targetType.AdditionalProperties.Flags);
 
                         // although we don't use the result here, it's important to call NarrowType to collect diagnostics
-                        var narrowedType = NarrowType(newConfig, extraPropertySyntax?.Value ?? expression, extraProperty.Value.TypeReference.Type, additionalPropertiesAssignmentType);
+                        if (config.currentlyProcessing.Add((extraPropertySyntax?.Value ?? expression, extraProperty.Value.TypeReference.Type, additionalPropertiesAssignmentType)))
+                        {
+                            var narrowedType = NarrowType(newConfig, extraPropertySyntax?.Value ?? expression, extraProperty.Value.TypeReference.Type, additionalPropertiesAssignmentType);
+                        }
 
                         // TODO should we try and narrow the additional properties type? May be difficult
                     }


### PR DESCRIPTION
Resolves #16727 

In practice, infinite recursion usually occurs when we are narrowing a value against a target where both have the same type. The scenario test and linked issue demonstrate this with resource-derived types, but this can also happen with a user-defined type.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17028)