### PR TITLE
Support snapshots via JSONRPC interface

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/JsonRpcCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/JsonRpcCommandTests.cs
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using System.IO.Abstractions.TestingHelpers;
 using System.IO.Pipes;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Bicep.Cli.Rpc;
+using Bicep.Core.Json;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
@@ -226,6 +230,152 @@ resource baz 'My.Rp/foo@2020-01-01' = {
                     "/main.bicepparam",
                     "/valid.txt",
                 ]);
+            });
+    }
+
+    [TestMethod]
+    public async Task GetSnapshot_returns_a_snapshot()
+    {
+        var fileSystem = new MockFileSystem(
+            new Dictionary<string, MockFileData>
+            {
+                ["/main.bicepparam"] = """
+                    using './main.bicep'
+
+                    param location = 'eastus'
+                    """,
+                ["/main.bicep"] = """
+                    @description('Storage Account type')
+                    param storageAccountType string = 'Standard_LRS'
+
+                    @description('The storage account location.')
+                    param location string = resourceGroup().location
+
+                    @description('The name of the storage account')
+                    param storageAccountName string = 'store${uniqueString(resourceGroup().id)}'
+
+                    resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+                    name: storageAccountName
+                    location: location
+                    sku: {
+                        name: storageAccountType
+                    }
+                    kind: 'StorageV2'
+                    properties: {}
+                    }
+                    """,
+            });
+
+        await RunServerTest(
+            services => services.WithFileSystem(fileSystem),
+            async (client, token) =>
+            {
+                var response = await client.GetSnapshot(new("/main.bicepparam", new(
+                    TenantId: null,
+                    SubscriptionId: "11068ed9-6c31-4a47-8183-4eca6d84bb32",
+                    ResourceGroup: "myRg",
+                    Location: null,
+                    DeploymentName: null),
+                    null), token);
+
+                response.Snapshot.FromJson<JToken>().Should().DeepEqual(JObject.Parse("""
+                    {
+                      "predictedResources": [
+                        {
+                          "id": "/subscriptions/11068ed9-6c31-4a47-8183-4eca6d84bb32/resourceGroups/myRg/providers/Microsoft.Storage/storageAccounts/storepwt7yebfrftwu",
+                          "type": "Microsoft.Storage/storageAccounts",
+                          "name": "storepwt7yebfrftwu",
+                          "apiVersion": "2022-09-01",
+                          "location": "eastus",
+                          "sku": {
+                            "name": "Standard_LRS"
+                          },
+                          "kind": "StorageV2",
+                          "properties": {}
+                        }
+                      ],
+                      "diagnostics": []
+                    }
+                    """));
+            });
+    }
+
+    [TestMethod]
+    public async Task GetSnapshot_returns_a_snapshot_with_external_inputs()
+    {
+        var fileSystem = new MockFileSystem(
+            new Dictionary<string, MockFileData>
+            {
+                ["/main.bicepparam"] = """
+                    using './main.bicep'
+
+                    param location = externalInput('custom.binding', '__MY_REGION__')
+                    param storageAccountType = externalInput('custom.binding', '__UNRESOLVED_BINDING__')
+                    """,
+                ["/main.bicep"] = """
+                    @description('Storage Account type')
+                    param storageAccountType string = 'Standard_LRS'
+
+                    @description('The storage account location.')
+                    param location string = resourceGroup().location
+
+                    @description('The name of the storage account')
+                    param storageAccountName string = 'store${uniqueString(resourceGroup().id)}'
+
+                    resource sa 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+                    name: storageAccountName
+                    location: location
+                    sku: {
+                        name: storageAccountType
+                    }
+                    kind: 'StorageV2'
+                    properties: {}
+                    }
+                    """,
+                ["/bicepconfig.json"] = """
+                    {
+                      "experimentalFeaturesEnabled": {
+                        "externalInputFunction": true
+                      }
+                    }
+                    """,
+            });
+
+        await RunServerTest(
+            services => services.WithFileSystem(fileSystem),
+            async (client, token) =>
+            {
+                ImmutableArray<GetSnapshotRequest.ExternalInputValue> externalInputs = [
+                    new("custom.binding", "__MY_REGION__", "Antarctica"),
+                ];
+
+                var response = await client.GetSnapshot(new("/main.bicepparam", new(
+                    TenantId: null,
+                    SubscriptionId: "11068ed9-6c31-4a47-8183-4eca6d84bb32",
+                    ResourceGroup: "myRg",
+                    Location: null,
+                    DeploymentName: null),
+                    externalInputs), token);
+
+                response.Snapshot.FromJson<JToken>().Should().DeepEqual(JObject.Parse("""
+                    {
+                      "predictedResources": [
+                        {
+                          "id": "/subscriptions/11068ed9-6c31-4a47-8183-4eca6d84bb32/resourceGroups/myRg/providers/Microsoft.Storage/storageAccounts/storepwt7yebfrftwu",
+                          "type": "Microsoft.Storage/storageAccounts",
+                          "name": "storepwt7yebfrftwu",
+                          "apiVersion": "2022-09-01",
+                          "location": "Antarctica",
+                          "sku": {
+                            "name": "[externalInputs('custom_binding_1')]"
+                          },
+                          "kind": "StorageV2",
+                          "properties": {}
+                        }
+                      ],
+                      "diagnostics": []
+                    }
+                    """));
             });
     }
 }

--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -64,7 +64,7 @@ namespace Bicep.Cli.IntegrationTests
                 this.TemplateSpecRepositoryFactory = TemplateSpecRepositoryFactory ?? Repository.Create<ITemplateSpecRepositoryFactory>().Object;
                 this.Environment = Environment;
 
-                this.ModuleMetadataClient = ModuleMetadataClient ?? StrictMock.Of<IPublicModuleIndexHttpClient>().Object;
+                this.ModuleMetadataClient = ModuleMetadataClient ?? new MockPublicModuleIndexHttpClient();
             }
         }
 

--- a/src/Bicep.Cli.IntegrationTests/TestBase.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestBase.cs
@@ -64,7 +64,7 @@ namespace Bicep.Cli.IntegrationTests
                 this.TemplateSpecRepositoryFactory = TemplateSpecRepositoryFactory ?? Repository.Create<ITemplateSpecRepositoryFactory>().Object;
                 this.Environment = Environment;
 
-                this.ModuleMetadataClient = ModuleMetadataClient ?? new MockPublicModuleIndexHttpClient();
+                this.ModuleMetadataClient = ModuleMetadataClient ?? new MockPublicModuleIndexHttpClient(new());
             }
         }
 

--- a/src/Bicep.Cli/Commands/SnapshotCommand.cs
+++ b/src/Bicep.Cli/Commands/SnapshotCommand.cs
@@ -15,6 +15,7 @@ using Azure.Deployments.Templates.Engines;
 using Azure.Deployments.Templates.ParsedEntities;
 using Bicep.Cli.Arguments;
 using Bicep.Cli.Helpers;
+using Bicep.Cli.Helpers.Snapshot;
 using Bicep.Cli.Helpers.WhatIf;
 using Bicep.Cli.Logging;
 using Bicep.Core;
@@ -38,10 +39,6 @@ public class SnapshotCommand(
     BicepCompiler compiler,
     DiagnosticLogger diagnosticLogger) : ICommand
 {
-    public record Snapshot(
-        ImmutableArray<JsonElement> PredictedResources,
-        ImmutableArray<string> Diagnostics);
-
     public async Task<int> RunAsync(SnapshotArguments args, CancellationToken cancellationToken)
     {
         logger.LogWarning($"WARNING: The '{args.CommandName}' CLI command group is an experimental feature. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.");
@@ -97,181 +94,19 @@ public class SnapshotCommand(
             return null;
         }
 
-        var parameters = parametersContent.FromJson<DeploymentParametersDefinition>();
-        var template = TemplateEngine.ParseTemplate(templateContent);
-        var scope = compilation.GetEntrypointSemanticModel().TargetScope switch
-        {
-            ResourceScope.Tenant => TemplateDeploymentScope.Tenant,
-            ResourceScope.ManagementGroup => TemplateDeploymentScope.ManagementGroup,
-            ResourceScope.Subscription => TemplateDeploymentScope.Subscription,
-            ResourceScope.ResourceGroup => TemplateDeploymentScope.ResourceGroup,
-            var otherwise => throw new CommandLineException($"Cannot create snapshot of template with a target scope of {otherwise}"),
-        };
-
-        var expansionResult = await TemplateEngine.ExpandNestedDeployments(
-            EmitConstants.NestedDeploymentResourceApiVersion,
-            scope,
-            template,
-            parameters: ResolveParameters(parameters),
-            rootDeploymentMetadata: GetDeploymentMetadata(arguments, scope, template),
-            cancellationToken: cancellationToken);
-
-        return new(
-            [
-                ..expansionResult.preflightResources.Select(x => JsonElementFactory.CreateElement(JsonExtensions.ToJson(DeploymentPreflightResourceWithParsedExpressions.From(x)))),
-                ..expansionResult.extensibleResources.Select(x => JsonElementFactory.CreateElement(JsonExtensions.ToJson(x))),
-            ],
-            [
-                ..expansionResult.diagnostics.Select(d => $"{d.Target} {d.Level} {d.Code}: {d.Message}")
-            ]);
+        return await SnapshotHelper.GetSnapshot(
+            targetScope: compilation.GetEntrypointSemanticModel().TargetScope,
+            templateContent: templateContent,
+            parametersContent: parametersContent,
+            tenantId: arguments.TenantId,
+            subscriptionId: arguments.SubscriptionId,
+            resourceGroup: arguments.ResourceGroup,
+            location: arguments.Location,
+            deploymentName: arguments.DeploymentName,
+            cancellationToken: cancellationToken,
+            // TODO: Add support for external input values
+            externalInputs: []);
     }
-
-    private static Dictionary<string, ITemplateLanguageExpression>? ResolveParameters(DeploymentParametersDefinition? deploymentParameters)
-        => deploymentParameters?.Parameters?.ToDictionary(kvp => kvp.Key, kvp => ResolveParameter(kvp.Key, kvp.Value));
-
-    private static ITemplateLanguageExpression ResolveParameter(
-        string parameterName,
-        DeploymentParameterDefinition parameter)
-    {
-        if (parameter.Value is not null)
-        {
-            return JTokenConverter.ConvertToLanguageExpression(parameter.Value);
-        }
-
-        if (parameter.Reference is not null)
-        {
-            return new FunctionExpression("parameters", [parameterName.AsExpression()], null, irreducible: true);
-        }
-
-        if (parameter.Expression is not null)
-        {
-            return RewriteVisitor.Instance.Rewrite(ExpressionParser.ParseLanguageExpression(parameter.Expression));
-        }
-
-        throw new InvalidOperationException(
-            $"Parameters compilation produced an invalid object for parameter '{parameterName}'.");
-    }
-
-    private class RewriteVisitor : ExpressionRewriteVisitor
-    {
-        internal static readonly RewriteVisitor Instance = new();
-
-        private RewriteVisitor() { }
-
-        protected override ITemplateLanguageExpression ReplaceFunctionExpression(FunctionExpression expression)
-        {
-            if (expression.Name.Equals(LanguageConstants.ExternalInputsArmFunctionName, StringComparison.OrdinalIgnoreCase))
-            {
-                return expression with
-                {
-                    Arguments = [.. expression.Arguments.Select(Rewrite)],
-                    Properties = [.. expression.Properties.Select(Rewrite)],
-                    // we won't know the value of external inputs until the real deployment
-                    Irreducible = true,
-                };
-            }
-
-            return base.ReplaceFunctionExpression(expression);
-        }
-    }
-
-    private static Dictionary<string, ITemplateLanguageExpression> GetDeploymentMetadata(
-        SnapshotArguments arguments,
-        TemplateDeploymentScope scope,
-        Template template)
-    {
-        Dictionary<string, ITemplateLanguageExpression> metadata = new(StringComparer.OrdinalIgnoreCase);
-
-        if (arguments.TenantId is not null)
-        {
-            metadata[DeploymentMetadata.TenantKey] = new ObjectExpression(
-                [
-                    new("countryCode".AsExpression(), MetadataPlaceholder("tenant", "countryCode")),
-                    new("displayName".AsExpression(), MetadataPlaceholder("tenant", "displayName")),
-                    new("id".AsExpression(), $"/tenants/{arguments.TenantId}".AsExpression()),
-                    new("tenantId".AsExpression(), arguments.TenantId.AsExpression()),
-                ],
-                position: null);
-        }
-
-        if (arguments.SubscriptionId is not null)
-        {
-            if (scope is not TemplateDeploymentScope.Subscription and not TemplateDeploymentScope.ResourceGroup)
-            {
-                throw new CommandLineException($"Subscription ID cannot be specified for a template of scope {scope}");
-            }
-
-            metadata[DeploymentMetadata.SubscriptionKey] = new ObjectExpression(
-                [
-                    new("id".AsExpression(), $"/subscriptions/{arguments.SubscriptionId}".AsExpression()),
-                    new("subscriptionId".AsExpression(), arguments.SubscriptionId.AsExpression()),
-                    new(
-                        "tenantId".AsExpression(),
-                        arguments.TenantId?.AsExpression() ?? MetadataPlaceholder("tenant", "tenantId")),
-                    new("displayName".AsExpression(), MetadataPlaceholder("subscription", "displayName")),
-                ],
-                position: null);
-        }
-
-        if (arguments.ResourceGroup is not null)
-        {
-            if (scope is not TemplateDeploymentScope.ResourceGroup)
-            {
-                throw new CommandLineException($"Resource group name cannot be specified for a template of scope {scope}");
-            }
-
-            metadata[DeploymentMetadata.ResourceGroupKey] = new ObjectExpression(
-                [
-                    new("id".AsExpression(), arguments.SubscriptionId is not null
-                        ? $"/subscriptions/{arguments.SubscriptionId}/resourceGroups/{arguments.ResourceGroup}".AsExpression()
-                        : MetadataPlaceholder("resourceGroup", "id")),
-                    new("name".AsExpression(), arguments.ResourceGroup.AsExpression()),
-                    new("type".AsExpression(), "Microsoft.Resources/resourceGroups".AsExpression()),
-                    new("location".AsExpression(), arguments.Location is not null
-                        ? arguments.Location.AsExpression()
-                        : MetadataPlaceholder("resourceGroup", "location")),
-                    new("tags".AsExpression(), MetadataPlaceholder("resourceGroup", "tags")),
-                    new("managedBy".AsExpression(), MetadataPlaceholder("resourceGroup", "managedBy")),
-                    new("properties".AsExpression(), MetadataPlaceholder("resourceGroup", "properties")),
-                ],
-                position: null);
-        }
-
-        if (arguments.DeploymentName is not null ||
-            (arguments.Location is not null && scope is not TemplateDeploymentScope.ResourceGroup))
-        {
-            Dictionary<ITemplateLanguageExpression, ITemplateLanguageExpression> properties = new()
-            {
-                {
-                    "name".AsExpression(),
-                    arguments.DeploymentName?.AsExpression() ?? MetadataPlaceholder("deployment", "name")
-                },
-                {
-                    "properties".AsExpression(),
-                    new ObjectExpression(
-                        [
-                            new("template".AsExpression(), new ObjectExpression(
-                                [new("contentVersion".AsExpression(), template.ContentVersion.Value.AsExpression())],
-                                position: null))
-                        ],
-                        position: null)
-                },
-            };
-
-            if (scope is not TemplateDeploymentScope.ResourceGroup)
-            {
-                properties["location".AsExpression()] = arguments.Location?.AsExpression()
-                    ?? MetadataPlaceholder("deployment", "location");
-            }
-
-            metadata[DeploymentMetadata.DeploymentKey] = new ObjectExpression(properties, position: null);
-        }
-
-        return metadata;
-    }
-
-    private static ITemplateLanguageExpression MetadataPlaceholder(string name, params string[] properties)
-        => new FunctionExpression(name, [], [.. properties.Select(p => p.AsExpression())], null, irreducible: true);
 
     private Snapshot ReadSnapshot(IOUri uri)
     {
@@ -282,26 +117,14 @@ public class SnapshotCommand(
             throw new CommandLineException($"Error opening file {uri.GetLocalFilePath()}: {message}.");
         }
 
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-        return JsonSerializer.Deserialize<Snapshot>(contents, serializerOptions) ?? throw new InvalidOperationException($"Failed to read from {uri.GetLocalFilePath()}");
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+        return SnapshotHelper.Deserialize(contents);
     }
 
     private void WriteSnapshot(IOUri uri, Snapshot newSnapshot)
     {
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-        var contents = JsonSerializer.Serialize(newSnapshot, serializerOptions) ?? throw new InvalidOperationException($"Failed to write to {uri.GetLocalFilePath()}");
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+        var contents = SnapshotHelper.Serialize(newSnapshot);
 
         var file = fileExplorer.GetFile(uri);
         file.Write(contents);
     }
-
-    private static readonly JsonSerializerOptions serializerOptions = new(JsonSerializerDefaults.Web)
-    {
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        WriteIndented = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true,
-    };
 }

--- a/src/Bicep.Cli/Helpers/Snapshot/Snapshot.cs
+++ b/src/Bicep.Cli/Helpers/Snapshot/Snapshot.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Bicep.Cli.Helpers.Snapshot;
+
+[JsonSerializable(typeof(Snapshot))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+public partial class SnapshotSerializationContext : JsonSerializerContext { }
+
+public record Snapshot(
+    ImmutableArray<JsonElement> PredictedResources,
+    ImmutableArray<string> Diagnostics);

--- a/src/Bicep.Cli/Helpers/Snapshot/SnapshotDiffer.cs
+++ b/src/Bicep.Cli/Helpers/Snapshot/SnapshotDiffer.cs
@@ -20,10 +20,11 @@ using JsonDiffPatchDotNet;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Bicep.Cli.Helpers;
+namespace Bicep.Cli.Helpers.Snapshot;
+
 public class SnapshotDiffer
 {
-    public static IReadOnlyList<DeploymentWhatIfResourceChangeDefinition> CalculateChanges(SnapshotCommand.Snapshot source, SnapshotCommand.Snapshot target)
+    public static IReadOnlyList<DeploymentWhatIfResourceChangeDefinition> CalculateChanges(Snapshot source, Snapshot target)
     {
         var changes = new List<DeploymentWhatIfResourceChangeDefinition>();
         var differ = new LinearDiffer<DeploymentWhatIfResource>(

--- a/src/Bicep.Cli/Helpers/Snapshot/SnapshotHelper.cs
+++ b/src/Bicep.Cli/Helpers/Snapshot/SnapshotHelper.cs
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Deployments.Core.Configuration;
+using Azure.Deployments.Core.Definitions;
+using Azure.Deployments.Core.Definitions.Schema;
+using Azure.Deployments.Core.Entities;
+using Azure.Deployments.Engine.Definitions;
+using Azure.Deployments.Expression.Intermediate;
+using Azure.Deployments.Expression.Intermediate.Extensions;
+using Azure.Deployments.Templates.Engines;
+using Azure.Deployments.Templates.ParsedEntities;
+using Bicep.Cli.Arguments;
+using Bicep.Cli.Helpers;
+using Bicep.Cli.Helpers.WhatIf;
+using Bicep.Cli.Logging;
+using Bicep.Core;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Emit;
+using Bicep.Core.Extensions;
+using Bicep.Core.FileSystem;
+using Bicep.Core.Json;
+using Bicep.Core.Semantics;
+using Bicep.Core.TypeSystem;
+using Bicep.IO.Abstraction;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+using Newtonsoft.Json.Linq;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace Bicep.Cli.Helpers.Snapshot;
+
+public static class SnapshotHelper
+{
+    public record ExternalInputValue(
+        string Kind,
+        JToken? Config,
+        JToken Value);
+
+    public static async Task<Snapshot> GetSnapshot(
+        ResourceScope targetScope,
+        string templateContent,
+        string parametersContent,
+        string? tenantId,
+        string? subscriptionId,
+        string? resourceGroup,
+        string? deploymentName,
+        string? location,
+        ImmutableArray<ExternalInputValue> externalInputs,
+        CancellationToken cancellationToken)
+    {
+        var parameters = parametersContent.FromJson<DeploymentParametersDefinition>();
+        var template = TemplateEngine.ParseTemplate(templateContent);
+
+        var scope = targetScope switch
+        {
+            ResourceScope.Tenant => TemplateDeploymentScope.Tenant,
+            ResourceScope.ManagementGroup => TemplateDeploymentScope.ManagementGroup,
+            ResourceScope.Subscription => TemplateDeploymentScope.Subscription,
+            ResourceScope.ResourceGroup => TemplateDeploymentScope.ResourceGroup,
+            var otherwise => throw new CommandLineException($"Cannot create snapshot of template with a target scope of {otherwise}"),
+        };
+
+        var expansionResult = await TemplateEngine.ExpandNestedDeployments(
+            EmitConstants.NestedDeploymentResourceApiVersion,
+            scope,
+            template,
+            parameters: ResolveParameters(parameters, externalInputs),
+            rootDeploymentMetadata: GetDeploymentMetadata(tenantId, subscriptionId, resourceGroup, deploymentName, location, scope, template),
+            cancellationToken: cancellationToken);
+
+        return new(
+            [
+                ..expansionResult.preflightResources.Select(x => JsonElementFactory.CreateElement(JsonExtensions.ToJson(DeploymentPreflightResourceWithParsedExpressions.From(x)))),
+                ..expansionResult.extensibleResources.Select(x => JsonElementFactory.CreateElement(JsonExtensions.ToJson(x))),
+            ],
+            [
+                ..expansionResult.diagnostics.Select(d => $"{d.Target} {d.Level} {d.Code}: {d.Message}")
+            ]);
+    }
+
+    private static JToken? TryGetExternalInputValue(DeploymentExternalInputDefinition externalInputDefinition, ImmutableArray<ExternalInputValue> externalInputs)
+    {
+        if (externalInputs.FirstOrDefault(
+            x => x.Kind == externalInputDefinition.Kind &&
+            JToken.DeepEquals(x.Config, externalInputDefinition.Config)) is not {} externalInputValue)
+        {
+            return null;
+        }
+
+        // return an explicit JValue if null, to differentiate from a missing value
+        return externalInputValue.Value ?? JValue.CreateNull();
+    }
+
+    private static Dictionary<string, ITemplateLanguageExpression> ResolveParameters(DeploymentParametersDefinition parameters, ImmutableArray<ExternalInputValue> externalInputs)
+    {
+        ParametersRewriteVisitor rewriteVisitor = new(parameters, input => TryGetExternalInputValue(input, externalInputs));
+        
+        return parameters.Parameters.ToDictionary(
+            kvp => kvp.Key,
+            kvp => ResolveParameter(kvp.Key, kvp.Value, rewriteVisitor));
+    }
+
+    private static ITemplateLanguageExpression ResolveParameter(
+        string parameterName,
+        DeploymentParameterDefinition parameter,
+        ParametersRewriteVisitor rewriteVisitor)
+    {
+        if (parameter.Value is not null)
+        {
+            return JTokenConverter.ConvertToLanguageExpression(parameter.Value);
+        }
+
+        if (parameter.Reference is not null)
+        {
+            return new FunctionExpression("parameters", [parameterName.AsExpression()], null, irreducible: true);
+        }
+
+        if (parameter.Expression is not null)
+        {
+            return rewriteVisitor.Rewrite(ExpressionParser.ParseLanguageExpression(parameter.Expression));
+        }
+
+        throw new InvalidOperationException(
+            $"Parameters compilation produced an invalid object for parameter '{parameterName}'.");
+    }
+
+    private class ParametersRewriteVisitor : ExpressionRewriteVisitor
+    {
+        private readonly DeploymentParametersDefinition parameters;
+        private readonly Func<DeploymentExternalInputDefinition, JToken?> tryResolveExternalInput;
+
+        public ParametersRewriteVisitor(DeploymentParametersDefinition parameters, Func<DeploymentExternalInputDefinition, JToken?> tryResolveExternalInput)
+        {
+            this.parameters = parameters;
+            this.tryResolveExternalInput = tryResolveExternalInput;
+        }
+
+        protected override ITemplateLanguageExpression ReplaceFunctionExpression(FunctionExpression expression)
+        {
+            if (expression.Name.Equals(LanguageConstants.ExternalInputsArmFunctionName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (expression.Arguments.Count() != 1 ||
+                    expression.Arguments[0] is not StringExpression stringLiteral)
+                {
+                    // we will never codegen this function
+                    throw new InvalidOperationException();
+                }
+
+                var externalInput = parameters.ExternalInputDefinitions[stringLiteral.Value];
+                if (tryResolveExternalInput(externalInput) is {} value)
+                {
+                    return ExpressionParser.ParseLanguageExpression(value);
+                }
+
+                return expression with
+                {
+                    Arguments = [.. expression.Arguments.Select(Rewrite)],
+                    Properties = [.. expression.Properties.Select(Rewrite)],
+                    // we won't know the value of external inputs until the real deployment
+                    Irreducible = true,
+                };
+            }
+
+            return base.ReplaceFunctionExpression(expression);
+        }
+    }
+
+    private static Dictionary<string, ITemplateLanguageExpression> GetDeploymentMetadata(
+        string? tenantId,
+        string? subscriptionId,
+        string? resourceGroup,
+        string? deploymentName,
+        string? location,
+        TemplateDeploymentScope scope,
+        Template template)
+    {
+        Dictionary<string, ITemplateLanguageExpression> metadata = new(StringComparer.OrdinalIgnoreCase);
+
+        if (tenantId is not null)
+        {
+            metadata[DeploymentMetadata.TenantKey] = new ObjectExpression(
+                [
+                    new("countryCode".AsExpression(), MetadataPlaceholder("tenant", "countryCode")),
+                    new("displayName".AsExpression(), MetadataPlaceholder("tenant", "displayName")),
+                    new("id".AsExpression(), $"/tenants/{tenantId}".AsExpression()),
+                    new("tenantId".AsExpression(), tenantId.AsExpression()),
+                ],
+                position: null);
+        }
+
+        if (subscriptionId is not null)
+        {
+            if (scope is not TemplateDeploymentScope.Subscription and not TemplateDeploymentScope.ResourceGroup)
+            {
+                throw new CommandLineException($"Subscription ID cannot be specified for a template of scope {scope}");
+            }
+
+            metadata[DeploymentMetadata.SubscriptionKey] = new ObjectExpression(
+                [
+                    new("id".AsExpression(), $"/subscriptions/{subscriptionId}".AsExpression()),
+                    new("subscriptionId".AsExpression(), subscriptionId.AsExpression()),
+                    new(
+                        "tenantId".AsExpression(),
+                        tenantId?.AsExpression() ?? MetadataPlaceholder("tenant", "tenantId")),
+                    new("displayName".AsExpression(), MetadataPlaceholder("subscription", "displayName")),
+                ],
+                position: null);
+        }
+
+        if (resourceGroup is not null)
+        {
+            if (scope is not TemplateDeploymentScope.ResourceGroup)
+            {
+                throw new CommandLineException($"Resource group name cannot be specified for a template of scope {scope}");
+            }
+
+            metadata[DeploymentMetadata.ResourceGroupKey] = new ObjectExpression(
+                [
+                    new("id".AsExpression(), subscriptionId is not null
+                        ? $"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}".AsExpression()
+                        : MetadataPlaceholder("resourceGroup", "id")),
+                    new("name".AsExpression(), resourceGroup.AsExpression()),
+                    new("type".AsExpression(), "Microsoft.Resources/resourceGroups".AsExpression()),
+                    new("location".AsExpression(), location is not null
+                        ? location.AsExpression()
+                        : MetadataPlaceholder("resourceGroup", "location")),
+                    new("tags".AsExpression(), MetadataPlaceholder("resourceGroup", "tags")),
+                    new("managedBy".AsExpression(), MetadataPlaceholder("resourceGroup", "managedBy")),
+                    new("properties".AsExpression(), MetadataPlaceholder("resourceGroup", "properties")),
+                ],
+                position: null);
+        }
+
+        if (deploymentName is not null ||
+            (location is not null && scope is not TemplateDeploymentScope.ResourceGroup))
+        {
+            Dictionary<ITemplateLanguageExpression, ITemplateLanguageExpression> properties = new()
+            {
+                {
+                    "name".AsExpression(),
+                    deploymentName?.AsExpression() ?? MetadataPlaceholder("deployment", "name")
+                },
+                {
+                    "properties".AsExpression(),
+                    new ObjectExpression(
+                        [
+                            new("template".AsExpression(), new ObjectExpression(
+                                [new("contentVersion".AsExpression(), template.ContentVersion.Value.AsExpression())],
+                                position: null))
+                        ],
+                        position: null)
+                },
+            };
+
+            if (scope is not TemplateDeploymentScope.ResourceGroup)
+            {
+                properties["location".AsExpression()] = location?.AsExpression()
+                    ?? MetadataPlaceholder("deployment", "location");
+            }
+
+            metadata[DeploymentMetadata.DeploymentKey] = new ObjectExpression(properties, position: null);
+        }
+
+        return metadata;
+    }
+
+    private static ITemplateLanguageExpression MetadataPlaceholder(string name, params string[] properties)
+        => new FunctionExpression(name, [], [.. properties.Select(p => p.AsExpression())], null, irreducible: true);
+
+    public static Snapshot Deserialize(string contents)
+        => JsonSerializer.Deserialize<Snapshot>(contents, SnapshotSerializationContext.Default.Snapshot) ?? throw new InvalidOperationException("Failed to deserialize snapshot");
+
+    public static string Serialize(Snapshot newSnapshot)
+        => JsonSerializer.Serialize(newSnapshot, SnapshotSerializationContext.Default.Snapshot);
+}

--- a/src/Bicep.Cli/Rpc/ICliJsonRpcProtocol.cs
+++ b/src/Bicep.Cli/Rpc/ICliJsonRpcProtocol.cs
@@ -55,6 +55,27 @@ public record GetFileReferencesResponse(
 public record GetMetadataRequest(
     string Path);
 
+public record GetSnapshotRequest(
+    string Path,
+    GetSnapshotRequest.MetadataDefinition Metadata,
+    ImmutableArray<GetSnapshotRequest.ExternalInputValue>? ExternalInputs)
+{
+    public record MetadataDefinition(
+        string? TenantId,
+        string? SubscriptionId,
+        string? ResourceGroup,
+        string? Location,
+        string? DeploymentName);
+
+    public record ExternalInputValue(
+        string Kind,
+        JToken? Config,
+        JToken Value);
+}
+
+public record GetSnapshotResponse(
+    string Snapshot);
+
 public record GetMetadataResponse(
     ImmutableArray<GetMetadataResponse.MetadataDefinition> Metadata,
     ImmutableArray<GetMetadataResponse.SymbolDefinition> Parameters,
@@ -144,4 +165,10 @@ public interface ICliJsonRpcProtocol
     /// </summary>
     [JsonRpcMethod("bicep/getFileReferences", UseSingleObjectParameterDeserialization = true)]
     Task<GetFileReferencesResponse> GetFileReferences(GetFileReferencesRequest request, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a snapshot for a given parameter file.
+    /// </summary>
+    [JsonRpcMethod("bicep/getSnapshot", UseSingleObjectParameterDeserialization = true)]
+    Task<GetSnapshotResponse> GetSnapshot(GetSnapshotRequest request, CancellationToken cancellationToken);
 }

--- a/src/Bicep.Core.UnitTests/Mock/MockPublicModuleIndexHttpClient.cs
+++ b/src/Bicep.Core.UnitTests/Mock/MockPublicModuleIndexHttpClient.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Registry.Catalog.Implementation.PublicRegistries;
+using Bicep.Core.Resources;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Providers;
+using Bicep.Core.TypeSystem.Types;
+using Moq;
+
+namespace Bicep.Core.UnitTests.Mock;
+
+public class MockPublicModuleIndexHttpClient : IPublicModuleIndexHttpClient
+{
+    public Task<ImmutableArray<PublicModuleIndexEntry>> GetModuleIndexAsync() => Task.FromResult(ImmutableArray<PublicModuleIndexEntry>.Empty);
+}

--- a/src/Bicep.Core.UnitTests/Mock/MockPublicModuleIndexHttpClient.cs
+++ b/src/Bicep.Core.UnitTests/Mock/MockPublicModuleIndexHttpClient.cs
@@ -13,5 +13,9 @@ namespace Bicep.Core.UnitTests.Mock;
 
 public class MockPublicModuleIndexHttpClient : IPublicModuleIndexHttpClient
 {
+    public MockPublicModuleIndexHttpClient(HttpClient _)
+    {
+    }
+
     public Task<ImmutableArray<PublicModuleIndexEntry>> GetModuleIndexAsync() => Task.FromResult(ImmutableArray<PublicModuleIndexEntry>.Empty);
 }

--- a/src/Bicep.LangServer.IntegrationTests/LangServerScenarioTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/LangServerScenarioTests.cs
@@ -167,14 +167,4 @@ Description of foo
 
 """);
     }
-
-    private class MockPublicModuleIndexHttpClient : IPublicModuleIndexHttpClient
-    {
-        public MockPublicModuleIndexHttpClient(HttpClient _)
-        {
-        }
-
-        public Task<ImmutableArray<PublicModuleIndexEntry>> GetModuleIndexAsync() => Task.FromResult(ImmutableArray<PublicModuleIndexEntry>.Empty);
-    }
-
 }


### PR DESCRIPTION
## Description

Adds a new method to the Bicep JSONRPC interface: `bicep/getSnapshot`. The request and response contract are defined as such:

```csharp
public record GetSnapshotRequest(
    string Path,
    GetSnapshotRequest.MetadataDefinition Metadata,
    ImmutableArray<GetSnapshotRequest.ExternalInputValue>? ExternalInputs)
{
    public record MetadataDefinition(
        string? TenantId,
        string? SubscriptionId,
        string? ResourceGroup,
        string? Location,
        string? DeploymentName);

    public record ExternalInputValue(
        string Kind,
        JToken? Config,
        JToken Value);
}

public record GetSnapshotResponse(
    string Snapshot);
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
- [x] This feature may require updates to [Public Bicep documentation](https://learn.microsoft.com/azure/azure-resource-manager/bicep).
