### PR TITLE
Fix bicep decompile-params if file is different name

### DIFF
--- a/src/Bicep.Cli/Arguments/DecompileParamsArguments.cs
+++ b/src/Bicep.Cli/Arguments/DecompileParamsArguments.cs
@@ -78,16 +78,6 @@ namespace Bicep.Cli.Arguments
             {
                 throw new CommandLineException($"The --outdir and --outfile parameters cannot both be used");
             }
-
-            if (!OutputToStdOut && !AllowOverwrite)
-            {
-                string outputFilePath = Path.ChangeExtension(PathHelper.ResolvePath(InputFile), LanguageConstants.ParamsFileExtension);
-                if (File.Exists(outputFilePath))
-                {
-                    throw new CommandLineException($"The output path \"{outputFilePath}\" already exists. Use --force to overwrite the existing file.");
-                }
-
-            }
         }
 
         public static Func<DecompileParamsArguments, IOUri, string> OutputFileExtensionResolver { get; } = (_, _) => LanguageConstants.ParamsFileExtension;


### PR DESCRIPTION
## Description

Related issue #14092 

## Example Usage

Whenever a user attempts to decompile a parameter file with a different name, it still throws that the file already exist and `--force` should be used. Whenever `--force` is applied, the file is generated with the different name.

<img width="1494" height="1305" alt="image" src="https://github.com/user-attachments/assets/23f8b07e-8c81-4c8a-b50d-cbb0ba875ff1" />

This change removes the additional check. Validated with latest build locally:

<img width="1528" height="1177" alt="image" src="https://github.com/user-attachments/assets/bb357eb5-584f-4b23-81f4-4e38c8a9b62a" />


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17795)