### PR TITLE
Allow outer variable completions in user-defined functions

### DIFF
--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -213,7 +213,7 @@ namespace Bicep.Core.Semantics
         public override void VisitTypedLambdaSyntax(TypedLambdaSyntax syntax)
         {
             // create new scope without any descendants
-            var scope = new LocalScope(string.Empty, syntax, syntax.Body, ImmutableArray<DeclaredSymbol>.Empty, ImmutableArray<LocalScope>.Empty, ScopeResolution.InheritFunctionsOnly);
+            var scope = new LocalScope(string.Empty, syntax, syntax.Body, ImmutableArray<DeclaredSymbol>.Empty, ImmutableArray<LocalScope>.Empty, ScopeResolution.InheritFunctionsAndVariablesOnly);
             this.PushScope(scope);
 
             /*

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -369,7 +369,7 @@ namespace Bicep.Core.Semantics
                     break;
                 }
 
-                if (scope.ScopeResolution == ScopeResolution.InheritFunctionsOnly)
+                if (scope.ScopeResolution == ScopeResolution.InheritFunctionsAndVariablesOnly)
                 {
                     // FIXME: How can we make sure only wildcard import instance functions are included in the local scope?
                     symbolFilter = symbol => symbol is VariableSymbol or ImportedVariableSymbol or DeclaredFunctionSymbol or ImportedFunctionSymbol or WildcardImportSymbol;

--- a/src/Bicep.Core/Semantics/ScopeResolution.cs
+++ b/src/Bicep.Core/Semantics/ScopeResolution.cs
@@ -11,9 +11,9 @@ public enum ScopeResolution
     InheritAll,
 
     /// <summary>
-    ///   Inherit only function symbols from the parent scope.
+    ///   Inherit only function and variable symbols from the parent scope.
     /// </summary>
-    InheritFunctionsOnly,
+    InheritFunctionsAndVariablesOnly,
 
     /// <summary>
     ///   Only symbols that have not been declared by a parent (or above) scope.

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -1067,9 +1067,9 @@ namespace Bicep.LanguageServer.Completions
                         break;
                     }
 
-                    if (scope.ScopeResolution == ScopeResolution.InheritFunctionsOnly)
+                    if (scope.ScopeResolution == ScopeResolution.InheritFunctionsAndVariablesOnly)
                     {
-                        symbolFilter = symbol => symbol is DeclaredFunctionSymbol;
+                        symbolFilter = symbol => symbol is VariableSymbol or ImportedVariableSymbol or DeclaredFunctionSymbol or ImportedFunctionSymbol or WildcardImportSymbol;
                     }
                 }
             }


### PR DESCRIPTION
## Description

Offer completions for outer variables in user-defined functions. Support for outer variables was added via https://github.com/Azure/bicep/pull/14531.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17198)