### PR TITLE
File I/O abstraction part 16: `Migrate Bicep.Cli.BuildCommand`

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using System.Text.RegularExpressions;
 using Bicep.Cli.UnitTests;
 using Bicep.Core;
@@ -55,7 +56,7 @@ namespace Bicep.Cli.IntegrationTests
                 output.Should().BeEmpty();
 
                 error.Should().NotBeEmpty();
-                error.Should().Contain($@"The specified input ""/dev/zero"" was not recognized as a Bicep file. Bicep files must use the {LanguageConstants.LanguageFileExtension} extension.");
+                error.Should().Contain($@"The specified input ""{Path.GetFullPath("/dev/zero")}"" was not recognized as a Bicep file. Bicep files must use the {LanguageConstants.LanguageFileExtension} extension.");
             }
         }
 
@@ -310,13 +311,24 @@ output myOutput string = 'hello!'
                 (input: "nofile.bicep", expectOutput: false)
             };
 
+            var fileSystem = new MockFileSystem();
+
             foreach (var (input, _) in fileResults)
             {
+                fileSystem.AddFile($"{outputPath}/{input}", contents);
+                // Since Matcher uses the real file system, we need to save the files to the
+                // real file system as well so it can find the files.
                 FileHelper.SaveResultFile(TestContext, input, contents, outputPath);
             }
 
+            if (!useRootPath)
+            {
+                fileSystem.Directory.SetCurrentDirectory(outputPath);
+            }
+
+
             var (output, error, result) = await Bicep(
-                services => services.WithEnvironment(useRootPath ? TestEnvironment.Default : TestEnvironment.Default with { CurrentDirectory = outputPath }),
+                services => services.WithFileSystem(fileSystem),
                 ["build",
                     "--pattern",
                     useRootPath ? $"{outputPath}/file*.bicep" : "file*.bicep"]);
@@ -327,8 +339,8 @@ output myOutput string = 'hello!'
 
             foreach (var (input, expectOutput) in fileResults)
             {
-                var outputFile = Path.ChangeExtension(input, ".json");
-                File.Exists(Path.Combine(outputPath, outputFile)).Should().Be(expectOutput);
+                var outputFile = fileSystem.Path.ChangeExtension(input, ".json");
+                fileSystem.File.Exists(fileSystem.Path.Combine(outputPath, outputFile)).Should().Be(expectOutput);
             }
         }
 

--- a/src/Bicep.Cli/Arguments/BuildArguments.cs
+++ b/src/Bicep.Cli/Arguments/BuildArguments.cs
@@ -3,11 +3,12 @@
 
 using System.Collections.Immutable;
 using Bicep.Cli.Helpers;
+using Bicep.Core;
 using Bicep.Core.FileSystem;
 
 namespace Bicep.Cli.Arguments;
 
-public class BuildArguments : ArgumentsBase
+public class BuildArguments : ArgumentsBase, IFilePatternInputOutputArguments<BuildArguments>
 {
     public BuildArguments(string[] args) : base(Constants.Command.Build)
     {
@@ -111,6 +112,8 @@ public class BuildArguments : ArgumentsBase
 
         DiagnosticsFormat ??= Arguments.DiagnosticsFormat.Default;
     }
+
+    public static string OutputFileExtension => LanguageConstants.JsonFileExtension;
 
     public bool OutputToStdOut { get; }
 

--- a/src/Bicep.Cli/Arguments/IFilePatternArguments.cs
+++ b/src/Bicep.Cli/Arguments/IFilePatternArguments.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Cli.Arguments
+{
+    public interface IFilePatternArguments
+    {
+        string? FilePattern { get; }
+    }
+}

--- a/src/Bicep.Cli/Arguments/IFilePatternInputArguments.cs
+++ b/src/Bicep.Cli/Arguments/IFilePatternInputArguments.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Cli.Arguments
+{
+    public interface IFilePatternInputArguments : IFilePatternArguments, IInputArguments
+    {
+    }
+}

--- a/src/Bicep.Cli/Arguments/IFilePatternInputOutputArguments.cs
+++ b/src/Bicep.Cli/Arguments/IFilePatternInputOutputArguments.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Cli.Arguments
+{
+    public interface IFilePatternInputOutputArguments<T> : IFilePatternArguments, IInputOutputArguments<T>
+        where T : IFilePatternInputOutputArguments<T>
+    {
+    }
+}

--- a/src/Bicep.Cli/Arguments/IInputArguments.cs
+++ b/src/Bicep.Cli/Arguments/IInputArguments.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Cli.Arguments
+{
+    public interface IInputArguments
+    {
+        string? InputFile { get; }
+    }
+}

--- a/src/Bicep.Cli/Arguments/IInputOutputArguments.cs
+++ b/src/Bicep.Cli/Arguments/IInputOutputArguments.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Cli.Arguments
+{
+    public interface IInputOutputArguments<T> : IInputArguments, IOutputArguments<T>
+        where T : IInputOutputArguments<T>
+    {
+    }
+}

--- a/src/Bicep.Cli/Arguments/IOutputArguments.cs
+++ b/src/Bicep.Cli/Arguments/IOutputArguments.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Cli.Arguments
+{
+    public interface IOutputArguments<T> where T : IOutputArguments<T>
+    {
+        abstract static string OutputFileExtension { get; }
+
+        string? OutputDir { get; }
+
+        string? OutputFile { get; }
+    }
+}

--- a/src/Bicep.Cli/Arguments/InputOutputArgumentsResolver.cs
+++ b/src/Bicep.Cli/Arguments/InputOutputArgumentsResolver.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO.Abstractions;
+using Azure.Deployments.Core.Extensions;
+using Bicep.IO.Abstraction;
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace Bicep.Cli.Arguments
+{
+    public class InputOutputArgumentsResolver
+    {
+        private readonly IFileSystem fileSystem;
+
+        public InputOutputArgumentsResolver(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        public IOUri PathToUri(string path) => IOUri.FromLocalFilePath(GetFullPath(path));
+
+        public (IOUri inputUri, IOUri outputUri) ResolveInputOutputArguments<T>(T arguments)
+            where T : IInputOutputArguments<T>
+        {
+            ArgumentNullException.ThrowIfNull(arguments.InputFile);
+
+            var inputUri = this.PathToUri(arguments.InputFile);
+            var outputUri = this.ResolveOutputUri(inputUri, arguments.OutputDir, arguments.OutputFile, T.OutputFileExtension);
+
+            return (inputUri, outputUri);
+        }
+
+        public IReadOnlyList<(IOUri InputUri, IOUri OutputUri)> ResolveFilePatternInputOutputArguments<T>(T arguments)
+            where T : IFilePatternInputOutputArguments<T>
+        {
+            if (arguments.InputFile is not null)
+            {
+                return [this.ResolveInputOutputArguments(arguments)];
+            }
+
+            if (arguments.FilePattern is not null)
+            {
+                var result = new List<(IOUri InputUri, IOUri OutputUri)>();
+                var (rootUri, inputRelativePaths) = this.ResolveFilePattern(arguments.FilePattern);
+
+                foreach (var inputRelativePath in inputRelativePaths)
+                {
+                    var inputUri = rootUri.Resolve(inputRelativePath);
+                    var outputRootPath = arguments.OutputDir ?? rootUri.GetLocalFilePath();
+                    var outputRelativePath = this.fileSystem.Path.ChangeExtension(inputRelativePath, T.OutputFileExtension);
+                    var outputPath = this.fileSystem.Path.Combine(outputRootPath, outputRelativePath);
+                    var outputUri = this.PathToUri(outputPath);
+
+                    result.Add((inputUri, outputUri));
+                }
+
+                return result;
+            }
+
+            throw new InvalidOperationException("Either InputFile or FilePattern must be specified.");
+        }
+
+        private IOUri ResolveOutputUri(IOUri inputUri, string? outputDir, string? outputFile, string outputFileExtension)
+        {
+            if (outputDir is not null)
+            {
+                outputDir = this.fileSystem.Path.GetFullPath(outputDir);
+                var outputFileName = inputUri.GetFileNameWithoutExtension().ToString() + outputFileExtension;
+                var outputPath = this.fileSystem.Path.Combine(outputDir, outputFileName);
+
+                return this.PathToUri(outputPath);
+            }
+
+            if (outputFile is not null)
+            {
+                return this.PathToUri(this.fileSystem.Path.GetFullPath(outputFile));
+            }
+
+            return inputUri.WithExtension(outputFileExtension);
+        }
+
+        private string GetFullPath(string path) => this.fileSystem.Path.GetFullPath(path);
+
+        private (IOUri rootUri, IReadOnlyList<string> relativePaths) ResolveFilePattern(string filePattern)
+        {
+            var (rootPath, relativePattern) = SplitFilePatternOnWildcard(filePattern);
+            var rootUri = IOUri.FromLocalFilePath(rootPath);
+
+            Matcher matcher = new();
+            matcher.AddInclude(relativePattern);
+
+            var relativePaths = new List<string>();
+            foreach (var filePath in matcher.GetResultsInFullPath(rootPath))
+            {
+                var fileUri = IOUri.FromLocalFilePath(filePath);
+                var relativePath = fileUri.GetPathRelativeTo(rootUri);
+                relativePaths.Add(relativePath);
+            }
+
+            return (rootUri, relativePaths);
+        }
+
+        public (string rootPath, string relativePattern) SplitFilePatternOnWildcard(string filePattern)
+        {
+            var directorySeparatorChar = this.fileSystem.Path.DirectorySeparatorChar;
+            var altDirectorySeparatorChar = this.fileSystem.Path.AltDirectorySeparatorChar;
+
+            var wildcardIndex = filePattern.IndexOf('*');
+            if (wildcardIndex == -1)
+            {
+                wildcardIndex = filePattern.Length;
+            }
+
+            // We intentionally want different behavior on different OSes.
+            // Linux treats \ as a regular character, while Windows treats it as a path separator.
+            var prevDirIndex = filePattern[..wildcardIndex].LastIndexOfAny([directorySeparatorChar, altDirectorySeparatorChar]);
+            var rootPath = prevDirIndex != -1 ? filePattern[..prevDirIndex] : "";
+            var relativePattern = prevDirIndex != -1 ? filePattern[(prevDirIndex + 1)..] : filePattern;
+
+            if (rootPath.IsNullOrEmpty())
+            {
+                rootPath = this.fileSystem.Directory.GetCurrentDirectory();
+            }
+
+            rootPath = rootPath.EndsWith(directorySeparatorChar) || rootPath.EndsWith(altDirectorySeparatorChar) ? rootPath : rootPath + directorySeparatorChar;
+            rootPath = this.GetFullPath(rootPath);
+
+            return (rootPath, relativePattern);
+        }
+    }
+}

--- a/src/Bicep.Cli/Arguments/PublishArguments.cs
+++ b/src/Bicep.Cli/Arguments/PublishArguments.cs
@@ -4,7 +4,7 @@ using Bicep.Cli.Extensions;
 
 namespace Bicep.Cli.Arguments
 {
-    public class PublishArguments : ArgumentsBase
+    public class PublishArguments : ArgumentsBase, IInputArguments
     {
         public PublishArguments(string[] args, IOContext io) : base(Constants.Command.Publish)
         {

--- a/src/Bicep.Cli/Commands/BuildCommand.cs
+++ b/src/Bicep.Cli/Commands/BuildCommand.cs
@@ -1,48 +1,45 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.IO.Abstractions;
 using Bicep.Cli.Arguments;
 using Bicep.Cli.Helpers;
 using Bicep.Cli.Logging;
 using Bicep.Cli.Services;
 using Bicep.Core;
-using Bicep.Core.Features;
-using Bicep.Core.FileSystem;
-using Bicep.Core.Utils;
-using Microsoft.Extensions.FileSystemGlobbing;
+using Bicep.IO.Abstraction;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 
 namespace Bicep.Cli.Commands;
 
 public class BuildCommand(
     ILogger logger,
-    IEnvironment environment,
+    InputOutputArgumentsResolver inputOutputArgumentsResolver,
     DiagnosticLogger diagnosticLogger,
     BicepCompiler compiler,
     OutputWriter writer) : ICommand
 {
     public async Task<int> RunAsync(BuildArguments args)
     {
-        if (args.InputFile is null)
+        var hasErrors = false;
+        var inputOutputUriPairs = inputOutputArgumentsResolver.ResolveFilePatternInputOutputArguments(args);
+        var outputToStdOut = inputOutputUriPairs.Count == 1 && args.OutputToStdOut; // If there are multiple input files, we ignore the args.OutputToStdOut flag.
+
+        foreach (var (inputUri, outputUri) in inputOutputUriPairs)
         {
-            var summaryMultiple = await CompileMultiple(args);
-            return CommandHelper.GetExitCode(summaryMultiple);
+            ArgumentHelper.ValidateBicepFile(inputUri);
+
+            var result = await Compile(inputUri, outputUri, args.NoRestore, args.DiagnosticsFormat, outputToStdOut);
+            hasErrors |= result.HasErrors;
         }
 
-        var inputUri = ArgumentHelper.GetFileUri(args.InputFile);
-        ArgumentHelper.ValidateBicepFile(inputUri);
+        var summary = new DiagnosticSummary(hasErrors);
 
-        var outputUri = CommandHelper.GetJsonOutputUri(inputUri, args.OutputDir, args.OutputFile);
-
-        var summary = await Compile(inputUri, outputUri, args.NoRestore, args.DiagnosticsFormat, args.OutputToStdOut);
         return CommandHelper.GetExitCode(summary);
     }
 
-    private async Task<DiagnosticSummary> Compile(Uri inputUri, Uri outputUri, bool noRestore, DiagnosticsFormat? diagnosticsFormat, bool outputToStdOut)
+    private async Task<DiagnosticSummary> Compile(IOUri inputUri, IOUri outputUri, bool noRestore, DiagnosticsFormat? diagnosticsFormat, bool outputToStdOut)
     {
-        var compilation = await compiler.CreateCompilation(inputUri, skipRestore: noRestore);
+        var compilation = await compiler.CreateCompilation(inputUri.ToUri(), skipRestore: noRestore);
         CommandHelper.LogExperimentalWarning(logger, compilation);
 
         var summary = diagnosticLogger.LogDiagnostics(ArgumentHelper.GetDiagnosticOptions(diagnosticsFormat), compilation);
@@ -60,20 +57,5 @@ public class BuildCommand(
         }
 
         return summary;
-    }
-
-    public async Task<DiagnosticSummary> CompileMultiple(BuildArguments args)
-    {
-        var hasErrors = false;
-
-        foreach (var (inputUri, outputUri) in CommandHelper.GetInputAndOutputFilesForPattern(environment, args.FilePattern, args.OutputDir, PathHelper.GetJsonOutputPath))
-        {
-            ArgumentHelper.ValidateBicepFile(inputUri);
-
-            var result = await Compile(inputUri, outputUri, args.NoRestore, args.DiagnosticsFormat, false);
-            hasErrors |= result.HasErrors;
-        }
-
-        return new(hasErrors);
     }
 }

--- a/src/Bicep.Cli/Helpers/ArgumentHelper.cs
+++ b/src/Bicep.Cli/Helpers/ArgumentHelper.cs
@@ -5,7 +5,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Bicep.Cli.Arguments;
 using Bicep.Cli.Logging;
+using Bicep.Core.Extensions;
 using Bicep.Core.FileSystem;
+using Bicep.IO.Abstraction;
 using Json.Patch;
 
 namespace Bicep.Cli.Helpers;
@@ -42,6 +44,14 @@ public class ArgumentHelper
     [return: NotNullIfNotNull(nameof(filePath))]
     public static Uri? GetFileUri(string? filePath, IFileSystem? fileSystem = null)
         => filePath is { } ? PathHelper.FilePathToFileUrl(PathHelper.ResolvePath(filePath, fileSystem: fileSystem)) : null;
+
+    public static void ValidateBicepFile(IOUri fileUri)
+    {
+        if (!fileUri.HasBicepExtension())
+        {
+            throw new CommandLineException(string.Format(CliResources.UnrecognizedBicepFileExtensionMessage, fileUri.ToString()));
+        }
+    }
 
     public static void ValidateBicepFile(Uri fileUri)
     {

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -167,6 +167,7 @@ namespace Bicep.Cli
                 .AddLocalDeploy()
                 .AddCommands()
                 .AddSingleton(CreateLoggerFactory(io).CreateLogger("bicep"))
+                .AddSingleton<InputOutputArgumentsResolver>()
                 .AddSingleton<DiagnosticLogger>()
                 .AddSingleton<OutputWriter>()
                 .AddSingleton<PlaceholderParametersWriter>()

--- a/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/ErrorBuilderTests.cs
@@ -226,7 +226,7 @@ namespace Bicep.Core.UnitTests.Diagnostics
                 return ArtifactType.Module;
             }
 
-            if (parameter.ParameterType == typeof(IOUri) || parameter.ParameterType == typeof(IOUri?))
+            if (parameter.ParameterType == typeof(IOUri))
             {
                 return new IOUri("file", "", "/foo");
             }

--- a/src/Bicep.Core/Extensions/IFileHandleExtensions.cs
+++ b/src/Bicep.Core/Extensions/IFileHandleExtensions.cs
@@ -90,10 +90,9 @@ namespace Bicep.Core.Extensions
         public static void Write(this IFileHandle fileHandle, string text)
         {
             using var fileStream = fileHandle.OpenWrite();
-            using var writer = new StreamWriter(fileStream);
+            using var writer = new StreamWriter(fileStream, leaveOpen: true);
+
             writer.Write(text);
-            // without this, we may leave old data behind if the new text is shorter than the old one
-            fileStream.SetLength(text.Length);
         }
 
         private static ResultWithDiagnosticBuilder<T> HandleFileReadError<T>(Func<T> readOperation) => HandleFileReadError(() => new ResultWithDiagnosticBuilder<T>(readOperation()));

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -138,7 +138,7 @@ namespace Bicep.Core.Registry
                             throw new InvalidOperationException("The configuration file URI must be set when trying to resolve an extension reference.");
                         }
 
-                        var extensionUri = config.ConfigFileUri.Value.Resolve(extensionPath);
+                        var extensionUri = config.ConfigFileUri.Resolve(extensionPath);
 
                         return new(extensionUri.GetPathRelativeTo(referencingFile.FileHandle.Uri));
                     }

--- a/src/Bicep.Core/Registry/Oci/OciArtifactAddressComponents.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactAddressComponents.cs
@@ -7,7 +7,7 @@ using Bicep.Core.Diagnostics;
 
 namespace Bicep.Core.Registry.Oci
 {
-    public readonly struct OciArtifactAddressComponents : IOciArtifactAddressComponents
+    public class OciArtifactAddressComponents : IOciArtifactAddressComponents, IEquatable<OciArtifactAddressComponents>
     {
         public OciArtifactAddressComponents(string registry, string repository, string? tag, string? digest)
         {
@@ -52,20 +52,14 @@ namespace Bicep.Core.Registry.Oci
             ? $"{this.Registry}/{this.Repository}:{this.Tag}"
             : $"{this.Registry}/{this.Repository}@{this.Digest}";
 
+        public bool Equals(OciArtifactAddressComponents? other) =>
+            other is not null &&
+            OciArtifactReferenceFacts.RegistryComparer.Equals(this.Registry, other.Registry) &&
+            OciArtifactReferenceFacts.RepositoryComparer.Equals(this.Repository, other.Repository) &&
+            OciArtifactReferenceFacts.TagComparer.Equals(this.Tag, other.Tag) &&
+            OciArtifactReferenceFacts.DigestComparer.Equals(this.Digest, other.Digest);
 
-        public override bool Equals(object? obj)
-        {
-            if (obj is not OciArtifactAddressComponents other)
-            {
-                return false;
-            }
-
-            return
-                OciArtifactReferenceFacts.RegistryComparer.Equals(this.Registry, other.Registry) &&
-                OciArtifactReferenceFacts.RepositoryComparer.Equals(this.Repository, other.Repository) &&
-                OciArtifactReferenceFacts.TagComparer.Equals(this.Tag, other.Tag) &&
-                OciArtifactReferenceFacts.DigestComparer.Equals(this.Digest, other.Digest);
-        }
+        public override bool Equals(object? obj) => this.Equals(obj as OciArtifactAddressComponents);
 
         public override int GetHashCode()
         {

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -35,7 +35,7 @@ namespace Bicep.Core.Semantics.Namespaces
 {
     public static class SystemNamespaceType
     {
-        private readonly record struct LoadTextContentResult(IOUri FileUri, string Content);
+        private record LoadTextContentResult(IOUri FileUri, string Content);
 
         public const string BuiltInName = "sys";
         public const long UniqueStringHashLength = 13;

--- a/src/Bicep.Core/SourceLink/ArchivedSourceFileLink.cs
+++ b/src/Bicep.Core/SourceLink/ArchivedSourceFileLink.cs
@@ -10,6 +10,6 @@ namespace Bicep.Core.SourceLink;
 /// </summary>
 /// <param name="Range">Span of the origin of this link in the source file (e.g. the module path of a module declaration syntax line)</param>
 /// <param name="Target">The target file for this link (e.g. the path of the source file pointed to by the module path inside the source.tgz file)</param>
-public readonly record struct ArchivedSourceFileLink(TextRange Range, string Target)
+public record ArchivedSourceFileLink(TextRange Range, string Target)
 {
 }

--- a/src/Bicep.IO/Abstraction/IOUri.cs
+++ b/src/Bicep.IO/Abstraction/IOUri.cs
@@ -30,7 +30,7 @@ namespace Bicep.IO.Abstraction
     /// <see href="https://datatracker.ietf.org/doc/html/rfc8089">RFC8089</see>
     /// to satisfy the functionality requirements of Bicep.
     /// </remarks>
-    public readonly struct IOUri : IEquatable<IOUri>
+    public class IOUri : IEquatable<IOUri>
     {
         public static class GlobalSettings
         {
@@ -147,7 +147,8 @@ namespace Bicep.IO.Abstraction
 
         public override bool Equals(object? @object) => @object is IOUri other && this.Equals(other);
 
-        public bool Equals(IOUri other) =>
+        public bool Equals(IOUri? other) =>
+            other is not null &&
             this.SchemeEquals(other) &&
             this.AuthorityEquals(other) &&
             this.PathEquals(other) &&

--- a/src/Bicep.IO/Abstraction/IOUriExtensions.cs
+++ b/src/Bicep.IO/Abstraction/IOUriExtensions.cs
@@ -11,6 +11,19 @@ namespace Bicep.IO.Abstraction
 {
     public static class IOUriExtensions
     {
+        public static ReadOnlySpan<char> GetFileNameWithoutExtension(this IOUri uri)
+        {
+            var fileName = uri.PathSegments.LastOrDefault() ?? "";
+            int lastDotIndex = GetExtensionStartIndex(fileName);
+
+            if (lastDotIndex == -1)
+            {
+                return fileName.AsSpan();
+            }
+
+            return fileName.AsSpan(0, lastDotIndex);
+        }
+
         public static ReadOnlySpan<char> GetExtension(this IOUri uri)
         {
             int lastDotIndex = GetExtensionStartIndex(uri.Path);

--- a/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
@@ -40,7 +40,7 @@ namespace Bicep.IO.FileSystem
         {
             this.GetParent().EnsureExists();
 
-            return this.FileSystem.File.OpenWrite(this.FilePath);
+            return this.FileSystem.FileStream.New(this.FilePath, FileMode.Create, FileAccess.Write, FileShare.None);
         }
 
         public void Delete() => this.FileSystem.File.Delete(this.FilePath);

--- a/src/Bicep.LangServer/Handlers/BicepDeploymentGraphHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDeploymentGraphHandler.cs
@@ -100,7 +100,7 @@ namespace Bicep.LanguageServer.Handlers
                         var moduleRelativePath = moduleSymbol.DeclaringModule.TryGetPath()?.TryGetLiteralValue();
                         var moduleFileUri = moduleRelativePath is not null
                             ? directoryUri.Resolve(moduleRelativePath)
-                            : (IOUri?)null;
+                            : null;
 
                         var isCollection = moduleSymbol.IsCollection;
                         var moduleSpan = moduleSymbol.DeclaringModule.Span;
@@ -109,13 +109,13 @@ namespace Bicep.LanguageServer.Handlers
 
                         var hasChildren = false;
 
-                        if (moduleFileUri.HasValue &&
+                        if (moduleFileUri is not null &&
                             moduleSymbol.TryGetSemanticModel().IsSuccess(out var moduleSemanticModel, out var _) &&
                             moduleSemanticModel is SemanticModel bicepModel &&
                             (bicepModel.Root.ResourceDeclarations.Any() || bicepModel.Root.ModuleDeclarations.Any()))
                         {
                             hasChildren = true;
-                            queue.Enqueue((bicepModel, moduleFileUri.Value, id));
+                            queue.Enqueue((bicepModel, moduleFileUri, id));
                         }
 
                         nodesBySymbol[symbol] = new BicepDeploymentGraphNode(id, "<module>", isCollection, range, hasChildren, moduleHasError, fileUri);

--- a/src/Bicep.Local.Deploy/Engine/LocalDeploymentEngineHost.cs
+++ b/src/Bicep.Local.Deploy/Engine/LocalDeploymentEngineHost.cs
@@ -30,7 +30,7 @@ public class LocalDeploymentEngineHost : DeploymentEngineHostBase
 {
     private readonly LocalExtensionDispatcher extensionHostManager;
 
-    public readonly record struct ExtensionInfo(string ExtensionName, string ExtensionVersion, string Method);
+    public record ExtensionInfo(string ExtensionName, string ExtensionVersion, string Method);
 
     public LocalDeploymentEngineHost(
         LocalExtensionDispatcher extensionHostManager,

--- a/src/Bicep.TestFixtures/Bicep.TextFixtures/Utils/TestExternalArtifactManager.cs
+++ b/src/Bicep.TestFixtures/Bicep.TextFixtures/Utils/TestExternalArtifactManager.cs
@@ -14,7 +14,7 @@ namespace Bicep.TextFixtures.Utils
 {
     public class TestExternalArtifactManager
     {
-        public readonly record struct RegistryModulePublishArguments(string ModuleArtifactId, string ModuleContent, bool WithSource = false, string? DocumentationUri = null);
+        public record RegistryModulePublishArguments(string ModuleArtifactId, string ModuleContent, bool WithSource = false, string? DocumentationUri = null);
 
         private readonly FakeContainerRegistryClientFactory containerRegistryClientFactory;
         private readonly FakeTemplateSpecRepository templateSpecRepository;


### PR DESCRIPTION
This is a relatively small migration PR with the following changes:

- Migrated the `Bicep.Cli.BuildCommand` class and its dependencies to use `Bicep.IO and IFileSystem`, removing reliance on System.IO. This sets the foundation for migrating other CLI commands in future PRs.
- Refactored several large structs into classes to improve maintainability and reduce value-type overhead.
- Fixes a bug in `FileSystemFileHandle.OpenWrite`: Previously, it used `IFileSystem.File.OpenWrite()`, which internally uses `FileMode.OpenOrCreate`. This led to race conditions in tests because it doesn't clear existing file contents. The fix is to explicitly create a `FileStream` with `FileMode.Create` to ensure that the file is always overwritten.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17516)