### PR TITLE
Remove unused OpenTelemetry dependency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,4 @@
 *.sh text eol=lf
 /src/Bicep.Core.Samples/Files/**/Assets/**/*.txt -text
 /src/Bicep.Core.Samples/Files/baselines/*_LF/**/*.bicep eol=lf
-/src/Bicep.Core.Samples/Files/baselines/*_LF/**/*.json eol=lf
 /src/Bicep.Core.Samples/Files/baselines/*_CRLF/**/*.bicep eol=crlf
-/src/Bicep.Core.Samples/Files/baselines/*_CRLF/**/*.json eol=lf

--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,24 +118,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -151,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -168,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -219,14 +218,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -425,16 +423,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -614,21 +602,6 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "System.Diagnostics.DiagnosticSource": "9.0.1"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -988,33 +961,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1709,7 +1655,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1746,10 +1692,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -112,8 +112,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -127,24 +127,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -160,10 +159,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -177,10 +176,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -228,14 +227,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -412,16 +410,6 @@
           "Newtonsoft.Json.Bson": "1.0.2",
           "System.Memory": "4.5.5",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -603,21 +591,6 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "System.Diagnostics.DiagnosticSource": "9.0.1"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -909,33 +882,6 @@
         "contentHash": "QYFyxhaABwmq3p/21VrZNYvCg3DaEoN/wUuw5nmfAf0X3HLjgupwhkEWdgfb9nvGAUIv3osmZoD3kKl4jxEmYQ==",
         "dependencies": {
           "Newtonsoft.Json": "12.0.1"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "runtime.linux-arm.runtime.native.System.IO.Ports": {
@@ -1598,7 +1544,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1635,10 +1581,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -134,8 +134,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -149,24 +149,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -182,10 +181,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -199,10 +198,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -250,14 +249,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -420,16 +418,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -577,21 +565,6 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.1",
           "System.Diagnostics.DiagnosticSource": "9.0.1"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -773,33 +746,6 @@
         "contentHash": "QYFyxhaABwmq3p/21VrZNYvCg3DaEoN/wUuw5nmfAf0X3HLjgupwhkEWdgfb9nvGAUIv3osmZoD3kKl4jxEmYQ==",
         "dependencies": {
           "Newtonsoft.Json": "12.0.1"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "runtime.linux-arm.runtime.native.System.IO.Ports": {
@@ -1420,7 +1366,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1457,10 +1403,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
+++ b/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Deployments.ClientTools" Version="1.329.0" />
+    <PackageReference Include="Azure.Deployments.ClientTools" Version="1.359.0" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
   </ItemGroup>
 </Project>

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -4,19 +4,21 @@
     "net8.0": {
       "Azure.Deployments.ClientTools": {
         "type": "Direct",
-        "requested": "[1.329.0, )",
-        "resolved": "1.329.0",
-        "contentHash": "uJX2oVWVea0q+i69PvRFKnmnR7iC7UX4O8leyyKlRxVAAcM+pIUuJl5GI1qL3zES2zN8bayvoMpCICIe2A3GKw==",
+        "requested": "[1.359.0, )",
+        "resolved": "1.359.0",
+        "contentHash": "peTRd/XZEpJTzlmo114eXDFBmmM0d36QebU8ZjBehnWOUnXsZ3/fN7rptGQ9Z6ufk2uYjBfbP9JgiOC1D4kUvw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
+          "StreamJsonRpc": "2.17.8",
           "System.Collections.Immutable": "8.0.0",
           "System.Diagnostics.DiagnosticSource": "8.0.1",
           "System.IO.Packaging": "8.0.1",
           "System.Memory": "4.5.5",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Reflection.Emit.Lightweight": "4.7.0",
+          "System.Text.Json": "8.0.5"
         }
       },
       "FluentAssertions": {
@@ -120,8 +122,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -135,24 +137,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -168,10 +169,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -185,10 +186,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -236,14 +237,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -409,6 +409,21 @@
         "resolved": "8.1.0",
         "contentHash": "KJFnA0MV83bNOhvYbjIX1iDykhwFXoQu0KV7E1SVbNA/CmO2I7SAm2Baly0eS7VJ2GwlmStLajBfeiNgTpvYzQ=="
       },
+      "MessagePack": {
+        "type": "Transitive",
+        "resolved": "2.5.108",
+        "contentHash": "kcVRbdWP3xNWLZmmpm4DFO+kuXf6mUR2mHZ27WoZIEFIv9hazuUd80injXhNrZnlq/FklAdCsLOil5M76I4Ndg==",
+        "dependencies": {
+          "MessagePack.Annotations": "2.5.108",
+          "Microsoft.NET.StringTools": "17.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "2.5.108",
+        "contentHash": "28aNCvfJClgwaKr26gf2S6LT+C1PNyPxiG+ihYpy8uCJsRLJEDoCt2I0Uk5hqOPQ8P8hI0ESy520oMkZkPmsOQ=="
+      },
       "Microsoft.ApplicationInsights": {
         "type": "Transitive",
         "resolved": "2.22.0",
@@ -426,16 +441,6 @@
           "Newtonsoft.Json.Bson": "1.0.2",
           "System.Memory": "4.5.5",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -605,21 +610,6 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
         }
       },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
-        }
-      },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
         "resolved": "5.0.10",
@@ -673,6 +663,15 @@
         "type": "Transitive",
         "resolved": "6.35.0",
         "contentHash": "xuR8E4Rd96M41CnUSCiOJ2DBh+z+zQSmyrYHdYhD6K4fXBcQGVnRCFQ0efROUYpP+p0zC1BLKr0JRpVuujTZSg=="
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.4.0",
+        "contentHash": "06T6Hqfs3JDIaBvJaBRFFMIdU7oE0OMab5Xl8LKQjWPxBQr3BgVFKMQPTC+GsSEuYREWmK6g5eOd7Xqd9p1YCA==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Transitive",
@@ -976,33 +975,6 @@
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
         }
       },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
-        }
-      },
       "RichardSzalay.MockHttp": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -1093,6 +1065,26 @@
           "System.Private.Uri": "4.3.2",
           "System.Runtime": "4.3.1",
           "System.Text.RegularExpressions": "4.3.1"
+        }
+      },
+      "StreamJsonRpc": {
+        "type": "Transitive",
+        "resolved": "2.17.8",
+        "contentHash": "XxxYqGwcaH/3uBel6Ur54ldMIdW2sd80B0nbN4iqMyBXkiBoiVDmtyJv6ow3jaCkRmJLEFrX2/PEWvSsdBldlw==",
+        "dependencies": {
+          "MessagePack": "2.5.108",
+          "Microsoft.Bcl.AsyncInterfaces": "7.0.0",
+          "Microsoft.VisualStudio.Threading": "17.7.35",
+          "Microsoft.VisualStudio.Threading.Analyzers": "17.7.35",
+          "Microsoft.VisualStudio.Validation": "17.6.11",
+          "Nerdbank.Streams": "2.10.69",
+          "Newtonsoft.Json": "13.0.1",
+          "System.Collections.Immutable": "7.0.0",
+          "System.Diagnostics.DiagnosticSource": "7.0.2",
+          "System.IO.Pipelines": "7.0.0",
+          "System.Text.Encodings.Web": "7.0.0",
+          "System.Text.Json": "7.0.3",
+          "System.Threading.Tasks.Dataflow": "7.0.0"
         }
       },
       "System.Buffers": {
@@ -1602,6 +1594,11 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Threading.Tasks.Dataflow": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "BmSJ4b0e2nlplV/RdWVxvH7WECTHACofv06dx/JwOYc0n56eK1jIWdQKNYYsReSO4w8n1QA5stOzSQcfaVBkJg=="
+      },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
         "resolved": "4.5.4",
@@ -1647,7 +1644,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1684,10 +1681,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Core.Samples/Files/baselines/PrettyPrint_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/PrettyPrint_LF/main.symbols.bicep
@@ -204,7 +204,7 @@ var forceBreak15 = true ? { foo: 0 } : {
     bar: 1}
 
 var forceBreak16 = union({ foo: 0 }, {
-//@[04:16) Variable forceBreak16. Type: { bar: 456, foo: 123 }. Declaration start char: 0, length: 79
+//@[04:16) Variable forceBreak16. Type: { foo: 123, bar: 456 }. Declaration start char: 0, length: 79
     foo: 123
     bar: 456
 } // comment

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,24 +118,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -151,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -168,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -219,14 +218,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -411,16 +409,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -586,21 +574,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -957,33 +930,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1630,7 +1576,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1667,10 +1613,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -151,8 +151,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -166,24 +166,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -199,10 +198,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -216,10 +215,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -267,14 +266,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -446,16 +444,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -621,21 +609,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -976,33 +949,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "runtime.linux-arm.runtime.native.System.IO.Ports": {
@@ -1636,7 +1582,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1673,10 +1619,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Semver" Version="3.0.0" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="Azure.Deployments.Templates" Version="1.329.0" />
+    <PackageReference Include="Azure.Deployments.Templates" Version="1.359.0" />
     <PackageReference Include="Azure.Bicep.Types" Version="0.5.110" />
     <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.764" />
     <PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.644" />

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -53,15 +53,14 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Direct",
-        "requested": "[1.329.0, )",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "requested": "[1.359.0, )",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -289,8 +288,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -304,10 +303,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -351,16 +350,6 @@
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Json.More.Net": "2.1.0"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -846,11 +835,6 @@
         "dependencies": {
           "System.Configuration.ConfigurationManager": "8.0.1"
         }
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "4.5.2",
-        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
       },
       "System.Security.AccessControl": {
         "type": "Transitive",

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,24 +118,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -151,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -168,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -219,14 +218,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -411,16 +409,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -586,21 +574,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -957,33 +930,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1630,7 +1576,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1667,10 +1613,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,24 +118,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -151,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -168,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -219,14 +218,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -411,16 +409,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -586,21 +574,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -957,33 +930,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1630,7 +1576,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1667,10 +1613,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -92,8 +92,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -107,10 +107,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -124,14 +124,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -214,16 +213,6 @@
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Json.More.Net": "2.1.0"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -814,11 +803,6 @@
           "System.Configuration.ConfigurationManager": "8.0.1"
         }
       },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "4.5.2",
-        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
-      },
       "System.Security.AccessControl": {
         "type": "Transitive",
         "resolved": "4.7.0",
@@ -981,7 +965,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -134,8 +134,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -149,24 +149,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -182,10 +181,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -199,10 +198,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -250,14 +249,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -442,16 +440,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -617,21 +605,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -971,33 +944,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1644,7 +1590,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1681,10 +1627,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -154,24 +154,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -187,10 +186,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -204,10 +203,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -255,14 +254,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -447,16 +445,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -622,21 +610,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -985,33 +958,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "runtime.linux-arm.runtime.native.System.IO.Ports": {
@@ -1653,7 +1599,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1690,10 +1636,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -135,8 +135,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -150,24 +150,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -183,10 +182,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -200,10 +199,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -251,14 +250,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -407,16 +405,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -547,21 +535,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -781,33 +754,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "runtime.linux-arm.runtime.native.System.IO.Ports": {
@@ -1414,7 +1360,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1451,10 +1397,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -136,24 +136,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -169,10 +168,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -186,10 +185,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -237,14 +236,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -429,16 +427,6 @@
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -604,21 +592,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -967,33 +940,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1640,7 +1586,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1677,10 +1623,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Local.Deploy/Bicep.Local.Deploy.csproj
+++ b/src/Bicep.Local.Deploy/Bicep.Local.Deploy.csproj
@@ -12,10 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Deployments.Engine" Version="1.329.0" />
+    <PackageReference Include="Azure.Deployments.Engine" Version="1.359.0" />
     <PackageReference Include="Azure.Deployments.Extensibility.Core" Version="0.1.67" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensibilityHostManager.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensibilityHostManager.cs
@@ -23,8 +23,6 @@ using Bicep.Core.TypeSystem.Types;
 using Bicep.IO.Abstraction;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
-using OpenTelemetry;
-using OpenTelemetry.Trace;
 using IAsyncDisposable = System.IAsyncDisposable;
 
 
@@ -43,11 +41,6 @@ public class LocalExtensibilityHostManager : IAsyncDisposable
     private readonly WorkerJobDispatcherClient jobDispatcher;
     private readonly LocalDeploymentEngine localDeploymentEngine;
 
-    /// <summary>
-    /// Gets or sets the trace provider, required to enable producing non-null activities.
-    /// </summary>
-    private TracerProvider TraceProvider { get; set; }
-
     public LocalExtensibilityHostManager(
         IFileExplorer fileExplorer,
         IModuleDispatcher moduleDispatcher,
@@ -55,10 +48,6 @@ public class LocalExtensibilityHostManager : IAsyncDisposable
         ITokenCredentialFactory credentialFactory,
         Func<Uri, Task<LocalExtensibilityHost>> extensionFactory)
     {
-        this.TraceProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(OperationActivitySource.DefaultName)
-            .Build();
-
         var services = new ServiceCollection()
             .RegisterLocalDeployServices(this)
             .BuildServiceProvider();

--- a/src/Bicep.Local.Deploy/LocalDeploymentEngineHost.cs
+++ b/src/Bicep.Local.Deploy/LocalDeploymentEngineHost.cs
@@ -92,12 +92,12 @@ public class LocalDeploymentEngineHost : DeploymentEngineHostBase
         return stringToBeSanitized;
     }
 
-
     public override async Task<HttpResponseMessage> CallExtensibilityHostV2(
         HttpMethod requestMethod,
         Uri requestUri,
         HttpContent content,
         AuthenticationToken extensibilityHostToken,
+        string msiIdentityUrl,
         CancellationToken cancellationToken)
     {
         var extensionName = requestUri.Segments[^4].TrimEnd('/');

--- a/src/Bicep.Local.Deploy/packages.lock.json
+++ b/src/Bicep.Local.Deploy/packages.lock.json
@@ -4,20 +4,19 @@
     "net8.0": {
       "Azure.Deployments.Engine": {
         "type": "Direct",
-        "requested": "[1.329.0, )",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "requested": "[1.359.0, )",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -89,17 +88,6 @@
         "resolved": "3.7.112",
         "contentHash": "j0jcfnTjvhytRanVR34Gaj6RFKk8EDmVhRW7929nWjCo8tzBxsa3XmFmbSGDA6nWXGhfehTixWhPgGWAbz+NQA=="
       },
-      "OpenTelemetry": {
-        "type": "Direct",
-        "requested": "[1.9.0, )",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
       "Azure.Bicep.Types": {
         "type": "Transitive",
         "resolved": "0.5.110",
@@ -150,8 +138,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -165,15 +153,15 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -187,10 +175,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -227,14 +215,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -370,16 +357,6 @@
         "contentHash": "O3KclMcPVFYTZsTeZBpwtKd/lYrNc3AFR+xi9j3Q4CfhDufOUx25TMMWJOcFRrqVklvKQ4Kl+0UhlNX1iDGoRw==",
         "dependencies": {
           "JsonPointer.Net": "5.0.0"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -525,21 +502,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -706,23 +668,6 @@
         "contentHash": "QYFyxhaABwmq3p/21VrZNYvCg3DaEoN/wUuw5nmfAf0X3HLjgupwhkEWdgfb9nvGAUIv3osmZoD3kKl4jxEmYQ==",
         "dependencies": {
           "Newtonsoft.Json": "12.0.1"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "runtime.linux-arm.runtime.native.System.IO.Ports": {
@@ -1119,11 +1064,6 @@
           "System.Configuration.ConfigurationManager": "8.0.1"
         }
       },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "4.5.2",
-        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
-      },
       "System.Runtime.Extensions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1324,7 +1264,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.Local.Extension.Mock/packages.lock.json
+++ b/src/Bicep.Local.Extension.Mock/packages.lock.json
@@ -97,8 +97,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -112,10 +112,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -129,14 +129,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -282,16 +281,6 @@
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Json.More.Net": "2.1.0"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -882,11 +871,6 @@
           "System.Configuration.ConfigurationManager": "8.0.1"
         }
       },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "4.5.2",
-        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
-      },
       "System.Security.AccessControl": {
         "type": "Transitive",
         "resolved": "4.7.0",
@@ -1049,7 +1033,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,24 +118,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -151,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -168,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -219,14 +218,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -422,16 +420,6 @@
           "Newtonsoft.Json.Bson": "1.0.2",
           "System.Memory": "4.5.5",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -678,17 +666,17 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
+        "resolved": "6.0.0",
+        "contentHash": "ZDskjagmBAbv+K8rYW9VhjPplhbOE63xUD0DiuydZJwt15dRyoqicYklLd86zzeintUc7AptDkHn+YhhYkYo8A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
@@ -1094,33 +1082,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1833,7 +1794,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1870,10 +1831,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -116,8 +116,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -131,24 +131,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -164,10 +163,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -181,10 +180,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -232,14 +231,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -419,16 +417,6 @@
           "Newtonsoft.Json.Bson": "1.0.2",
           "System.Memory": "4.5.5",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -675,17 +663,17 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
+        "resolved": "6.0.0",
+        "contentHash": "ZDskjagmBAbv+K8rYW9VhjPplhbOE63xUD0DiuydZJwt15dRyoqicYklLd86zzeintUc7AptDkHn+YhhYkYo8A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
@@ -1096,33 +1084,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1835,7 +1796,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1872,10 +1833,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,24 +118,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -151,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -168,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -219,14 +218,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -422,16 +420,6 @@
           "Newtonsoft.Json.Bson": "1.0.2",
           "System.Memory": "4.5.5",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -678,17 +666,17 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
+        "resolved": "6.0.0",
+        "contentHash": "ZDskjagmBAbv+K8rYW9VhjPplhbOE63xUD0DiuydZJwt15dRyoqicYklLd86zzeintUc7AptDkHn+YhhYkYo8A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
+          "Microsoft.Extensions.Configuration": "6.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "6.0.0"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
@@ -1094,33 +1082,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "RichardSzalay.MockHttp": {
@@ -1833,7 +1794,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1870,10 +1831,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -198,8 +198,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -213,10 +213,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -230,14 +230,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -312,16 +311,6 @@
         "dependencies": {
           "Humanizer.Core": "2.14.1",
           "Json.More.Net": "2.1.1"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -1213,7 +1202,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -98,8 +98,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -113,24 +113,23 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "S9SEAtTi5FY35i/lFm2oXjdm48kt1Mm84wrTzng3+oEBNZicKUbfYR8dqaYvAp51wJSLxaWJFtM1b4JbUl+gLw=="
+        "resolved": "1.359.0",
+        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "opqzdZE/gJURKdnarqGucUGk16JP9PN0VduTsa/oCDddY1Rh1gJvZOXoXQMnmCVKDZtRsqBxOF/JRlO+uG+7DA==",
+        "resolved": "1.359.0",
+        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.DiffEngine": "1.329.0",
-          "Azure.Deployments.Extensibility": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.DiffEngine": "1.359.0",
+          "Azure.Deployments.Extensibility": "1.359.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.329.0",
+          "Azure.Deployments.Templates": "1.359.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -146,10 +145,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -163,10 +162,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "76j9DGdjpUmvUoBAT4Eh3u1DSudnNmdQugjJiYyureWTaK+kqt8h2eHflcRFGsb3LIRuz6gOH/NBQrVotVibwQ==",
+        "resolved": "1.359.0",
+        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -214,14 +213,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -427,16 +425,6 @@
           "Newtonsoft.Json.Bson": "1.0.2",
           "System.Memory": "4.5.5",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -664,21 +652,6 @@
         "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
-      "Microsoft.Extensions.Logging.Configuration": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ixXXV0G/12g6MXK65TLngYN9V5hQQRuV+fZi882WIoVJT7h5JvoYoxTEwCgdqwLjSneqh1O+66gM8sMr9z/rsQ==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -1059,33 +1032,6 @@
         "contentHash": "+p+py79MrNG3QnqRrBp5J7Wc810HFFczMH8/WLIiUqih1bqmKPFY9l/uzBvq1Ko8+YO/8tzI7BDffHvaguISEw==",
         "dependencies": {
           "OmniSharp.Extensions.LanguageProtocol": "0.19.9"
-        }
-      },
-      "OpenTelemetry": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "7scS6BUhwYeSXEDGhCxMSezmvyCoDU5kFQbmfyW9iVvVTcWhec+1KIN33/LOCdBXRkzt2y7+g03mkdAB0XZ9Fw==",
-        "dependencies": {
-          "Microsoft.Extensions.Diagnostics.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "8.0.0",
-          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.9.0"
-        }
-      },
-      "OpenTelemetry.Api": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "Xz8ZvM1Lm0m7BbtGBnw2JlPo++YKyMp08zMK5p0mf+cIi5jeMt2+QsYu9X6YEAbjCxBQYwEak5Z8sY6Ig2WcwQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "8.0.0"
-        }
-      },
-      "OpenTelemetry.Api.ProviderBuilderExtensions": {
-        "type": "Transitive",
-        "resolved": "1.9.0",
-        "contentHash": "L0D4LBR5JFmwLun5MCWVGapsJLV0ANZ+XXu9NEI3JE/HRKkRuUO+J2MuHD5DBwiU//QMYYM4B22oev1hVLoHDQ==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "OpenTelemetry.Api": "1.9.0"
         }
       },
       "Perfolizer": {
@@ -1737,7 +1683,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1774,10 +1720,9 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.329.0, )",
+          "Azure.Deployments.Engine": "[1.359.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
-          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )",
-          "OpenTelemetry": "[1.9.0, )"
+          "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }
       },
       "Azure.Bicep.Local.Extension": {

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -114,8 +114,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "+Zk/3V5DTfqXXRNzjMxjf//CEI3t6YwQPwae/l2FLjmIpDgyIvHtgAeRxy+8QSRY0x50hYNxj1Rc+RWRor2ZKw==",
+        "resolved": "1.359.0",
+        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -129,10 +129,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "MDlbjduJj8ZDiIllgN8MxBGdZ/2gqwb/XecpQCMRMxhxDHUEr6TOV+mGHd0Y9g/OpjSVxBX9e2rU31k7meCtWQ==",
+        "resolved": "1.359.0",
+        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -146,14 +146,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.329.0",
-        "contentHash": "XuVbRBTaV0vGcjK7hGt7+u6lGBcdx3zqFR+Qjq8L6dGmPSbQtTiy+JJdVqe0vkLs62o5jExCJClCYSm4cy4Wgg==",
+        "resolved": "1.359.0",
+        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.329.0",
-          "Azure.Deployments.Expression": "1.329.0",
+          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Expression": "1.359.0",
           "IPNetwork2": "2.6.598",
-          "Microsoft.Automata.SRM": "1.2.2",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -287,16 +286,6 @@
         "type": "Transitive",
         "resolved": "8.0.15",
         "contentHash": "eKlqQasjNZD0B3thB+nX7kkpG/RiZlXObmjX+JurWycnssGp1q9iZjKn2SqKA45Pouw+529aQUYYP2/QCE5xIQ=="
-      },
-      "Microsoft.Automata.SRM": {
-        "type": "Transitive",
-        "resolved": "1.2.2",
-        "contentHash": "+tdYyUEbSOO5q86TOHKzy7MiT/gqTq4aEpOmFglMw9GDXM0BnT93AG02YT29Wi+qCZmt+APPy+VJEgHUEa89Mw==",
-        "dependencies": {
-          "System.Collections.Immutable": "1.6.0",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -899,11 +888,6 @@
           "System.Configuration.ConfigurationManager": "8.0.1"
         }
       },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "4.5.2",
-        "contentHash": "wprSFgext8cwqymChhrBLu62LMg/1u92bU+VOwyfBimSPVFXtsNqEWC92Pf9ofzJFlk4IHmJA75EDJn1b2goAQ=="
-      },
       "System.Security.AccessControl": {
         "type": "Transitive",
         "resolved": "4.7.0",
@@ -1075,7 +1059,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.329.0, )",
+          "Azure.Deployments.Templates": "[1.359.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",


### PR DESCRIPTION
This creates package hash mismatch errors when switching between open-source and closed-source repos (because internal copies of these packages are signed with a different cert, and thus have a different hash)