### PR TITLE
feat: BRM Tool - Removed deprecated `pathFilter` property from BRM version schema

### DIFF
--- a/src/Bicep.RegistryModuleTool/JsonSchemas/schema.version.json
+++ b/src/Bicep.RegistryModuleTool/JsonSchemas/schema.version.json
@@ -11,15 +11,6 @@
       "type": "string",
       "pattern": "^v?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-(?:[\\da-z\\-]+)(?:\\.(?:[\\da-z\\-]+))*)?$",
       "description": "The major.minor-pre version to use as the basis for version calculations."
-    },
-    "pathFilters": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "pattern": "^(:\\^|:!|:/|[^:])"
-      },
-      "uniqueItems": true,
-      "description": "An array of pathspec-like strings that are used to filter commits when calculating the version height. A commit will not increment the version height if its changed files are not included by these filters.\nPaths are relative to this file."
     }
   },
   "required": [


### PR DESCRIPTION
## Description

- Removed deprecated `pathFilter` property from BRM version schema
- The filter is hardcoded into the CI to not allow contributors to change the CI's publishing behavior

> Note: The `pathFilter` was already removed from all `version.json` files in the BRM repository

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
