### PR TITLE
`use-secure-value-for-secure-inputs` linter rule: Remove some false positives

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSecureValueForSecureInputsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSecureValueForSecureInputsRuleTests.cs
@@ -88,4 +88,32 @@ resource ubuntuVM 'Microsoft.Compute/virtualMachines@2020-12-01' = {
     [TestMethod]
     public void Linter_validation_should_not_warn_for_secure_password_field(string text)
         => CompileAndTest(text, 0);
+
+    [DataRow("""
+param sqlLogicalServer object
+
+resource sqlLogicalServerRes 'Microsoft.Sql/servers@2024-05-01-preview' = {
+  name: sqlLogicalServer.name
+  location: resourceGroup().location
+  properties: {
+    administratorLogin: null
+    administratorLoginPassword: null
+  }
+}
+""")]
+    [DataRow("""
+param sqlLogicalServer object
+
+resource sqlLogicalServerRes 'Microsoft.Sql/servers@2024-05-01-preview' = {
+  name: sqlLogicalServer.name
+  location: resourceGroup().location
+  properties: {
+    administratorLogin: null
+    administratorLoginPassword: ''
+  }
+}
+""")]
+    [TestMethod]
+    public void Linter_validation_should_not_warn_for_null_or_empty_string_assignment(string text)
+        => CompileAndTest(text, 0);
 }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSecureValueForSecureInputsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseSecureValueForSecureInputsRuleTests.cs
@@ -116,4 +116,28 @@ resource sqlLogicalServerRes 'Microsoft.Sql/servers@2024-05-01-preview' = {
     [TestMethod]
     public void Linter_validation_should_not_warn_for_null_or_empty_string_assignment(string text)
         => CompileAndTest(text, 0);
+
+    [DataRow("""
+resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' existing = {
+  name: 'mystorageaccount'
+}
+
+resource script 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: 'azcli-script'
+  location: 'westus'
+  kind: 'AzureCLI'
+  properties: {
+    azCliVersion: '2.0.81'
+    scriptContent: 'echo "Hello, World!"'
+    retentionInterval: 'PT1H'
+    storageAccountSettings: {
+      storageAccountName: storageAccount.name
+      storageAccountKey: storageAccount.listKeys().keys[0].value
+    }
+  }
+}
+""")]
+    [TestMethod]
+    public void Linter_validation_should_not_warn_for_chained_values(string text)
+        => CompileAndTest(text, 0);
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseSecureValueForSecureInputsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseSecureValueForSecureInputsRule.cs
@@ -63,6 +63,8 @@ public sealed class UseSecureValueForSecureInputsRule : LinterRuleBase
         {
             if (model.GetTypeInfo(property.Value) is { } type &&
                 type is not ErrorType &&
+                type is not NullType &&
+                type is not StringLiteralType { RawStringValue: "" } &&
                 !type.ValidationFlags.HasFlag(TypeSymbolValidationFlags.IsSecure))
             {
                 yield return CreateDiagnosticForSpan(

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseSecureValueForSecureInputsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseSecureValueForSecureInputsRule.cs
@@ -9,6 +9,7 @@ using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Providers;
 using Bicep.Core.TypeSystem.Types;
 
 namespace Bicep.Core.Analyzers.Linter.Rules;
@@ -59,8 +60,16 @@ public sealed class UseSecureValueForSecureInputsRule : LinterRuleBase
 
     public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
     {
+        var resourceTypeResolver = ResourceTypeResolver.Create(model);
         foreach (var property in GetSecureObjectPropertiesFromTypeInformation(model))
         {
+            if (!IsDeployTimeConstant(property, model, resourceTypeResolver))
+            {
+                // Let's ignore the case where insecure runtime values are used - this is complicated due to lack of accurate type information.
+                // The main thing we are trying to block is hard-coded values, insecure parameters, and value calculated from these.
+                continue;
+            }
+
             if (model.GetTypeInfo(property.Value) is { } type &&
                 type is not ErrorType &&
                 type is not NullType &&
@@ -73,5 +82,13 @@ public sealed class UseSecureValueForSecureInputsRule : LinterRuleBase
                     [string.Join('.', property.TryGetKeyText() ?? string.Empty), type.Name]);
             }
         }
+    }
+
+    private static bool IsDeployTimeConstant(ObjectPropertySyntax syntax, SemanticModel model, ResourceTypeResolver resolver)
+    {
+        var diagWriter = ToListDiagnosticWriter.Create();
+        DeployTimeConstantValidator.CheckDeployTimeConstantViolations(syntax, syntax.Value, model, diagWriter, resolver);
+
+        return diagWriter.GetDiagnostics().Count == 0;
     }
 }


### PR DESCRIPTION
Closes #17051
Closes #17092

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17107)