### PR TITLE
Remove auxiliary file size limit for local deploy

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/LoadFunctionsTests.cs
@@ -7,6 +7,8 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.FileSystem;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.TextFixtures.Utils;
+using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
@@ -798,6 +800,30 @@ var fileObj = loadJsonContent('file.json')
 }
 "));
             }
+        }
+
+        [TestMethod]
+        public async Task LoadJsonFunction_LocalDeploy_NoCharacterCountLimit()
+        {
+            var result = await TestCompiler
+                .ForMockFileSystemCompilation()
+                .Compile(
+                    ("main.bicep", """
+                        var fileObj = loadJsonContent('file.json')
+                        """),
+                    ("bicepconfig.json", """
+                        {
+                          "experimentalFeaturesEnabled": {
+                            "localDeploy": true
+                          }
+                        }
+                        """),
+                    ("file.json", $$"""
+                          "long" : "{{new string('x', LanguageConstants.MaxJsonFileCharacterLimit + 1)}}"
+                        }
+                        """));
+
+            result.Diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
         }
 
         /**** loadYamlContent ****/

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1371,7 +1371,9 @@ namespace Bicep.Core.Semantics.Namespaces
                 tokenSelectorPath = tokenSelectorType.RawStringValue;
             }
 
-            if (TryLoadTextContentFromFile(model, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, LanguageConstants.MaxJsonFileCharacterLimit)
+            int? characterLimit = model.Features.LocalDeployEnabled ? null : LanguageConstants.MaxJsonFileCharacterLimit;
+
+            if (TryLoadTextContentFromFile(model, diagnostics, (arguments[0], argumentTypes[0]), arguments.Length > 2 ? (arguments[2], argumentTypes[2]) : null, characterLimit)
                 .IsSuccess(out var result, out var errorDiagnostic) &&
                 objectParser.TryExtractFromObject(result.Content, tokenSelectorPath, positionables, out errorDiagnostic, out var token))
             {
@@ -1433,7 +1435,7 @@ namespace Bicep.Core.Semantics.Namespaces
                 new StringLiteralExpression(null, envVariableValue));
         }
 
-        private static ResultWithDiagnostic<LoadTextContentResult> TryLoadTextContentFromFile(SemanticModel model, IDiagnosticWriter diagnostics, (FunctionArgumentSyntax syntax, TypeSymbol typeSymbol) filePathArgument, (FunctionArgumentSyntax syntax, TypeSymbol typeSymbol)? encodingArgument, int maxCharacters)
+        private static ResultWithDiagnostic<LoadTextContentResult> TryLoadTextContentFromFile(SemanticModel model, IDiagnosticWriter diagnostics, (FunctionArgumentSyntax syntax, TypeSymbol typeSymbol) filePathArgument, (FunctionArgumentSyntax syntax, TypeSymbol typeSymbol)? encodingArgument, int? maxCharacters)
         {
             if (filePathArgument.typeSymbol is not StringLiteralType filePathType)
             {


### PR DESCRIPTION
Some local extensions handle large JSON files. The PR adds support for them.