### PR TITLE
Assign Identity to Module Support

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleTests.cs
@@ -801,7 +801,7 @@ module {symbolicName} 'mod.bicep' = [for x in []: {{
         }
 
         [TestMethod]
-        public void Modules_can_be_compiled_with_identity_successfully()
+        public void Module_can_be_compiled_with_identity_with_param_and_function_successfully()
         {
             var mainUri = new Uri("file:///main.bicep");
             var moduleAUri = new Uri("file:///modulea.bicep");
@@ -816,21 +816,24 @@ param identityId string
 
 module modulea 'modulea.bicep' = {
   name: 'modulea'
-  identities: [
-    identityId
-  ]
-  dependsOn: [
-    moduleb
-  ]
   params: {
     inputa: inputa
     inputb: inputb
   }
 }
 
+func test () string => 'val'
+
 module moduleb 'moduleb.bicep' = {
   name: 'moduleb'
-  identities: []
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identityId}': {}
+      '${test()}': {}
+      id: {}
+    }
+  }
   params: {
     inputa: inputa
     inputb: inputb
@@ -840,10 +843,7 @@ module moduleb 'moduleb.bicep' = {
 module modulec 'moduleb.bicep' = {
   name: 'modulec'
   identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${identityId}': {}
-    }
+    type: 'None'
   }
   params: {
     inputa: inputa
@@ -851,8 +851,6 @@ module modulec 'moduleb.bicep' = {
   }
 }
 
-output outputa string = modulea.outputs.outputa
-output outputb string = moduleb.outputs.outputb
 ",
                 [moduleAUri] = @"
 param inputa string
@@ -876,6 +874,155 @@ output outputb string = '${inputa}-${inputb}'
             compilation.GetTestTemplate().Should().NotBeEmpty();
             var templateString = compilation.GetTestTemplate();
             templateString.Should().NotBeNull();
+            var template = JToken.Parse(templateString);
+            template.Should().NotBeNull();
+            var test = template.SelectToken("resources.moduleb.identity")?.ToString();
+            template.Should().HaveValueAtPath("$.resources.moduleb.identity", new JObject()
+            {
+                ["type"] = new JValue("UserAssigned"),
+                ["userAssignedIdentities"] = new JObject()
+                {
+                    ["[format('{0}', parameters('identityId'))]"] = new JObject(),
+                    ["[format('{0}', __bicep.test())]"] = new JObject(),
+                    ["id"] = new JObject(),
+                },
+            });
+            template.Should().HaveValueAtPath("$.resources.modulec.identity", new JObject()
+            {
+                ["type"] = new JValue("None"),
+            });
+        }
+
+        [TestMethod]
+        public void Module_can_be_compiled_with_identity_successfully()
+        {
+            var result = CompilationHelper.Compile(
+                ServicesWithResourceTyped,
+("main.bicep", @"
+module mod './module.bicep' = {
+    identity: {
+        type: 'UserAssigned'
+        userAssignedIdentities: {
+            identityId: {}
+        }
+    }
+    name: 'test'
+    params: {
+        keyVaultUri: 'keyVaultUri'
+        identityId: 'identityId'
+    }
+}
+
+"),
+("module.bicep", @"
+param keyVaultUri string
+param identityId string
+
+output out string = '${keyVaultUri}-${identityId}'
+"));
+            result.Should().NotHaveAnyDiagnostics();
+
+            result.Template.Should().HaveValueAtPath("$.resources[0].identity", new JObject()
+            {
+                ["type"] = new JValue("UserAssigned"),
+                ["userAssignedIdentities"] = new JObject()
+                {
+                    ["identityId"] = new JObject(),
+                },
+            });
+        }
+
+        [TestMethod]
+        public void Module_can_be_compiled_with_identity_successfully_with_object_param()
+        {
+            var result = CompilationHelper.Compile(
+                ServicesWithResourceTyped,
+("main.bicep", @"
+param identity object
+module mod './module.bicep' = {
+    identity: identity
+    name: 'test'
+    params: {
+        keyVaultUri: 'keyVaultUri'
+        identityId: 'identityId'
+    }
+}
+
+"),
+("module.bicep", @"
+param keyVaultUri string
+param identityId string
+
+output out string = '${keyVaultUri}-${identityId}'
+"));
+            result.Should().NotHaveAnyDiagnostics();
+
+            result.Template.Should().HaveValueAtPath("$.resources[0].identity", new JValue("[parameters('identity')]"));
+        }
+
+        [TestMethod]
+        public void Module_incorrect_identity_raises_diagnostics()
+        {
+            var result = CompilationHelper.Compile(
+                ServicesWithResourceTyped,
+("main.bicep", @"
+module mod './module.bicep' = {
+    identity: {
+        userAssignedIdentities: [
+            'val'
+        ]
+        additionalProperty: {}
+    }
+    name: 'test'
+    params: {
+        keyVaultUri: 'keyVaultUri'
+        identityId: 'identityId'
+    }
+}
+
+"),
+("module.bicep", @"
+param keyVaultUri string
+param identityId string
+
+output out string = '${keyVaultUri}-${identityId}'
+"));
+            result.Should().HaveDiagnostics(new[]
+            {
+                ("BCP035", DiagnosticLevel.Error, "The specified \"object\" declaration is missing the following required properties: \"type\"."),
+                ("BCP036", DiagnosticLevel.Error, "The property \"userAssignedIdentities\" expected a value of type \"object\" but the provided value is of type \"['val']\"."),
+                ("BCP037", DiagnosticLevel.Error, "The property \"additionalProperty\" is not allowed on objects of type \"identity\". Permissible properties include \"type\".")
+            });
+        }
+
+        [TestMethod]
+        public void Module_invalid_identity_type_raises_diagnostics()
+        {
+            var result = CompilationHelper.Compile(
+                ServicesWithResourceTyped,
+("main.bicep", @"
+module mod './module.bicep' = {
+    identity: {
+        type: 'SystemAssigned'
+    }
+    name: 'test'
+    params: {
+        keyVaultUri: 'keyVaultUri'
+        identityId: 'identityId'
+    }
+}
+
+"),
+("module.bicep", @"
+param keyVaultUri string
+param identityId string
+
+output out string = '${keyVaultUri}-${identityId}'
+"));
+            result.Should().HaveDiagnostics(new[]
+            {
+                ("BCP088", DiagnosticLevel.Error, "The property \"type\" expected a value of type \"'None' | 'UserAssigned'\" but the provided value is of type \"'SystemAssigned'\". Did you mean \"'UserAssigned'\"?")
+            });
         }
 
         private static void ModuleTemplateHashValidator(Compilation compilation, string expectedTemplateHash)

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -287,13 +287,18 @@ namespace Bicep.Core
             yield return new NamedTypeProperty("description", String, TypePropertyFlags.Constant);
         }
 
+        private static readonly TypeSymbol identityTypeString =
+            TypeHelper.CreateTypeUnion(
+                TypeFactory.CreateStringLiteralType("None"),
+                TypeFactory.CreateStringLiteralType("UserAssigned"));
+
         private static readonly IEnumerable<NamedTypeProperty> identityProperties = new[]
         {
-                new NamedTypeProperty("type", String, TypePropertyFlags.Required),
+                new NamedTypeProperty("type", identityTypeString, TypePropertyFlags.Required),
                 new NamedTypeProperty("userAssignedIdentities", Object, TypePropertyFlags.None)
         };
 
-        public static readonly TypeSymbol IdentityObject = new ObjectType("identityObject", TypeSymbolValidationFlags.Default, identityProperties);
+        public static readonly TypeSymbol IdentityObject = new ObjectType("identity", TypeSymbolValidationFlags.Default, identityProperties);
 
         public static IEnumerable<string> GetResourceScopeDescriptions(ResourceScope resourceScope)
         {

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -172,6 +172,7 @@ namespace Bicep.Core
         public const string ModuleExtensionConfigsPropertyName = "extensionConfigs";
         public const string ModuleOutputsPropertyName = "outputs";
         public const string ModuleNamePropertyName = "name";
+        public const string ModuleIdentityPropertyName = "identity";
 
         // test properties
         public const string TestParamsPropertyName = "params";
@@ -286,6 +287,14 @@ namespace Bicep.Core
             yield return new NamedTypeProperty("description", String, TypePropertyFlags.Constant);
         }
 
+        private static readonly IEnumerable<NamedTypeProperty> identityProperties = new[]
+        {
+                new NamedTypeProperty("type", String, TypePropertyFlags.Required),
+                new NamedTypeProperty("userAssignedIdentities", Object, TypePropertyFlags.None)
+        };
+
+        public static readonly TypeSymbol IdentityObject = new ObjectType("identityObject", TypeSymbolValidationFlags.Default, identityProperties);
+
         public static IEnumerable<string> GetResourceScopeDescriptions(ResourceScope resourceScope)
         {
             if (resourceScope == ResourceScope.None)
@@ -360,7 +369,8 @@ namespace Bicep.Core
                 new(ResourceScopePropertyName, CreateResourceScopeReference(moduleScope), scopePropertyFlags),
                 new(ModuleParamsPropertyName, paramsType, paramsRequiredFlag | TypePropertyFlags.WriteOnly),
                 new(ModuleOutputsPropertyName, outputsType, TypePropertyFlags.ReadOnly),
-                new(ResourceDependsOnPropertyName, ResourceOrResourceCollectionRefArray, TypePropertyFlags.WriteOnly | TypePropertyFlags.DisallowAny)
+                new(ResourceDependsOnPropertyName, ResourceOrResourceCollectionRefArray, TypePropertyFlags.WriteOnly | TypePropertyFlags.DisallowAny),
+                new(ModuleIdentityPropertyName, IdentityObject, TypePropertyFlags.None),
             ];
 
             if (features is { ExtensibilityEnabled: true, ModuleExtensionConfigsEnabled: true })


### PR DESCRIPTION
## Description

Add identity object to modules. Will add builtin functions later to convert params to identity object: az.noneIdentity(), az.systemAssignedIdentity(), az.userAssignedIdentity(input array), az.systemAndUserAssignedIdentity(input array)



## Example Usage

Bicep
```
param identityId string

module mod './module.bicep' = {
    identity: {
        type: 'UserAssigned'
        userAssignedIdentities: {
            '${identityId}': {}
        }
    }
    name: 'mod'
    params: {
        keyVaultUri: 'keyVaultUri'
        identityId: identityId
    }
}
```
ARM Template
```
"mod": {
      "type": "Microsoft.Resources/deployments",
      "apiVersion": "2022-09-01",
      "identity": {
        "type": "UserAssigned",
        "userAssignedIdentities": {
          "[format('{0}', parameters('identityId'))]": {}
        }
      },
      "name": "mod",
      "properties": {
          ...
      }
```


## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
- [X] This feature may require updates to [Public Bicep documentation](https://learn.microsoft.com/azure/azure-resource-manager/bicep).
