### PR TITLE
Update dependabot policy to re-approve on every push

### DIFF
--- a/.github/policies/prMgmt.dependabot.yml
+++ b/.github/policies/prMgmt.dependabot.yml
@@ -13,12 +13,9 @@ configuration:
           - payloadType: Pull_Request
           - hasLabel:
               label: dependencies
-          - not:
-              hasLabel:
-                label: auto-merge
           - isActivitySender:
               user: dependabot[bot]
-              issueAuthor: False
+              issueAuthor: True
         then:
           - approvePullRequest:
               comment: ":shipit:"


### PR DESCRIPTION
With https://github.com/Azure/bicep/settings/rules/5351793, we now require a review on the most recent iteration, which means that if dependabot rebases on conflicts, the original review is classified as stale. This change avoids that by always auto-approving on every push.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17797)