### PR TITLE
Use an explicit 'workspace:*' as the version for local packages in vscode-bicep-ui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,11 @@ jobs:
       - name: Check npm version
         run: npm -v
 
+      - name: Install pnpm
+        run: npm install -g pnpm@latest-10
+
       - name: npm ci (vscode-bicep-ui)
-        run: npm ci
+        run: pnpm ci
         working-directory: ./src/vscode-bicep-ui
 
       - name: Build vscode-bicep-ui
@@ -123,7 +126,7 @@ jobs:
         working-directory: ./src/vscode-bicep-ui
 
       - name: npm ci (vscode-bicep)
-        run: npm ci
+        run: pnpm ci
         working-directory: ./src/vscode-bicep
 
       - name: Generate VSIX notice
@@ -170,8 +173,11 @@ jobs:
       - name: Check npm version
         run: npm -v
 
+      - name: Install pnpm
+        run: npm install -g pnpm@latest-10
+
       - name: npm ci
-        run: npm ci
+        run: pnpm ci
         working-directory: ./src/vscode-bicep-ui
 
       - name: Run lint

--- a/src/vscode-bicep-ui/apps/deploy-pane/package.json
+++ b/src/vscode-bicep-ui/apps/deploy-pane/package.json
@@ -32,7 +32,7 @@
     "@azure/arm-resources": "^5.2.0",
     "@azure/identity": "^4.9.1",
     "@microsoft/vscode-azext-utils": "^3.0.4",
-    "@vscode-bicep-ui/components": "^0.0.0",
+    "@vscode-bicep-ui/components": "workspace:*",
     "@vscode-elements/elements": "^1.11.0",
     "@vscode-elements/react-elements": "^0.8.0",
     "react": "^18.3.1",


### PR DESCRIPTION
Local sourcing of packages within the VS Code extension is already assured by our package-lock.json files, but being explicit in consuming packages' package.json files will keep it that way.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17158)