### PR TITLE
Improve `reduce` type inference

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -7428,4 +7428,26 @@ output locations array = flatten(map(databases, database => database.properties.
             ("BCP422", DiagnosticLevel.Warning, "A resource of type \"Microsoft.Storage/storageAccounts | null\" may or may not exist when this function is called, which could cause the deployment to fail."),
         });
     }
+
+    [TestMethod]
+    public void Test_Issue17456()
+    {
+        var result = CompilationHelper.Compile("""
+            var array = [
+              'a'
+              'b'
+              'c'
+              'd'
+              'e'
+              'f'
+              'g'
+              'a'
+              'b'
+            ]
+
+            output unique string[] = reduce(array, [], (acc, x) => union(acc, [x]))
+            """);
+
+        result.Should().NotHaveAnyDiagnostics();
+    }
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Lambdas_LF/main.symbols.bicep
@@ -100,11 +100,11 @@ var sortEmpty = sort([], (x, y) => int(x) < int(y))
 //@[004:013) Variable sortEmpty. Type: never[]. Declaration start char: 0, length: 51
 
 var reduceStringConcat = reduce(['abc', 'def', 'ghi'], '', (cur, next) => concat(cur, next))
-//@[060:063) Local cur. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 60, length: 3
+//@[060:063) Local cur. Type: string. Declaration start char: 60, length: 3
 //@[065:069) Local next. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 65, length: 4
 //@[004:022) Variable reduceStringConcat. Type: string. Declaration start char: 0, length: 92
 var reduceStringConcatEven = reduce(['abc', 'def', 'ghi'], '', (cur, next, i) => isEven(i) ? concat(cur, next) : cur)
-//@[064:067) Local cur. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 64, length: 3
+//@[064:067) Local cur. Type: string. Declaration start char: 64, length: 3
 //@[069:073) Local next. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 69, length: 4
 //@[075:076) Local i. Type: int. Declaration start char: 75, length: 1
 //@[004:026) Variable reduceStringConcatEven. Type: string. Declaration start char: 0, length: 117
@@ -118,12 +118,12 @@ var reduceObjectUnion = reduce([
   { bar: 456 }
   { baz: 789 }
 ], {}, (cur, next) => union(cur, next))
-//@[008:011) Local cur. Type: object | object | object. Declaration start char: 8, length: 3
+//@[008:011) Local cur. Type: object. Declaration start char: 8, length: 3
 //@[013:017) Local next. Type: object | object | object. Declaration start char: 13, length: 4
 var reduceEmpty = reduce([], 0, (cur, next) => cur)
-//@[033:036) Local cur. Type: never. Declaration start char: 33, length: 3
+//@[033:036) Local cur. Type: 0. Declaration start char: 33, length: 3
 //@[038:042) Local next. Type: never. Declaration start char: 38, length: 4
-//@[004:015) Variable reduceEmpty. Type: never. Declaration start char: 0, length: 51
+//@[004:015) Variable reduceEmpty. Type: 0. Declaration start char: 0, length: 51
 
 var itemForLoop = [for item in range(0, 10): item]
 //@[023:027) Local item. Type: int. Declaration start char: 23, length: 4
@@ -193,7 +193,7 @@ var objectMap6 = toObject(range(0, 10), i => '${i}', i => // comment
 var multiLine = reduce(['abc', 'def', 'ghi'], '', (
 //@[004:013) Variable multiLine. Type: string. Declaration start char: 0, length: 89
   cur,
-//@[002:005) Local cur. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 2, length: 3
+//@[002:005) Local cur. Type: string. Declaration start char: 2, length: 3
   next
 //@[002:006) Local next. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 2, length: 4
 ) => concat(cur, next))
@@ -202,7 +202,7 @@ var multiLineWithComment = reduce(['abc', 'def', 'ghi'], '', (
 //@[004:024) Variable multiLineWithComment. Type: string. Declaration start char: 0, length: 113
   // comment
   cur,
-//@[002:005) Local cur. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 2, length: 3
+//@[002:005) Local cur. Type: string. Declaration start char: 2, length: 3
   next
 //@[002:006) Local next. Type: 'abc' | 'def' | 'ghi'. Declaration start char: 2, length: 4
 ) => concat(cur, next))

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Expressions/parameters.symbols.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Expressions/parameters.symbols.bicepparam
@@ -38,7 +38,7 @@ param myObject = {
   padLeft: padLeft(13, 5)
   range: range(0, 3)
   reduce: reduce(['a', 'b', 'c'], '', (a, b) => '${a}-${b}')
-//@[39:40) Local a. Type: 'a' | 'b' | 'c'. Declaration start char: 39, length: 1
+//@[39:40) Local a. Type: string. Declaration start char: 39, length: 1
 //@[42:43) Local b. Type: 'a' | 'b' | 'c'. Declaration start char: 42, length: 1
   replace: replace('abc', 'b', '/')
   skip: skip([1, 2, 3], 1)

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Expressions/parameters.diagnostics.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Expressions/parameters.diagnostics.bicepparam
@@ -75,7 +75,7 @@ param testPadLeft = padLeft(13, 'foo')
 param testRange = range(0, 'foo')
 //@[27:32) [BCP070 (Error)] Argument of type "'foo'" is not assignable to parameter of type "int". (bicep https://aka.ms/bicep/core-diagnostics#BCP070) |'foo'|
 param testReduce = reduce(['a', 'b', 'c'], '', (a, b) => '${toObject(a)}-${b}')
-//@[47:78) [BCP070 (Error)] Argument of type "(('a' | 'b' | 'c'), ('a' | 'b' | 'c')) => error" is not assignable to parameter of type "(any, any[, int]) => any". (bicep https://aka.ms/bicep/core-diagnostics#BCP070) |(a, b) => '${toObject(a)}-${b}'|
+//@[47:78) [BCP070 (Error)] Argument of type "(string, ('a' | 'b' | 'c')) => error" is not assignable to parameter of type "(any, any[, int]) => any". (bicep https://aka.ms/bicep/core-diagnostics#BCP070) |(a, b) => '${toObject(a)}-${b}'|
 param testReplace = replace('abc', 'b', {})
 //@[40:42) [BCP070 (Error)] Argument of type "object" is not assignable to parameter of type "string". (bicep https://aka.ms/bicep/core-diagnostics#BCP070) |{}|
 param testSkip = skip([1, 2, 3], '1')

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Expressions/parameters.symbols.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_Expressions/parameters.symbols.bicepparam
@@ -69,7 +69,7 @@ param testPadLeft = padLeft(13, 'foo')
 param testRange = range(0, 'foo')
 //@[06:15) ParameterAssignment testRange. Type: error. Declaration start char: 0, length: 33
 param testReduce = reduce(['a', 'b', 'c'], '', (a, b) => '${toObject(a)}-${b}')
-//@[48:49) Local a. Type: 'a' | 'b' | 'c'. Declaration start char: 48, length: 1
+//@[48:49) Local a. Type: string. Declaration start char: 48, length: 1
 //@[51:52) Local b. Type: 'a' | 'b' | 'c'. Declaration start char: 51, length: 1
 //@[06:16) ParameterAssignment testReduce. Type: error. Declaration start char: 0, length: 79
 param testReplace = replace('abc', 'b', {})

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1145,7 +1145,37 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("array", LanguageConstants.Array, "The array to reduce.")
                     .WithRequiredParameter("initialValue", LanguageConstants.Any, "The initial value.")
                     .WithRequiredParameter("predicate", TypeHelper.CreateLambdaType([LanguageConstants.Any, LanguageConstants.Any], [LanguageConstants.Int], LanguageConstants.Any), "The predicate used to aggregate the current value and the next value. ",
-                        calculator: getArgumentType => CalculateLambdaFromArrayParam(getArgumentType, 0, t => TypeHelper.CreateLambdaType([t, t], [LanguageConstants.Int], LanguageConstants.Any)))
+                        calculator: getArgumentType =>
+                        {
+                            var toReduceType = getArgumentType(0);
+
+                            var elementType = toReduceType switch
+                            {
+                                ArrayType array => array.Item.Type,
+                                AnyType => LanguageConstants.Any,
+                                _ => null,
+                            };
+
+                            var seedType = getArgumentType(1);
+
+                            if (elementType is null || elementType is ErrorType || seedType is ErrorType)
+                            {
+                                return null;
+                            }
+
+                            var accumulationType = seedType switch
+                            {
+                                ErrorType error => error,
+                                _ when TypeHelper.TryGetArmPrimitiveType(seedType) is TypeSymbol armPrimitive => armPrimitive,
+                                _ => LanguageConstants.Any,
+                            };
+                            var firstArgType = toReduceType is ArrayType { MaxLength: <= 1 } ? seedType : accumulationType;
+
+                            return TypeHelper.CreateLambdaType(
+                                argumentTypes: [firstArgType, elementType],
+                                optionalArgumentTypes: [CalculateIndexTypeOfArray(toReduceType)],
+                                returnType: accumulationType);
+                        })
                     .WithReturnType(LanguageConstants.Any)
                     .WithReturnResultBuilder((_, _, _, argumentTypes) => argumentTypes[2] switch
                     {
@@ -1321,6 +1351,11 @@ namespace Bicep.Core.Semantics.Namespaces
             var itemType = arrayType.Item;
             return lambdaBuilder(itemType.Type);
         }
+
+        private static TypeSymbol CalculateIndexTypeOfArray(TypeSymbol arrayType) => TypeFactory.CreateIntegerType(
+            minValue: 0,
+            maxValue: (arrayType as ArrayType)?.MaxLength,
+            validationFlags: arrayType.ValidationFlags);
 
         private static TypeSymbol? CalculateLambdaFromObjectValues(GetFunctionArgumentType getArgumentType, int arrayIndex, Func<TypeSymbol, LambdaType> lambdaBuilder)
         {

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -2640,19 +2640,9 @@ namespace Bicep.Core.TypeSystem
 
         private TypeSymbol? TryGetArmPrimitiveType(TypeSymbol type, SyntaxBase syntax) => type switch
         {
-            BooleanLiteralType or BooleanType => LanguageConstants.Bool,
-            IntegerLiteralType or IntegerType => LanguageConstants.Int,
-            StringLiteralType or StringType => LanguageConstants.String,
             ResourceType when features.ResourceTypedParamsAndOutputsEnabled => LanguageConstants.String,
-            ObjectType or DiscriminatedObjectType => LanguageConstants.Object,
-            TupleType or ArrayType => LanguageConstants.Array,
-            UnionType when TypeHelper.TryRemoveNullability(type) is { } nonNull => TryGetArmPrimitiveType(nonNull, syntax),
             UnionType when IsExplicitUnion(syntax) => LanguageConstants.Any,
-            UnionType union when union.Members.Select(m => TryGetArmPrimitiveType(m.Type, syntax)).ToArray() is { } mTypes &&
-                !mTypes.Any(t => t is null) &&
-                mTypes.ToHashSet() is { } mUniqueTypes &&
-                mUniqueTypes.Count == 1 => mUniqueTypes.Single(),
-            _ => null,
+            _ => TypeHelper.TryGetArmPrimitiveType(type),
         };
 
         private static bool IsExplicitUnion(SyntaxBase syntax) => syntax switch


### PR DESCRIPTION
Resolves #17456 

`reduce` was previously using the element type of the reduced array as the type of the accumulator value, which caused some difficult to debug errors.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17574)