### PR TITLE
fix and add test for invalid parameter type

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -640,5 +640,31 @@ param intParam = 42
                 File.Exists(Path.Combine(bicepOutputPath, outputFile)).Should().Be(true, f);
             }
         }
+
+        [TestMethod]
+        public async Task BuildParams_Extends_InvalidType_ThrowsError()
+        {
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+            FileHelper.SaveResultFile(TestContext, "main.bicep", "param tag string", outputPath);
+            FileHelper.SaveResultFile(TestContext, "base.bicepparam", @"
+            using none
+            param tag = false
+            ", outputPath);
+            var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicepparam", @"
+            using 'main.bicep'
+            extends 'base.bicepparam'
+            ", outputPath);
+
+            var expectedOutputFile = FileHelper.GetResultFilePath(TestContext, "main.json", outputPath);
+            File.Exists(expectedOutputFile).Should().BeFalse();
+
+            var (output, error, result) = await Bicep(["build-params", inputFile]);
+
+            File.Exists(expectedOutputFile).Should().BeFalse();
+
+            output.Should().BeEmpty();
+            error.Should().Contain("Error BCP260: The parameter \"tag\" expects a value of type \"string\" but the provided value is of type \"false\".");
+            result.Should().Be(1);
+        }
     }
 }

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Intermediate;
 using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
+using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
@@ -664,6 +665,15 @@ namespace Bicep.Core.Emit
                             referencedValueHasError = true;
                         }
                     }
+
+                }
+                var bicepFile = model.SourceFileGrouping.SourceFiles.First(sourceFile => sourceFile is BicepFile);
+                var paramDefinitionFromBicepFile = model.ModelLookup.GetSemanticModel(bicepFile).Parameters.First(e => e.Key == symbol.Name);
+
+                if (paramDefinitionFromBicepFile.Value.TypeReference.Type != symbol.Type)
+                {
+                    diagnostics.WriteMultiple(DiagnosticBuilder.ForPosition(symbol.NameSource).ParameterTypeMismatch(symbol.Name, paramDefinitionFromBicepFile.Value.TypeReference.Type, symbol.Type));
+                    referencedValueHasError = true;
                 }
 
                 if (referencedValueHasError)


### PR DESCRIPTION
Fixes #16731 

Adding diagnostic error when there is a type mismatch between the parameter in the bicep file and the parameter in the bicepparam file.

Also adding a test to verify the error message is correct
