### PR TITLE
Enable decompilation of KV reference in parameters json

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/DecompileParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/DecompileParamsCommandTests.cs
@@ -174,7 +174,7 @@ namespace Bicep.Cli.IntegrationTests
             {
                 output.Should().BeEmpty();
                 error.AsLines().Should().Contain(DecompilationDisclaimer);
-                error.AsLines().Should().Contain($"{jsonPath}: Decompilation failed with fatal error \"No value found parameter foo\"");
+                error.AsLines().Should().Contain($"{jsonPath}: Decompilation failed with fatal error \"[5:10]: No value found parameter foo\"");
                 result.Should().Be(1);
             }
         }

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Parameters/keyvaultreference/parameters.bicepparam
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Parameters/keyvaultreference/parameters.bicepparam
@@ -1,0 +1,9 @@
+using '' /*TODO: Provide a path to a bicep template*/
+
+param adminUsername = 'tim'
+
+param adminPassword = az.getSecret('2fbf906e-1101-4bc0-b64f-adc44e462fff', 'INSTRUCTOR', 'TimKV', 'vm-password', '1.0')
+
+param adminPassword2 = az.getSecret('2fbf906e-1101-4bc0-b64f-adc44e462fff', 'INSTRUCTOR', 'TimKV', 'vm-password')
+
+param dnsLabelPrefix = 'newvm79347a'

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Parameters/keyvaultreference/parameters.json
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Parameters/keyvaultreference/parameters.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "adminUsername": {
+            "value": "tim"
+        },
+        "adminPassword": {
+            "reference": {
+                "keyVault": {
+                    "id": "/subscriptions/2fbf906e-1101-4bc0-b64f-adc44e462fff/resourceGroups/INSTRUCTOR/providers/Microsoft.KeyVault/vaults/TimKV"
+                },
+                "secretName": "vm-password",
+                "secretVersion": "1.0"
+            }
+        },
+        "adminPassword2": {
+            "reference": {
+                "keyVault": {
+                    "id": "/subscriptions/2fbf906e-1101-4bc0-b64f-adc44e462fff/resourceGroups/INSTRUCTOR/providers/Microsoft.KeyVault/vaults/TimKV"
+                },
+                "secretName": "vm-password"
+            }
+        },
+        "dnsLabelPrefix": {
+            "value": "newvm79347a"
+        }
+    }
+}

--- a/src/Bicep.Decompiler.IntegrationTests/ParamsDecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/ParamsDecompilationTests.cs
@@ -156,7 +156,8 @@ namespace Bicep.Decompiler.IntegrationTests
                         "keyVault": {
                           "id": "/subscriptions/2fbf906e-1101-4bc0-b64f-adc44e462fff/resourceGroups/INSTRUCTOR/providers/Microsoft.KeyVault/vaults/TimKV"
                         },
-                        "secretName": "vm-password"
+                        "secretName": "vm-password",
+                        "secretVersion": "1.0"
                       }
                     },
 
@@ -172,7 +173,7 @@ namespace Bicep.Decompiler.IntegrationTests
 
                 param adminUsername = 'tim'
 
-                param adminPassword = ? /*KeyVault references are not supported in Bicep Parameters files*/
+                param adminPassword = az.getSecret('2fbf906e-1101-4bc0-b64f-adc44e462fff', 'INSTRUCTOR', 'TimKV', 'vm-password', '1.0')
 
                 param dnsLabelPrefix = 'newvm79347a'
 
@@ -194,7 +195,6 @@ namespace Bicep.Decompiler.IntegrationTests
 
             filesToSave[entryPointUri].Should().Be(expectedBicepparamFile);
         }
-
 
         [TestMethod]
         public void Decompiler_Decompiles_ParametersContainingMetadata()

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepDecompileParamsCommandHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepDecompileParamsCommandHandlerTests.cs
@@ -82,7 +82,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
     }
   }
 }";
-            var expectedErrorMsg = "Decompilation failed. Please fix the following problems and try again: No value found parameter foo";
+            var expectedErrorMsg = "Decompilation failed. Please fix the following problems and try again: [5:10]: No value found parameter foo";
 
             var paramFilePath = FileHelper.SaveResultFile(TestContext, "param.json", paramFile);
 


### PR DESCRIPTION
## Description
Closes #14939. Decompile KV reference in parameters.json into `az.getSecret(...)`.

## Example Usage

```json5
{
  ...
  "parameters": {
    "mySecret": {
      "reference": {
        "keyVault": {
          "id": "/subscriptions/<subId>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vaultname>"
        },
        "secretName": "mySecret",
        "secretVersion": "1.0"
      }
    }
  }
}
```

```bicep
param mySecret = az.getSecret('<subId>', '<rg>', '<vaultname>', 'mySecret', '1.0')
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17196)