### PR TITLE
Add MCP best-practices tool

### DIFF
--- a/src/Bicep.Core.UnitTests/Logging/TestContextLoggerProvider.cs
+++ b/src/Bicep.Core.UnitTests/Logging/TestContextLoggerProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Logging;
+
+public class TestContextLoggerProvider(TestContext testContext) : ILoggerProvider
+{
+    private class TestContextLogger(TestContext testContext) : ILogger, IDisposable
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            => this;
+
+        public void Dispose()
+        {
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => testContext.WriteLine($"[{logLevel}] {formatter(state, exception)}");
+    }
+
+    public ILogger CreateLogger(string categoryName)
+        => new TestContextLogger(testContext);
+
+    public void Dispose() { }
+}

--- a/src/Bicep.McpServer.UnitTests/BicepToolsTests.cs
+++ b/src/Bicep.McpServer.UnitTests/BicepToolsTests.cs
@@ -3,13 +3,10 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using Azure.Deployments.Core.Helpers;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Baselines;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.WindowsAzure.ResourceStack.Common.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Bicep.McpServer.UnitTests;
 
@@ -57,5 +54,17 @@ public class BicepToolsTests
 
         baselineFile.WriteToOutputFolder(response);
         baselineFile.ShouldHaveExpectedJsonValue();
+    }
+
+    [TestMethod]
+    public void GetBicepBestPractices_returns_best_practices_markdown()
+    {
+        var response = tools.GetBicepBestPractices();
+
+        var expectedBestPractices = BinaryData.FromStream(typeof(BicepTools).Assembly.GetManifestResourceStream("Files/bestpractices.md")!).ToString();
+        response.Should().Be(expectedBestPractices);
+
+        // Update this if the file content changes - it's just here as a sanity check to make sure we're decoding the content correctly
+        expectedBestPractices.Should().StartWith("# Bicep best-practices");
     }
 }

--- a/src/Bicep.McpServer.UnitTests/Helpers/McpServerHelper.cs
+++ b/src/Bicep.McpServer.UnitTests/Helpers/McpServerHelper.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+using Bicep.Core.UnitTests.Logging;
+using Bicep.McpServer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using OmniSharp.Extensions.LanguageServer.Server;
+
+namespace Bicep.McpServer.UnitTests.Helpers;
+
+public sealed class McpServerHelper : IAsyncDisposable
+{
+    public IHost Server { get; }
+    public IMcpClient Client { get; }
+
+    private McpServerHelper(IHost server, IMcpClient client)
+    {
+        Server = server;
+        Client = client;
+    }
+
+    /// <summary>
+    /// Creates and initializes a new MCP server using stream transport.
+    /// </summary>
+    public static async Task<McpServerHelper> StartServer(TestContext testContext, Action<IServiceCollection>? onRegisterServices = null)
+    {
+        var clientPipe = new Pipe();
+        var serverPipe = new Pipe();
+
+        var builder = Host.CreateEmptyApplicationBuilder(settings: null);
+        builder.Services
+            .AddMcpDependencies()
+            .AddMcpServer()
+            .WithStreamServerTransport(
+                inputStream: serverPipe.Reader.AsStream(),
+                outputStream: clientPipe.Writer.AsStream())
+            .WithTools<BicepTools>();
+
+        onRegisterServices?.Invoke(builder.Services);
+
+        var server = builder.Build();
+        var _ = server.RunAsync(CancellationToken.None); // do not wait on this async method, or you'll be waiting a long time!
+
+        var loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddProvider(new TestContextLoggerProvider(testContext)));
+
+        var client = await McpClientFactory.CreateAsync(
+            clientTransport: new StreamClientTransport(
+                serverInput: serverPipe.Writer.AsStream(),
+                serverOutput: clientPipe.Reader.AsStream()),
+            loggerFactory: loggerFactory,
+            cancellationToken: CancellationToken.None);
+
+        return new McpServerHelper(server, client);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Server.StopAsync();
+        await Client.DisposeAsync();
+    }
+}

--- a/src/Bicep.McpServer.UnitTests/ServerTests.cs
+++ b/src/Bicep.McpServer.UnitTests/ServerTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.McpServer.UnitTests.Helpers;
+using FluentAssertions;
+using ModelContextProtocol.Client;
+
+namespace Bicep.McpServer.UnitTests;
+
+[TestClass]
+public class ServerTests
+{
+    [NotNull]
+    public TestContext? TestContext { get; set; }
+
+    [TestMethod]
+    public async Task List_tools_returns_full_list_of_tools()
+    {
+        await using var helper = await McpServerHelper.StartServer(TestContext);
+
+        var tools = await helper.Client.ListToolsAsync();
+
+        tools.OrderBy(x => x.Name).Should().SatisfyRespectively(
+            x => x.Name.Should().Be("get_az_resource_type_schema"),
+            x => x.Name.Should().Be("get_bicep_best_practices"),
+            x => x.Name.Should().Be("list_az_resource_types_for_provider"));
+    }
+}

--- a/src/Bicep.McpServer.UnitTests/packages.lock.json
+++ b/src/Bicep.McpServer.UnitTests/packages.lock.json
@@ -974,17 +974,17 @@
       },
       "ModelContextProtocol": {
         "type": "Transitive",
-        "resolved": "0.3.0-preview.1",
-        "contentHash": "il9gKINohZ4V4zpsNELg7fNch89D1GcmsnyMDWMnaH5TURDGPwXdw1gfUAc1D/K2jLGHDWNeIkPyuak+uzZSWA==",
+        "resolved": "0.3.0-preview.2",
+        "contentHash": "tC4pwKzNPFXFqyqhAcq40QnkSF+md29UKGsaDkF9Pw8oinWqFoC3Nr9AF+YbpIWo8Jc6Nz9S7+LuJwqpZWfLOw==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "ModelContextProtocol.Core": "0.3.0-preview.1"
+          "ModelContextProtocol.Core": "0.3.0-preview.2"
         }
       },
       "ModelContextProtocol.Core": {
         "type": "Transitive",
-        "resolved": "0.3.0-preview.1",
-        "contentHash": "KAMAog1SioXF2x22yfS6RltIykAs7J95qqidM8oW3cD8cSeYDdOVK1MbbWaTPsvMMcCi5uV4givwGyveubDErw==",
+        "resolved": "0.3.0-preview.2",
+        "contentHash": "pM25u8vx2RximQMIU9/b0Nwg201SI4B87wNgaxO3FhAksWFbL7ApRcNdYnyj8qfwEdAY+wIksdYoIBcyb5Aipw==",
         "dependencies": {
           "Microsoft.Extensions.AI.Abstractions": "9.6.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
@@ -1833,7 +1833,7 @@
         "dependencies": {
           "Azure.Bicep.Core": "[1.0.0, )",
           "Microsoft.Extensions.Hosting": "[9.0.5, )",
-          "ModelContextProtocol": "[0.3.0-preview.1, )"
+          "ModelContextProtocol": "[0.3.0-preview.2, )"
         }
       },
       "bicep.textfixtures": {

--- a/src/Bicep.McpServer/Bicep.McpServer.csproj
+++ b/src/Bicep.McpServer/Bicep.McpServer.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.1" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bicep.McpServer/Bicep.McpServer.csproj
+++ b/src/Bicep.McpServer/Bicep.McpServer.csproj
@@ -8,6 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="./Files/**/*.*" />
+    <EmbeddedResource Include="./Files/**/*.*" LogicalName="$([System.String]::new('Files/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" WithCulture="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.1" />
   </ItemGroup>

--- a/src/Bicep.McpServer/BicepTools.cs
+++ b/src/Bicep.McpServer/BicepTools.cs
@@ -75,5 +75,5 @@ public sealed class BicepTools(
     These practices help improve maintainability, security, and reliability of your Bicep files.
     This is helpful additional context if you've been asked to generate Bicep code.
     """)]
-    public static string GetBicepBestPractices() => BestPracticesMarkdownLazy.Value.ToString();
+    public string GetBicepBestPractices() => BestPracticesMarkdownLazy.Value.ToString();
 }

--- a/src/Bicep.McpServer/BicepTools.cs
+++ b/src/Bicep.McpServer/BicepTools.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.ComponentModel;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Bicep.Core.TypeSystem.Providers.Az;
@@ -16,15 +17,23 @@ public sealed class BicepTools(
     AzResourceTypeLoader azResourceTypeLoader,
     ResourceVisitor resourceVisitor)
 {
+    private static Lazy<BinaryData> BestPracticesMarkdownLazy { get; } = new(() =>
+        BinaryData.FromStream(
+            typeof(BicepTools).Assembly.GetManifestResourceStream("Files/bestpractices.md") ??
+            throw new InvalidOperationException("Could not find embedded resource 'Files/bestpractices.md'")));
+
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    [McpServerTool, Description(@"Lists all available Azure resource types for a specific provider. The return value is a newline-separated list
-    of resource types including their API version, e.g. Microsoft.KeyVault/vaults@2024-11-01. Such information is the most accurate and up-to-date
-    as it is sourced from the Azure Resource Provider APIs.")]
+    [McpServerTool(Title = "List available Azure resource types", Destructive = false, Idempotent = true, OpenWorld = false, ReadOnly = true)]
+    [Description("""
+    Lists all available Azure resource types for a specific provider.
+    The return value is a newline-separated list of resource types including their API version, e.g. Microsoft.KeyVault/vaults@2024-11-01.
+    Such information is the most accurate and up-to-date as it is sourced from the Azure Resource Provider APIs.
+    """)]
     public string ListAzResourceTypesForProvider(
         [Description("The resource provider (or namespace) of the Azure resource; e.g. Microsoft.KeyVault")] string providerNamespace)
     {
@@ -41,8 +50,11 @@ public sealed class BicepTools(
         }
     }
 
-    [McpServerTool, Description(@"Gets the schema for a specific Azure resource type and API version. Such information is the most accurate and up-to-date
-    as it is sourced from the Azure Resource Provider APIs.")]
+    [McpServerTool(Title = "Get Azure resource type schema", Destructive = false, Idempotent = true, OpenWorld = false, ReadOnly = true)]
+    [Description("""
+    Gets the schema for a specific Azure resource type and API version.
+    Such information is the most accurate and up-to-date as it is sourced from the Azure Resource Provider APIs.
+    """)]
     public string GetAzResourceTypeSchema(
         [Description("The resource type of the Azure resource; e.g. Microsoft.KeyVault/vaults")] string azResourceType,
         [Description("The API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview")] string apiVersion)
@@ -56,4 +68,12 @@ public sealed class BicepTools(
 
         return JsonSerializer.Serialize(allComplexTypes, JsonSerializerOptions);
     }
+
+    [McpServerTool(Title = "Get Bicep best-practices", Destructive = false, Idempotent = true, OpenWorld = false, ReadOnly = true)]
+    [Description("""
+    Lists up-to-date recommended Bicep best-practices for authoring templates.
+    These practices help improve maintainability, security, and reliability of your Bicep files.
+    This is helpful additional context if you've been asked to generate Bicep code.
+    """)]
+    public static string GetBicepBestPractices() => BestPracticesMarkdownLazy.Value.ToString();
 }

--- a/src/Bicep.McpServer/Files/bestpractices.md
+++ b/src/Bicep.McpServer/Files/bestpractices.md
@@ -1,0 +1,12 @@
+This best-practices doc builds on top of information available at https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep.
+
+## Rules
+Here are some general-purpose best-practices for authoring high-quality Bicep code.
+1. Avoid using open types such as `array` or `object` when referencing types where possible (e.g. in `output` or `param` statements). Instead, use User-Defined Types to define a more precise type.
+1. Do not add references from child resources to parent resources by using `/` charaters in the child resource `name` property. Instead, use the `parent` property with a symbolic reference to the parent resource.
+1. If you are generating a child resource type, Sometimes this may require you to add an `existing` resource for the parent if the parent is not already present in the file.
+1. Avoid setting the `name` field for `module` statements - it is no longer required.
+1. When generating `param` or `output` statements, ALWAYS use the `@secure()` decorator if sensitive data is present.
+
+## Glossary
+* Child resource: an Azure resource type with type name consisting of more than 1 `/` characters. For example, `Microsoft.Network/virtualNetworks/subnets` is a child resource. `Microsoft.Network/virtualNetworks` is not.

--- a/src/Bicep.McpServer/Files/bestpractices.md
+++ b/src/Bicep.McpServer/Files/bestpractices.md
@@ -1,12 +1,29 @@
-This best-practices doc builds on top of information available at https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep.
+# Bicep best-practices
+This list of best-practices builds on top of information available at https://learn.microsoft.com/azure/azure-resource-manager/bicep. It provides a more opinionated and up-to-date set of rules for generating high-quality Bicep code. You should aim to follow these rules whenever generating or modifying Bicep code.
 
 ## Rules
-Here are some general-purpose best-practices for authoring high-quality Bicep code.
-1. Avoid using open types such as `array` or `object` when referencing types where possible (e.g. in `output` or `param` statements). Instead, use User-Defined Types to define a more precise type.
+### General
+1. Avoid setting the `name` field for `module` statements - it is no longer required.
+1. If you need to input or output a set of logically-grouped values, generate a single `param` or `output` statement with a User-Defined Type instead of emitting a `param` or `output` statement for each value.
+1. If generating parameters, default to generating Bicep parameters files (`*.bicepparam`), instead of ARM parameters files (`*.json`).
+
+### Resources
 1. Do not add references from child resources to parent resources by using `/` charaters in the child resource `name` property. Instead, use the `parent` property with a symbolic reference to the parent resource.
 1. If you are generating a child resource type, Sometimes this may require you to add an `existing` resource for the parent if the parent is not already present in the file.
-1. Avoid setting the `name` field for `module` statements - it is no longer required.
+1. If you see diagnostic codes `BCP036`, `BCP037` or `BCP081`, this may indicate you have hallucinated resource types or resource type properties. You may need to double-check against available resource type schema to tune your output.
+1. Avoid using the multiple `resourceId()` functions and `reference()` function where possible. Instead use symbolic names to refer to ids or properties, creating `existing` resources if needed. For example, write `foo.id` or `foo.properties.id` instead of `resourceId('...')` or `reference('...').id`.
+
+### Types
+1. Avoid using open types such as `array` or `object` when referencing types where possible (e.g. in `output` or `param` statements). Instead, use User-defined types to define a more precise type.
+1. Use typed variables instead of untyped variables when exporting values with the `@export()` decorator. For example, use `var foo string = 'blah'` instead of `var foo = bar`.
+1. When using User-defined types, aim to avoid repetition, and comment properties with `@description()` where the context is unclear.
+1. If you are passing data directly to or from a resource body via a `param` or `output` statement, try to use existing Resource-derived types (`resourceInput<'type@version'>` and `resourceOutput<'type@version'>`) instead of writing User-defined types.
+
+### Security
 1. When generating `param` or `output` statements, ALWAYS use the `@secure()` decorator if sensitive data is present.
+
+### Syntax
+1. If you hit warnings or errors with null properties, prefer solving them with the safe-dereference (`.?`) operator, in conjunction with the coalesce (`??`) operator. For example, `a.?b ?? c` is better than `a!.b` which may cause runtime errors, or `a != null ? a.b : c` which is unnecessarily verbose.
 
 ## Glossary
 * Child resource: an Azure resource type with type name consisting of more than 1 `/` characters. For example, `Microsoft.Network/virtualNetworks/subnets` is a child resource. `Microsoft.Network/virtualNetworks` is not.

--- a/src/Bicep.McpServer/packages.lock.json
+++ b/src/Bicep.McpServer/packages.lock.json
@@ -56,12 +56,12 @@
       },
       "ModelContextProtocol": {
         "type": "Direct",
-        "requested": "[0.3.0-preview.1, )",
-        "resolved": "0.3.0-preview.1",
-        "contentHash": "il9gKINohZ4V4zpsNELg7fNch89D1GcmsnyMDWMnaH5TURDGPwXdw1gfUAc1D/K2jLGHDWNeIkPyuak+uzZSWA==",
+        "requested": "[0.3.0-preview.2, )",
+        "resolved": "0.3.0-preview.2",
+        "contentHash": "tC4pwKzNPFXFqyqhAcq40QnkSF+md29UKGsaDkF9Pw8oinWqFoC3Nr9AF+YbpIWo8Jc6Nz9S7+LuJwqpZWfLOw==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "ModelContextProtocol.Core": "0.3.0-preview.1"
+          "ModelContextProtocol.Core": "0.3.0-preview.2"
         }
       },
       "Nerdbank.GitVersioning": {
@@ -654,8 +654,8 @@
       },
       "ModelContextProtocol.Core": {
         "type": "Transitive",
-        "resolved": "0.3.0-preview.1",
-        "contentHash": "KAMAog1SioXF2x22yfS6RltIykAs7J95qqidM8oW3cD8cSeYDdOVK1MbbWaTPsvMMcCi5uV4givwGyveubDErw==",
+        "resolved": "0.3.0-preview.2",
+        "contentHash": "pM25u8vx2RximQMIU9/b0Nwg201SI4B87wNgaxO3FhAksWFbL7ApRcNdYnyj8qfwEdAY+wIksdYoIBcyb5Aipw==",
         "dependencies": {
           "Microsoft.Extensions.AI.Abstractions": "9.6.0",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",


### PR DESCRIPTION
## Description

Add MCP best-practices tool.

The goal is to return a markdown file which contains opinionated rules on how to author high-quality Bicep code. Over time, we should keep this up-to-date.

Example before and after for code generated with/without this by GPT 4.1, where I'm specifically testing its ability to generate child resources using the `parent` property:
* Before: 
    <img height="400" alt="image" src="https://github.com/user-attachments/assets/f39337ea-f0b2-4323-a597-cbdf17b24435" />
* After:
    <img height="400" alt="image" src="https://github.com/user-attachments/assets/f91cb610-d91d-429c-ba68-3fdc72ee1b3a" />


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17572)