### PR TITLE
Upgrade global.json to .NET 9

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,7 +4,7 @@
   },
   "sdk": {
     "allowPrerelease": false,
-    "version": "8.0.413",
+    "version": "9.0.303",
     "rollForward": "disable"
   }
 }

--- a/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
@@ -16,8 +16,6 @@ namespace Bicep.Core.IntegrationTests.Scenarios;
 [TestClass]
 public class NullabilityTests
 {
-    private static ServiceBuilder Services => new();
-
     [DataTestMethod]
     [DynamicData(nameof(GetTemplatesWithSingleUnexpectedlyNullableValue), DynamicDataSourceType.Method)]
     public void Unexpectedly_nullable_types_raise_fixable_warning(string templateWithNullablyTypedValue, string templateWithNonNullAssertion, TypeSymbol expectedType, TypeSymbol actualType)

--- a/src/Bicep.Wasm/Bicep.Wasm.csproj
+++ b/src/Bicep.Wasm/Bicep.Wasm.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RazorLangVersion>3.0</RazorLangVersion>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -55,7 +55,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.5" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.0" />
-    <PackageVersion Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="9.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.12.0" />
     <PackageVersion Include="Microsoft.PowerPlatform.ResourceStack" Version="7.0.0.2080" />

--- a/src/playground/vite.config.mts
+++ b/src/playground/vite.config.mts
@@ -14,7 +14,7 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: normalizePath(path.resolve(__dirname, '../Bicep.Wasm/bin/Release/net8.0/wwwroot/_framework') + '/**/*.*'),
+          src: normalizePath(path.resolve(__dirname, '../Bicep.Wasm/bin/Release/net9.0/wwwroot/_framework') + '/**/*.*'),
           dest: './_framework',
         },
       ],


### PR DESCRIPTION
.NET 9 has some performance improvements for package restore, and a cleaner UI.

Note that this PR doesn't upgrade any of our core libraries to target .NET 9.