### PR TITLE
Remove redundant checks for empty parameter assignments in parameter evaluation

### DIFF
--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -609,6 +609,11 @@ namespace Bicep.Core.Emit
             ParameterAssignmentEvaluator evaluator,
             IDiagnosticWriter diagnostics)
         {
+            if (model.HasParsingErrors())
+            {
+                return ImmutableDictionary<ParameterAssignmentSymbol, ParameterAssignmentValue>.Empty;
+            }
+
             var referencesInValues = model.Binder.Bindings.Values.OfType<DeclaredSymbol>().Distinct()
                 .ToImmutableDictionary(p => p, p => SymbolicReferenceCollector.CollectSymbolsReferenced(model.Binder, p.DeclaringSyntax));
             var generated = ImmutableDictionary.CreateBuilder<ParameterAssignmentSymbol, ParameterAssignmentValue>();


### PR DESCRIPTION
## Description

Remove the early return in `EmitLimitationCalculator.CalculateParameterAssignments()` that skipped evaluation when a .bicepparam file contained no local `param` declarations. This ensures `extends` clauses are still resolved, imported parameter assignments flow through, and missing/invalid `extends` targets now surface diagnostics.

## Before change:

Logic short‑circuited if `model.Root.ParameterAssignments.IsEmpty` OR there were parsing errors.

Example .bicepparam file with only:

```bicep
using 'main.bicep'
extends 'not-exists.bicepparam'
```

produced no parameter evaluation and (critically) suppressed the diagnostic for the non‑existent `not-exists.bicepparam`.

Imported parameters from an extended file were silently ignored when the extending file had zero local params.

## After change:

- `extends` declarations are always processed (unless the syntax itself is malformed).
- Missing file now produces the expected diagnostic (e.g. BCP091).
- Parameters defined only in the extended file are now included in evaluation/emission.
- Behavior for files that already had local params is unchanged.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17807)