### PR TITLE
adding powershell support to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,9 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "lts",
       "nodeGypDependencies": true
+    },
+    "ghcr.io/devcontainers/features/powershell:1": {
+      "version": "latest"
     }
   }
 }

--- a/scripts/bcode.ps1
+++ b/scripts/bcode.ps1
@@ -5,4 +5,11 @@
 
 $ENV:BICEP_LANGUAGE_SERVER_PATH=[System.IO.Path]::Join($PSScriptRoot,"..\src\Bicep.LangServer\bin\Debug\net8.0\Bicep.LangServer.dll")
 $ENV:Path=[System.IO.Path]::Join($PSScriptRoot,"..\src\Bicep.Cli\bin\Debug\net8.0") + ";" + $ENV:Path
-& Start-Process -FilePath "code" -WindowStyle hidden -ArgumentList $args
+if ($IsWindows)
+{
+  & Start-Process -FilePath "code" -WindowStyle hidden -ArgumentList $args
+}
+else
+{
+  & Start-Process -FilePath "code" -ArgumentList $args
+}


### PR DESCRIPTION
## Description

This PR introduces support for PowerShell in the development container and updates the [bcode.ps1](https://github.com/Azure/bicep/blob/polatengin/add-powershell-to-devcontainer/scripts/bcode.ps1#L8) script to work correctly across platforms (Windows and Linux).

## ✅ Changes Made

- Added PowerShell feature to devcontainer

```json
"ghcr.io/devcontainers/features/powershell:1": {
  "version": "latest"
}
```

- Updated bcode.ps1 to avoid `-WindowStyle` error on Linux

Replaced the use of `-WindowStyle` hidden with a conditional check using `$IsWindows`.

The `-WindowStyle` parameter is not supported on non-Windows platforms and throws an error when used on Linux or macOS.

Implementation of the start-Process can be seen in https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs#L1857. It throws error when `-WindowStyle` used on non-Windows platforms.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17471)