### PR TITLE
Add fix to decompile desiredStateConfiguration resources

### DIFF
--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -1784,6 +1784,11 @@ namespace Bicep.Decompiler
                         SyntaxFactory.TargetScopeKeywordToken,
                         SyntaxFactory.AssignmentToken,
                         SyntaxFactory.CreateStringLiteral("subscription"));
+                case "/dsc/schemas/v3/bundled/config/document.json":
+                    return new TargetScopeSyntax(
+                        SyntaxFactory.TargetScopeKeywordToken,
+                        SyntaxFactory.AssignmentToken,
+                        SyntaxFactory.CreateStringLiteral("desiredStateConfiguration"));
                 case "/schemas/2014-04-01-preview/deploymentTemplate.json":
                 case "/schemas/2015-01-01/deploymentTemplate.json":
                 case "/schemas/2019-04-01/deploymentTemplate.json":


### PR DESCRIPTION
## Description

Fixes: #17763

## Example Usage

```json
// main.json
{
  "$schema": "https://aka.ms/dsc/schemas/v3/bundled/config/document.json",
  "contentVersion": "1.0.0.0",
  "metadata": {
    "_generator": {
      "name": "bicep",
      "version": "0.37.4.10188",
      "templateHash": "852473872901319578"
    }
  },
  "resources": [
    {
      "type": "Microsoft.DSC.Debug/Echo",
      "apiVersion": "2025-01-01",
      "name": "example",
      "properties": {
        "output": "Hello from DSC world!"
      }
    }
  ]
}
```

Run `bicep decompile main.json`. Should return:

```bicep
targetScope = 'desiredStateConfiguration'
resource example 'Microsoft.DSC.Debug/Echo@2025-01-01' = {
  name: 'example'
  properties: {
    output: 'Hello from DSC world!'
  }
}
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17764)