### PR TITLE
Add linter rule to warn on usage of outdated AzPowerShell version in deployment scripts

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseLatestAzPowerShellVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseLatestAzPowerShellVersionRuleTests.cs
@@ -1,83 +1,68 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Bicep.Core.UnitTests.Assertions;
-using FluentAssertions;
+using Bicep.Core.Analyzers.Linter.Rules;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests;
+
+[TestClass]
+public class UseLatestAzPowerShellVersionRuleTests : LinterRuleTestsBase
 {
-    [TestClass]
-    public class UseLatestAzPowerShellVersionRuleTests : LinterRuleTestsBase
+    private void CompileAndTest(string text, int expectedDiagnosticCount, Options? options = null)
     {
-        [TestMethod]
-        public void DeploymentScriptWithOldVersion_ShouldWarn()
-        {
-            var result = Compile(@"
-resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-  name: 'test-script'
-  location: resourceGroup().location
-  kind: 'AzurePowerShell'
-  properties: {
-    azPowerShellVersion: '3.0'
-    scriptContent: 'Write-Output \"Hello World\"'
-    retentionInterval: 'PT1H'
-  }
-}");
-
-            result.Should().HaveDiagnostics(new[] {
-                ("use-latest-az-powershell-version", DiagnosticLevel.Warning, "Deployment script is using AzPowerShell version '3.0' which is below the recommended minimum version '11.0'. Consider upgrading to version 11.0 or higher to avoid EOL Ubuntu 20.04 LTS."),
-            });
-        }
-
-        [TestMethod]
-        public void DeploymentScriptWithNewVersion_ShouldNotWarn()
-        {
-            var result = Compile(@"
-resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-  name: 'test-script'
-  location: resourceGroup().location
-  kind: 'AzurePowerShell'
-  properties: {
-    azPowerShellVersion: '11.0'
-    scriptContent: 'Write-Output \"Hello World\"'
-    retentionInterval: 'PT1H'
-  }
-}");
-
-            result.Should().NotHaveAnyDiagnostics();
-        }
-
-        [TestMethod]
-        public void NonDeploymentScriptResource_ShouldNotWarn()
-        {
-            var result = Compile(@"
-resource storage 'Microsoft.Storage/storageAccounts@2021-02-01' = {
-  name: 'teststorage'
-  location: resourceGroup().location
-  sku: {
-    name: 'Standard_LRS'
-  }
-}");
-
-            result.Should().NotHaveAnyDiagnostics();
-        }
-
-        [TestMethod]
-        public void DeploymentScriptWithoutAzPowerShellVersion_ShouldNotWarn()
-        {
-            var result = Compile(@"
-resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-  name: 'test-script'
-  location: resourceGroup().location
-  kind: 'AzureCLI'
-  properties: {
-    scriptContent: 'echo \"Hello World\"'
-    retentionInterval: 'PT1H'
-  }
-}");
-
-            result.Should().NotHaveAnyDiagnostics();
-        }
+        AssertLinterRuleDiagnostics(UseLatestAzPowerShellVersionRule.Code, text, expectedDiagnosticCount, options);
     }
+
+    [DataRow("""
+    resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+      name: 'test-script'
+      location: resourceGroup().location
+      kind: 'AzurePowerShell'
+      properties: {
+        azPowerShellVersion: '3.0'
+        scriptContent: 'Write-Output "Hello World"'
+        retentionInterval: 'PT1H'
+      }
+    }
+    """)]
+    [TestMethod]
+    public void Linter_validation_should_warn_for_old_azpowershell_version(string text)
+        => CompileAndTest(text, 1);
+
+    [DataRow("""
+    resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+      name: 'test-script'
+      location: resourceGroup().location
+      kind: 'AzurePowerShell'
+      properties: {
+        azPowerShellVersion: '11.0'
+        scriptContent: 'Write-Output "Hello World"'
+        retentionInterval: 'PT1H'
+      }
+    }
+    """)]
+    [DataRow("""
+    resource storage 'Microsoft.Storage/storageAccounts@2021-02-01' = {
+      name: 'teststorage'
+      location: resourceGroup().location
+      sku: {
+        name: 'Standard_LRS'
+      }
+    }
+    """)]
+    [DataRow("""
+    resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+      name: 'test-script'
+      location: resourceGroup().location
+      kind: 'AzureCLI'
+      properties: {
+        scriptContent: 'echo "Hello World"'
+        retentionInterval: 'PT1H'
+      }
+    }
+    """)]
+    [TestMethod]
+    public void Linter_validation_should_not_warn_for_new_or_irrelevant_cases(string text)
+        => CompileAndTest(text, 0);
 } 

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseLatestAzPowerShellVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseLatestAzPowerShellVersionRuleTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.UnitTests.Assertions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
+{
+    [TestClass]
+    public class UseLatestAzPowerShellVersionRuleTests : LinterRuleTestsBase
+    {
+        [TestMethod]
+        public void DeploymentScriptWithOldVersion_ShouldWarn()
+        {
+            var result = Compile(@"
+resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: 'test-script'
+  location: resourceGroup().location
+  kind: 'AzurePowerShell'
+  properties: {
+    azPowerShellVersion: '3.0'
+    scriptContent: 'Write-Output \"Hello World\"'
+    retentionInterval: 'PT1H'
+  }
+}");
+
+            result.Should().HaveDiagnostics(new[] {
+                ("use-latest-az-powershell-version", DiagnosticLevel.Warning, "Deployment script is using AzPowerShell version '3.0' which is below the recommended minimum version '11.0'. Consider upgrading to version 11.0 or higher to avoid EOL Ubuntu 20.04 LTS."),
+            });
+        }
+
+        [TestMethod]
+        public void DeploymentScriptWithNewVersion_ShouldNotWarn()
+        {
+            var result = Compile(@"
+resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: 'test-script'
+  location: resourceGroup().location
+  kind: 'AzurePowerShell'
+  properties: {
+    azPowerShellVersion: '11.0'
+    scriptContent: 'Write-Output \"Hello World\"'
+    retentionInterval: 'PT1H'
+  }
+}");
+
+            result.Should().NotHaveAnyDiagnostics();
+        }
+
+        [TestMethod]
+        public void NonDeploymentScriptResource_ShouldNotWarn()
+        {
+            var result = Compile(@"
+resource storage 'Microsoft.Storage/storageAccounts@2021-02-01' = {
+  name: 'teststorage'
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+}");
+
+            result.Should().NotHaveAnyDiagnostics();
+        }
+
+        [TestMethod]
+        public void DeploymentScriptWithoutAzPowerShellVersion_ShouldNotWarn()
+        {
+            var result = Compile(@"
+resource script 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: 'test-script'
+  location: resourceGroup().location
+  kind: 'AzureCLI'
+  properties: {
+    scriptContent: 'echo \"Hello World\"'
+    retentionInterval: 'PT1H'
+  }
+}");
+
+            result.Should().NotHaveAnyDiagnostics();
+        }
+    }
+} 

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseLatestAzPowerShellVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseLatestAzPowerShellVersionRule.cs
@@ -68,8 +68,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             private bool IsDeploymentScriptResource(ResourceDeclarationSyntax syntax)
             {
-                return syntax.TypeString?.StringTokens.Any(token =>
-                    token.Value.Contains("Microsoft.Resources/deploymentScripts")) == true;
+                return syntax.TypeString?.TryGetLiteralValue()?.Contains("Microsoft.Resources/deploymentScripts") == true;
             }
 
             private string? GetAzPowerShellVersion(ResourceDeclarationSyntax syntax)
@@ -89,7 +88,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
                         if (azPowerShellVersionProperty?.Value is StringSyntax stringSyntax)
                         {
-                            return stringSyntax.SegmentValues.FirstOrDefault();
+                            return stringSyntax.TryGetLiteralValue();
                         }
                     }
                 }
@@ -99,7 +98,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             private bool IsVersionBelowMinimum(string version)
             {
                 if (string.IsNullOrWhiteSpace(version))
+                {
                     return false;
+                }
                 if (Version.TryParse(version, out var parsedVersion) &&
                     Version.TryParse(MinimumAzPowerShellVersion, out var minimumVersion))
                 {

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseLatestAzPowerShellVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseLatestAzPowerShellVersionRule.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.CodeAction;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
+using Bicep.Core.Syntax;
+using Bicep.Core.Text;
+using System.Globalization;
+
+namespace Bicep.Core.Analyzers.Linter.Rules
+{
+    public sealed class UseLatestAzPowerShellVersionRule : LinterRuleBase
+    {
+        public new const string Code = "use-latest-az-powershell-version";
+        private const string MinimumAzPowerShellVersion = "11.0";
+
+        public UseLatestAzPowerShellVersionRule() : base(
+            code: Code,
+            description: CoreResources.UseLatestAzPowerShellVersionRuleDescription,
+            LinterRuleCategory.BestPractice)
+        { }
+
+        public override string FormatMessage(params object[] values)
+        {
+            return string.Format(CoreResources.UseLatestAzPowerShellVersionRuleMessageFormat, values);
+        }
+
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
+        {
+            var visitor = new DeploymentScriptVisitor(this, model, diagnosticLevel);
+            visitor.Visit(model.SourceFile.ProgramSyntax);
+            return visitor.Diagnostics;
+        }
+
+        private class DeploymentScriptVisitor : AstVisitor
+        {
+            private readonly UseLatestAzPowerShellVersionRule rule;
+            private readonly SemanticModel model;
+            private readonly DiagnosticLevel diagnosticLevel;
+            private readonly List<IDiagnostic> diagnostics = new();
+
+            public IEnumerable<IDiagnostic> Diagnostics => diagnostics;
+
+            public DeploymentScriptVisitor(UseLatestAzPowerShellVersionRule rule, SemanticModel model, DiagnosticLevel diagnosticLevel)
+            {
+                this.rule = rule;
+                this.model = model;
+                this.diagnosticLevel = diagnosticLevel;
+            }
+
+            public override void VisitResourceDeclarationSyntax(ResourceDeclarationSyntax syntax)
+            {
+                if (IsDeploymentScriptResource(syntax))
+                {
+                    var azPowerShellVersion = GetAzPowerShellVersion(syntax);
+                    if (azPowerShellVersion != null && IsVersionBelowMinimum(azPowerShellVersion))
+                    {
+                        diagnostics.Add(rule.CreateDiagnosticForSpan(
+                            diagnosticLevel,
+                            syntax.Span,
+                            azPowerShellVersion,
+                            MinimumAzPowerShellVersion));
+                    }
+                }
+                base.VisitResourceDeclarationSyntax(syntax);
+            }
+
+            private bool IsDeploymentScriptResource(ResourceDeclarationSyntax syntax)
+            {
+                return syntax.TypeString?.StringTokens.Any(token =>
+                    token.Value.Contains("Microsoft.Resources/deploymentScripts")) == true;
+            }
+
+            private string? GetAzPowerShellVersion(ResourceDeclarationSyntax syntax)
+            {
+                if (syntax.Value is ObjectSyntax objectSyntax)
+                {
+                    var properties = objectSyntax.Properties;
+                    var propertiesProperty = properties.FirstOrDefault(p =>
+                        p.Key is IdentifierSyntax identifier &&
+                        identifier.IdentifierName == "properties");
+
+                    if (propertiesProperty?.Value is ObjectSyntax propertiesObject)
+                    {
+                        var azPowerShellVersionProperty = propertiesObject.Properties.FirstOrDefault(p =>
+                            p.Key is IdentifierSyntax identifier &&
+                            identifier.IdentifierName == "azPowerShellVersion");
+
+                        if (azPowerShellVersionProperty?.Value is StringSyntax stringSyntax)
+                        {
+                            return stringSyntax.SegmentValues.FirstOrDefault();
+                        }
+                    }
+                }
+                return null;
+            }
+
+            private bool IsVersionBelowMinimum(string version)
+            {
+                if (string.IsNullOrWhiteSpace(version))
+                    return false;
+                if (Version.TryParse(version, out var parsedVersion) &&
+                    Version.TryParse(MinimumAzPowerShellVersion, out var minimumVersion))
+                {
+                    return parsedVersion < minimumVersion;
+                }
+                return false;
+            }
+        }
+    }
+} 

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -1201,5 +1201,22 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("WhatIfShortCircuitingRuleMessageFormat", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use AzPowerShell version 11.0 or higher in deployment scripts to avoid EOL Ubuntu 20.04 LTS.
+        /// </summary>
+        internal static string UseLatestAzPowerShellVersionRuleDescription {
+            get {
+                return ResourceManager.GetString("UseLatestAzPowerShellVersionRuleDescription", resourceCulture);
+            }
+        }
+        /// <summary>
+        ///   Looks up a localized string similar to Deployment script is using AzPowerShell version '{0}' which is below the recommended minimum version '{1}'. Consider upgrading to version 11.0 or higher to avoid EOL Ubuntu 20.04 LTS.
+        /// </summary>
+        internal static string UseLatestAzPowerShellVersionRuleMessageFormat {
+            get {
+                return ResourceManager.GetString("UseLatestAzPowerShellVersionRuleMessageFormat", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -544,4 +544,10 @@
   <data name="ImportMustBeUsedRuleMessageFormat" xml:space="preserve">
     <value>Import "{0}" is declared but never used.</value>
   </data>
+  <data name="UseLatestAzPowerShellVersionRuleDescription" xml:space="preserve">
+    <value>Use AzPowerShell version 11.0 or higher in deployment scripts to avoid EOL Ubuntu 20.04 LTS</value>
+  </data>
+  <data name="UseLatestAzPowerShellVersionRuleMessageFormat" xml:space="preserve">
+    <value>Deployment script is using AzPowerShell version '{0}' which is below the recommended minimum version '{1}'. Consider upgrading to version 11.0 or higher to avoid EOL Ubuntu 20.04 LTS.</value>
+  </data>
 </root>

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -776,6 +776,16 @@
                       "$ref": "#/definitions/rule-def-level-off"
                     }
                   ]
+                },
+                "use-latest-az-powershell-version": {
+                  "allOf": [
+                    {
+                      "description": "Use AzPowerShell version 11.0 or higher in deployment scripts to avoid EOL Ubuntu 20.04 LTS. Defaults to 'Warning'. See https://aka.ms/bicep/linter-diagnostics#use-latest-az-powershell-version"
+                    },
+                    {
+                      "$ref": "#/definitions/rule-def-level-warning"
+                    }
+                  ]
                 }
               }
             }


### PR DESCRIPTION
## Description

Fixes #8805 

This change will now warn users if they use an older version of Powershell in Deployment Scripts, since container images rely on Ubuntu versions. As per documentation from Ubuntu the version 20.04 LTS reached EOL on May 31, 2025, which corresponds to Powershell version 11.

Seems like this documentation is outdated: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-script-develop?tabs=PowerShell, it says an older version from Ubuntu:

![image](https://github.com/user-attachments/assets/0b3c8532-702a-44e5-8a45-e91145a5f703)

## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
