### PR TITLE
Only use `listOutputsWithSecureValues` to dereference secure outputs

### DIFF
--- a/src/Bicep.Core.IntegrationTests/DereferenceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/DereferenceTests.cs
@@ -455,6 +455,7 @@ public class DereferenceTests
                 output nullableFoo string? = mod.?outputs.?foo
                 output nullableFoo2 string? = mod2.?outputs.?foo
                 output bar string? = mod.?outputs.bar
+                output nullableBar string? = mod.?outputs.?bar
             
                 """),
             ("mod.bicep", """
@@ -472,11 +473,12 @@ public class DereferenceTests
         result.Template.Should().HaveValueAtPath("$.outputs.name.value", "[if(parameters('condition'), 'mod', null())]");
         result.Template.Should().HaveValueAtPath("$.outputs.outputs.value", "[if(parameters('condition'), listOutputsWithSecureValues('mod', '2022-09-01'), null())]");
         result.Template.Should().HaveValueAtPath("$.outputs.outputs2.value", "[tryGet(if(not(parameters('condition')), reference('mod2'), null()), 'outputs')]");
-        result.Template.Should().HaveValueAtPath("$.outputs.foo.value", "[tryGet(if(parameters('condition'), listOutputsWithSecureValues('mod', '2022-09-01'), null()), 'foo')]");
+        result.Template.Should().HaveValueAtPath("$.outputs.foo.value", "[tryGet(if(parameters('condition'), reference('mod'), null()), 'outputs', 'foo', 'value')]");
         result.Template.Should().HaveValueAtPath("$.outputs.foo2.value", "[tryGet(if(not(parameters('condition')), reference('mod2'), null()), 'outputs', 'foo', 'value')]");
-        result.Template.Should().HaveValueAtPath("$.outputs.nullableFoo.value", "[tryGet(if(parameters('condition'), listOutputsWithSecureValues('mod', '2022-09-01'), null()), 'foo')]");
+        result.Template.Should().HaveValueAtPath("$.outputs.nullableFoo.value", "[tryGet(tryGet(tryGet(if(parameters('condition'), reference('mod'), null()), 'outputs'), 'foo'), 'value')]");
         result.Template.Should().HaveValueAtPath("$.outputs.nullableFoo2.value", "[tryGet(tryGet(tryGet(if(not(parameters('condition')), reference('mod2'), null()), 'outputs'), 'foo'), 'value')]");
         result.Template.Should().HaveValueAtPath("$.outputs.bar.value", "[tryGet(if(parameters('condition'), listOutputsWithSecureValues('mod', '2022-09-01'), null()), 'bar')]");
+        result.Template.Should().HaveValueAtPath("$.outputs.nullableBar.value", "[tryGet(if(parameters('condition'), listOutputsWithSecureValues('mod', '2022-09-01'), null()), 'bar')]");
     }
 
     [TestMethod]

--- a/src/Bicep.Core/Intermediate/Expression.cs
+++ b/src/Bicep.Core/Intermediate/Expression.cs
@@ -233,6 +233,7 @@ public record ModuleOutputPropertyAccessExpression(
     SyntaxBase? SourceSyntax,
     Expression Base,
     string PropertyName,
+    bool IsSecureOutput,
     AccessExpressionFlags Flags
 ) : AccessExpression(SourceSyntax, Base, new StringLiteralExpression(null, PropertyName), Flags)
 {

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -1050,6 +1050,10 @@ public class ExpressionBuilder
                 propertyAccess,
                 ConvertWithoutLowering(propertyAccess.BaseExpression),
                 propertyAccess.PropertyName.IdentifierName,
+                IsSecureOutput: TypeHelper.SatisfiesCondition(
+                    Context.SemanticModel.GetTypeInfo(childPropertyAccess.BaseExpression),
+                    x => (x as ModuleType)?.TryGetOutputType(propertyAccess.PropertyName.IdentifierName) is { } outputType &&
+                        TypeHelper.IsOrContainsSecureType(outputType)),
                 flags);
         }
 

--- a/src/Bicep.Core/TypeSystem/Types/ModuleType.cs
+++ b/src/Bicep.Core/TypeSystem/Types/ModuleType.cs
@@ -33,16 +33,22 @@ namespace Bicep.Core.TypeSystem.Types
             };
 
         public TypeSymbol? TryGetParameterType(string propertyName)
+            => TryGetNestedBodyPropertyType(LanguageConstants.ModuleParamsPropertyName, propertyName);
+
+        private TypeSymbol? TryGetNestedBodyPropertyType(string bodyPropertyName, string nestedPropertyName)
         {
             if (Body is ObjectType objectType &&
-                objectType.Properties.TryGetValue(LanguageConstants.ModuleParamsPropertyName, out var paramsProperty) &&
-                paramsProperty.TypeReference.Type is ObjectType paramsType &&
-                paramsType.Properties.TryGetValue(propertyName, out var property))
+                objectType.Properties.TryGetValue(bodyPropertyName, out var bodyProperty) &&
+                bodyProperty.TypeReference.Type is ObjectType bodyPropertyObject &&
+                bodyPropertyObject.Properties.TryGetValue(nestedPropertyName, out var property))
             {
                 return property.TypeReference.Type;
             }
 
             return null;
         }
+
+        public TypeSymbol? TryGetOutputType(string outputName)
+            => TryGetNestedBodyPropertyType(LanguageConstants.ModuleOutputsPropertyName, outputName);
     }
 }


### PR DESCRIPTION
Resolves #16991 

The compiler will currently use the `listOutputsWithSecureValues` to dereference any output (sensitive or not) from a module that contains any sensitive outputs. This PR ensures that the list function will only be used when the specific output being referred to is sensitive.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17423)