### PR TITLE
fixing dotnet format issues, and addressing IDE0305: Collection initialization can be simplified errors/warnings

### DIFF
--- a/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ArmDeclarationToExpressionConverter.cs
@@ -280,7 +280,7 @@ internal class ArmDeclarationToExpressionConverter
             .ToImmutableArray();
 
         return new(sourceSyntax,
-            new(itemExpressions.Select(i => i.Value.ExpressedType).ToImmutableArray<ITypeReference>(), TypeSymbolValidationFlags.Default),
+            new([.. itemExpressions.Select(i => i.Value.ExpressedType)], TypeSymbolValidationFlags.Default),
             itemExpressions);
     }
 
@@ -304,7 +304,7 @@ internal class ArmDeclarationToExpressionConverter
             }));
 
             return new TupleTypeExpression(sourceSyntax,
-                new(ImmutableArray.CreateRange<ITypeReference>(itemExpressions.Select(i => i.Value.ExpressedType)),
+                new([.. itemExpressions.Select(i => i.Value.ExpressedType)],
                     TypeSymbolValidationFlags.Default),
                 itemExpressions);
         }
@@ -487,7 +487,7 @@ internal class ArmDeclarationToExpressionConverter
         {
             var baseExpression = ConvertToExpression(new FunctionExpression(func.Function,
                 func.Parameters,
-                func.Properties.Take(func.Properties.Length - 1).ToArray()));
+                [.. func.Properties.Take(func.Properties.Length - 1)]));
 
             return ConvertToExpression(outermostPropertyAccess) switch
             {
@@ -507,7 +507,7 @@ internal class ArmDeclarationToExpressionConverter
             return new SynthesizedUserDefinedFunctionCallExpression(sourceSyntax,
                 namespaceName,
                 functionName,
-                func.Parameters.Select(ConvertToExpression).ToImmutableArray());
+                [.. func.Parameters.Select(ConvertToExpression)]);
         }
 
         return func.Function.ToLowerInvariant() switch
@@ -530,7 +530,7 @@ internal class ArmDeclarationToExpressionConverter
                 },
             // this is less robust than decompilation analysis (e.g., the "add" function will not be transformed to a binary expression), but since this expression is produced only to be lightly manipulated and recompiled to ARM JSON, it's fine to be lax here
             // this choice should be revisited if this converter is used outside of the Bicep.Core.Emit namespace
-            _ => new FunctionCallExpression(sourceSyntax, func.Function, func.Parameters.Select(ConvertToExpression).ToImmutableArray()),
+            _ => new FunctionCallExpression(sourceSyntax, func.Function, [.. func.Parameters.Select(ConvertToExpression)]),
         };
     }
     #endregion variableConversion

--- a/src/Bicep.Core/Emit/CompileTimeImports/ImportedSymbolDeclarationMigrator.cs
+++ b/src/Bicep.Core/Emit/CompileTimeImports/ImportedSymbolDeclarationMigrator.cs
@@ -101,7 +101,7 @@ internal class ImportedSymbolDeclarationMigrator : ExpressionRewriteVisitor
     {
         var (namespaceName, name) = GetFunctionName(declaredSymbolNames[expression.Symbol]);
         return new SynthesizedUserDefinedFunctionCallExpression(sourceSyntax, namespaceName, name,
-            expression.Parameters.Select(Replace).ToImmutableArray());
+            [.. expression.Parameters.Select(Replace)]);
     }
 
     public override Expression ReplaceSynthesizedVariableReferenceExpression(SynthesizedVariableReferenceExpression expression)

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -151,17 +151,19 @@ namespace Bicep.Core.Emit
             }
 
             private ImmutableArray<IArmIdSegment> NameSegmentsFor(DeclaredResourceMetadata resource)
-                => model.ResourceAncestors.GetAncestors(resource)
-                    .Reverse()
-                    .SelectMany(r => r.IndexExpression switch
-                    {
-                        SyntaxBase idx when model.GetTypeInfo(idx) is IntegerLiteralType literalIndex
-                            => new[] { NameSegmentFor(r.Resource), new LiteralIdSegment(literalIndex.Value.ToString()) },
-                        SyntaxBase idx => new[] { NameSegmentFor(r.Resource), new NonLiteralIdSegment(idx) },
-                        _ => NameSegmentFor(r.Resource).AsEnumerable(),
-                    })
-                    .Append(NameSegmentFor(resource))
-                    .ToImmutableArray();
+                =>
+                [
+                    .. model.ResourceAncestors.GetAncestors(resource)
+                            .Reverse()
+                            .SelectMany(r => r.IndexExpression switch
+                            {
+                                SyntaxBase idx when model.GetTypeInfo(idx) is IntegerLiteralType literalIndex
+                                    => new[] { NameSegmentFor(r.Resource), new LiteralIdSegment(literalIndex.Value.ToString()) },
+                                SyntaxBase idx => new[] { NameSegmentFor(r.Resource), new NonLiteralIdSegment(idx) },
+                                _ => NameSegmentFor(r.Resource).AsEnumerable(),
+                            }),
+                    NameSegmentFor(resource),
+                ];
 
             private IArmIdSegment NameSegmentFor(DeclaredResourceMetadata resource)
                 => IArmIdSegment.For(resource.TryGetNameSyntax(), model) switch

--- a/src/Bicep.Core/Emit/ExpressionConverter.cs
+++ b/src/Bicep.Core/Emit/ExpressionConverter.cs
@@ -509,7 +509,7 @@ namespace Bicep.Core.Emit
         }
 
         public IEnumerable<LanguageExpression> GetResourceNameSegments(DeclaredResourceMetadata resource)
-            => GetResourceNameSegments(resource, expressionBuilder.GetResourceNameSyntaxSegments(resource).ToImmutableArray());
+            => GetResourceNameSegments(resource, [.. expressionBuilder.GetResourceNameSyntaxSegments(resource)]);
 
         public IEnumerable<LanguageExpression> GetResourceNameSegments(DeclaredResourceMetadata resource, ImmutableArray<SyntaxBase> nameSegments)
         {
@@ -956,7 +956,7 @@ namespace Bicep.Core.Emit
             => CreateFunction(name, parameters as IEnumerable<LanguageExpression>);
 
         private static FunctionExpression CreateFunction(string name, IEnumerable<LanguageExpression> parameters)
-            => new(name, parameters.ToArray(), []);
+            => new(name, [.. parameters], []);
 
         private static FunctionExpression AppendProperties(FunctionExpression function, params LanguageExpression[] properties)
             => AppendProperties(function, properties as IEnumerable<LanguageExpression>);

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -53,10 +53,9 @@ namespace Bicep.Core.Emit
             var visitor = new InlineDependencyVisitor(model, null);
             visitor.Visit(model.Root.Syntax);
 
-            return visitor.shouldInlineCache
+            return [.. visitor.shouldInlineCache
                 .Where(kvp => kvp.Value == Decision.Inline)
-                .Select(kvp => kvp.Key)
-                .ToImmutableHashSet();
+                .Select(kvp => kvp.Key)];
         }
 
         /// <summary>

--- a/src/Bicep.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Bicep.Core/Extensions/EnumerableExtensions.cs
@@ -76,7 +76,7 @@ namespace Bicep.Core.Extensions
 
         public static T[] ToArrayExcludingNull<T>(this IEnumerable<T?> source)
             where T : class
-            => source.WhereNotNull().ToArray();
+            => [.. source.WhereNotNull()];
 
         public static ILookup<T, T> InvertLookup<T>(this ILookup<T, T> source)
             => source.SelectMany(group => group.Select(val => (group.Key, val)))

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -77,7 +77,7 @@ public class ExpressionBuilder
                     return new InterpolatedStringExpression(
                         @string,
                         @string.SegmentValues,
-                        @string.Expressions.Select(ConvertWithoutLowering).ToImmutableArray());
+                        [.. @string.Expressions.Select(ConvertWithoutLowering)]);
                 }
             case IntegerLiteralSyntax @int:
                 {
@@ -134,8 +134,8 @@ public class ExpressionBuilder
 
                 return new LambdaExpression(
                     lambda,
-                    variables.Select(x => x.Name.IdentifierName).ToImmutableArray(),
-                    variables.Select<LocalVariableSyntax, TypeExpression?>(x => null).ToImmutableArray(),
+                    [.. variables.Select(x => x.Name.IdentifierName)],
+                    [.. variables.Select<LocalVariableSyntax, TypeExpression?>(x => null)],
                     ConvertWithoutLowering(lambda.Body),
                     null);
             case TypedLambdaSyntax lambda:
@@ -143,8 +143,8 @@ public class ExpressionBuilder
 
                 return new LambdaExpression(
                     lambda,
-                    typedVariables.Select(x => x.Name.IdentifierName).ToImmutableArray(),
-                    typedVariables.Select(x => ConvertTypeWithoutLowering(x.Type)).ToImmutableArray<TypeExpression?>(),
+                    [.. typedVariables.Select(x => x.Name.IdentifierName)],
+                    [.. typedVariables.Select(x => ConvertTypeWithoutLowering(x.Type))],
                     ConvertWithoutLowering(lambda.Body),
                     ConvertTypeWithoutLowering(lambda.ReturnType));
 
@@ -265,13 +265,13 @@ public class ExpressionBuilder
             ResourceTypeSyntax resource => new ResourceTypeExpression(resource, GetTypeInfo<ResourceType>(resource)),
             ObjectTypeSyntax objectTypeSyntax => new ObjectTypeExpression(syntax,
                 GetTypeInfo<ObjectType>(syntax),
-                objectTypeSyntax.Properties.Select(p => ConvertWithoutLowering<ObjectTypePropertyExpression>(p)).ToImmutableArray(),
+                [.. objectTypeSyntax.Properties.Select(p => ConvertWithoutLowering<ObjectTypePropertyExpression>(p))],
                 objectTypeSyntax.AdditionalProperties is SyntaxBase addlPropertiesSyntax
                     ? ConvertWithoutLowering<ObjectTypeAdditionalPropertiesExpression>(addlPropertiesSyntax)
                     : null),
             TupleTypeSyntax tupleTypeSyntax => new TupleTypeExpression(syntax,
                 GetTypeInfo<TupleType>(syntax),
-                tupleTypeSyntax.Items.Select(i => ConvertWithoutLowering<TupleTypeItemExpression>(i)).ToImmutableArray()),
+                [.. tupleTypeSyntax.Items.Select(i => ConvertWithoutLowering<TupleTypeItemExpression>(i))]),
             ArrayTypeSyntax arrayTypeSyntax => new ArrayTypeExpression(syntax,
                 GetTypeInfo<ArrayType>(syntax),
                 ConvertTypeWithoutLowering(arrayTypeSyntax.Item.Value)),
@@ -280,17 +280,17 @@ public class ExpressionBuilder
                 new DiscriminatedObjectTypeExpression(
                     syntax,
                     discriminatedObjectType,
-                    unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)).ToImmutableArray()),
+                    [.. unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value))]),
             UnionTypeSyntax unionTypeSyntax when Context.SemanticModel.GetTypeInfo(unionTypeSyntax) is UnionType unionType
-                => new UnionTypeExpression(syntax, unionType, unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)).ToImmutableArray()),
+                => new UnionTypeExpression(syntax, unionType, [.. unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value))]),
             UnionTypeSyntax unionTypeSyntax => Context.SemanticModel.GetTypeInfo(unionTypeSyntax) switch
             {
                 ErrorType errorType => throw new ArgumentException($"Failed to convert syntax of type {syntax.GetType()}"),
-                UnionType unionType => new UnionTypeExpression(syntax, unionType, ImmutableArray.CreateRange(unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)))),
+                UnionType unionType => new UnionTypeExpression(syntax, unionType, [.. unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value))]),
                 // If a union type expression's members all refer to the same literal value, the type of the expression will be a single literal rather than a union
                 TypeSymbol otherwise => new UnionTypeExpression(syntax,
                     new UnionType(string.Empty, [otherwise]),
-                    ImmutableArray.CreateRange(unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value)))),
+                    [.. unionTypeSyntax.Members.Select(m => ConvertTypeWithoutLowering(m.Value))]),
             },
             ParenthesizedTypeSyntax parenthesizedExpression => ConvertTypeWithoutLowering(parenthesizedExpression.Expression),
             NonNullableTypeSyntax nonNullableTypeSyntax => new NonNullableTypeExpression(nonNullableTypeSyntax, ConvertTypeWithoutLowering(nonNullableTypeSyntax.Base)),
@@ -567,7 +567,7 @@ public class ExpressionBuilder
             .Where(x => x.TryGetKeyText() is not { } key || !ModulePropertiesToOmit.Contains(key))
             .Select(ConvertObjectProperty)
             .Append(CreateModuleNameExpression(symbol, objectBody));
-        Expression bodyExpression = new ObjectExpression(body, properties.ToImmutableArray());
+        Expression bodyExpression = new ObjectExpression(body, [.. properties]);
 
         var parameters = objectBody.TryGetPropertyByName(LanguageConstants.ModuleParamsPropertyName);
         var extensionConfigs = objectBody.TryGetPropertyByName(LanguageConstants.ModuleExtensionConfigsPropertyName);
@@ -599,15 +599,14 @@ public class ExpressionBuilder
     }
 
     private ImmutableArray<ResourceDependencyExpression> BuildDependencyExpressions(DeclaredSymbol dependent, SyntaxBase body)
-        => Context.ResourceDependencies[dependent]
+        => [.. Context.ResourceDependencies[dependent]
             .SelectMany(dd => ToDependencyExpressions(dd, body, Context.ResourceDependencies))
             .GroupBy(t => t.Target.Resource)
             .SelectMany(g => g.FirstOrDefault(t => t.Target.IndexExpression is null) is { } dependencyOnCollection
                 ? dependencyOnCollection.AsEnumerable()
                 : g.Distinct(t => t.Target))
             .OrderBy(t => t.TargetKey)  // order to generate a deterministic template
-            .Select(t => t.Expression)
-            .ToImmutableArray();
+            .Select(t => t.Expression)];
 
     private DeclaredResourceExpression ConvertResource(ResourceDeclarationSyntax syntax)
     {
@@ -690,7 +689,7 @@ public class ExpressionBuilder
         var properties = ((ObjectSyntax)body).Properties
             .Where(x => x.TryGetKeyText() is not { } key || !propertiesToOmit.Contains(key))
             .Select(ConvertObjectProperty);
-        Expression bodyExpression = new ObjectExpression(body, properties.ToImmutableArray());
+        Expression bodyExpression = new ObjectExpression(body, [.. properties]);
 
         if (condition is not null)
         {
@@ -810,7 +809,7 @@ public class ExpressionBuilder
                 return new FunctionCallExpression(
                     function,
                     function.Name.IdentifierName,
-                    function.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                    [.. function.Arguments.Select(a => ConvertWithoutLowering(a.Expression))]);
 
             case InstanceFunctionCallSyntax method:
                 var (baseSyntax, indexExpression) = SyntaxHelper.UnwrapArrayAccessSyntax(method.BaseExpression);
@@ -822,7 +821,7 @@ public class ExpressionBuilder
                     return new FunctionCallExpression(
                         method,
                         method.Name.IdentifierName,
-                        method.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                        [.. method.Arguments.Select(a => ConvertWithoutLowering(a.Expression))]);
                 }
 
                 var resource = Context.SemanticModel.ResourceMetadata.TryLookup(baseSyntax);
@@ -843,7 +842,7 @@ public class ExpressionBuilder
                             new StringLiteralExpression(method.Name, method.Name.IdentifierName),
                             new ArrayExpression(
                                 method,
-                                method.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray()),
+                                [.. method.Arguments.Select(a => ConvertWithoutLowering(a.Expression))]),
                         ]);
                 }
 
@@ -862,7 +861,7 @@ public class ExpressionBuilder
                         method,
                         new ResourceReferenceExpression(method.BaseExpression, resource, indexContext),
                         method.Name.IdentifierName,
-                        method.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                        [.. method.Arguments.Select(a => ConvertWithoutLowering(a.Expression))]);
                 }
 
                 throw new InvalidOperationException($"Unrecognized base expression {baseSymbol?.Kind}");
@@ -884,7 +883,7 @@ public class ExpressionBuilder
             return new UserDefinedFunctionCallExpression(
                 functionCall,
                 declaredFunction,
-                functionCall.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                [.. functionCall.Arguments.Select(a => ConvertWithoutLowering(a.Expression))]);
         }
 
         if (Context.SemanticModel.GetSymbolInfo(functionCall) is ImportedFunctionSymbol importedFunction)
@@ -892,7 +891,7 @@ public class ExpressionBuilder
             return new ImportedUserDefinedFunctionCallExpression(
                 functionCall,
                 importedFunction,
-                functionCall.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                [.. functionCall.Arguments.Select(a => ConvertWithoutLowering(a.Expression))]);
         }
 
         if (functionCall is InstanceFunctionCallSyntax instanceFunctionCall &&
@@ -902,7 +901,7 @@ public class ExpressionBuilder
                 functionCall,
                 wildcardImport,
                 instanceFunctionCall.Name.IdentifierName,
-                functionCall.Arguments.Select(a => ConvertWithoutLowering(a.Expression)).ToImmutableArray());
+                [.. functionCall.Arguments.Select(a => ConvertWithoutLowering(a.Expression))]);
         }
 
         if (Context.SemanticModel.TypeManager.GetMatchedFunctionResultValue(functionCall) is { } functionValue)

--- a/src/Bicep.Core/Intermediate/ExpressionFactory.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionFactory.cs
@@ -21,10 +21,10 @@ public static class ExpressionFactory
             value);
 
     public static ObjectExpression CreateObject(IEnumerable<ObjectPropertyExpression> properties, SyntaxBase? sourceSyntax = null)
-        => new(sourceSyntax, properties.ToImmutableArray());
+        => new(sourceSyntax, [.. properties]);
 
     public static ArrayExpression CreateArray(IEnumerable<Expression> items, SyntaxBase? sourceSyntax = null)
-        => new(sourceSyntax, items.ToImmutableArray());
+        => new(sourceSyntax, [.. items]);
 
     public static StringLiteralExpression CreateStringLiteral(string value, SyntaxBase? sourceSyntax = null)
         => new(sourceSyntax, value);
@@ -49,7 +49,7 @@ public static class ExpressionFactory
         => CreateFunctionCall(functionName, parameters, sourceSyntax);
 
     public static FunctionCallExpression CreateFunctionCall(string functionName, IEnumerable<Expression> parameters, SyntaxBase? sourceSyntax = null)
-        => new(sourceSyntax, functionName, parameters.ToImmutableArray());
+        => new(sourceSyntax, functionName, [.. parameters]);
 
     public static FunctionCallExpression CreateGeneratedModuleName(ModuleSymbol moduleSymbol, Expression? indexExpression = null)
     {

--- a/src/Bicep.Core/Parsing/BaseParser.cs
+++ b/src/Bicep.Core/Parsing/BaseParser.cs
@@ -1418,7 +1418,7 @@ namespace Bicep.Core.Parsing
             {
                 Synchronize(true, expectedTypes);
 
-                skippedTokens = reader.Slice(startReaderPosition, reader.Position - startReaderPosition).ToArray();
+                skippedTokens = [.. reader.Slice(startReaderPosition, reader.Position - startReaderPosition)];
                 skippedSpan = TextSpan.SafeBetween(skippedTokens, startToken.Span.Position);
             }
 

--- a/src/Bicep.Core/Parsing/Lexer.cs
+++ b/src/Bicep.Core/Parsing/Lexer.cs
@@ -24,10 +24,13 @@ namespace Bicep.Core.Parsing
             {'$', '$'}
         }.ToImmutableSortedDictionary();
 
-        private static readonly ImmutableArray<string> CharacterEscapeSequences = SingleCharacterEscapes.Keys
-            .Select(c => $"\\{c}")
-            .Append("\\u{...}")
-            .ToImmutableArray();
+        private static readonly ImmutableArray<string> CharacterEscapeSequences =
+        [
+            .. SingleCharacterEscapes.Keys
+                        .Select(c => $"\\{c}")
+,
+            "\\u{...}",
+        ];
 
         private const int MultilineStringTerminatingQuoteCount = 3;
 

--- a/src/Bicep.Core/Parsing/Token.cs
+++ b/src/Bicep.Core/Parsing/Token.cs
@@ -14,8 +14,8 @@ namespace Bicep.Core.Parsing
         {
             Type = type;
             Span = span;
-            LeadingTrivia = leadingTrivia.ToImmutableArray();
-            TrailingTrivia = trailingTrivia.ToImmutableArray();
+            LeadingTrivia = [.. leadingTrivia];
+            TrailingTrivia = [.. trailingTrivia];
 
 #if DEBUG
             var leadingNonNil = LeadingTrivia.Where(x => x.Span != TextSpan.Nil).ToArray();

--- a/src/Bicep.Core/Parsing/TokenReader.cs
+++ b/src/Bicep.Core/Parsing/TokenReader.cs
@@ -10,7 +10,7 @@ namespace Bicep.Core.Parsing
 
         public TokenReader(IEnumerable<Token> tokens)
         {
-            this.Tokens = tokens.ToArray();
+            this.Tokens = [.. tokens];
             this.Position = 0;
         }
 

--- a/src/Bicep.Core/PrettyPrint/Documents/NestDocument.cs
+++ b/src/Bicep.Core/PrettyPrint/Documents/NestDocument.cs
@@ -32,7 +32,7 @@ namespace Bicep.Core.PrettyPrint.Documents
         {
             RuntimeHelpers.EnsureSufficientExecutionStack();
 
-            return new NestDocument(this.level + 1, this.successors.Select(s => s.Nest()).ToImmutableArray());
+            return new NestDocument(this.level + 1, [.. this.successors.Select(s => s.Nest())]);
         }
 
         public void Layout(StringBuilder sb, string indent, string newline)

--- a/src/Bicep.Core/PrettyPrint/Documents/TextDocument.cs
+++ b/src/Bicep.Core/PrettyPrint/Documents/TextDocument.cs
@@ -33,7 +33,7 @@ namespace Bicep.Core.PrettyPrint.Documents
         {
             RuntimeHelpers.EnsureSufficientExecutionStack();
 
-            return new TextDocument(this.text, successors.Select(s => s.Nest()).ToImmutableArray());
+            return new TextDocument(this.text, [.. successors.Select(s => s.Nest())]);
         }
 
         public void Layout(StringBuilder sb, string indent, string newline)

--- a/src/Bicep.Core/PrettyPrintV2/Documents/GlueDocument.cs
+++ b/src/Bicep.Core/PrettyPrintV2/Documents/GlueDocument.cs
@@ -8,7 +8,7 @@ namespace Bicep.Core.PrettyPrintV2.Documents
     public class GlueDocument : ContainerDocument
     {
         public GlueDocument(IEnumerable<Document> documents)
-            : base(documents.ToImmutableArray())
+            : base([.. documents])
         {
         }
     }

--- a/src/Bicep.Core/PrettyPrintV2/Documents/GroupDocument.cs
+++ b/src/Bicep.Core/PrettyPrintV2/Documents/GroupDocument.cs
@@ -8,7 +8,7 @@ namespace Bicep.Core.PrettyPrintV2.Documents
     public sealed class GroupDocument : ContainerDocument
     {
         public GroupDocument(IEnumerable<Document> documents)
-            : base(documents.ToImmutableArray())
+            : base([.. documents])
         {
         }
     }

--- a/src/Bicep.Core/PrettyPrintV2/Documents/IndentDocument.cs
+++ b/src/Bicep.Core/PrettyPrintV2/Documents/IndentDocument.cs
@@ -8,7 +8,7 @@ namespace Bicep.Core.PrettyPrintV2.Documents
     public sealed class IndentDocument : ContainerDocument
     {
         public IndentDocument(IEnumerable<Document> documents)
-            : base(documents.ToImmutableArray())
+            : base([.. documents])
         {
         }
     }

--- a/src/Bicep.Core/Registry/ArtifactHelper.cs
+++ b/src/Bicep.Core/Registry/ArtifactHelper.cs
@@ -10,8 +10,7 @@ namespace Bicep.Core.Registry;
 public static class ArtifactHelper
 {
     public static ImmutableHashSet<ArtifactReference> GetValidArtifactReferences(IEnumerable<ArtifactResolutionInfo> artifacts)
-        => artifacts
+        => [.. artifacts
             .Select(t => t.Reference)
-            .WhereNotNull()
-            .ToImmutableHashSet();
+            .WhereNotNull()];
 }

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -102,14 +102,13 @@ namespace Bicep.Core.Semantics
                     return [];
                 }
 
-                return this.SourceFile.Template.Outputs
+                return [.. this.SourceFile.Template.Outputs
                     .Select(outputProperty => new OutputMetadata(
                             outputProperty.Key,
                             GetType(outputProperty.Value),
                             TryGetMetadataDescription(outputProperty.Value.Metadata),
                             GetType(outputProperty.Value).Type.IsSecureType())
-                     )
-                    .ToImmutableArray();
+                     )];
             });
         }
 
@@ -273,9 +272,7 @@ namespace Bicep.Core.Semantics
                     exports.AddRange(@namespace.Members.Where(kvp => IsExported(kvp.Value))
                         .Select(kvp => new ExportedFunctionMetadata(
                             Name: $"{namePrefix}{kvp.Key}",
-                            Parameters: kvp.Value.Parameters.CoalesceEnumerable()
-                                .Select(p => new ExportedFunctionParameterMetadata(p.Name?.Value ?? string.Empty, GetType(p), GetMostSpecificDescription(p)))
-                                .ToImmutableArray(),
+                            Parameters: [.. kvp.Value.Parameters.CoalesceEnumerable().Select(p => new ExportedFunctionParameterMetadata(p.Name?.Value ?? string.Empty, GetType(p), GetMostSpecificDescription(p)))],
                             Return: new(GetType(kvp.Value.Output), GetMostSpecificDescription(kvp.Value.Output)),
                             Description: kvp.Value.Metadata?.Value is JObject metadataObject ? GetDescriptionFromMetadata(metadataObject) : null)));
                 }
@@ -313,7 +310,7 @@ namespace Bicep.Core.Semantics
                 }
                 else
                 {
-                    exportsBuilder.Add(exportsByName.Key, new DuplicatedExportMetadata(exportsByName.Key, exportsByName.Select(e => e.Kind.ToString()).ToImmutableArray()));
+                    exportsBuilder.Add(exportsByName.Key, new DuplicatedExportMetadata(exportsByName.Key, [.. exportsByName.Select(e => e.Kind.ToString())]));
                 }
             }
 

--- a/src/Bicep.Core/Semantics/Binder.cs
+++ b/src/Bicep.Core/Semantics/Binder.cs
@@ -96,7 +96,7 @@ namespace Bicep.Core.Semantics
 
         public ImmutableHashSet<DeclaredSymbol> GetSymbolsReferencedInDeclarationOf(DeclaredSymbol symbol)
             => symbolsDirectlyReferencedInDeclarations.GetOrAdd(symbol,
-                s => SymbolicReferenceCollector.CollectSymbolsReferenced(this, s.DeclaringSyntax).Keys.ToImmutableHashSet());
+                s => [.. SymbolicReferenceCollector.CollectSymbolsReferenced(this, s.DeclaringSyntax).Keys]);
 
         public ImmutableHashSet<DeclaredSymbol> GetReferencedSymbolClosureFor(DeclaredSymbol symbol)
             => referencedSymbolClosures.GetOrAdd(symbol, CalculateReferencedSymbolClosure);

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -28,7 +28,7 @@ namespace Bicep.Core.Semantics
             Description = description;
             ResultBuilder = resultBuilder;
             Evaluator = evaluator;
-            FixedParameters = fixedParameters.ToImmutableArray();
+            FixedParameters = [.. fixedParameters];
             VariableParameter = variableParameter;
             Flags = flags;
 

--- a/src/Bicep.Core/Semantics/FunctionSymbol.cs
+++ b/src/Bicep.Core/Semantics/FunctionSymbol.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.Semantics
         public FunctionSymbol(ObjectType declaringObject, string name, IEnumerable<FunctionOverload> overloads)
             : base(name)
         {
-            Overloads = overloads.ToImmutableArray();
+            Overloads = [.. overloads];
             FunctionFlags = Overloads.First().Flags;
 
             if (Overloads.Skip(1).Any(fo => fo.Flags != FunctionFlags))

--- a/src/Bicep.Core/Semantics/LocalScope.cs
+++ b/src/Bicep.Core/Semantics/LocalScope.cs
@@ -16,8 +16,8 @@ namespace Bicep.Core.Semantics
             this.DeclaringSyntax = declaringSyntax;
             this.BindingSyntax = bindingSyntax;
             this.ScopeResolution = scopeResolution;
-            this.Locals = locals.ToImmutableArray();
-            this.ChildScopes = childScopes.ToImmutableArray();
+            this.Locals = [.. locals];
+            this.ChildScopes = [.. childScopes];
         }
 
         /// <summary>

--- a/src/Bicep.Core/Semantics/Metadata/ExportMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ExportMetadata.cs
@@ -27,7 +27,7 @@ public record ExportedFunctionParameterMetadata(string Name, ITypeReference Type
 public record ExportedFunctionReturnMetadata(ITypeReference TypeReference, string? Description);
 
 public record ExportedFunctionMetadata(string Name, ImmutableArray<ExportedFunctionParameterMetadata> Parameters, ExportedFunctionReturnMetadata Return, string? Description)
-    : ExportMetadata(ExportMetadataKind.Function, Name, new LambdaType(Parameters.Select(md => md.TypeReference).ToImmutableArray(), [], Return.TypeReference), Description);
+    : ExportMetadata(ExportMetadataKind.Function, Name, new LambdaType([.. Parameters.Select(md => md.TypeReference)], [], Return.TypeReference), Description);
 
 public record DuplicatedExportMetadata(string Name, ImmutableArray<string> ExportKindsWithSameName)
     : ExportMetadata(ExportMetadataKind.Error, Name, ErrorType.Empty(), $"The name \"{Name}\" is ambiguous because it refers to exports of the following kinds: {string.Join(", ", ExportKindsWithSameName)}.");

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
@@ -39,7 +39,7 @@ namespace Bicep.Core.Semantics.Namespaces
         private delegate bool VisibilityDelegate(ResourceScope scope, BicepSourceFileKind sourceFileKind);
         private record NamespaceValue<T>(T Value, VisibilityDelegate IsVisible);
 
-        private static readonly ImmutableArray<NamespaceValue<FunctionOverload>> Overloads = GetAzOverloads().ToImmutableArray();
+        private static readonly ImmutableArray<NamespaceValue<FunctionOverload>> Overloads = [.. GetAzOverloads()];
 
         private static FunctionOverload.ResultBuilderDelegate AddDiagnosticsAndReturnResult(TypeSymbol returnType, DiagnosticBuilder.DiagnosticBuilderDelegate writeDiagnostic)
         {

--- a/src/Bicep.Core/SourceLink/SourceArchive.cs
+++ b/src/Bicep.Core/SourceLink/SourceArchive.cs
@@ -127,7 +127,7 @@ namespace Bicep.Core.SourceLink
                 sourceFileGrouping.SourceFiles.Select(x => new SourceFileWithArtifactReference(x, uriToArtifactReference.TryGetValue(x.Uri, out var reference) ? reference : null));
 
             var documentLinks = SourceCodeDocumentLinkHelper.GetAllModuleDocumentLinks(sourceFileGrouping);
-            return CreateFor(sourceFileGrouping.EntryPoint.Uri, sourceFileGrouping.EntryPoint.Features.CacheRootDirectory, documentLinks, sourceFilesWithArtifactReference.ToArray());
+            return CreateFor(sourceFileGrouping.EntryPoint.Uri, sourceFileGrouping.EntryPoint.Features.CacheRootDirectory, documentLinks, [.. sourceFilesWithArtifactReference]);
         }
 
         // TODO(shenglol): The method is only used by tests. It would be ideal to remove it.
@@ -135,7 +135,7 @@ namespace Bicep.Core.SourceLink
         public static SourceArchive CreateFor(Uri entrypointFileUri, IDirectoryHandle? cacheRoot, IReadOnlyDictionary<Uri, SourceCodeDocumentUriLink[]>? documentLinks, params SourceFileWithArtifactReference[] sourceFiles)
         {
             // Don't package template spec files - they don't appear in the compiled JSON so we shouldn't expose them
-            sourceFiles = sourceFiles.Where(sf => sf.SourceFile is not TemplateSpecFile).ToArray();
+            sourceFiles = [.. sourceFiles.Where(sf => sf.SourceFile is not TemplateSpecFile)];
 
             // Filter out any links where the source or target is not in our list of files to package
             var sourceFileUris = sourceFiles.Select(sf => sf.SourceFile.Uri).ToArray();
@@ -303,7 +303,7 @@ namespace Bicep.Core.SourceLink
             return uriBasedDocumentLinks?.Select(
                 x => new KeyValuePair<string, ImmutableArray<SourceCodeDocumentPathLink>>(
                     sourceUriToRelativePathMap[x.Key],
-                    x.Value.Select(link => DocumentPathLinkFromUriLink(sourceUriToRelativePathMap, link)).ToImmutableArray()
+                    [.. x.Value.Select(link => DocumentPathLinkFromUriLink(sourceUriToRelativePathMap, link))]
                 )).ToImmutableDictionary();
         }
 

--- a/src/Bicep.Core/Syntax/ArraySyntax.cs
+++ b/src/Bicep.Core/Syntax/ArraySyntax.cs
@@ -14,7 +14,7 @@ namespace Bicep.Core.Syntax
             AssertTokenType(closeBracket, nameof(closeBracket), TokenType.RightSquare);
 
             this.OpenBracket = openBracket;
-            this.Children = children.ToImmutableArray();
+            this.Children = [.. children];
             this.CloseBracket = closeBracket;
         }
 

--- a/src/Bicep.Core/Syntax/DecorableSyntax.cs
+++ b/src/Bicep.Core/Syntax/DecorableSyntax.cs
@@ -8,7 +8,7 @@ public abstract class DecorableSyntax : SyntaxBase
 {
     protected DecorableSyntax(IEnumerable<SyntaxBase> leadingNodes)
     {
-        this.LeadingNodes = leadingNodes.ToImmutableArray();
+        this.LeadingNodes = [.. leadingNodes];
     }
 
     public ImmutableArray<SyntaxBase> LeadingNodes { get; }

--- a/src/Bicep.Core/Syntax/DisableNextLineDiagnosticsSyntaxTrivia.cs
+++ b/src/Bicep.Core/Syntax/DisableNextLineDiagnosticsSyntaxTrivia.cs
@@ -12,7 +12,7 @@ namespace Bicep.Core.Syntax
         public DisableNextLineDiagnosticsSyntaxTrivia(SyntaxTriviaType type, TextSpan span, string text, IEnumerable<Token> diagnosticCodes)
             : base(type, span, text)
         {
-            DiagnosticCodes = diagnosticCodes.ToImmutableArray();
+            DiagnosticCodes = [.. diagnosticCodes];
         }
 
         public ImmutableArray<Token> DiagnosticCodes { get; }

--- a/src/Bicep.Core/Syntax/FunctionCallSyntaxBase.cs
+++ b/src/Bicep.Core/Syntax/FunctionCallSyntaxBase.cs
@@ -16,9 +16,9 @@ namespace Bicep.Core.Syntax
 
             this.Name = name;
             this.OpenParen = openParen;
-            this.Children = children.ToImmutableArray();
+            this.Children = [.. children];
             this.CloseParen = closeParen;
-            this.Arguments = this.Children.OfType<FunctionArgumentSyntax>().ToImmutableArray();
+            this.Arguments = [.. this.Children.OfType<FunctionArgumentSyntax>()];
         }
 
         public IdentifierSyntax Name { get; }

--- a/src/Bicep.Core/Syntax/ISyntaxHierarchyExtensions.cs
+++ b/src/Bicep.Core/Syntax/ISyntaxHierarchyExtensions.cs
@@ -30,10 +30,9 @@ namespace Bicep.Core.Syntax
         /// <returns>The list of ancestors.</returns>
         public static ImmutableArray<TSyntax> GetAllAncestors<TSyntax>(this ISyntaxHierarchy hierarchy, SyntaxBase syntax)
             where TSyntax : SyntaxBase
-            => EnumerateAncestorsUpwards(hierarchy, syntax)
+            => [.. EnumerateAncestorsUpwards(hierarchy, syntax)
                 .OfType<TSyntax>()
-                .Reverse()
-                .ToImmutableArray();
+                .Reverse()];
 
         /// <summary>
         /// Gets the nearest ancestor assignable to <typeparamref name="TSyntax" /> above <paramref name="syntax" />

--- a/src/Bicep.Core/Syntax/ImportedSymbolsListSyntax.cs
+++ b/src/Bicep.Core/Syntax/ImportedSymbolsListSyntax.cs
@@ -14,7 +14,7 @@ public class ImportedSymbolsListSyntax : SyntaxBase
         AssertTokenType(closeBrace, nameof(closeBrace), TokenType.RightBrace);
 
         this.OpenBrace = openBrace;
-        this.Children = children.ToImmutableArray();
+        this.Children = [.. children];
         this.CloseBrace = closeBrace;
     }
 

--- a/src/Bicep.Core/Syntax/ObjectSyntax.cs
+++ b/src/Bicep.Core/Syntax/ObjectSyntax.cs
@@ -14,7 +14,7 @@ namespace Bicep.Core.Syntax
             AssertTokenType(closeBrace, nameof(closeBrace), TokenType.RightBrace);
 
             this.OpenBrace = openBrace;
-            this.Children = children.ToImmutableArray();
+            this.Children = [.. children];
             this.CloseBrace = closeBrace;
         }
 

--- a/src/Bicep.Core/Syntax/ObjectTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/ObjectTypeSyntax.cs
@@ -15,7 +15,7 @@ public class ObjectTypeSyntax : TypeSyntax
         AssertTokenType(closeBrace, nameof(closeBrace), TokenType.RightBrace);
 
         OpenBrace = openBrace;
-        Children = children.ToImmutableArray();
+        Children = [.. children];
         CloseBrace = closeBrace;
     }
 

--- a/src/Bicep.Core/Syntax/ParameterizedTypeInstantiationSyntaxBase.cs
+++ b/src/Bicep.Core/Syntax/ParameterizedTypeInstantiationSyntaxBase.cs
@@ -17,9 +17,9 @@ public abstract class ParameterizedTypeInstantiationSyntaxBase : TypeSyntax, ISy
 
         this.Name = name;
         this.OpenChevron = openChevron;
-        this.Children = children.ToImmutableArray();
+        this.Children = [.. children];
         this.CloseChevron = closeChevron;
-        this.Arguments = this.Children.OfType<ParameterizedTypeArgumentSyntax>().ToImmutableArray();
+        this.Arguments = [.. this.Children.OfType<ParameterizedTypeArgumentSyntax>()];
     }
 
     public IdentifierSyntax Name { get; }

--- a/src/Bicep.Core/Syntax/ProgramSyntax.cs
+++ b/src/Bicep.Core/Syntax/ProgramSyntax.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.Syntax
     {
         public ProgramSyntax(IEnumerable<SyntaxBase> children, Token endOfFile)
         {
-            this.Children = children.ToImmutableArray();
+            this.Children = [.. children];
             this.EndOfFile = endOfFile;
         }
 

--- a/src/Bicep.Core/Syntax/SeparatedSyntaxList.cs
+++ b/src/Bicep.Core/Syntax/SeparatedSyntaxList.cs
@@ -9,8 +9,8 @@ namespace Bicep.Core.Syntax
     {
         public SeparatedSyntaxList(IEnumerable<SyntaxBase> elements, IEnumerable<SyntaxBase> separators, TextSpan span)
         {
-            this.Elements = elements.ToImmutableArray();
-            this.Separators = separators.ToImmutableArray();
+            this.Elements = [.. elements];
+            this.Separators = [.. separators];
             this.Span = span;
 
             if (this.Elements.Any())

--- a/src/Bicep.Core/Syntax/SkippedTriviaSyntax.cs
+++ b/src/Bicep.Core/Syntax/SkippedTriviaSyntax.cs
@@ -16,8 +16,8 @@ namespace Bicep.Core.Syntax
         public SkippedTriviaSyntax(TextSpan span, IEnumerable<SyntaxBase> elements, IEnumerable<Diagnostic> diagnostics)
         {
             this.Span = span;
-            this.Elements = elements.ToImmutableArray();
-            this.Diagnostics = diagnostics.ToImmutableArray();
+            this.Elements = [.. elements];
+            this.Diagnostics = [.. diagnostics];
         }
 
         public override bool IsSkipped => true;

--- a/src/Bicep.Core/Syntax/StringSyntax.cs
+++ b/src/Bicep.Core/Syntax/StringSyntax.cs
@@ -8,11 +8,11 @@ namespace Bicep.Core.Syntax
 {
     public class StringSyntax(IEnumerable<Token> stringTokens, IEnumerable<SyntaxBase> expressions, IEnumerable<string> segmentValues) : ExpressionSyntax
     {
-        public ImmutableArray<Token> StringTokens { get; } = stringTokens.ToImmutableArray();
+        public ImmutableArray<Token> StringTokens { get; } = [.. stringTokens];
 
-        public ImmutableArray<SyntaxBase> Expressions { get; } = expressions.ToImmutableArray();
+        public ImmutableArray<SyntaxBase> Expressions { get; } = [.. expressions];
 
-        public ImmutableArray<string> SegmentValues { get; } = segmentValues.ToImmutableArray();
+        public ImmutableArray<string> SegmentValues { get; } = [.. segmentValues];
 
         public override void Accept(ISyntaxVisitor visitor)
             => visitor.VisitStringSyntax(this);

--- a/src/Bicep.Core/Syntax/StringTypeLiteralSyntax.cs
+++ b/src/Bicep.Core/Syntax/StringTypeLiteralSyntax.cs
@@ -8,11 +8,11 @@ namespace Bicep.Core.Syntax
 {
     public class StringTypeLiteralSyntax(IEnumerable<Token> stringTokens, IEnumerable<SyntaxBase> expressions, IEnumerable<string> segmentValues) : TypeSyntax
     {
-        public ImmutableArray<Token> StringTokens { get; } = stringTokens.ToImmutableArray();
+        public ImmutableArray<Token> StringTokens { get; } = [.. stringTokens];
 
-        public ImmutableArray<SyntaxBase> Expressions { get; } = expressions.ToImmutableArray();
+        public ImmutableArray<SyntaxBase> Expressions { get; } = [.. expressions];
 
-        public ImmutableArray<string> SegmentValues { get; } = segmentValues.ToImmutableArray();
+        public ImmutableArray<string> SegmentValues { get; } = [.. segmentValues];
 
         public override void Accept(ISyntaxVisitor visitor)
             => visitor.VisitStringTypeLiteralSyntax(this);

--- a/src/Bicep.Core/Syntax/TupleTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/TupleTypeSyntax.cs
@@ -15,7 +15,7 @@ public class TupleTypeSyntax : TypeSyntax
         AssertTokenType(closeBracket, nameof(closeBracket), TokenType.RightSquare);
 
         this.OpenBracket = openBracket;
-        this.Children = children.ToImmutableArray();
+        this.Children = [.. children];
         this.CloseBracket = closeBracket;
     }
 

--- a/src/Bicep.Core/Syntax/TypedVariableBlockSyntax.cs
+++ b/src/Bicep.Core/Syntax/TypedVariableBlockSyntax.cs
@@ -14,9 +14,9 @@ public class TypedVariableBlockSyntax : SyntaxBase
         AssertTokenType(openParen, nameof(openParen), TokenType.LeftParen);
 
         this.OpenParen = openParen;
-        this.Children = children.ToImmutableArray();
+        this.Children = [.. children];
         this.CloseParen = closeParen;
-        this.Arguments = this.Children.OfType<TypedLocalVariableSyntax>().ToImmutableArray();
+        this.Arguments = [.. this.Children.OfType<TypedLocalVariableSyntax>()];
     }
 
     public Token OpenParen { get; }

--- a/src/Bicep.Core/Syntax/UnionTypeSyntax.cs
+++ b/src/Bicep.Core/Syntax/UnionTypeSyntax.cs
@@ -9,7 +9,7 @@ public class UnionTypeSyntax : TypeSyntax
 {
     public UnionTypeSyntax(IEnumerable<SyntaxBase> children)
     {
-        Children = children.ToImmutableArray();
+        Children = [.. children];
         if (!Members.Any())
         {
             throw new ArgumentException("Union types must contain at least one member");

--- a/src/Bicep.Core/Syntax/VariableBlockSyntax.cs
+++ b/src/Bicep.Core/Syntax/VariableBlockSyntax.cs
@@ -14,9 +14,9 @@ namespace Bicep.Core.Syntax
             AssertTokenType(openParen, nameof(openParen), TokenType.LeftParen);
 
             this.OpenParen = openParen;
-            this.Children = children.ToImmutableArray();
+            this.Children = [.. children];
             this.CloseParen = closeParen;
-            this.Arguments = this.Children.OfType<LocalVariableSyntax>().ToImmutableArray();
+            this.Arguments = [.. this.Children.OfType<LocalVariableSyntax>()];
         }
 
         public Token OpenParen { get; }

--- a/src/Bicep.Core/TypeSystem/Providers/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Az/AzResourceTypeProvider.cs
@@ -188,7 +188,7 @@ namespace Bicep.Core.TypeSystem.Providers.Az
         }
 
         public AzResourceTypeProvider(IResourceTypeLoader resourceTypeLoader)
-            : base(resourceTypeLoader.GetAvailableTypes().ToImmutableHashSet())
+            : base([.. resourceTypeLoader.GetAvailableTypes()])
         {
             this.resourceTypeLoader = resourceTypeLoader;
             definedTypeCache = new ResourceTypeCache();

--- a/src/Bicep.Core/TypeSystem/Providers/Az/ManagementGroupScopeType.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Az/ManagementGroupScopeType.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.TypeSystem.Providers.Az
         public ManagementGroupScopeType(IEnumerable<FunctionArgumentSyntax> arguments, IEnumerable<NamedTypeProperty> properties)
             : base("managementGroup", TypeSymbolValidationFlags.Default, properties, null)
         {
-            Arguments = arguments.ToImmutableArray();
+            Arguments = [.. arguments];
         }
 
         public ImmutableArray<FunctionArgumentSyntax> Arguments { get; }

--- a/src/Bicep.Core/TypeSystem/Providers/Az/ResourceGroupScopeType.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Az/ResourceGroupScopeType.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.TypeSystem.Providers.Az
         public ResourceGroupScopeType(IEnumerable<FunctionArgumentSyntax> arguments, IEnumerable<NamedTypeProperty> properties)
             : base("resourceGroup", TypeSymbolValidationFlags.Default, properties, null)
         {
-            Arguments = arguments.ToImmutableArray();
+            Arguments = [.. arguments];
         }
 
         public ImmutableArray<FunctionArgumentSyntax> Arguments { get; }

--- a/src/Bicep.Core/TypeSystem/Providers/Az/SubscriptionScopeType.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Az/SubscriptionScopeType.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.TypeSystem.Providers.Az
         public SubscriptionScopeType(IEnumerable<FunctionArgumentSyntax> arguments, IEnumerable<NamedTypeProperty> properties)
             : base("subscription", TypeSymbolValidationFlags.Default, properties, null)
         {
-            Arguments = arguments.ToImmutableArray();
+            Arguments = [.. arguments];
         }
 
         public ImmutableArray<FunctionArgumentSyntax> Arguments { get; }

--- a/src/Bicep.Core/TypeSystem/Providers/Az/TenantScopeType.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Az/TenantScopeType.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.TypeSystem.Providers.Az
         public TenantScopeType(IEnumerable<FunctionArgumentSyntax> arguments, IEnumerable<NamedTypeProperty> properties)
             : base("tenant", TypeSymbolValidationFlags.Default, properties, null)
         {
-            Arguments = arguments.ToImmutableArray();
+            Arguments = [.. arguments];
         }
 
         public ImmutableArray<FunctionArgumentSyntax> Arguments { get; }

--- a/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeProvider.cs
@@ -24,7 +24,7 @@ namespace Bicep.Core.TypeSystem.Providers.K8s
         ];
 
         public K8sResourceTypeProvider(K8sResourceTypeLoader resourceTypeLoader)
-            : base(resourceTypeLoader.GetAvailableTypes().ToImmutableHashSet())
+            : base([.. resourceTypeLoader.GetAvailableTypes()])
         {
             this.resourceTypeLoader = resourceTypeLoader;
             definedTypeCache = new ResourceTypeCache();

--- a/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/MicrosoftGraph/MicrosoftGraphResourceTypeProvider.cs
@@ -36,7 +36,7 @@ namespace Bicep.Core.TypeSystem.Providers.MicrosoftGraph
                 UniqueNamePropertyName);
 
         public MicrosoftGraphResourceTypeProvider(MicrosoftGraphResourceTypeLoader resourceTypeLoader)
-            : base(resourceTypeLoader.GetAvailableTypes().ToImmutableHashSet())
+            : base([.. resourceTypeLoader.GetAvailableTypes()])
         {
             this.resourceTypeLoader = resourceTypeLoader;
             definedTypeCache = new ResourceTypeCache();

--- a/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ThirdPartyResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ThirdParty/ThirdPartyResourceTypeProvider.cs
@@ -15,7 +15,7 @@ namespace Bicep.Core.TypeSystem.Providers.ThirdParty
         private readonly ResourceTypeCache generatedTypeCache;
 
         public ThirdPartyResourceTypeProvider(ThirdPartyResourceTypeLoader resourceTypeLoader)
-            : base(resourceTypeLoader.GetAvailableTypes().ToImmutableHashSet())
+            : base([.. resourceTypeLoader.GetAvailableTypes()])
         {
             this.resourceTypeLoader = resourceTypeLoader;
             definedTypeCache = new ResourceTypeCache();

--- a/src/Bicep.Core/TypeSystem/ResourceDerivedTypeResolver.cs
+++ b/src/Bicep.Core/TypeSystem/ResourceDerivedTypeResolver.cs
@@ -290,8 +290,8 @@ public class ResourceDerivedTypeResolver
 
         return hasChanges
             ? new(
-                resolvedParameterTypes.Take(unresolved.ArgumentTypes.Length).ToImmutableArray(),
-                resolvedParameterTypes.Skip(unresolved.ArgumentTypes.Length).ToImmutableArray(),
+                [.. resolvedParameterTypes.Take(unresolved.ArgumentTypes.Length)],
+                [.. resolvedParameterTypes.Skip(unresolved.ArgumentTypes.Length)],
                 resolvedReturnType)
             : unresolved;
     }

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -494,20 +494,6 @@ namespace Bicep.Core.TypeSystem
             {
                 var errors = new List<IDiagnostic>();
 
-                var declaredType = typeManager.GetDeclaredType(syntax);
-
-                this.ValidateDecorators(syntax.Decorators, declaredType ?? LanguageConstants.Any, diagnostics);
-
-                foreach (var decorator in syntax.Decorators)
-                {
-                    if (decorator.Expression is FunctionCallSyntax functionCallSyntax &&
-                        functionCallSyntax.Name.IdentifierName == LanguageConstants.ParameterInlinePropertyName &&
-                        syntax.Value is not SkippedTriviaSyntax)
-                    {
-                        diagnostics.Write(DiagnosticBuilder.ForPosition(decorator).InlineMustNotHaveValueAssigned());
-                    }
-                }
-
                 var valueType = this.typeManager.GetTypeInfo(syntax.Value);
                 CollectErrors(errors, valueType);
 

--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -61,7 +61,7 @@ namespace Bicep.Core.TypeSystem
         public static TypeSymbol MakeNullable(ITypeReference typeReference) => CreateTypeUnion(typeReference, LanguageConstants.Null);
 
         public static LambdaType CreateLambdaType(IEnumerable<ITypeReference> argumentTypes, IEnumerable<ITypeReference> optionalArgumentTypes, TypeSymbol returnType)
-            => new(argumentTypes.ToImmutableArray(), optionalArgumentTypes.ToImmutableArray(), returnType);
+            => new([.. argumentTypes], [.. optionalArgumentTypes], returnType);
 
         /// <summary>
         /// Returns an ordered enumerable of type names.

--- a/src/Bicep.Core/TypeSystem/TypeValidator.cs
+++ b/src/Bicep.Core/TypeSystem/TypeValidator.cs
@@ -620,9 +620,7 @@ namespace Bicep.Core.TypeSystem
                 }
 
                 return new TupleType(validationFlags: targetTuple.ValidationFlags,
-                    items: Enumerable.Range(0, expressionTuple.Items.Length)
-                        .Select(idx => NarrowType(config, expression, expressionTuple.Items[idx].Type, targetTuple.Items[idx].Type))
-                        .ToImmutableArray<ITypeReference>());
+                    items: [.. Enumerable.Range(0, expressionTuple.Items.Length).Select(idx => NarrowType(config, expression, expressionTuple.Items[idx].Type, targetTuple.Items[idx].Type))]);
             }
 
             if (expressionType is ArrayType expressionArrayType)
@@ -1095,7 +1093,7 @@ namespace Bicep.Core.TypeSystem
                                 ShouldWarnForPropertyMismatch(targetType),
                             TryGetSourceDeclaration(config),
                             expression as ObjectSyntax,
-                            missingRequiredProperties.Select(p => p.Name).ToList(),
+                            [.. missingRequiredProperties.Select(p => p.Name)],
                             blockName,
                             config.IsResourceDeclaration && missingRequiredProperties.Any(p => !p.Flags.HasFlag(TypePropertyFlags.SystemProperty)),
                             parsingErrorLookup));

--- a/src/Bicep.Core/TypeSystem/Types/ErrorType.cs
+++ b/src/Bicep.Core/TypeSystem/Types/ErrorType.cs
@@ -21,7 +21,7 @@ namespace Bicep.Core.TypeSystem.Types
             => Create(diagnostic.AsEnumerable());
 
         public static ErrorType Create(IEnumerable<IDiagnostic> diagnostics)
-            => new(diagnostics.ToImmutableArray());
+            => new([.. diagnostics]);
 
         public static ErrorType Empty()
             => new([]);


### PR DESCRIPTION
One of the new style rules in dotnet recommends using a different way to initialize collections. You can find the details here: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0305

After upgrading to dotnet 9 (and later this year dotnet 10), we need to fix warnings and errors that appear when running `dotnet build` command.

This PR updates how collections are initialized to follow the new style rule.

Additionally, running `dotnet format` found some format inconsistencies in the codebase. This PR fixes those as well.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17043)