### PR TITLE
Handle case insensitive name clashes for imported variable, func, and type symbols

### DIFF
--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -870,10 +870,11 @@ namespace Bicep.Core.Emit
             foreach (var (symbolTypePluralName, symbolsOfType) in new (string, IEnumerable<DeclaredSymbol>)[]
             {
                 ("parameters", model.Root.ParameterDeclarations),
-                ("variables", model.Root.VariableDeclarations),
+                ("variables", model.Root.VariableDeclarations.Concat<DeclaredSymbol>(model.Root.ImportedVariables)),
                 ("outputs", model.Root.OutputDeclarations),
-                ("types", model.Root.TypeDeclarations),
+                ("types", model.Root.TypeDeclarations.Concat<DeclaredSymbol>(model.Root.ImportedTypes)),
                 ("asserts", model.Root.AssertDeclarations),
+                ("functions", model.Root.FunctionDeclarations.Concat<DeclaredSymbol>(model.Root.ImportedFunctions))
             })
             {
                 BlockCaseInsensitiveNameClashes(symbolTypePluralName, symbolsOfType, s => s.Name, s => s.NameSource, diagnostics);


### PR DESCRIPTION
Closes #17192. 

## Description

Handle case insensitive name clashes for imported variable, func, and type symbols.

## Example Usage
_exports_:
![image](https://github.com/user-attachments/assets/41e00e23-7bb8-40cb-b0b6-77db8f6ad1ab)

_main.bicep_:
![image](https://github.com/user-attachments/assets/8d5e5833-8315-4eb8-8813-13d97b7f4076)

_diagnostics on main.bicep_:
![image](https://github.com/user-attachments/assets/e64306d9-4520-45b3-93a3-b6a11c410979)


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17200)