### PR TITLE
Disable linter rule "Maximum number of variables used" when the file does not contain declarations used in files meant to deployed and variables are exported

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/MaxNumberVariablesRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/MaxNumberVariablesRuleTests.cs
@@ -35,6 +35,10 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             new string[] {
                 "Too many variables. Number of variables is limited to 512."
             })]
+        [DataRow(2, 514, @"
+        @export()
+        var v% = %
+        ", new string[] {})]
         [DataTestMethod]
         public void TooManyVariables(int i, int j, string pattern, string[] expectedMessages)
         {


### PR DESCRIPTION
## Description

Fixes  #15456

The linter rule "Maximum number of variables used" is modified to ignore a file containing more than 512 variables when:
-  No `param`, `output`, `resource` and `module` declarations are present in the file
- At least one variable in the file is exported

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
- [ ] This feature may require updates to [Public Bicep documentation](https://learn.microsoft.com/azure/azure-resource-manager/bicep).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17149)