### PR TITLE
adding completion support for 'extends' keyword

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -374,6 +374,12 @@ using 'bar.bicep'
                     x.Label.Should().Be("param");
                     x.Detail.Should().Be("Parameter assignment keyword");
                     x.Kind.Should().Be(CompletionItemKind.Keyword);
+                },
+                x =>
+                {
+                    x.Label.Should().Be("extends");
+                    x.Detail.Should().Be("Extends keyword");
+                    x.Kind.Should().Be(CompletionItemKind.Keyword);
                 });
         }
 

--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -340,6 +340,12 @@ using './nested1/|'
             completions.Should().SatisfyRespectively(
                 x =>
                 {
+                    x.Label.Should().Be("extends");
+                    x.Detail.Should().Be("Extends keyword");
+                    x.Kind.Should().Be(CompletionItemKind.Keyword);
+                },
+                x =>
+                {
                     x.Label.Should().Be("param");
                     x.Detail.Should().Be("Parameter assignment keyword");
                     x.Kind.Should().Be(CompletionItemKind.Keyword);

--- a/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/ParamsCompletionTests.cs
@@ -371,14 +371,14 @@ using 'bar.bicep'
             completions.Should().SatisfyRespectively(
                 x =>
                 {
-                    x.Label.Should().Be("param");
-                    x.Detail.Should().Be("Parameter assignment keyword");
+                    x.Label.Should().Be("extends");
+                    x.Detail.Should().Be("Extends keyword");
                     x.Kind.Should().Be(CompletionItemKind.Keyword);
                 },
                 x =>
                 {
-                    x.Label.Should().Be("extends");
-                    x.Detail.Should().Be("Extends keyword");
+                    x.Label.Should().Be("param");
+                    x.Detail.Should().Be("Parameter assignment keyword");
                     x.Kind.Should().Be(CompletionItemKind.Keyword);
                 });
         }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -199,6 +199,8 @@ namespace Bicep.LanguageServer.Completions
 
                         yield return CreateKeywordCompletion(LanguageConstants.ParameterKeyword, "Parameter assignment keyword", context.ReplacementRange);
 
+                        yield return CreateKeywordCompletion(LanguageConstants.ExtendsKeyword, "Extends keyword", context.ReplacementRange);
+
                         break;
 
                     default:


### PR DESCRIPTION
Fixes #16732 

adding completion support for 'extends' keyword

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17194)