### PR TITLE
Detect usage of fully-qualified non-deterministic functions in resource identifiers

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseStableResourceIdentifiersRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseStableResourceIdentifiersRuleTests.cs
@@ -26,7 +26,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             });
         }
 
-        [DataRow(@"
+        [DataRow("""
             param location string = resourceGroup().location
 
             resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
@@ -36,9 +36,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
               sku: {
                 name: 'Standard_LRS'
               }
-            }"
-        )]
-        [DataRow(@"
+            }
+            """)]
+        [DataRow("""
             param location string = resourceGroup().location
             param snap string
 
@@ -52,9 +52,10 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
               sku: {
                 name: 'Standard_LRS'
               }
-            }"
-        )]
-        [DataRow(@"
+            }
+            """)]
+        [DataRow(
+            """
             param location string = resourceGroup().location
             param snap string = newGuid()
 
@@ -68,11 +69,12 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
               sku: {
                 name: 'Standard_LRS'
               }
-            }",
+            }
+            """,
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> snap (default value) -> newGuid()).",
-            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> crackle -> snap (default value) -> newGuid())."
-        )]
-        [DataRow(@"
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> crackle -> snap (default value) -> newGuid()).")]
+        [DataRow(
+            """
             param location string = resourceGroup().location
             param snap string = utcNow('F')
 
@@ -86,11 +88,12 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
               sku: {
                 name: 'Standard_LRS'
               }
-            }",
+            }
+            """,
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> snap (default value) -> utcNow('F')).",
-            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> crackle -> snap (default value) -> utcNow('F'))."
-        )]
-        [DataRow(@"
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> crackle -> snap (default value) -> utcNow('F')).")]
+        [DataRow(
+            """
             param location string = resourceGroup().location
             param snap string = '${newGuid()}${newGuid()}${utcNow('u')}'
 
@@ -104,14 +107,42 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
               sku: {
                 name: 'Standard_LRS'
               }
-            }",
+            }
+            """,
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> snap (default value) -> newGuid()).",
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> snap (default value) -> newGuid()).",
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> snap (default value) -> utcNow('u')).",
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> crackle -> snap (default value) -> newGuid()).",
             "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> pop -> crackle -> snap (default value) -> newGuid()).",
-            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> crackle -> snap (default value) -> utcNow('u'))."
-        )]
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'utcNow' function (storage.name -> pop -> crackle -> snap (default value) -> utcNow('u')).")]
+        [DataRow(
+            """
+            param name string = sys.newGuid()
+            param location string = resourceGroup().location
+            
+            resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+              name: name
+              location: location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }
+            """,
+            "Resource identifiers should be reproducible outside of their initial deployment context. Resource storage's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (storage.name -> name (default value) -> sys.newGuid()).")]
+        [DataRow(
+            """
+            func newGuid() string => "abc"
+            
+            resource storage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+              name: newGuid()
+              location: location
+              kind: 'StorageV2'
+              sku: {
+                name: 'Standard_LRS'
+              }
+            }
+            """)]
         [DataTestMethod]
         public void TestRule(string text, params string[] expectedMessages)
         {

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseStableResourceIdentifiersRule.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 
 namespace Bicep.Core.Analyzers.Linter.Rules
@@ -60,11 +61,23 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
             {
-                if (NonDeterministicFunctionNames.Contains(syntax.Name.IdentifierName))
+                VisitFunctionCallBaseSyntax(syntax);
+                base.VisitFunctionCallSyntax(syntax);
+            }
+
+            public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
+            {
+                VisitFunctionCallBaseSyntax(syntax);
+                base.VisitInstanceFunctionCallSyntax(syntax);
+            }
+
+            private void VisitFunctionCallBaseSyntax(FunctionCallSyntaxBase syntax)
+            {
+                if (SemanticModelHelper.TryGetFunctionInNamespace(model, SystemNamespaceType.BuiltInName, syntax) is not null &&
+                    NonDeterministicFunctionNames.Contains(syntax.Name.IdentifierName))
                 {
                     pathsToNonDeterministicFunctionsUsed.Add((FormatPath(syntax.ToString()), syntax.Name.IdentifierName));
                 }
-                base.VisitFunctionCallSyntax(syntax);
             }
 
             public override void VisitVariableAccessSyntax(VariableAccessSyntax syntax)


### PR DESCRIPTION
The `use-stable-resource-identifiers` linter will not currently trigger on fully qualified function calls, just unqualified function calls.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17505)