### PR TITLE
Remove deprecated CLI arguments

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/FormatCommandTests.cs
@@ -20,21 +20,6 @@ namespace Bicep.Cli.IntegrationTests
     public partial class FormatCommandTests : TestBase
     {
         [TestMethod]
-        public async Task Format_WithDeprecatedParams_PrintsDeprecationMessage()
-        {
-            var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", "output myOutput string = 'hello!'");
-
-            var (output, error, result) = await Bicep("format", bicepPath, "--newline", "crlf", "--indentKind", "space", "--indentSize", "4", "--insertFinalNewline");
-
-            result.Should().Be(0);
-            output.Should().BeEmpty();
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --newline is deprecated and will be removed in a future version of Bicep CLI. Use --newline-kind instead.");
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --indentKind is deprecated and will be removed in a future version of Bicep CLI. Use --indent-kind instead.");
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --indentSize is deprecated and will be removed in a future version of Bicep CLI. Use --indent-size instead.");
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --insertFinalNewline is deprecated and will be removed in a future version of Bicep CLI. Use --insert-final-newline instead.");
-        }
-
-        [TestMethod]
         public async Task Format_WithLegacyFormatterEnabled_InvokesLegacyFormatter()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()

--- a/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/PublishCommandTests.cs
@@ -130,20 +130,6 @@ namespace Bicep.Cli.IntegrationTests
             error.Should().MatchRegex(@"The --documentation-uri should be a well formed uri string.");
         }
 
-        // TODO: Enable this once Azure CLI is updated to support the new parameters.
-        [TestMethod]
-        public async Task Publish_WithDeprecatedParameter_PrintsDeprecationMessage()
-        {
-            var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
-            var bicepPath = FileHelper.SaveResultFile(TestContext, "input.bicep", @"output myOutput string = 'hello!'");
-            var (output, error, result) = await Bicep(settings, "publish", bicepPath, "--target", "br:example.azurecr.io/hello/there:v1", "--documentationUri", "invalid_uri");
-
-            result.Should().Be(1);
-            output.Should().BeEmpty();
-            error.Should().MatchRegex(@"The --documentationUri should be a well formed uri string.");
-            error.Should().MatchRegex(@"DEPRECATED: The parameter --documentationUri is deprecated and will be removed in a future version of Bicep CLI. Use --documentation-uri instead.");
-        }
-
         [DataTestMethod]
         [DynamicData(nameof(GetValidDataSetsWithDocUriAndPublishSource), DynamicDataSourceType.Method, DynamicDataDisplayName = nameof(GetTestDisplayName))]
         public async Task Publish_AllValidDataSets_ShouldSucceed(string testName, DataSet dataSet, string documentationUri, bool publishSource)

--- a/src/Bicep.Cli.UnitTests/ArgumentParserTests.cs
+++ b/src/Bicep.Cli.UnitTests/ArgumentParserTests.cs
@@ -11,21 +11,19 @@ namespace Bicep.Cli.UnitTests
     [TestClass]
     public class ArgumentParserTests
     {
-        private static readonly IOContext IO = new(new StringWriter(), new StringWriter());
-
         private static readonly IFileSystem FileSystem = new FileSystem();
 
         [TestMethod]
         public void Empty_parameters_should_return_null()
         {
-            var arguments = ArgumentParser.TryParse([], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse([], FileSystem);
             arguments.Should().BeNull();
         }
 
         [TestMethod]
         public void Wrong_command_should_return_null()
         {
-            var arguments = ArgumentParser.TryParse(["wrong"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["wrong"], FileSystem);
             arguments.Should().BeNull();
         }
 
@@ -102,7 +100,7 @@ namespace Bicep.Cli.UnitTests
         [DataRow(new[] { "format", "--fake" }, "Unrecognized parameter \"--fake\"")]
         public void Invalid_args_trigger_validation_exceptions(string[] parameters, string expectedException)
         {
-            Action parseFunc = () => ArgumentParser.TryParse(parameters, IO, FileSystem);
+            Action parseFunc = () => ArgumentParser.TryParse(parameters, FileSystem);
 
             parseFunc.Should().Throw<CommandLineException>().WithMessage(expectedException);
         }
@@ -110,7 +108,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFile_ShouldReturnOneFile()
         {
-            var arguments = ArgumentParser.TryParse(["build", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["build", "file1"], FileSystem);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -125,7 +123,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFileStdOut_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(["build", "--stdout", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["build", "--stdout", "file1"], FileSystem);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -140,7 +138,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFileStdOut_and_no_restore_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(["build", "--stdout", "--no-restore", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["build", "--stdout", "--no-restore", "file1"], FileSystem);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -155,7 +153,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void BuildOneFileStdOutAllCaps_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(["build", "--STDOUT", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["build", "--STDOUT", "file1"], FileSystem);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -171,7 +169,7 @@ namespace Bicep.Cli.UnitTests
         public void Build_with_outputdir_parameter_should_parse_correctly()
         {
             // Use relative . to ensure directory exists else the parser will throw.
-            var arguments = ArgumentParser.TryParse(["build", "--outdir", ".", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["build", "--outdir", ".", "file1"], FileSystem);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -187,7 +185,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Build_with_outputfile_parameter_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(["build", "--outfile", "jsonFile", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["build", "--outfile", "jsonFile", "file1"], FileSystem);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -202,7 +200,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Build_with_outputfile_and_no_restore_parameter_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(["build", "--outfile", "jsonFile", "file1", "--no-restore"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["build", "--outfile", "jsonFile", "file1", "--no-restore"], FileSystem);
             var buildArguments = (BuildArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -217,7 +215,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void License_argument_should_return_appropriate_RootArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(["--license"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["--license"], FileSystem);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -232,7 +230,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Third_party_notices_argument_should_return_appropriate_RootArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(["--third-party-notices"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["--third-party-notices"], FileSystem);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -247,7 +245,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Version_argument_should_return_VersionArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(["--version"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["--version"], FileSystem);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -262,7 +260,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Help_argument_should_return_HelpArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(["--help"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["--help"], FileSystem);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -277,7 +275,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Version_argument_should_return_VersionShortArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(["-v"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["-v"], FileSystem);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -292,7 +290,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Help_argument_should_return_HelpShortArguments_instance()
         {
-            var arguments = ArgumentParser.TryParse(["-h"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["-h"], FileSystem);
 
             arguments.Should().BeOfType<RootArguments>();
             if (arguments is RootArguments rootArguments)
@@ -307,7 +305,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void DecompileOneFile_ShouldReturnOneFile()
         {
-            var arguments = ArgumentParser.TryParse(["decompile", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["decompile", "file1"], FileSystem);
             var buildOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -321,7 +319,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void DecompileOneFileStdOut_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(["decompile", "--stdout", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["decompile", "--stdout", "file1"], FileSystem);
             var buildOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -335,7 +333,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void DecompileOneFileStdOutAllCaps_ShouldReturnOneFileAndStdout()
         {
-            var arguments = ArgumentParser.TryParse(["decompile", "--STDOUT", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["decompile", "--STDOUT", "file1"], FileSystem);
             var buildOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -350,7 +348,7 @@ namespace Bicep.Cli.UnitTests
         public void Decompile_with_outputdir_parameter_should_parse_correctly()
         {
             // Use relative . to ensure directory exists else the parser will throw.
-            var arguments = ArgumentParser.TryParse(["decompile", "--outdir", ".", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["decompile", "--outdir", ".", "file1"], FileSystem);
             var buildOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -364,7 +362,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Decompile_with_outputfile_parameter_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(["decompile", "--outfile", "jsonFile", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["decompile", "--outfile", "jsonFile", "file1"], FileSystem);
             var buildOrDecompileArguments = (DecompileArguments?)arguments;
 
             // using classic assert so R# understands the value is not null
@@ -378,7 +376,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Publish_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(["publish", "file1", "--target", "target1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["publish", "file1", "--target", "target1"], FileSystem);
             arguments.Should().BeOfType<PublishArguments>();
             var typed = (PublishArguments)arguments!;
 
@@ -390,7 +388,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Publish_with_no_restore_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(["publish", "file1", "--target", "target1", "--no-restore"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["publish", "file1", "--target", "target1", "--no-restore"], FileSystem);
             arguments.Should().BeOfType<PublishArguments>();
             var typed = (PublishArguments)arguments!;
 
@@ -402,7 +400,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Restore__with_no_force_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(["restore", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["restore", "file1"], FileSystem);
             arguments.Should().BeOfType<RestoreArguments>();
             var typed = (RestoreArguments)arguments!;
 
@@ -413,7 +411,7 @@ namespace Bicep.Cli.UnitTests
         [TestMethod]
         public void Restore_with_force_should_parse_correctly()
         {
-            var arguments = ArgumentParser.TryParse(["restore", "--force", "file1"], IO, FileSystem);
+            var arguments = ArgumentParser.TryParse(["restore", "--force", "file1"], FileSystem);
             arguments.Should().BeOfType<RestoreArguments>();
             var typed = (RestoreArguments)arguments!;
 

--- a/src/Bicep.Cli/Arguments/FormatArguments.cs
+++ b/src/Bicep.Cli/Arguments/FormatArguments.cs
@@ -12,7 +12,7 @@ namespace Bicep.Cli.Arguments;
 
 public class FormatArguments : ArgumentsBase
 {
-    public FormatArguments(string[] args, IOContext io, IFileSystem fileSystem) : base(Constants.Command.Format)
+    public FormatArguments(string[] args, IFileSystem fileSystem) : base(Constants.Command.Format)
     {
         ArgumentNullException.ThrowIfNull(fileSystem);
 
@@ -42,25 +42,6 @@ public class FormatArguments : ArgumentsBase
                     i++;
                     break;
 
-                case "--newline":
-                    io.WriteParameterDeprecationWarning("--newline", "--newline-kind");
-
-                    if (args.Length == i + 1)
-                    {
-                        throw new CommandLineException($"The --newline parameter expects an argument");
-                    }
-                    if (NewlineKind is not null)
-                    {
-                        throw new CommandLineException($"The --newline parameter cannot be specified twice");
-                    }
-                    if (!Enum.TryParse<NewlineKind>(args[i + 1], true, out var newline) || !Enum.IsDefined(newline))
-                    {
-                        throw new CommandLineException($"The --newline parameter only accepts these values: {string.Join(" | ", Enum.GetNames(typeof(NewlineKind)))}");
-                    }
-                    NewlineKind = newline;
-                    i++;
-                    break;
-
                 case "--newline-kind":
                     if (args.Length == i + 1)
                     {
@@ -70,7 +51,7 @@ public class FormatArguments : ArgumentsBase
                     {
                         throw new CommandLineException($"The --newline-kind parameter cannot be specified twice");
                     }
-                    if (!Enum.TryParse(args[i + 1], true, out newline) || !Enum.IsDefined(newline))
+                    if (!Enum.TryParse<NewlineKind>(args[i + 1], true, out var newline) || !Enum.IsDefined(newline))
                     {
                         throw new CommandLineException($"The --newline-kind parameter only accepts these values: {string.Join(" | ", Enum.GetNames(typeof(NewlineKind)))}");
                     }
@@ -78,24 +59,6 @@ public class FormatArguments : ArgumentsBase
                     i++;
                     break;
 
-                case "--indentkind":
-                    io.WriteParameterDeprecationWarning("--indentKind", "--indent-kind");
-
-                    if (args.Length == i + 1)
-                    {
-                        throw new CommandLineException($"The --indentKind parameter expects an argument");
-                    }
-                    if (IndentKind is not null)
-                    {
-                        throw new CommandLineException($"The --indentKind parameter cannot be specified twice");
-                    }
-                    if (!Enum.TryParse<IndentKind>(args[i + 1], true, out var indentKind) || !Enum.IsDefined(indentKind))
-                    {
-                        throw new CommandLineException($"The --indentKind parameter only accepts these cdvalues: {string.Join(" | ", Enum.GetNames(typeof(IndentKind)))}");
-                    }
-                    IndentKind = indentKind;
-                    i++;
-                    break;
                 case "--indent-kind":
                     if (args.Length == i + 1)
                     {
@@ -105,7 +68,7 @@ public class FormatArguments : ArgumentsBase
                     {
                         throw new CommandLineException($"The --indent-kind parameter cannot be specified twice");
                     }
-                    if (!Enum.TryParse(args[i + 1], true, out indentKind) || !Enum.IsDefined(indentKind))
+                    if (!Enum.TryParse<IndentKind>(args[i + 1], true, out var indentKind) || !Enum.IsDefined(indentKind))
                     {
                         throw new CommandLineException($"The --indent-kind parameter only accepts these values: {string.Join(" | ", Enum.GetNames(typeof(IndentKind)))}");
                     }
@@ -113,24 +76,6 @@ public class FormatArguments : ArgumentsBase
                     i++;
                     break;
 
-                case "--indentsize":
-                    io.WriteParameterDeprecationWarning("--indentSize", "--indent-size");
-
-                    if (args.Length == i + 1)
-                    {
-                        throw new CommandLineException($"The --indentSize parameter expects an argument");
-                    }
-                    if (IndentSize is not null)
-                    {
-                        throw new CommandLineException($"The --indentSize parameter cannot be specified twice");
-                    }
-                    if (!int.TryParse(args[i + 1], out var indentSize))
-                    {
-                        throw new CommandLineException($"The --indentSize parameter only accepts integer values");
-                    }
-                    IndentSize = indentSize;
-                    i++;
-                    break;
                 case "--indent-size":
                     if (args.Length == i + 1)
                     {
@@ -140,39 +85,12 @@ public class FormatArguments : ArgumentsBase
                     {
                         throw new CommandLineException($"The --indent-size parameter cannot be specified twice");
                     }
-                    if (!int.TryParse(args[i + 1], out indentSize))
+                    if (!int.TryParse(args[i + 1], out var indentSize))
                     {
                         throw new CommandLineException($"The --indent-size parameter only accepts integer values");
                     }
                     IndentSize = indentSize;
                     i++;
-                    break;
-
-                case "--insertfinalnewline":
-                    io.WriteParameterDeprecationWarning("--insertFinalNewline", "--insert-final-newline");
-
-                    if (InsertFinalNewline is not null)
-                    {
-                        throw new CommandLineException($"The --insertFinalNewline parameter cannot be specified twice");
-                    }
-
-                    if (args.Length == i + 1)
-                    {
-                        InsertFinalNewline = true;
-                        break;
-                    }
-
-                    if (bool.TryParse(args[i + 1], out var insertFinalNewline))
-                    {
-                        InsertFinalNewline = insertFinalNewline;
-                        i++;
-                    }
-                    else
-                    {
-                        // Either "true" or "false" is not supplied after "--insertFinalNewline", or the value is not a valid boolean.
-                        // Treat it as only "--insertFinalNewline" is specified without a value, and default to true.
-                        InsertFinalNewline = true;
-                    }
                     break;
 
                 case "--insert-final-newline":
@@ -187,7 +105,7 @@ public class FormatArguments : ArgumentsBase
                         break;
                     }
 
-                    if (bool.TryParse(args[i + 1], out insertFinalNewline))
+                    if (bool.TryParse(args[i + 1], out var insertFinalNewline))
                     {
                         InsertFinalNewline = insertFinalNewline;
                         i++;

--- a/src/Bicep.Cli/Arguments/PublishArguments.cs
+++ b/src/Bicep.Cli/Arguments/PublishArguments.cs
@@ -6,7 +6,7 @@ namespace Bicep.Cli.Arguments
 {
     public class PublishArguments : ArgumentsBase, IInputArguments
     {
-        public PublishArguments(string[] args, IOContext io) : base(Constants.Command.Publish)
+        public PublishArguments(string[] args) : base(Constants.Command.Publish)
         {
             for (int i = 0; i < args.Length; i++)
             {
@@ -32,29 +32,6 @@ namespace Bicep.Cli.Arguments
                         i++;
                         break;
 
-                    case "--documentationuri":
-                        // TODO: Uncomment this once Azure CLI is updated to support the new parameter.
-                        io.WriteParameterDeprecationWarning("--documentationUri", "--documentation-uri");
-
-                        if (isLast)
-                        {
-                            throw new CommandLineException("The --documentationUri parameter expects an argument.");
-                        }
-
-                        if (this.DocumentationUri is not null)
-                        {
-                            throw new CommandLineException("The --documentationUri parameter cannot be specified more than once.");
-                        }
-
-                        DocumentationUri = args[i + 1];
-
-                        if (!Uri.IsWellFormedUriString(DocumentationUri, UriKind.Absolute))
-                        {
-                            throw new CommandLineException("The --documentationUri should be a well formed uri string.");
-                        }
-
-                        i++;
-                        break;
                     case "--documentation-uri":
                         if (isLast)
                         {

--- a/src/Bicep.Cli/Arguments/PublishExtensionArguments.cs
+++ b/src/Bicep.Cli/Arguments/PublishExtensionArguments.cs
@@ -7,7 +7,8 @@ namespace Bicep.Cli.Arguments
 {
     public class PublishExtensionArguments : ArgumentsBase
     {
-        public PublishExtensionArguments(string[] args, string commandName, IOContext io) : base(commandName)
+        public PublishExtensionArguments(string[] args)
+            : base(Constants.Command.PublishExtension)
         {
             for (int i = 0; i < args.Length; i++)
             {

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -66,7 +66,7 @@ namespace Bicep.Cli
 
             try
             {
-                switch (ArgumentParser.TryParse(args, this.io, services.GetRequiredService<IFileSystem>()))
+                switch (ArgumentParser.TryParse(args, services.GetRequiredService<IFileSystem>()))
                 {
                     case BuildArguments buildArguments when buildArguments.CommandName == Constants.Command.Build: // bicep build [options]
                         return await services.GetRequiredService<BuildCommand>().RunAsync(buildArguments);

--- a/src/Bicep.Cli/Services/ArgumentParser.cs
+++ b/src/Bicep.Cli/Services/ArgumentParser.cs
@@ -9,7 +9,7 @@ namespace Bicep.Cli.Services
 {
     public static class ArgumentParser
     {
-        public static ArgumentsBase? TryParse(string[] args, IOContext io, IFileSystem fileSystem)
+        public static ArgumentsBase? TryParse(string[] args, IFileSystem fileSystem)
         {
             if (args.Length < 1)
             {
@@ -31,12 +31,12 @@ namespace Bicep.Cli.Services
                 Constants.Command.Build => new BuildArguments(args[1..]),
                 Constants.Command.Test => new TestArguments(args[1..]),
                 Constants.Command.BuildParams => new BuildParamsArguments(args[1..]),
-                Constants.Command.Format => new FormatArguments(args[1..], io, fileSystem),
+                Constants.Command.Format => new FormatArguments(args[1..], fileSystem),
                 Constants.Command.GenerateParamsFile => new GenerateParametersFileArguments(args[1..]),
                 Constants.Command.Decompile => new DecompileArguments(args[1..]),
                 Constants.Command.DecompileParams => new DecompileParamsArguments(args[1..]),
-                Constants.Command.PublishExtension => new PublishExtensionArguments(args[1..], Constants.Command.PublishExtension, io),
-                Constants.Command.Publish => new PublishArguments(args[1..], io),
+                Constants.Command.PublishExtension => new PublishExtensionArguments(args[1..]),
+                Constants.Command.Publish => new PublishArguments(args[1..]),
                 Constants.Command.Restore => new RestoreArguments(args[1..]),
                 Constants.Command.Lint => new LintArguments(args[1..]),
                 Constants.Command.JsonRpc => new JsonRpcArguments(args[1..]),


### PR DESCRIPTION
It's been a while since we added support for the new arguments in Azure CLI, so it's time to remove the deprecated ones.