### PR TITLE
Build snapshot from templates lib

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Cli.IntegrationTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,20 +118,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -150,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -167,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -218,12 +218,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1655,7 +1655,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1692,7 +1692,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Cli.UnitTests/packages.lock.json
+++ b/src/Bicep.Cli.UnitTests/packages.lock.json
@@ -112,8 +112,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -127,20 +127,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -159,10 +159,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -176,10 +176,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -227,12 +227,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1544,7 +1544,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1581,7 +1581,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Cli/Arguments/SnapshotArguments.cs
+++ b/src/Bicep.Cli/Arguments/SnapshotArguments.cs
@@ -12,6 +12,7 @@ public class SnapshotArguments : ArgumentsBase
     private const string SubscriptionIdArgument = "--subscription-id";
     private const string LocationArgument = "--location";
     private const string ResourceGroupArgument = "--resource-group";
+    private const string DeploymentNameArgument = "--deployment-name";
 
     public enum SnapshotMode
     {
@@ -55,6 +56,12 @@ public class SnapshotArguments : ArgumentsBase
                     i++;
                     break;
 
+                case DeploymentNameArgument:
+                    ArgumentHelper.ValidateNotAlreadySet(DeploymentNameArgument, DeploymentName);
+                    DeploymentName = ArgumentHelper.GetValueWithValidation(DeploymentNameArgument, args, i);
+                    i++;
+                    break;
+
                 default:
                     if (args[i].StartsWith("--"))
                     {
@@ -86,4 +93,6 @@ public class SnapshotArguments : ArgumentsBase
     public string? Location { get; }
 
     public string? ResourceGroup { get; }
+
+    public string? DeploymentName { get; }
 }

--- a/src/Bicep.Cli/packages.lock.json
+++ b/src/Bicep.Cli/packages.lock.json
@@ -134,8 +134,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -149,20 +149,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -181,10 +181,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -198,10 +198,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -249,12 +249,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1366,7 +1366,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1403,7 +1403,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
+++ b/src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Deployments.ClientTools" Version="1.359.0" />
+    <PackageReference Include="Azure.Deployments.ClientTools" Version="1.364.0" />
     <PackageReference Update="Nerdbank.GitVersioning" Version="3.7.112" />
   </ItemGroup>
 </Project>

--- a/src/Bicep.Core.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Core.IntegrationTests/packages.lock.json
@@ -4,11 +4,11 @@
     "net8.0": {
       "Azure.Deployments.ClientTools": {
         "type": "Direct",
-        "requested": "[1.359.0, )",
-        "resolved": "1.359.0",
-        "contentHash": "peTRd/XZEpJTzlmo114eXDFBmmM0d36QebU8ZjBehnWOUnXsZ3/fN7rptGQ9Z6ufk2uYjBfbP9JgiOC1D4kUvw==",
+        "requested": "[1.364.0, )",
+        "resolved": "1.364.0",
+        "contentHash": "4j0MLEWzFDCnwCCzKJLnvVe63Ao+90IoFu+vQoMAMARkwz/zEukae7I1V6LrQxpvIydENmC5S4H/5D+PtOow0w==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
           "Newtonsoft.Json": "13.0.3",
@@ -122,8 +122,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -137,20 +137,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -169,10 +169,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -186,10 +186,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -237,12 +237,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1644,7 +1644,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1681,7 +1681,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Core.Samples/packages.lock.json
+++ b/src/Bicep.Core.Samples/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,20 +118,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -150,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -167,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -218,12 +218,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1576,7 +1576,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1613,7 +1613,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Core.UnitTests/packages.lock.json
+++ b/src/Bicep.Core.UnitTests/packages.lock.json
@@ -151,8 +151,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -166,20 +166,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -198,10 +198,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -215,10 +215,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -266,12 +266,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1582,7 +1582,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1619,7 +1619,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Core/Bicep.Core.csproj
+++ b/src/Bicep.Core/Bicep.Core.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Semver" Version="3.0.0" />
     <PackageReference Include="SharpYaml" Version="2.1.1" />
-    <PackageReference Include="Azure.Deployments.Templates" Version="1.359.0" />
+    <PackageReference Include="Azure.Deployments.Templates" Version="1.364.0" />
     <PackageReference Include="Azure.Bicep.Types" Version="0.5.110" />
     <PackageReference Include="Azure.Bicep.Types.Az" Version="0.2.764" />
     <PackageReference Include="Azure.Bicep.Types.K8s" Version="0.1.644" />

--- a/src/Bicep.Core/packages.lock.json
+++ b/src/Bicep.Core/packages.lock.json
@@ -53,13 +53,13 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Direct",
-        "requested": "[1.359.0, )",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "requested": "[1.364.0, )",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -288,8 +288,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -303,10 +303,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",

--- a/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Decompiler.IntegrationTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,20 +118,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -150,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -167,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -218,12 +218,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1576,7 +1576,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1613,7 +1613,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Decompiler.UnitTests/packages.lock.json
+++ b/src/Bicep.Decompiler.UnitTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,20 +118,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -150,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -167,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -218,12 +218,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1576,7 +1576,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1613,7 +1613,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Decompiler/packages.lock.json
+++ b/src/Bicep.Decompiler/packages.lock.json
@@ -92,8 +92,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -107,10 +107,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -124,12 +124,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -965,7 +965,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.LangServer.IntegrationTests/packages.lock.json
+++ b/src/Bicep.LangServer.IntegrationTests/packages.lock.json
@@ -134,8 +134,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -149,20 +149,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -181,10 +181,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -198,10 +198,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -249,12 +249,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1590,7 +1590,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1627,7 +1627,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.LangServer.UnitTests/packages.lock.json
+++ b/src/Bicep.LangServer.UnitTests/packages.lock.json
@@ -139,8 +139,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -154,20 +154,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -186,10 +186,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -203,10 +203,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -254,12 +254,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1599,7 +1599,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1636,7 +1636,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.LangServer/packages.lock.json
+++ b/src/Bicep.LangServer/packages.lock.json
@@ -135,8 +135,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -150,20 +150,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -182,10 +182,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -199,10 +199,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -250,12 +250,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1360,7 +1360,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1397,7 +1397,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
+++ b/src/Bicep.Local.Deploy.IntegrationTests/packages.lock.json
@@ -121,8 +121,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -136,20 +136,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -168,10 +168,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -185,10 +185,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -236,12 +236,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1586,7 +1586,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1623,7 +1623,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Local.Deploy/Bicep.Local.Deploy.csproj
+++ b/src/Bicep.Local.Deploy/Bicep.Local.Deploy.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Deployments.Engine" Version="1.359.0" />
+    <PackageReference Include="Azure.Deployments.Engine" Version="1.364.0" />
     <PackageReference Include="Azure.Deployments.Extensibility.Core" Version="0.1.67" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
   </ItemGroup>

--- a/src/Bicep.Local.Deploy/packages.lock.json
+++ b/src/Bicep.Local.Deploy/packages.lock.json
@@ -4,16 +4,16 @@
     "net8.0": {
       "Azure.Deployments.Engine": {
         "type": "Direct",
-        "requested": "[1.359.0, )",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "requested": "[1.364.0, )",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -138,8 +138,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -153,15 +153,15 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -175,10 +175,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -215,12 +215,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1264,7 +1264,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.Local.Extension.Mock/packages.lock.json
+++ b/src/Bicep.Local.Extension.Mock/packages.lock.json
@@ -97,8 +97,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -112,10 +112,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -129,12 +129,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1033,7 +1033,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.IntegrationTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,20 +118,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -150,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -167,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -218,12 +218,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1794,7 +1794,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1831,7 +1831,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.TestFixtures/packages.lock.json
@@ -116,8 +116,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -131,20 +131,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -163,10 +163,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -180,10 +180,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -231,12 +231,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1796,7 +1796,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1833,7 +1833,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool.UnitTests/packages.lock.json
@@ -103,8 +103,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -118,20 +118,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -150,10 +150,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -167,10 +167,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -218,12 +218,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1794,7 +1794,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1831,7 +1831,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.RegistryModuleTool/packages.lock.json
+++ b/src/Bicep.RegistryModuleTool/packages.lock.json
@@ -198,8 +198,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -213,10 +213,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -230,12 +230,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1202,7 +1202,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",

--- a/src/Bicep.Tools.Benchmark/packages.lock.json
+++ b/src/Bicep.Tools.Benchmark/packages.lock.json
@@ -98,8 +98,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -113,20 +113,20 @@
       },
       "Azure.Deployments.DiffEngine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "O+uRcXh8cAFH/hIcTOuS3/XdmGZ1DE0ywmVBpHajsu/SKjiUL4TpYoTGycI/RDufVTCMsAiKhpm7Gm+RSNiSnA=="
+        "resolved": "1.364.0",
+        "contentHash": "VBSUmOS9qX2kKn+0F9e6OIZWqdw/qA16lmqDEcP9mT1xW3utt3AQxcPUi1ZrcrTATXfUc3KzwaFoNZMOujGGzQ=="
       },
       "Azure.Deployments.Engine": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "Q+JguV1lfOQGXys5OY/SsiuR5Tz7JIgq2LA6dyjYokAOxLE2SRFdbbOQjtrXRrIqAS2zfgMYeSz54M2qtkwpvQ==",
+        "resolved": "1.364.0",
+        "contentHash": "MRXgnS0XOsxeUXHgOjDaFJDiwIqpKHMNyV4Qk+Olk9wLMn7FE0EBPD7b3gqNSgjbNw0hYQP47W8q0JpM+605aw==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.DiffEngine": "1.359.0",
-          "Azure.Deployments.Extensibility": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.DiffEngine": "1.364.0",
+          "Azure.Deployments.Extensibility": "1.364.0",
           "Azure.Deployments.ResourceMetadata": "1.71.0",
-          "Azure.Deployments.Templates": "1.359.0",
+          "Azure.Deployments.Templates": "1.364.0",
           "IPNetwork2": "2.6.598",
           "JsonDiffPatch.Net": "2.3.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
@@ -145,10 +145,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -162,10 +162,10 @@
       },
       "Azure.Deployments.Extensibility": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "tJQ6LxmIOTqPzRbgBW6foyK84Gvr9022RU227uOvqWcx2gY4lduLuYsWs/zDYftxQCLcmvzksc+EcLYWbEkCnw==",
+        "resolved": "1.364.0",
+        "contentHash": "r7jyzWIh1vOhz2tC47CEkn/HxO3VqGdMogYNRa12/w3EVKX03f5vf59u2X3f/8Hw7IQ4AmWiuUcSLliR8ARUDw==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "Microsoft.AspNet.WebApi.Client": "6.0.0",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -213,12 +213,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1683,7 +1683,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",
@@ -1720,7 +1720,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Azure.Bicep.Local.Extension": "[1.0.0, )",
-          "Azure.Deployments.Engine": "[1.359.0, )",
+          "Azure.Deployments.Engine": "[1.364.0, )",
           "Azure.Deployments.Extensibility.Core": "[0.1.67, )",
           "Microsoft.AspNet.WebApi.Client": "[6.0.0, )"
         }

--- a/src/Bicep.Wasm/packages.lock.json
+++ b/src/Bicep.Wasm/packages.lock.json
@@ -114,8 +114,8 @@
       },
       "Azure.Deployments.Core": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "3GdAy22A7nTL7embHyIjESvDzHaNnetDNxfQY3OOZKIOlmK50XotDyJjLekgLJZIcXYgRHzWgqOPYVdBZnvx9A==",
+        "resolved": "1.364.0",
+        "contentHash": "4ylrVR8csYWceLCTX1lKZd4J5K7U3z4bdqQXK/1qcgGEPJbYmYZn5RSkxLxwxFhEsTCUPoun3IHNIWuTTqanWQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -129,10 +129,10 @@
       },
       "Azure.Deployments.Expression": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "lKLAFDTOKj0c6JtqZitIs4cWY76WeWkgknqJnWf2eIIt00A4JBNYkL0Inqm/dFwlfk953ggbOSxrjasc2xSGJg==",
+        "resolved": "1.364.0",
+        "contentHash": "2ORTapDJ1+lXVrmKDD5FDelDDi7B+RU+c3lkIAZtiGrdqMSJ8HDHrMgs+nmg8u8WX+woH4bRM4zpyJh8Z4IMRg==",
         "dependencies": {
-          "Azure.Deployments.Core": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -146,12 +146,12 @@
       },
       "Azure.Deployments.Templates": {
         "type": "Transitive",
-        "resolved": "1.359.0",
-        "contentHash": "KmrCLjXdIaC1uC1EHCdjILBNcA39vqdabldZEw+ZcQPUVMSylvcJw3/JKDh8MfY7ct6LSdn2k+WYKBocck1e7g==",
+        "resolved": "1.364.0",
+        "contentHash": "OYJfjHecg5Wx9lEE+oUuBafANdTTkBOYCkrie4L3A3EYiMhWG/Ei6NQmkdbJ6VMyrhTaoehesQlmoFWD6q+YVQ==",
         "dependencies": {
           "Azure.Bicep.Types": "0.5.110",
-          "Azure.Deployments.Core": "1.359.0",
-          "Azure.Deployments.Expression": "1.359.0",
+          "Azure.Deployments.Core": "1.364.0",
+          "Azure.Deployments.Expression": "1.364.0",
           "IPNetwork2": "2.6.598",
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "Microsoft.PowerPlatform.ResourceStack": "7.0.0.2070",
@@ -1059,7 +1059,7 @@
           "Azure.Bicep.Types.Az": "[0.2.764, )",
           "Azure.Bicep.Types.K8s": "[0.1.644, )",
           "Azure.Containers.ContainerRegistry": "[1.1.1, )",
-          "Azure.Deployments.Templates": "[1.359.0, )",
+          "Azure.Deployments.Templates": "[1.364.0, )",
           "Azure.Identity": "[1.13.2, )",
           "Azure.ResourceManager.Resources": "[1.9.0, )",
           "JsonPatch.Net": "[3.3.0, )",


### PR DESCRIPTION
Updates snapshot command to use latest version of Azure.Deployments packages, in which the public API for nested deployment expansion was moved to the Templates library.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17140)