### PR TITLE
Update params-file-grammar.md

### DIFF
--- a/docs/params-file-grammar.md
+++ b/docs/params-file-grammar.md
@@ -1,17 +1,17 @@
 program -> statement* EOF 
 statement -> 
   usingDecl |
-  parameterDecl |
+  paramDecl |
   NL
 
 usingDecl ->
-  "using" stringLiteral NL
+  "using" stringLiteral | "none" NL
 
+paramDecl ->
+  "param" IDENTIFIER(name) "=" literalValue NL
 
-  importDecl -> decorator* "import" IDENTIFIER(providerName) "as" IDENTIFIER(aliasName) object? NL
-
-parameterDecl ->
-  "parameter" IDENTIFIER(name) "=" literalValue NL
+varDecl ->
+  "var" IDENTIFIER(name) "=" literalValue NL
 
 stringLiteral -> "'" STRINGCHAR* "'"
 

--- a/docs/params-file-grammar.md
+++ b/docs/params-file-grammar.md
@@ -1,3 +1,7 @@
+# Language Grammar
+The following is the active pseudo-grammar of the Bicep parameters file
+
+```
 program -> statement* EOF 
 statement -> 
   usingDecl |
@@ -6,6 +10,20 @@ statement ->
 
 usingDecl ->
   "using" (stringLiteral | "none") NL
+
+compileTimeImportDecl -> decorator* "import" compileTimeImportTarget compileTimeImportFromClause
+
+compileTimeImportTarget ->
+  importedSymbolsList |
+  wildcardImport
+
+importedSymbolsList -> "{" ( NL+ ( importedSymbolsListItem NL+ )* )? "}"
+
+importedSymbolsListItem -> IDENTIFIER(originalSymbolName) extensionAsClause?
+
+wildcardImport -> "*" extensionAsClause
+
+compileTimeImportFromClause -> "from" interpString(path)
 
 paramDecl ->
   "param" IDENTIFIER(name) "=" literalValue NL
@@ -22,3 +40,4 @@ objectProperty -> ( IDENTIFIER(name) | stringLiteral ) ":" literalValue
 
 array -> "[" ( NL+ arrayItem* )? "]"
 arrayItem -> literalValue NL+
+```

--- a/docs/params-file-grammar.md
+++ b/docs/params-file-grammar.md
@@ -5,7 +5,7 @@ statement ->
   NL
 
 usingDecl ->
-  "using" stringLiteral | "none" NL
+  "using" (stringLiteral | "none") NL
 
 paramDecl ->
   "param" IDENTIFIER(name) "=" literalValue NL


### PR DESCRIPTION
## Description

Removed importDecl which I don't think exists in Bicepparam files.

Renamed parameterDecl and updated keyword to param because that is the actual keyword.

Added varDecl to support the `var` keyword.

Added "none" as an option for usingDecl.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17510)