### PR TITLE
Enable speculative reference evaluation in snapshot helper

### DIFF
--- a/src/Bicep.Cli/Helpers/Snapshot/SnapshotHelper.cs
+++ b/src/Bicep.Cli/Helpers/Snapshot/SnapshotHelper.cs
@@ -72,6 +72,7 @@ public static class SnapshotHelper
             template,
             parameters: ResolveParameters(parameters, externalInputs),
             rootDeploymentMetadata: GetDeploymentMetadata(tenantId, subscriptionId, resourceGroup, deploymentName, location, scope, template),
+            referenceFunctionPreflightEnabled: true,
             cancellationToken: cancellationToken);
 
         return new(


### PR DESCRIPTION
## Description

Reference evaluation in nested deployment expansion requires an explicit opt-in. This isn't currently being supplied in the snapshot helper, which causes snapshots to have more unevaluated expressions than you would see from the what-if API.

## Example Usage

No change to usage.

## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17512)