### PR TITLE
Correct codegen for v1 local extensibility

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/bicepconfig.json
+++ b/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "localDeploy": true
+  },
+  "extensions": {
+    "http": "br:example.azurecr.io/extensions/foo:1.2.3"
+  }
+}

--- a/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/main.bicep
+++ b/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/main.bicep
@@ -1,0 +1,25 @@
+targetScope = 'local'
+
+extension http
+
+param coords {
+  latitude: string
+  longitude: string
+}
+
+resource gridpointsReq 'request@v1' = {
+  uri: 'https://api.weather.gov/points/${coords.latitude},${coords.longitude}'
+  format: 'raw'
+}
+
+var gridpoints = json(gridpointsReq.body).properties
+
+module gridCoords 'module.bicep' = {
+  name: 'gridCoords'
+  scope: resourceGroup('f33917e6-545f-452a-af87-e976c97e056d', 'mockRg')
+  params: {
+    gridpoints: gridpoints
+  }
+}
+
+output gridId string = gridCoords.outputs.gridId

--- a/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/main.bicepparam
+++ b/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/main.bicepparam
@@ -1,0 +1,6 @@
+using 'main.bicep'
+
+param coords = {
+  latitude: '47.6363726'
+  longitude: '-122.1357068'
+}

--- a/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/module.bicep
+++ b/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/azure/module.bicep
@@ -1,0 +1,7 @@
+param gridpoints {
+  gridId: string
+  gridX: int
+  gridY: int
+}
+
+output gridId string = gridpoints.gridId

--- a/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/weather/bicepconfig.json
+++ b/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/weather/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "localDeploy": true
+  },
+  "extensions": {
+    "http": "br:example.azurecr.io/extensions/foo:1.2.3"
+  }
+}

--- a/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/weather/main.bicep
+++ b/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/weather/main.bicep
@@ -1,0 +1,38 @@
+targetScope = 'local'
+
+extension http
+
+param coords {
+  latitude: string
+  longitude: string
+}
+
+resource gridpointsReq 'request@v1' = {
+  uri: 'https://api.weather.gov/points/${coords.latitude},${coords.longitude}'
+  format: 'raw'
+}
+
+var gridpoints = json(gridpointsReq.body).properties
+
+resource forecastReq 'request@v1' = {
+  uri: 'https://api.weather.gov/gridpoints/${gridpoints.gridId}/${gridpoints.gridX},${gridpoints.gridY}/forecast'
+  format: 'raw'
+}
+
+var forecast = json(forecastReq.body).properties
+
+type forecastType = {
+  name: string
+  temperature: int
+}
+
+var val = 'Name'
+
+func getForecast() string => 'Forecast: ${val}'
+
+output forecast forecastType[] = map(forecast.periods, p => {
+  name: p.name
+  temperature: p.temperature
+})
+
+output forecastString string = getForecast()

--- a/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/weather/main.bicepparam
+++ b/src/Bicep.Cli.IntegrationTests/Files/LocalDeployCommandTests/weather/main.bicepparam
@@ -1,0 +1,6 @@
+using 'main.bicep'
+
+param coords = {
+  latitude: '47.6363726'
+  longitude: '-122.1357068'
+}

--- a/src/Bicep.Cli.IntegrationTests/LocalDeployCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/LocalDeployCommandTests.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.IO.Abstractions.TestingHelpers;
+using System.IO.Pipes;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Azure.Deployments.Core.Definitions;
+using Azure.Deployments.Extensibility.Core.V2.Models;
+using Bicep.Cli.Rpc;
+using Bicep.Cli.UnitTests.Assertions;
+using Bicep.Core.Configuration;
+using Bicep.Core.Json;
+using Bicep.Core.Registry;
+using Bicep.Core.Registry.Oci;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Baselines;
+using Bicep.Core.UnitTests.Mock;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Local.Deploy;
+using Bicep.Local.Deploy.Azure;
+using Bicep.Local.Deploy.Extensibility;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+using Moq;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
+
+namespace Bicep.Cli.IntegrationTests;
+
+[TestClass]
+public class LocalDeployCommandTests : TestBase
+{
+    private static ExtensionPackage GetMockLocalDeployPackage(BinaryData? tgzData = null)
+    {
+        tgzData ??= ExtensionResourceTypeHelper.GetHttpExtensionTypesTgz();
+
+        var architecture = SupportedArchitectures.TryGetCurrent() ?? throw new InvalidOperationException("Failed to get current architecture");
+
+        // this doesn't need to contain a real binary, because this test emulates the local binary connection
+        ExtensionBinary binary = new(architecture, BinaryData.FromBytes([]));
+        return new ExtensionPackage(tgzData, true, [binary]);
+    }
+
+    private static void RegisterExtensionMocks(
+        IServiceCollection services,
+        ILocalExtension? localExtension = null,
+        IArmDeploymentProvider? armDeploymentProvider = null)
+    {
+        localExtension ??= StrictMock.Of<ILocalExtension>().Object;
+        armDeploymentProvider ??= StrictMock.Of<IArmDeploymentProvider>().Object;
+
+        var mockExtensionFactory = StrictMock.Of<ILocalExtensionFactory>();
+        mockExtensionFactory.Setup(x => x.Start(It.IsAny<Uri>())).ReturnsAsync(localExtension);
+
+        services
+            .AddSingleton(mockExtensionFactory.Object)
+            .AddSingleton(armDeploymentProvider);
+    }
+
+    [TestMethod]
+    public async Task Local_deploy_should_succeed()
+    {
+        var paramFile = new EmbeddedFile(typeof(LocalDeployCommandTests).Assembly, "Files/LocalDeployCommandTests/weather/main.bicepparam");
+        var baselineFolder = BaselineFolder.BuildOutputFolder(TestContext, paramFile);
+
+        var extensionMock = StrictMock.Of<ILocalExtension>();
+        extensionMock.Setup(x => x.CreateOrUpdate(It.IsAny<ResourceSpecification>(), It.IsAny<CancellationToken>()))
+            .Returns<ResourceSpecification, CancellationToken>((req, _) =>
+            {
+                var outputProperties = req.Properties["uri"]?.ToString() switch
+                {
+                    "https://api.weather.gov/points/47.6363726,-122.1357068" => new JsonObject
+                    {
+                        ["body"] = """
+                        {
+                          "properties": {
+                            "gridId": "SEW",
+                            "gridX": 131,
+                            "gridY": 68
+                          }
+                        }
+                        """
+                    },
+                    "https://api.weather.gov/gridpoints/SEW/131,68/forecast" => new JsonObject
+                    {
+                        ["body"] = """
+                        {
+                          "properties": {
+                            "periods": [
+                              {
+                                "name": "Tonight",
+                                "temperature": 47
+                              },
+                              {
+                                "name": "Wednesday",
+                                "temperature": 64
+                              },
+                              {
+                                "name": "Wednesday Night",
+                                "temperature": 46
+                              }
+                            ]
+                          }
+                        }
+                        """
+                    },
+                    _ => throw new InvalidOperationException("Unexpected URI"),
+                };
+
+                return Task.FromResult(new LocalExtensionOperationResponse(new Resource(req.Type, req.ApiVersion, req.Properties, (outputProperties as JsonObject)!, "Succeeded"), null));
+            });
+
+
+        var services = await ExtensionTestHelper.GetServiceBuilderWithPublishedExtension(GetMockLocalDeployPackage(), new(LocalDeployEnabled: true));
+        var clientFactory = services.Build().Construct<IContainerRegistryClientFactory>();
+
+        var result = await Bicep(
+            new InvocationSettings(ClientFactory: clientFactory),
+            services => RegisterExtensionMocks(services, extensionMock.Object),
+            TestContext.CancellationTokenSource.Token,
+            ["local-deploy", baselineFolder.EntryFile.OutputFilePath]);
+
+        result.Should().Succeed();
+        result.Stdout.Should().EqualIgnoringWhitespace("""
+Output forecast: [
+  {
+    "name": "Tonight",
+    "temperature": 47
+  },
+  {
+    "name": "Wednesday",
+    "temperature": 64
+  },
+  {
+    "name": "Wednesday Night",
+    "temperature": 46
+  }
+]
+Output forecastString: "Forecast: Name"
+Resource forecastReq (Create): Succeeded
+Resource gridpointsReq (Create): Succeeded
+Result: Succeeded
+
+""");
+    }
+
+    [TestMethod]
+    public async Task Local_deploy_with_azure_should_succeed()
+    {
+        var paramFile = new EmbeddedFile(typeof(LocalDeployCommandTests).Assembly, "Files/LocalDeployCommandTests/azure/main.bicepparam");
+        var baselineFolder = BaselineFolder.BuildOutputFolder(TestContext, paramFile);
+
+        var extensionMock = StrictMock.Of<ILocalExtension>();
+        extensionMock.Setup(x => x.CreateOrUpdate(It.IsAny<ResourceSpecification>(), It.IsAny<CancellationToken>()))
+            .Returns<ResourceSpecification, CancellationToken>((req, _) =>
+            {
+                var outputProperties = req.Properties["uri"]?.ToString() switch
+                {
+                    "https://api.weather.gov/points/47.6363726,-122.1357068" => new JsonObject
+                    {
+                        ["body"] = """
+                        {
+                          "properties": {
+                            "gridId": "SEW",
+                            "gridX": 131,
+                            "gridY": 68
+                          }
+                        }
+                        """
+                    },
+                    _ => throw new InvalidOperationException("Unexpected URI"),
+                };
+
+                return Task.FromResult(new LocalExtensionOperationResponse(new Resource(req.Type, req.ApiVersion, req.Properties, (outputProperties as JsonObject)!, "Succeeded"), null));
+            });
+
+        var deploymentProviderMock = StrictMock.Of<IArmDeploymentProvider>();
+
+        deploymentProviderMock.Setup(x => x.StartDeployment(It.IsAny<RootConfiguration>(), It.IsAny<DeploymentLocator>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns<RootConfiguration, DeploymentLocator, string, string, CancellationToken>(async (config, locator, templateString, parametersString, _) =>
+            {
+                await Task.CompletedTask;
+
+                var template = JsonSerializer.Deserialize<JsonElement>(templateString);
+                var parameters = JsonSerializer.Deserialize<JsonElement>(parametersString);
+            });
+
+        deploymentProviderMock.Setup(x => x.CheckDeployment(It.IsAny<RootConfiguration>(), It.IsAny<DeploymentLocator>(), It.IsAny<CancellationToken>()))
+            .Returns<RootConfiguration, DeploymentLocator, CancellationToken>(async (config, locator, _) =>
+            {
+                await Task.CompletedTask;
+ 
+                return new(
+                    new()
+                    {
+                        Properties = new()
+                        {
+                            ProvisioningState = ProvisioningState.Succeeded,
+                            Outputs = new()
+                            {
+                                ["gridId"] = new()
+                                {
+                                    Value = "SEW",
+                                }
+                            }
+                        },
+                    },
+                    []);
+            });
+
+        var services = await ExtensionTestHelper.GetServiceBuilderWithPublishedExtension(GetMockLocalDeployPackage(), new(LocalDeployEnabled: true));
+        var clientFactory = services.Build().Construct<IContainerRegistryClientFactory>();
+
+        var result = await Bicep(
+            new InvocationSettings(ClientFactory: clientFactory),
+            services => RegisterExtensionMocks(services, extensionMock.Object, deploymentProviderMock.Object),
+            TestContext.CancellationTokenSource.Token,
+            ["local-deploy", baselineFolder.EntryFile.OutputFilePath]);
+
+        result.Should().Succeed();
+        result.Stdout.Should().EqualIgnoringWhitespace("""
+Output gridId: "SEW"
+Resource gridpointsReq (Create): Succeeded
+Resource gridCoords (Create): Succeeded
+Result: Succeeded
+""");
+    }
+}

--- a/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
+++ b/src/Bicep.Cli/Helpers/ServiceCollectionExtensions.cs
@@ -19,6 +19,8 @@ using Bicep.Core.Utils;
 using Bicep.Decompiler;
 using Bicep.IO.Abstraction;
 using Bicep.IO.FileSystem;
+using Bicep.Local.Deploy.Azure;
+using Bicep.Local.Deploy.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using Environment = Bicep.Core.Utils.Environment;
 using LocalFileSystem = System.IO.Abstractions.FileSystem;
@@ -84,4 +86,9 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddBicepDecompiler(this IServiceCollection services) => services
         .AddSingleton<BicepDecompiler>();
+
+    public static IServiceCollection AddLocalDeploy(this IServiceCollection services) => services
+        .AddSingleton<LocalExtensionDispatcherFactory>()
+        .AddSingleton<IArmDeploymentProvider, ArmDeploymentProvider>()
+        .AddSingleton<ILocalExtensionFactory, GrpcLocalExtensionFactory>();
 }

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -164,6 +164,7 @@ namespace Bicep.Cli
             => new ServiceCollection()
                 .AddBicepCore()
                 .AddBicepDecompiler()
+                .AddLocalDeploy()
                 .AddCommands()
                 .AddSingleton(CreateLoggerFactory(io).CreateLogger("bicep"))
                 .AddSingleton<DiagnosticLogger>()

--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -204,10 +204,14 @@ public static class RegistryHelper
     public static async Task PublishExtensionToRegistryAsync(IDependencyHelper services, string target, BinaryData tgzData, Uri? bicepFileUri = null)
         => await PublishExtensionToRegistryAsync(services, target, new ExtensionPackage(tgzData, false, []), bicepFileUri);
 
-    public static async Task PublishExtensionToRegistryAsync(IDependencyHelper services, string target, ExtensionPackage package, Uri? bicepFileUri = null)
-    {
-        var dispatcher = services.Construct<IModuleDispatcher>();
+    public static Task PublishExtensionToRegistryAsync(IDependencyHelper services, string target, ExtensionPackage package, Uri? bicepFileUri = null)
+        => PublishExtensionToRegistryAsync(services.Construct<IModuleDispatcher>(), services.Construct<ISourceFileFactory>(), target, package, bicepFileUri);
 
+    public static Task PublishExtensionToRegistryAsync(IServiceProvider services, string target, ExtensionPackage package, Uri? bicepFileUri = null)
+        => PublishExtensionToRegistryAsync(services.GetRequiredService<IModuleDispatcher>(), services.GetRequiredService<ISourceFileFactory>(), target, package, bicepFileUri);
+
+    private static async Task PublishExtensionToRegistryAsync(IModuleDispatcher dispatcher, ISourceFileFactory sourceFileFactory, string target, ExtensionPackage package, Uri? bicepFileUri = null)
+    {
         if (!target.StartsWith("br:"))
         {
             // convert to a relative path, as this is the only format supported for the local filesystem
@@ -215,7 +219,6 @@ public static class RegistryHelper
             target = Path.GetFileName(targetUri.LocalPath);
         }
 
-        var sourceFileFactory = services.Construct<ISourceFileFactory>();
         var bicepFile = bicepFileUri is not null ? sourceFileFactory.CreateBicepFile(bicepFileUri, "") : BicepTestConstants.DummyBicepFile;
 
         if (!dispatcher.TryGetArtifactReference(bicepFile, ArtifactType.Extension, target).IsSuccess(out var targetReference, out var errorBuilder))

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -1232,6 +1232,18 @@ namespace Bicep.Core.Emit
             }
         }
 
+        private void EmitResourceExtensionReference(ExpressionEmitter emitter, string extensionAlias)
+        {
+            if (this.Context.SemanticModel.Features.ModuleExtensionConfigsEnabled)
+            {
+                emitter.EmitProperty("extension", extensionAlias);
+            }
+            else
+            {
+                emitter.EmitProperty("import", extensionAlias);
+            }
+        }
+
         private void EmitResource(ExpressionEmitter emitter, ImmutableArray<ExtensionExpression> extensions, DeclaredResourceExpression resource)
         {
             var metadata = resource.ResourceMetadata;
@@ -1258,15 +1270,7 @@ namespace Bicep.Core.Emit
                 var extensionSymbol = extensions.FirstOrDefault(i => metadata.Type.DeclaringNamespace.AliasNameEquals(i.Name));
                 if (extensionSymbol is not null)
                 {
-                    if (this.Context.SemanticModel.Features.ModuleExtensionConfigsEnabled)
-                    {
-                        emitter.EmitProperty("extension", extensionSymbol.Name);
-                    }
-                    else
-                    {
-                        // TODO(extensibility): Consider removing this
-                        emitter.EmitProperty("import", extensionSymbol.Name);
-                    }
+                    EmitResourceExtensionReference(emitter, extensionSymbol.Name);
                 }
 
                 // Emit the options property if there are entries in the DecoratorConfig dictionary
@@ -1481,7 +1485,7 @@ namespace Bicep.Core.Emit
         {
             emitter.EmitObject(() =>
             {
-                emitter.EmitProperty("extension", "az0synthesized");
+                EmitResourceExtensionReference(emitter, "az0synthesized");
 
                 var body = module.Body;
                 if (body is ForLoopExpression forLoop)

--- a/src/Bicep.LangServer/IServiceCollectionExtensions.cs
+++ b/src/Bicep.LangServer/IServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ using Bicep.LanguageServer.Settings;
 using Bicep.LanguageServer.Snippets;
 using Bicep.LanguageServer.Telemetry;
 using Bicep.LanguageServer.Utils;
+using Bicep.Local.Deploy.Azure;
+using Bicep.Local.Deploy.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using LocalFileSystem = System.IO.Abstractions.FileSystem;
 
@@ -59,12 +61,18 @@ public static class IServiceCollectionExtensions
     public static IServiceCollection AddBicepDecompiler(this IServiceCollection services) => services
         .AddSingleton<BicepDecompiler>();
 
+    public static IServiceCollection AddLocalDeploy(this IServiceCollection services) => services
+        .AddSingleton<LocalExtensionDispatcherFactory>()
+        .AddSingleton<IArmDeploymentProvider, ArmDeploymentProvider>()
+        .AddSingleton<ILocalExtensionFactory, GrpcLocalExtensionFactory>();
+
     public static IServiceCollection AddServerDependencies(
         this IServiceCollection services,
         BicepLangServerOptions bicepLangServerOptions
     ) => services
         .AddBicepCore()
         .AddBicepDecompiler()
+        .AddLocalDeploy()
         .AddSingleton<IWorkspace, Workspace>()
         .AddSingleton<ISnippetsProvider, SnippetsProvider>()
         .AddSingleton<ITelemetryProvider, TelemetryProvider>()

--- a/src/Bicep.Local.Deploy.IntegrationTests/EndToEndDeploymentTests.cs
+++ b/src/Bicep.Local.Deploy.IntegrationTests/EndToEndDeploymentTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 using Azure.Deployments.Core.Definitions;
 using Azure.Deployments.Extensibility.Core.V2.Models;
 using Bicep.Core.Configuration;
@@ -13,6 +14,7 @@ using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
 using Bicep.Core.UnitTests.Utils;
 using Bicep.IO.Abstraction;
+using Bicep.Local.Deploy.Azure;
 using Bicep.Local.Deploy.Extensibility;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +22,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Moq;
 using Newtonsoft.Json.Linq;
+using static Bicep.Core.UnitTests.Utils.CompilationHelper;
 
 namespace Bicep.Local.Deploy.IntegrationTests;
 
@@ -102,18 +105,13 @@ param coords = {
 }
 """));
 
-        result.Should().NotHaveAnyDiagnostics();
-
-        var parametersFile = result.Compilation.Emitter.Parameters().Parameters!;
-        var templateFile = result.Compilation.Emitter.Parameters().Template!.Template!;
-
         JsonObject identifiers = new()
                 {
                     { "name", "someName" },
                     { "namespace", "someNamespace" }
                 };
 
-        var extensionMock = StrictMock.Of<LocalExtensionHost>();
+        var extensionMock = StrictMock.Of<ILocalExtension>();
         extensionMock.Setup(x => x.CreateOrUpdate(It.Is<ResourceSpecification>(req => req.Properties["uri"]!.ToString() == "https://api.weather.gov/points/47.6363726,-122.1357068"), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((req, _) =>
             {
@@ -157,17 +155,7 @@ param coords = {
                 return Task.FromResult(new LocalExtensionOperationResponse(new Resource(req.Type, req.ApiVersion, identifiers, req.Properties, "Succeeded"), null));
             });
 
-        var serviceProvider = services.Build().Construct<IServiceProvider>();
-        var dispatcher = BicepTestConstants.CreateModuleDispatcher(serviceProvider);
-        await using LocalExtensionHostManager extensionHostManager = new(
-            serviceProvider.GetRequiredService<IFileExplorer>(),
-            dispatcher,
-            StrictMock.Of<IConfigurationManager>().Object,
-            StrictMock.Of<ITokenCredentialFactory>().Object,
-            uri => Task.FromResult(extensionMock.Object));
-        await extensionHostManager.InitializeExtensions(result.Compilation);
-
-        var localDeployResult = await extensionHostManager.Deploy(templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
+        var localDeployResult = await Deploy(services, extensionMock.Object, result);
 
         localDeployResult.Deployment.Properties.ProvisioningState.Should().Be(ProvisioningState.Succeeded);
         localDeployResult.Deployment.Properties.Outputs["forecastString"].Value.Should().DeepEqual("Forecast: Name");
@@ -244,18 +232,13 @@ param coords = {
 }
 """));
 
-        result.Should().NotHaveAnyDiagnostics();
-
-        var parametersFile = result.Compilation.Emitter.Parameters().Parameters!;
-        var templateFile = result.Compilation.Emitter.Parameters().Template!.Template!;
-
         JsonObject identifiers = new()
                 {
                     { "name", "someName" },
                     { "namespace", "someNamespace" }
                 };
 
-        var extensionMock = StrictMock.Of<LocalExtensionHost>();
+        var extensionMock = StrictMock.Of<ILocalExtension>();
         extensionMock.Setup(x => x.CreateOrUpdate(It.Is<ResourceSpecification>(req => req.Properties["uri"]!.ToString() == "https://api.weather.gov/points/47.6363726,-122.1357068"), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((req, _) =>
             {
@@ -271,17 +254,7 @@ param coords = {
                 return Task.FromResult(new LocalExtensionOperationResponse(new Resource(req.Type, req.ApiVersion, identifiers, req.Properties, "Succeeded"), new ErrorData(new Error() { Code = "Code", Message = "Error message" })));
             });
 
-        var serviceProvider = services.Build().Construct<IServiceProvider>();
-        var dispatcher = BicepTestConstants.CreateModuleDispatcher(serviceProvider);
-        await using LocalExtensionHostManager extensionHostManager = new(
-            serviceProvider.GetRequiredService<IFileExplorer>(),
-            dispatcher,
-            StrictMock.Of<IConfigurationManager>().Object,
-            StrictMock.Of<ITokenCredentialFactory>().Object,
-            uri => Task.FromResult(extensionMock.Object));
-        await extensionHostManager.InitializeExtensions(result.Compilation);
-
-        var localDeployResult = await extensionHostManager.Deploy(templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
+        var localDeployResult = await Deploy(services, extensionMock.Object, result);
 
         localDeployResult.Deployment.Properties.ProvisioningState.Should().Be(ProvisioningState.Failed, because: $"Extension returned '{nameof(Resource)}' and '{nameof(ErrorData)}' as part of its response and it is not allowed. Extensions should return one or the other to indicate success or failure respectively.");
         localDeployResult.Deployment.Properties.Error.Should().NotBeNull();
@@ -351,18 +324,13 @@ param coords = {
 }
 """));
 
-        result.Should().NotHaveAnyDiagnostics();
-
-        var parametersFile = result.Compilation.Emitter.Parameters().Parameters!;
-        var templateFile = result.Compilation.Emitter.Parameters().Template!.Template!;
-
         JsonObject identifiers = new()
                 {
                     { "name", "someName" },
                     { "namespace", "someNamespace" }
                 };
 
-        var extensionMock = StrictMock.Of<LocalExtensionHost>();
+        var extensionMock = StrictMock.Of<ILocalExtension>();
         extensionMock.Setup(x => x.CreateOrUpdate(It.Is<ResourceSpecification>(req => req.Properties["uri"]!.ToString() == "https://api.weather.gov/points/47.6363726,-122.1357068"), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((req, _) =>
             {
@@ -378,17 +346,7 @@ param coords = {
                 return Task.FromResult(new LocalExtensionOperationResponse(new Resource(req.Type, req.ApiVersion, identifiers, req.Properties, "Succeeded"), new ErrorData(new Error() { Code = "Code", Message = "Error message" })));
             });
 
-        var serviceProvider = services.Build().Construct<IServiceProvider>();
-        var dispatcher = BicepTestConstants.CreateModuleDispatcher(serviceProvider);
-        await using LocalExtensionHostManager extensionHostManager = new(
-            serviceProvider.GetRequiredService<IFileExplorer>(),
-            dispatcher,
-            StrictMock.Of<IConfigurationManager>().Object,
-            StrictMock.Of<ITokenCredentialFactory>().Object,
-            uri => Task.FromResult(extensionMock.Object));
-        await extensionHostManager.InitializeExtensions(result.Compilation);
-
-        var localDeployResult = await extensionHostManager.Deploy(templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
+        var localDeployResult = await Deploy(services, extensionMock.Object, result);
 
         localDeployResult.Deployment.Properties.ProvisioningState.Should().Be(ProvisioningState.Failed, because: $"Extension did not return '{nameof(Resource)}' or '{nameof(ErrorData)}' as part of its response. Extensions should return one or the other to indicate success or failure respectively.");
         localDeployResult.Deployment.Properties.Error.Should().NotBeNull();
@@ -458,29 +416,14 @@ param coords = {
 }
 """));
 
-        result.Should().NotHaveAnyDiagnostics();
-
-        var parametersFile = result.Compilation.Emitter.Parameters().Parameters!;
-        var templateFile = result.Compilation.Emitter.Parameters().Template!.Template!;
-
-        var extensionMock = StrictMock.Of<LocalExtensionHost>();
+        var extensionMock = StrictMock.Of<ILocalExtension>();
         extensionMock.Setup(x => x.CreateOrUpdate(It.Is<ResourceSpecification>(req => req.Properties["uri"]!.ToString() == "https://api.weather.gov/points/47.6363726,-122.1357068"), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((_, _) =>
             {
                 return Task.FromResult(new LocalExtensionOperationResponse(null, new ErrorData(new Error() { Code = "Code", Message = "Error message" })));
             });
 
-        var serviceProvider = services.Build().Construct<IServiceProvider>();
-        var dispatcher = BicepTestConstants.CreateModuleDispatcher(serviceProvider);
-        await using LocalExtensionHostManager extensionHostManager = new(
-            serviceProvider.GetRequiredService<IFileExplorer>(),
-            dispatcher,
-            StrictMock.Of<IConfigurationManager>().Object,
-            StrictMock.Of<ITokenCredentialFactory>().Object,
-            uri => Task.FromResult(extensionMock.Object));
-        await extensionHostManager.InitializeExtensions(result.Compilation);
-
-        var localDeployResult = await extensionHostManager.Deploy(templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
+        var localDeployResult = await Deploy(services, extensionMock.Object, result);
 
         localDeployResult.Deployment.Properties.ProvisioningState.Should().Be(ProvisioningState.Failed, because: "Extension returned a failure when attempting to create a resource.");
         localDeployResult.Deployment.Properties.Error.Should().NotBeNull();
@@ -529,17 +472,12 @@ output joke string = dadJoke.joke
 using 'main.bicep'
 """));
 
-        result.Should().NotHaveAnyDiagnostics();
-
-        var parametersFile = result.Compilation.Emitter.Parameters().Parameters!;
-        var templateFile = result.Compilation.Emitter.Parameters().Template!.Template!;
-
         JsonObject identifiers = new()
         {
             ["identifier"] = "foo",
         };
 
-        var extensionMock = StrictMock.Of<LocalExtensionHost>();
+        var extensionMock = StrictMock.Of<ILocalExtension>();
         extensionMock.Setup(x => x.CreateOrUpdate(It.IsAny<ResourceSpecification>(), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((req, _) =>
             {
@@ -554,17 +492,7 @@ using 'main.bicep'
                 return Task.FromResult(new LocalExtensionOperationResponse(new Resource(req.Type, req.ApiVersion, identifiers, req.Properties, "Succeeded"), null));
             });
 
-        var serviceProvider = services.Build().Construct<IServiceProvider>();
-        var dispatcher = BicepTestConstants.CreateModuleDispatcher(serviceProvider);
-        await using LocalExtensionHostManager extensibilityHandler = new(
-            serviceProvider.GetRequiredService<IFileExplorer>(),
-            dispatcher,
-            StrictMock.Of<IConfigurationManager>().Object,
-            StrictMock.Of<ITokenCredentialFactory>().Object,
-            uri => Task.FromResult(extensionMock.Object));
-        await extensibilityHandler.InitializeExtensions(result.Compilation);
-
-        var localDeployResult = await extensibilityHandler.Deploy(templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
+        var localDeployResult = await Deploy(services, extensionMock.Object, result);
 
         localDeployResult.Deployment.Properties.ProvisioningState.Should().Be(ProvisioningState.Succeeded);
     }
@@ -616,17 +544,12 @@ using 'main.bicep'
                 }
                 """));
 
-        result.Should().NotHaveAnyDiagnostics();
-
-        var parametersFile = result.Compilation.Emitter.Parameters().Parameters!;
-        var templateFile = result.Compilation.Emitter.Parameters().Template!.Template!;
-
         JsonObject identifiers = new()
         {
             ["identifier"] = "foo",
         };
 
-        var extensionMock = StrictMock.Of<LocalExtensionHost>();
+        var extensionMock = StrictMock.Of<ILocalExtension>();
         extensionMock.Setup(x => x.CreateOrUpdate(It.IsAny<ResourceSpecification>(), It.IsAny<CancellationToken>()))
             .Returns<ResourceSpecification, CancellationToken>((req, _) =>
             {
@@ -646,19 +569,32 @@ using 'main.bicep'
                 return Task.FromResult(new LocalExtensionOperationResponse(new Resource(req.Type, req.ApiVersion, identifiers, req.Properties, "Succeeded"), null));
             });
 
-        var serviceProvider = services.Build().Construct<IServiceProvider>();
-        var dispatcher = BicepTestConstants.CreateModuleDispatcher(serviceProvider);
-        await using LocalExtensionHostManager extensibilityHandler = new(
-            serviceProvider.GetRequiredService<IFileExplorer>(),
-            dispatcher,
-            StrictMock.Of<IConfigurationManager>().Object,
-            StrictMock.Of<ITokenCredentialFactory>().Object,
-            uri => Task.FromResult(extensionMock.Object));
-
-        await extensibilityHandler.InitializeExtensions(result.Compilation);
-
-        var localDeployResult = await extensibilityHandler.Deploy(templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
+        var localDeployResult = await Deploy(services, extensionMock.Object, result);
 
         localDeployResult.Deployment.Properties.ProvisioningState.Should().Be(ProvisioningState.Succeeded);
+    }
+
+    private async Task<LocalDeploymentResult> Deploy(ServiceBuilder services, ILocalExtension extension, ParamsCompilationResult result)
+    {
+        result.Should().NotHaveAnyDiagnostics();
+
+        var parametersFile = result.Compilation.Emitter.Parameters().Parameters!;
+        var templateFile = result.Compilation.Emitter.Parameters().Template!.Template!;
+
+        var mockExtensionFactory = StrictMock.Of<ILocalExtensionFactory>();
+        mockExtensionFactory.Setup(x => x.Start(It.IsAny<Uri>())).ReturnsAsync(extension);
+        var serviceProvider = services.Build().Construct<IServiceProvider>();
+        var moduleDispatcher = BicepTestConstants.CreateModuleDispatcher(serviceProvider);
+
+        await using LocalExtensionDispatcher extensionDispatcher = new(
+            serviceProvider.GetRequiredService<IFileExplorer>(),
+            moduleDispatcher,
+            serviceProvider.GetRequiredService<IConfigurationManager>(),
+            mockExtensionFactory.Object,
+            StrictMock.Of<IArmDeploymentProvider>().Object);
+
+        await extensionDispatcher.InitializeExtensions(result.Compilation);
+
+        return await extensionDispatcher.Deploy(templateFile, parametersFile, TestContext.CancellationTokenSource.Token);
     }
 }

--- a/src/Bicep.Local.Deploy/Azure/IArmDeploymentProvider.cs
+++ b/src/Bicep.Local.Deploy/Azure/IArmDeploymentProvider.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Core.Definitions;
+using Bicep.Core.Configuration;
+
+namespace Bicep.Local.Deploy.Azure;
+
+public interface IArmDeploymentProvider
+{
+    Task<LocalDeploymentResult> CheckDeployment(RootConfiguration configuration, DeploymentLocator deploymentLocator, CancellationToken cancellationToken);
+
+    Task StartDeployment(RootConfiguration configuration, DeploymentLocator deploymentLocator, string templateString, string parametersString, CancellationToken cancellationToken);
+}

--- a/src/Bicep.Local.Deploy/Engine/IServiceCollectionExtensions.cs
+++ b/src/Bicep.Local.Deploy/Engine/IServiceCollectionExtensions.cs
@@ -29,11 +29,11 @@ using Microsoft.WindowsAzure.ResourceStack.Common.BackgroundJobs.Configuration;
 using Microsoft.WindowsAzure.ResourceStack.Common.EventSources;
 using Microsoft.WindowsAzure.ResourceStack.Common.Storage.Volatile;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public static class IServiceCollectionExtensions
 {
-    public static IServiceCollection RegisterLocalDeployServices(this IServiceCollection services, LocalExtensionHostManager extensionHostManager)
+    public static IServiceCollection RegisterLocalDeployServices(this IServiceCollection services, LocalExtensionDispatcher extensionHostManager)
     {
         var eventSource = new TraceEventSource();
         services.AddSingleton<IGeneralEventSource>(eventSource);

--- a/src/Bicep.Local.Deploy/Engine/LocalDeploymentConfiguration.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalDeploymentConfiguration.cs
@@ -7,7 +7,7 @@ using Azure.Deployments.Engine;
 using Azure.Deployments.Engine.Dependencies;
 using Azure.Deployments.Engine.Interfaces;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public class LocalDeploymentConfiguration : IAzureDeploymentConfiguration
 {

--- a/src/Bicep.Local.Deploy/Engine/LocalDeploymentEngine.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalDeploymentEngine.cs
@@ -18,7 +18,7 @@ using Microsoft.WindowsAzure.ResourceStack.Common.Instrumentation;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public class LocalDeploymentEngine
 {

--- a/src/Bicep.Local.Deploy/Engine/LocalDeploymentEngineHost.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalDeploymentEngineHost.cs
@@ -22,18 +22,18 @@ using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 using Microsoft.WindowsAzure.ResourceStack.Common.Services.ADAuthentication;
 using Newtonsoft.Json.Linq;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 #nullable disable
 
 public class LocalDeploymentEngineHost : DeploymentEngineHostBase
 {
-    private readonly LocalExtensionHostManager extensionHostManager;
+    private readonly LocalExtensionDispatcher extensionHostManager;
 
     public readonly record struct ExtensionInfo(string ExtensionName, string ExtensionVersion, string Method);
 
     public LocalDeploymentEngineHost(
-        LocalExtensionHostManager extensionHostManager,
+        LocalExtensionDispatcher extensionHostManager,
         IDeploymentsRequestContext requestContext,
         IDeploymentEventSource deploymentEventSource,
         IKeyVaultDataProvider keyVaultDataProvider,

--- a/src/Bicep.Local.Deploy/Engine/LocalDeploymentSettings.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalDeploymentSettings.cs
@@ -7,7 +7,7 @@ using System.Collections.Immutable;
 using Azure.Deployments.Engine.Definitions;
 using Azure.Deployments.Engine.Interfaces;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public class LocalDeploymentSettings : IAzureDeploymentSettings
 {

--- a/src/Bicep.Local.Deploy/Engine/LocalEnablementConfigProvider.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalEnablementConfigProvider.cs
@@ -3,7 +3,7 @@
 
 using Azure.Deployments.Core.FeatureEnablement;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public class LocalEnablementConfigProvider : IEnablementConfigProvider
 {

--- a/src/Bicep.Local.Deploy/Engine/LocalHttpContentHandler.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalHttpContentHandler.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Azure.Deployments.Engine.External;
 using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public class LocalHttpContentHandler : IHttpContentHandler
 {

--- a/src/Bicep.Local.Deploy/Engine/LocalKeyVaultDataProvider.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalKeyVaultDataProvider.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Azure.Deployments.Core.Entities;
 using Azure.Deployments.Engine.Interfaces;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public class LocalKeyVaultDataProvider : IKeyVaultDataProvider
 {

--- a/src/Bicep.Local.Deploy/Engine/LocalRequestContext.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalRequestContext.cs
@@ -4,7 +4,7 @@
 using Azure.Deployments.Core.Helpers;
 using Azure.Deployments.Engine.External;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 public class LocalRequestContext : IDeploymentsRequestContext
 {

--- a/src/Bicep.Local.Deploy/Engine/TraceEventSource.cs
+++ b/src/Bicep.Local.Deploy/Engine/TraceEventSource.cs
@@ -13,7 +13,7 @@ using Microsoft.WindowsAzure.ResourceStack.Common.BackgroundJobs;
 using Microsoft.WindowsAzure.ResourceStack.Common.EventSources;
 using Newtonsoft.Json.Linq;
 
-namespace Bicep.Local.Deploy;
+namespace Bicep.Local.Deploy.Engine;
 
 #nullable disable
 

--- a/src/Bicep.Local.Deploy/Extensibility/GrpcLocalExtensionFactory.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/GrpcLocalExtensionFactory.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Local.Deploy.Extensibility;
+
+public class GrpcLocalExtensionFactory : ILocalExtensionFactory
+{
+    Task<ILocalExtension> ILocalExtensionFactory.Start(Uri pathToBinary)
+        => GrpcLocalExtension.Start(pathToBinary);
+}

--- a/src/Bicep.Local.Deploy/Extensibility/ILocalExtension.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/ILocalExtension.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Deployments.Extensibility.Core.V2.Models;
+
+namespace Bicep.Local.Deploy.Extensibility;
+
+public interface ILocalExtension : IAsyncDisposable
+{
+    Task<LocalExtensionOperationResponse> Delete(ResourceReference request, CancellationToken cancellationToken);
+
+    Task<LocalExtensionOperationResponse> Get(ResourceReference request, CancellationToken cancellationToken);
+
+    Task<LocalExtensionOperationResponse> Preview(ResourceSpecification request, CancellationToken cancellationToken);
+
+    Task<LocalExtensionOperationResponse> CreateOrUpdate(ResourceSpecification request, CancellationToken cancellationToken);
+}

--- a/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionFactory.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/ILocalExtensionFactory.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Local.Deploy.Extensibility;
+
+public interface ILocalExtensionFactory
+{
+    Task<ILocalExtension> Start(Uri pathToBinary);
+}

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensionDispatcherFactory.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensionDispatcherFactory.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading;
+using Azure.Deployments.Core.Definitions;
+using Azure.Deployments.Engine.ExtensibilityV2.Contract.Models;
+using Azure.Deployments.Engine.Instrumentation;
+using Azure.Deployments.Engine.Workers;
+using Azure.Deployments.Extensibility.Core.V2.Json;
+using Azure.Deployments.Extensibility.Core.V2.Models;
+using Bicep.Core.Configuration;
+using Bicep.Core.Extensions;
+using Bicep.Core.Registry;
+using Bicep.Core.Registry.Auth;
+using Bicep.Core.Semantics;
+using Bicep.Core.TypeSystem.Types;
+using Bicep.IO.Abstraction;
+using Bicep.Local.Deploy.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.WindowsAzure.ResourceStack.Common.Json;
+
+namespace Bicep.Local.Deploy.Extensibility;
+
+public class LocalExtensionDispatcherFactory(
+    IFileExplorer fileExplorer,
+    IModuleDispatcher moduleDispatcher,
+    IConfigurationManager configurationManager,
+    ILocalExtensionFactory localExtensionFactory,
+    IArmDeploymentProvider armDeploymentProvider)
+{
+    public LocalExtensionDispatcher Create()
+        => new(
+            fileExplorer,
+            moduleDispatcher,
+            configurationManager,
+            localExtensionFactory,
+            armDeploymentProvider);
+}

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensionOperationResponse.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensionOperationResponse.cs
@@ -27,19 +27,3 @@ public static class LocalExtensionOperationResponseJsonDefaults
 
     public readonly static LocalExtensionOperationResponseContext SerializerContext = new(SerializerOptions);
 }
-
-public abstract class LocalExtensionHost : IAsyncDisposable
-{
-    public abstract Task<LocalExtensionOperationResponse> Delete(ResourceReference request, CancellationToken cancellationToken);
-
-    public abstract Task<LocalExtensionOperationResponse> Get(ResourceReference request, CancellationToken cancellationToken);
-
-    public abstract Task<LocalExtensionOperationResponse> Preview(ResourceSpecification request, CancellationToken cancellationToken);
-
-    public abstract Task<LocalExtensionOperationResponse> CreateOrUpdate(ResourceSpecification request, CancellationToken cancellationToken);
-
-    public virtual ValueTask DisposeAsync()
-    {
-        return ValueTask.CompletedTask;
-    }
-}


### PR DESCRIPTION
## Description

Fix a bug with incorrectly using `extension` instead of `import` for local deploy code generation.