### PR TITLE
Nightly installers - avoid hanging if there's no valid run found

### DIFF
--- a/scripts/install_cli_nightly.sh
+++ b/scripts/install_cli_nightly.sh
@@ -42,6 +42,9 @@ if [ -z "$branch" ]; then
 fi
 if [ -z "$runId" ]; then
   runId=$(gh run list -R $repo --branch $branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
+  if [ -z "$runId" ]; then
+    echo "Failed to find a successful build to install from"; exit 1;
+  fi
 fi
 tmpDir=$(mktemp -d)
 gh run download -R $repo $runId -n "bicep-release-$platform-$arch" --dir $tmpDir

--- a/scripts/install_vsix_nightly.ps1
+++ b/scripts/install_vsix_nightly.ps1
@@ -19,7 +19,10 @@ if (!$Branch) {
   $Branch = "main"
 }
 if (!$RunId) {
-    $RunId = & gh run list -R $Repo --branch $Branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId"; if(!$?) { throw }
+  $RunId = & gh run list -R $Repo --branch $Branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId"; if(!$?) { throw }
+  if (!$RunId) {
+    throw "Failed to find a successful build to install from"
+  }
 }
 $tmpDir = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
 & gh run download -R $Repo $RunId -n "vscode-bicep.vsix" --dir $tmpDir; if(!$?) { throw }

--- a/scripts/install_vsix_nightly.sh
+++ b/scripts/install_vsix_nightly.sh
@@ -24,6 +24,9 @@ if [ -z "$branch" ]; then
 fi
 if [ -z "$runId" ]; then
   runId=$(gh run list -R $repo --branch $branch --workflow build --status success -L 1 --json databaseId -q ".[0].databaseId")
+  if [ -z "$runId" ]; then
+    echo "Failed to find a successful build to install from"; exit 1;
+  fi
 fi
 tmpDir=$(mktemp -d)
 gh run download -R $repo $runId -n "vscode-bicep.vsix" --dir $tmpDir


### PR DESCRIPTION
The GH CLI appears to hang if a runId isn't provided - this PR just adds an explicit check for it