### PR TITLE
Add DSC scope support to ScopeHelper resource ID formatting

### DIFF
--- a/src/Bicep.Core/Emit/ScopeHelper.cs
+++ b/src/Bicep.Core/Emit/ScopeHelper.cs
@@ -283,6 +283,19 @@ namespace Bicep.Core.Emit
                         parentResourceId,
                         fullyQualifiedType,
                         nameSegments);
+                case ResourceScope.DesiredStateConfiguration:
+                    // DSC resources don't have traditional ARM resource IDs
+                    var dscNameParts = new List<LanguageExpression>
+                    {
+                        new JTokenExpression(fullyQualifiedType)
+                    };
+                    dscNameParts.AddRange(nameSegments);
+                    
+                    return new FunctionExpression("concat", [.. dscNameParts.SelectMany(expr => new LanguageExpression[] 
+                    { 
+                        expr, 
+                        new JTokenExpression("/") 
+                    }).SkipLast(1)], []);
                 default:
                     throw new InvalidOperationException($"Cannot format resourceId for scope {scopeData.RequestedScope}");
             }
@@ -314,6 +327,19 @@ namespace Bicep.Core.Emit
                         parentResourceId,
                         fullyQualifiedType,
                         nameSegments);
+                case ResourceScope.DesiredStateConfiguration:
+                    // DSC resources use the same unqualified format as the qualified one
+                    var dscNameParts = new List<LanguageExpression>
+                    {
+                        new JTokenExpression(fullyQualifiedType)
+                    };
+                    dscNameParts.AddRange(nameSegments);
+                    
+                    return new FunctionExpression("concat", [.. dscNameParts.SelectMany(expr => new LanguageExpression[] 
+                    { 
+                        expr, 
+                        new JTokenExpression("/") 
+                    }).SkipLast(1)], []);
                 default:
                     throw new InvalidOperationException($"Cannot format resourceId for scope {scopeData.RequestedScope}");
             }


### PR DESCRIPTION
## Description

Adds support for DSC scope to Bicep resource ID formatting. DSC resources don't use traditional ARM resource IDS, so the implementation uses a custom concatenation format. 

## Example Usage

Tested this change with a local file reported in issue #17670. Bicep file:

```bicep
targetScope = 'desiredStateConfiguration'

// use workaround where Bicep currently requires version in date format
resource echo 'Microsoft.DSC.Debug/Echo@2025-01-01' = {
  name: 'exampleEcho'
  properties: {
    output: 'Hello, world!'
  }
}

output exampleOutput string = echo.properties.output
```

Returns:

```json
{
  "$schema": "https://aka.ms/dsc/schemas/v3/bundled/config/document.json",
  "contentVersion": "1.0.0.0",
  "metadata": {
    "_generator": {
      "name": "bicep",
      "version": "0.37.52.64608",
      "templateHash": "928342520835393415"
    }
  },
  "resources": [
    {
      "type": "Microsoft.DSC.Debug/Echo",
      "apiVersion": "2025-01-01",
      "name": "exampleEcho",
      "properties": {
        "output": "Hello, world!"
      }
    }
  ],
  "outputs": {
    "exampleOutput": {
      "type": "string",
      "value": "[reference(concat('Microsoft.DSC.Debug/Echo', '/', 'exampleEcho'), '2025-01-01').output]"
    }
  }
}
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17805)