### PR TITLE
Add module identity snippets

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -540,39 +540,59 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' 
                     x.Prefix.Should().Be("required-properties");
                     x.Detail.Should().Be("Required properties");
                     x.CompletionPriority.Should().Be(CompletionPriority.Medium);
-                    x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
+                    x.Text.Should().Be(
+"""
+{
 	name: $1
 	location: $2
-}$0");
+}$0
+""");
                 },
                 x =>
                 {
                     x.Prefix.Should().Be("user-assigned-identity");
                     x.Detail.Should().Be("User assigned identity");
-                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
-                    x.Text.Should().BeEquivalentToIgnoringNewlines("""
-                        {
-                            identity: {
-                                type: 'UserAssigned'
-                                userAssignedIdentities: {
-                                    '${$0}': {}
-                                }
-                            }
-                        }
-                        """);
+                    x.CompletionPriority.Should().Be(CompletionPriority.Low);
+                    x.Text.Should().Be(
+"""
+{
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${${0:identityId}}': {}
+    }
+  }
+}
+""");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("user-assigned-identity-array");
+                    x.Detail.Should().Be("User assigned identity array");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Low);
+                    x.Text.Should().Be(
+"""
+{
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: toObject(${0:identityIdArray}, x => x, x => {})
+  }
+}
+""");
                 },
                 x =>
                 {
                     x.Prefix.Should().Be("none-identity");
                     x.Detail.Should().Be("None identity");
                     x.CompletionPriority.Should().Be(CompletionPriority.Low);
-                    x.Text.Should().BeEquivalentToIgnoringNewlines("""               
-                        {
-                            identity: {
-                                type: 'None'
-                            }
-                        }
-                        """);
+                    x.Text.Should().Be(
+"""               
+{
+  identity: {
+    type: 'None'
+  }
+}
+""");
                 });
         }
 

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -2,13 +2,16 @@
 // Licensed under the MIT License.
 
 using Bicep.Core;
+using Bicep.Core.Features;
 using Bicep.Core.Resources;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Providers.Az;
 using Bicep.Core.TypeSystem.Types;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.IO.Abstraction;
 using Bicep.LanguageServer.Completions;
 using Bicep.LanguageServer.Snippets;
 using FluentAssertions;
@@ -464,7 +467,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' 
             }, null);
             TypeSymbol typeSymbol = new ModuleType("module", ResourceScope.Module, objectType);
 
-            IEnumerable<Snippet> snippets = CreateSnippetsProvider().GetModuleBodyCompletionSnippets(typeSymbol);
+            IEnumerable<Snippet> snippets = CreateSnippetsProvider().GetModuleBodyCompletionSnippets(typeSymbol, BicepTestConstants.Features);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -487,7 +490,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' 
             }, null);
             TypeSymbol typeSymbol = new ModuleType("module", ResourceScope.Module, objectType);
 
-            IEnumerable<Snippet> snippets = CreateSnippetsProvider().GetModuleBodyCompletionSnippets(typeSymbol);
+            IEnumerable<Snippet> snippets = CreateSnippetsProvider().GetModuleBodyCompletionSnippets(typeSymbol, BicepTestConstants.Features);
 
             snippets.Should().SatisfyRespectively(
                 x =>
@@ -506,6 +509,70 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2019-06-01' 
 	name: $1
 	location: $2
 }$0");
+                });
+        }
+
+        [TestMethod]
+        public void GetModuleBodyCompletionSnippets_WithRequiredProperties_WithIdentity_ShouldReturnEmptyAndRequiredPropertiesAndIdentitySnippets()
+        {
+            var objectType = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
+            {
+                new NamedTypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
+                new NamedTypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
+                new NamedTypeProperty("id", LanguageConstants.String)
+            }, null);
+            TypeSymbol typeSymbol = new ModuleType("module", ResourceScope.Module, objectType);
+
+            var features = new OverriddenFeatureProvider(new FeatureProvider(BicepTestConstants.BuiltInConfiguration, BicepTestConstants.FileExplorer), new(ModuleIdentityEnabled: true));
+
+            IEnumerable<Snippet> snippets = CreateSnippetsProvider().GetModuleBodyCompletionSnippets(typeSymbol, features);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("{}");
+                    x.Detail.Should().Be("{}");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\t$0\n}");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("required-properties");
+                    x.Detail.Should().Be("Required properties");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
+	name: $1
+	location: $2
+}$0");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("user-assigned-identity");
+                    x.Detail.Should().Be("User assigned identity");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().BeEquivalentToIgnoringNewlines("""
+                        {
+                            identity: {
+                                type: 'UserAssigned'
+                                userAssignedIdentities: {
+                                    '${$0}': {}
+                                }
+                            }
+                        }
+                        """);
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("none-identity");
+                    x.Detail.Should().Be("None identity");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Low);
+                    x.Text.Should().BeEquivalentToIgnoringNewlines("""               
+                        {
+                            identity: {
+                                type: 'None'
+                            }
+                        }
+                        """);
                 });
         }
 

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -856,7 +856,7 @@ namespace Bicep.LanguageServer.Completions
         private IEnumerable<CompletionItem> CreateModuleBodyCompletions(SemanticModel model, BicepCompletionContext context, ModuleDeclarationSyntax moduleDeclarationSyntax)
         {
             TypeSymbol typeSymbol = model.GetTypeInfo(moduleDeclarationSyntax);
-            IEnumerable<Snippet> snippets = snippetsProvider.GetModuleBodyCompletionSnippets(typeSymbol.UnwrapArrayType());
+            IEnumerable<Snippet> snippets = snippetsProvider.GetModuleBodyCompletionSnippets(typeSymbol.UnwrapArrayType(), model.Features);
 
             foreach (Snippet snippet in snippets)
             {

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Features;
 using Bicep.Core.Resources;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Types;
@@ -13,7 +14,7 @@ namespace Bicep.LanguageServer.Snippets
 
         IEnumerable<Snippet> GetTopLevelNamedDeclarationSnippets();
 
-        IEnumerable<Snippet> GetModuleBodyCompletionSnippets(TypeSymbol typeSymbol);
+        IEnumerable<Snippet> GetModuleBodyCompletionSnippets(TypeSymbol typeSymbol, IFeatureProvider featureProvider);
 
         IEnumerable<Snippet> GetTestBodyCompletionSnippets(TypeSymbol typeSymbol);
 

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -189,32 +189,6 @@ public class SnippetsProvider : ISnippetsProvider
         return new Snippet(output, CompletionPriority.Medium, label, RequiredPropertiesDescription);
     }
 
-    private IEnumerable<Snippet> GetIdentitySnippets()
-    {
-        string userAssignedIdentityLabel = "user-assigned-identity";
-        string userAssignedIdentityDescription = "User assigned identity";
-        string noneIdentityLabel = "none-identity";
-        string noneIdentityDescription = "None identity";
-
-        yield return new Snippet("""
-            {
-                identity: {
-                    type: 'UserAssigned'
-                    userAssignedIdentities: {
-                        '${$0}': {}
-                    }
-                }
-            }
-            """, CompletionPriority.Medium, userAssignedIdentityLabel, userAssignedIdentityDescription);
-        yield return new Snippet("""
-            {
-                identity: {
-                    type: 'None'
-                }
-            }
-            """, CompletionPriority.Low, noneIdentityLabel, noneIdentityDescription);
-    }
-
     private Snippet GetEmptySnippet()
     {
         string label = "{}";
@@ -237,7 +211,7 @@ public class SnippetsProvider : ISnippetsProvider
 
             if (features.ModuleIdentityEnabled)
             {
-                IEnumerable<Snippet> identitySnippets = GetIdentitySnippets();
+                IEnumerable<Snippet> identitySnippets = GetModuleIdentitySnippets();
 
                 foreach (var identitySnippet in identitySnippets)
                 {
@@ -322,5 +296,43 @@ public class SnippetsProvider : ISnippetsProvider
                 }
             }
         }
+    }
+
+    private IEnumerable<Snippet> GetModuleIdentitySnippets()
+    {
+        string userAssignedIdentityLabel = "user-assigned-identity";
+        string userAssignedIdentityDescription = "User assigned identity";
+        string userAssignedIdentityArrayLabel = "user-assigned-identity-array";
+        string userAssignedIdentityArrayDescription = "User assigned identity array";
+        string noneIdentityLabel = "none-identity";
+        string noneIdentityDescription = "None identity";
+
+        yield return new Snippet("""
+            {
+              identity: {
+                type: 'UserAssigned'
+                userAssignedIdentities: {
+                  '${${0:identityId}}': {}
+                }
+              }
+            }
+            """, CompletionPriority.Low, userAssignedIdentityLabel, userAssignedIdentityDescription);
+
+        yield return new Snippet("""
+            {
+              identity: {
+                type: 'UserAssigned'
+                userAssignedIdentities: toObject(${0:identityIdArray}, x => x, x => {})
+              }
+            }
+            """, CompletionPriority.Low, userAssignedIdentityArrayLabel, userAssignedIdentityArrayDescription);
+
+        yield return new Snippet("""
+            {
+              identity: {
+                type: 'None'
+              }
+            }
+            """, CompletionPriority.Low, noneIdentityLabel, noneIdentityDescription);
     }
 }


### PR DESCRIPTION
## Description
Add identity snippets for UserAssigned identities and None type identities for modules when moduleIdentity feature is enabled.

## Example Usage
Example snippet results from VSCode extension: 
```
module none 'module.bicep' = {
  identity: {
    type: 'None'
  }
}

module userAssigned 'module.bicep' = {
  identity: {
    type: 'UserAssigned'
    userAssignedIdentities: {
      '${identityId}': {}
    }
  }
}

module userAssignedArray 'module.bicep' = {
  identity: {
    type: 'UserAssigned'
    userAssignedIdentities: toObject(identityIdArray, x => x, x => {})
  }
```


## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17233)