### PR TITLE
Fix regression that broke UNC path handling

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildCommandTests.cs
@@ -83,7 +83,7 @@ namespace Bicep.Cli.IntegrationTests
                 // ensure something got restored
 
                 settings.FeatureOverrides!.CacheRootDirectory!.Exists().Should().BeTrue();
-                Directory.EnumerateFiles(settings.FeatureOverrides.CacheRootDirectory!.Uri.GetLocalFilePath(), "*.json", SearchOption.AllDirectories).Should().NotBeEmpty();
+                Directory.EnumerateFiles(settings.FeatureOverrides.CacheRootDirectory!.Uri.GetFilePath(), "*.json", SearchOption.AllDirectories).Should().NotBeEmpty();
             }
 
             var compiledFilePath = Path.Combine(outputDirectory, DataSet.TestFileMainCompiled);

--- a/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
@@ -122,7 +122,7 @@ module mod 'br:mockregistry.io/test/foo:1.1' = {
                 fileSystem.Directory.SetCurrentDirectory(outputPath);
             }
 
-            var cacheRoot = fileExplorer.GetDirectory(IOUri.FromLocalFilePath(outputPath));
+            var cacheRoot = fileExplorer.GetDirectory(IOUri.FromFilePath(outputPath));
 
             var (output, error, result) = await Bicep(
                 services => services
@@ -260,7 +260,7 @@ module empty 'br:{registry}/{repository}@{digest}' = {{
             var restoredFile = cacheRootDirectory.GetFile("restored.bicep");
             restoredFile.Write(bicep);
 
-            var restoredFilePath = restoredFile.Uri.GetLocalFilePath();
+            var restoredFilePath = restoredFile.Uri.GetFilePath();
             var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
 
             var (output, error, result) = await Bicep(settings, "restore", restoredFilePath);
@@ -340,7 +340,7 @@ module empty 'br:{registry}/{repository}@{digest}' = {{
             var restoredFile = cacheRootDirectory.GetFile("restored.bicep");
             restoredFile.Write(bicep);
 
-            var restoredFilePath = restoredFile.Uri.GetLocalFilePath();
+            var restoredFilePath = restoredFile.Uri.GetFilePath();
 
             var settings = new InvocationSettings(new(TestContext, RegistryEnabled: true), clientFactory.Object, BicepTestConstants.TemplateSpecRepositoryFactory);
 

--- a/src/Bicep.Cli.UnitTests/Arguments/InputOutputArgumentsResolverTests.cs
+++ b/src/Bicep.Cli.UnitTests/Arguments/InputOutputArgumentsResolverTests.cs
@@ -132,7 +132,7 @@ public class InputOutputArgumentsResolverTests
 
         // Assert
         result.Should().NotBeNull();
-        result.IsLocalFile.Should().BeTrue();
+        result.IsFile.Should().BeTrue();
         mockPath.Verify(p => p.GetFullPath(windowsPath), Times.Once);
     }
 #endif
@@ -156,7 +156,7 @@ public class InputOutputArgumentsResolverTests
 
         // Assert
         result.Should().NotBeNull();
-        result.IsLocalFile.Should().BeTrue();
+        result.IsFile.Should().BeTrue();
         mockPath.Verify(p => p.GetFullPath(path), Times.Once);
     }
 }

--- a/src/Bicep.Cli/Arguments/InputOutputArgumentsResolver.cs
+++ b/src/Bicep.Cli/Arguments/InputOutputArgumentsResolver.cs
@@ -24,7 +24,7 @@ namespace Bicep.Cli.Arguments
                 throw new CommandLineException(string.Format(CliResources.FilePathContainsBackslash, path));
             }
 
-            return IOUri.FromLocalFilePath(GetFullPath(path));
+            return IOUri.FromFilePath(GetFullPath(path));
         }
 
         public IOUri ResolveInputArguments(IInputArguments arguments)
@@ -84,7 +84,7 @@ namespace Bicep.Cli.Arguments
                 foreach (var inputRelativePath in inputRelativePaths)
                 {
                     var inputUri = rootUri.Resolve(inputRelativePath);
-                    var outputRootPath = arguments.OutputDir ?? rootUri.GetLocalFilePath();
+                    var outputRootPath = arguments.OutputDir ?? rootUri.GetFilePath();
                     var outputRelativePath = this.fileSystem.Path.ChangeExtension(inputRelativePath, T.OutputFileExtensionResolver.Invoke(arguments, inputUri));
                     var outputPath = this.fileSystem.Path.Combine(outputRootPath, outputRelativePath);
                     var outputUri = this.PathToUri(outputPath);
@@ -122,7 +122,7 @@ namespace Bicep.Cli.Arguments
         private (IOUri rootUri, IReadOnlyList<string> relativePaths) ResolveFilePattern(string filePattern)
         {
             var (rootPath, relativePattern) = SplitFilePatternOnWildcard(filePattern);
-            var rootUri = IOUri.FromLocalFilePath(rootPath);
+            var rootUri = IOUri.FromFilePath(rootPath);
 
             Matcher matcher = new();
             matcher.AddInclude(relativePattern);
@@ -130,7 +130,7 @@ namespace Bicep.Cli.Arguments
             var relativePaths = new List<string>();
             foreach (var filePath in matcher.GetResultsInFullPath(rootPath))
             {
-                var fileUri = IOUri.FromLocalFilePath(filePath);
+                var fileUri = IOUri.FromFilePath(filePath);
                 var relativePath = fileUri.GetPathRelativeTo(rootUri);
                 relativePaths.Add(relativePath);
             }

--- a/src/Bicep.Cli/Commands/PublishExtensionCommand.cs
+++ b/src/Bicep.Cli/Commands/PublishExtensionCommand.cs
@@ -182,13 +182,13 @@ namespace Bicep.Cli.Commands
 
             var fileExplorer = new InMemoryFileExplorer();
 
-            var indexUri = IOUri.FromLocalFilePath("/index.json");
+            var indexUri = IOUri.FromFilePath("/index.json");
             var indexHandle = fileExplorer.GetFile(indexUri);
             indexHandle.Write(typeFiles.IndexFileContent);
 
             foreach (var (path, content) in typeFiles.TypeFileContents)
             {
-                var fileUri = IOUri.FromLocalFilePath($"/{path}");
+                var fileUri = IOUri.FromFilePath($"/{path}");
                 fileExplorer.GetFile(fileUri).Write(content);
             }
 

--- a/src/Bicep.Cli/Commands/SnapshotCommand.cs
+++ b/src/Bicep.Cli/Commands/SnapshotCommand.cs
@@ -132,7 +132,7 @@ public class SnapshotCommand(
         if (!file.TryReadAllText().IsSuccess(out var contents, out var failureBuilder))
         {
             var message = failureBuilder(DiagnosticBuilder.ForDocumentStart()).Message;
-            throw new CommandLineException($"Error opening file {uri.GetLocalFilePath()}: {message}.");
+            throw new CommandLineException($"Error opening file {uri.GetFilePath()}: {message}.");
         }
 
         return SnapshotHelper.Deserialize(contents);

--- a/src/Bicep.Cli/Rpc/CliJsonRpcServer.cs
+++ b/src/Bicep.Cli/Rpc/CliJsonRpcServer.cs
@@ -111,7 +111,7 @@ public class CliJsonRpcServer : ICliJsonRpcProtocol
         }
 
         return new(
-            [.. fileUris.Select(x => x.GetLocalFilePath()).OrderBy(x => x)]);
+            [.. fileUris.Select(x => x.GetFilePath()).OrderBy(x => x)]);
     }
 
     /// <inheritdoc/>

--- a/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
+++ b/src/Bicep.Core.UnitTests/Registry/CachedModules.cs
@@ -22,7 +22,7 @@ public static class CachedModules
     // Get all cached modules from the local on-disk registry cache
     public static ImmutableArray<CachedModule> GetCachedModules(IFileSystem fileSystem, IDirectoryHandle cacheRootDirectory)
     {
-        var cacheDir = fileSystem.DirectoryInfo.New(cacheRootDirectory.Uri.GetLocalFilePath());
+        var cacheDir = fileSystem.DirectoryInfo.New(cacheRootDirectory.Uri.GetFilePath());
         if (!cacheDir.Exists)
         {
             return [];

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -742,7 +742,7 @@ namespace Bicep.Core.UnitTests.Registry
             var parentModuleUri = new Uri(bicepPath);
 
             var featureProviderMock = StrictMock.Of<IFeatureProvider>();
-            var cacheRootDirectory = BicepTestConstants.FileExplorer.GetDirectory(IOUri.FromLocalFilePath(TestOutputPath));
+            var cacheRootDirectory = BicepTestConstants.FileExplorer.GetDirectory(IOUri.FromFilePath(TestOutputPath));
             featureProviderMock.Setup(m => m.CacheRootDirectory).Returns(cacheRootDirectory);
 
             var featureProviderFactoryMock = StrictMock.Of<IFeatureProviderFactory>();

--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -83,7 +83,7 @@ namespace Bicep.Core.UnitTests.Utils
         public static IDirectoryHandle GetCacheRootDirectory(TestContext testContext)
         {
             var path = GetUniqueTestOutputPath(testContext);
-            var uri = IOUri.FromLocalFilePath(path);
+            var uri = IOUri.FromFilePath(path);
 
             return BicepTestConstants.FileExplorer.GetDirectory(uri);
         }

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -74,6 +74,6 @@ namespace Bicep.Core.Features
                 : customPath);
 
         private IDirectoryHandle GetCacheRootDirectoryFromLocalPath(string localPath) =>
-            this.fileExplorer.GetDirectory(IOUri.FromLocalFilePath(localPath));
+            this.fileExplorer.GetDirectory(IOUri.FromFilePath(localPath));
     }
 }

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -208,7 +208,7 @@ namespace Bicep.Core.Registry
             // CONSIDER: Run these in parallel
             foreach (var reference in referencesEvaluated)
             {
-                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference).Uri.GetLocalFilePath()}");
+                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference).Uri.GetFilePath()}");
                 var (result, errorMessage) = await this.TryRestoreArtifactAsync(reference.ReferencingFile.Configuration, reference);
 
                 if (result is null)

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -57,7 +57,7 @@ namespace Bicep.Core.Registry
 
             foreach (var reference in references)
             {
-                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference).Uri.GetLocalFilePath()}");
+                using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference).Uri.GetFilePath()}");
                 try
                 {
                     var repository = this.repositoryFactory.CreateRepository(reference.ReferencingFile.Configuration, reference.SubscriptionId);

--- a/src/Bicep.IO.UnitTests/Abstraction/IOUriTests.cs
+++ b/src/Bicep.IO.UnitTests/Abstraction/IOUriTests.cs
@@ -23,6 +23,7 @@ namespace Bicep.IO.UnitTests.Abstraction
         [DataRow("file", "localhost", "")]
         [DataRow("file", "", "")]
         [DataRow("file", null, "")]
+        [DataRow("file", "server", "server")]
         public void IOUri_ByDefault_NormalizesAuthority(string scheme, string? authority, string expectedAuthority)
         {
             // Arrange & Act.
@@ -77,6 +78,7 @@ namespace Bicep.IO.UnitTests.Abstraction
         [DataRow("inmemory", null, "a/b/c", "inmemory:a/b/c")]
         [DataRow("inmemory", null, "a/b/../c", "inmemory:a/c")]
         [DataRow("file", "", "/a/b/c", "/a/b/c")]
+        [DataRow("file", null, "/a/b/c", "/a/b/c")]
         public void ToString_ByDefault_ReturnsUriOrLocalFilePath(string scheme, string? authority, string path, string expectedOutput)
         {
             // Arrange & Act.
@@ -277,19 +279,6 @@ namespace Bicep.IO.UnitTests.Abstraction
         }
 
         [TestMethod]
-        public void FromLocalFilePath_UncPath_ThrowsIOException()
-        {
-            // Arrange
-            var filePath = "//server/share";
-
-            // Act
-            Action act = () => IOUri.FromLocalFilePath(filePath);
-
-            // Assert
-            act.Should().Throw<IOException>().WithMessage("Unsupported UNC path.");
-        }
-
-        [TestMethod]
         public void FromLocalFilePath_ValidAbsolutePath_ReturnsExpectedUri()
         {
             // Arrange
@@ -318,6 +307,54 @@ namespace Bicep.IO.UnitTests.Abstraction
             uri.Scheme.Should().Be(IOUriScheme.File);
             uri.Authority.Should().Be("");
             uri.Path.Should().Be("/C:/a/b/c");
+        }
+
+        [DataTestMethod]
+        [DataRow(@"\\server\share\file.txt", "server", "/share/file.txt")]
+        [DataRow(@"\\myserver\documents\folder\file.bicep", "myserver", "/documents/folder/file.bicep")]
+        [DataRow(@"\\SERVER\SHARE\file.txt", "server", "/SHARE/file.txt")]
+        [DataRow(@"\\file-server\public\docs\readme.md", "file-server", "/public/docs/readme.md")]
+        public void FromLocalFilePath_UncPath_ReturnsExpectedUri(string uncPath, string expectedAuthority, string expectedPath)
+        {
+            // Act
+            var uri = IOUri.FromLocalFilePath(uncPath);
+
+            // Assert
+            uri.Scheme.Should().Be(IOUriScheme.File);
+            uri.Authority.Should().Be(expectedAuthority);
+            uri.Path.Should().Be(expectedPath);
+        }
+
+        [DataTestMethod]
+        [DataRow(@"\\server\share\file.txt")]
+        [DataRow(@"\\myserver\documents\folder\file.bicep")]
+        [DataRow(@"\\file-server\public\docs\readme.md")]
+        public void ToString_UncPath_ReturnsUncPath(string uncPath)
+        {
+            // Arrange
+            var uri = IOUri.FromLocalFilePath(uncPath);
+
+            // Act
+            var result = uri.ToString();
+
+            // Assert
+            result.Should().Be(uncPath);
+        }
+
+        [DataTestMethod]
+        [DataRow(@"\\server\share\file.txt", @"\\server\share\file.txt")]
+        [DataRow(@"\\myserver\documents\folder\file.bicep", @"\\myserver\documents\folder\file.bicep")]
+        [DataRow(@"\\file-server\public\docs\readme.md", @"\\file-server\public\docs\readme.md")]
+        public void TryGetLocalFilePath_UncPath_ReturnsCorrectLocalPath(string originalUncPath, string expectedLocalPath)
+        {
+            // Arrange
+            var uri = IOUri.FromLocalFilePath(originalUncPath);
+
+            // Act
+            var localPath = uri.TryGetLocalFilePath();
+
+            // Assert
+            localPath.Should().Be(expectedLocalPath);
         }
 #endif
     }

--- a/src/Bicep.IO.UnitTests/Abstraction/IOUriTests.cs
+++ b/src/Bicep.IO.UnitTests/Abstraction/IOUriTests.cs
@@ -79,7 +79,7 @@ namespace Bicep.IO.UnitTests.Abstraction
         [DataRow("inmemory", null, "a/b/../c", "inmemory:a/c")]
         [DataRow("file", "", "/a/b/c", "/a/b/c")]
         [DataRow("file", null, "/a/b/c", "/a/b/c")]
-        public void ToString_ByDefault_ReturnsUriOrLocalFilePath(string scheme, string? authority, string path, string expectedOutput)
+        public void ToString_ByDefault_ReturnsUriOrFilePath(string scheme, string? authority, string path, string expectedOutput)
         {
             // Arrange & Act.
             var resourceIdentifier = new IOUri(scheme, authority, path);
@@ -266,26 +266,26 @@ namespace Bicep.IO.UnitTests.Abstraction
         }
 
         [TestMethod]
-        public void FromLocalFilePath_RelativePath_ThrowsIOException()
+        public void FromFilePath_RelativePath_ThrowsIOException()
         {
             // Arrange
             var filePath = "a/b/c";
 
             // Act
-            Action act = () => IOUri.FromLocalFilePath(filePath);
+            Action act = () => IOUri.FromFilePath(filePath);
 
             // Assert
             act.Should().Throw<IOException>().WithMessage("File path must be absolute.");
         }
 
         [TestMethod]
-        public void FromLocalFilePath_ValidAbsolutePath_ReturnsExpectedUri()
+        public void FromFilePath_ValidAbsolutePath_ReturnsExpectedUri()
         {
             // Arrange
             var filePath = "/a/b/c";
 
             // Act
-            var uri = IOUri.FromLocalFilePath(filePath);
+            var uri = IOUri.FromFilePath(filePath);
 
             // Assert
             uri.Scheme.Should().Be(IOUriScheme.File);
@@ -295,13 +295,13 @@ namespace Bicep.IO.UnitTests.Abstraction
 
 #if WINDOWS_BUILD
         [TestMethod]
-        public void FromLocalFilePath_WindowsAbsolutePath_ReturnsExpectedUri()
+        public void FromFilePath_WindowsAbsolutePath_ReturnsExpectedUri()
         {
             // Arrange
             var filePath = "C:\\a\\b\\c";
 
             // Act
-            var uri = IOUri.FromLocalFilePath(filePath);
+            var uri = IOUri.FromFilePath(filePath);
 
             // Assert
             uri.Scheme.Should().Be(IOUriScheme.File);
@@ -314,10 +314,10 @@ namespace Bicep.IO.UnitTests.Abstraction
         [DataRow(@"\\myserver\documents\folder\file.bicep", "myserver", "/documents/folder/file.bicep")]
         [DataRow(@"\\SERVER\SHARE\file.txt", "server", "/SHARE/file.txt")]
         [DataRow(@"\\file-server\public\docs\readme.md", "file-server", "/public/docs/readme.md")]
-        public void FromLocalFilePath_UncPath_ReturnsExpectedUri(string uncPath, string expectedAuthority, string expectedPath)
+        public void FromFilePath_UncPath_ReturnsExpectedUri(string uncPath, string expectedAuthority, string expectedPath)
         {
             // Act
-            var uri = IOUri.FromLocalFilePath(uncPath);
+            var uri = IOUri.FromFilePath(uncPath);
 
             // Assert
             uri.Scheme.Should().Be(IOUriScheme.File);
@@ -332,7 +332,7 @@ namespace Bicep.IO.UnitTests.Abstraction
         public void ToString_UncPath_ReturnsUncPath(string uncPath)
         {
             // Arrange
-            var uri = IOUri.FromLocalFilePath(uncPath);
+            var uri = IOUri.FromFilePath(uncPath);
 
             // Act
             var result = uri.ToString();
@@ -345,13 +345,13 @@ namespace Bicep.IO.UnitTests.Abstraction
         [DataRow(@"\\server\share\file.txt", @"\\server\share\file.txt")]
         [DataRow(@"\\myserver\documents\folder\file.bicep", @"\\myserver\documents\folder\file.bicep")]
         [DataRow(@"\\file-server\public\docs\readme.md", @"\\file-server\public\docs\readme.md")]
-        public void TryGetLocalFilePath_UncPath_ReturnsCorrectLocalPath(string originalUncPath, string expectedLocalPath)
+        public void TryGetFilePath_UncPath_ReturnsCorrectLocalPath(string originalUncPath, string expectedLocalPath)
         {
             // Arrange
-            var uri = IOUri.FromLocalFilePath(originalUncPath);
+            var uri = IOUri.FromFilePath(originalUncPath);
 
             // Act
-            var localPath = uri.TryGetLocalFilePath();
+            var localPath = uri.TryGetFilePath();
 
             // Assert
             localPath.Should().Be(expectedLocalPath);

--- a/src/Bicep.IO.UnitTests/FileSystem/FileSystemDirectoryHandleTests.cs
+++ b/src/Bicep.IO.UnitTests/FileSystem/FileSystemDirectoryHandleTests.cs
@@ -52,7 +52,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             var childDirectory = directoryHandle.GetDirectory("child");
 
             // Assert.
-            childDirectory.Uri.GetLocalFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/child/"));
+            childDirectory.Uri.GetFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/child/"));
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             var childFile = directoryHandle.GetFile("child.txt");
 
             // Assert.
-            childFile.Uri.GetLocalFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/child.txt"));
+            childFile.Uri.GetFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/child.txt"));
         }
 
         [TestMethod]
@@ -95,7 +95,7 @@ namespace Bicep.IO.UnitTests.FileSystem
 
             // Assert.
             parentDirectory.Should().NotBeNull();
-            parentDirectory!.Uri.GetLocalFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/"));
+            parentDirectory!.Uri.GetFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/"));
         }
 
         [TestMethod]
@@ -144,7 +144,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             // Assert.
 #if WINDOWS_BUILD
             subdirectories.Should().HaveCount(2);
-            subdirectories.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { @"C:\dir\subdir1\", @"C:\dir\subdir2\" });
+            subdirectories.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\subdir1\", @"C:\dir\subdir2\" });
 #else
             subdirectories.Should().HaveCount(2);
             subdirectories.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/subdir1/", "/dir/subdir2/" });
@@ -168,7 +168,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             // Assert.
 #if WINDOWS_BUILD
             subdirectories.Should().HaveCount(2);
-            subdirectories.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { @"C:\dir\subdir1\", @"C:\dir\subdir2\" });
+            subdirectories.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\subdir1\", @"C:\dir\subdir2\" });
 #else
             subdirectories.Should().HaveCount(2);
             subdirectories.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/subdir1/", "/dir/subdir2/" });
@@ -207,7 +207,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             // Assert.
 #if WINDOWS_BUILD
             files.Should().HaveCount(2);
-            files.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { @"C:\dir\file1.txt", @"C:\dir\file2.txt" });
+            files.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\file1.txt", @"C:\dir\file2.txt" });
 #else
             files.Should().HaveCount(2);
             files.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/file1.txt", "/dir/file2.txt" });
@@ -231,7 +231,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             // Assert.
 #if WINDOWS_BUILD
             files.Should().HaveCount(2);
-            files.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { @"C:\dir\file1.txt", @"C:\dir\file3.txt" });
+            files.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\file1.txt", @"C:\dir\file3.txt" });
 #else
             files.Should().HaveCount(2);
             files.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/file1.txt", "/dir/file3.txt" });
@@ -242,7 +242,7 @@ namespace Bicep.IO.UnitTests.FileSystem
         {
             path = fileSystem.Path.GetFullPath(path);
 
-            return new(fileSystem, IOUri.FromLocalFilePath(path));
+            return new(fileSystem, IOUri.FromFilePath(path));
         }
     }
 }

--- a/src/Bicep.IO.UnitTests/FileSystem/FileSystemDirectoryHandleTests.cs
+++ b/src/Bicep.IO.UnitTests/FileSystem/FileSystemDirectoryHandleTests.cs
@@ -147,7 +147,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             subdirectories.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\subdir1\", @"C:\dir\subdir2\" });
 #else
             subdirectories.Should().HaveCount(2);
-            subdirectories.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/subdir1/", "/dir/subdir2/" });
+            subdirectories.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { "/dir/subdir1/", "/dir/subdir2/" });
 #endif
         }
 
@@ -171,7 +171,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             subdirectories.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\subdir1\", @"C:\dir\subdir2\" });
 #else
             subdirectories.Should().HaveCount(2);
-            subdirectories.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/subdir1/", "/dir/subdir2/" });
+            subdirectories.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { "/dir/subdir1/", "/dir/subdir2/" });
 #endif
         }
 
@@ -210,7 +210,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             files.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\file1.txt", @"C:\dir\file2.txt" });
 #else
             files.Should().HaveCount(2);
-            files.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/file1.txt", "/dir/file2.txt" });
+            files.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { "/dir/file1.txt", "/dir/file2.txt" });
 #endif
         }
 
@@ -234,7 +234,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             files.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { @"C:\dir\file1.txt", @"C:\dir\file3.txt" });
 #else
             files.Should().HaveCount(2);
-            files.Select(d => d.Uri.GetLocalFilePath()).Should().Contain(new[] { "/dir/file1.txt", "/dir/file3.txt" });
+            files.Select(d => d.Uri.GetFilePath()).Should().Contain(new[] { "/dir/file1.txt", "/dir/file3.txt" });
 #endif
         }
 

--- a/src/Bicep.IO.UnitTests/FileSystem/FileSystemFileHandleTests.cs
+++ b/src/Bicep.IO.UnitTests/FileSystem/FileSystemFileHandleTests.cs
@@ -50,7 +50,7 @@ namespace Bicep.IO.UnitTests.FileSystem
             var parentDirectory = fileHandle.GetParent();
 
             // Assert.
-            parentDirectory.Uri.GetLocalFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/"));
+            parentDirectory.Uri.GetFilePath().Should().Be(fileSystem.Path.GetFullPath("/dir/"));
         }
 
         [TestMethod]
@@ -77,7 +77,7 @@ namespace Bicep.IO.UnitTests.FileSystem
         {
             path = fileSystem.Path.GetFullPath(path);
 
-            return new FileSystemFileHandle(fileSystem, IOUri.FromLocalFilePath(path));
+            return new FileSystemFileHandle(fileSystem, IOUri.FromFilePath(path));
         }
     }
 }

--- a/src/Bicep.IO/Abstraction/FilePathFacts.cs
+++ b/src/Bicep.IO/Abstraction/FilePathFacts.cs
@@ -34,7 +34,7 @@ namespace Bicep.IO.Abstraction
         public static bool IsWindowsReservedFileName(string fileName) => WindowsReservedFileNames.Contains(fileName);
 
         public static bool IsWindowsDosDevicePath(string filePath) =>
-            filePath.StartsWith(@"\\.\", StringComparison.Ordinal) ||
+            filePath.StartsWith(@"\\?\", StringComparison.Ordinal) ||
             filePath.StartsWith(@"\\.\", StringComparison.Ordinal) ||
             filePath.StartsWith("//?/", StringComparison.Ordinal) ||
             filePath.StartsWith("//./", StringComparison.Ordinal);

--- a/src/Bicep.IO/Abstraction/IOUri.cs
+++ b/src/Bicep.IO/Abstraction/IOUri.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO.Enumeration;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -17,7 +16,7 @@ using System.Threading.Tasks;
 // - System.IO.Path.IsPathFullyQualified
 // - System.IO.Path.IsPathRooted
 // - System.IO.Path.Join
-using LocalFilePath = System.IO.Path;
+using FilePath = System.IO.Path;
 
 namespace Bicep.IO.Abstraction
 {
@@ -62,7 +61,9 @@ namespace Bicep.IO.Abstraction
 
         public string[] PathSegments => this.Path.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
-        public bool IsLocalFile => this.Scheme.IsFile && this.Authority == "";
+        public bool IsLocalFile => this.Scheme.IsFile;
+
+        public bool IsUnc => this.IsLocalFile && !string.IsNullOrEmpty(this.Authority);
 
         public StringComparison PathComparison => this.IsLocalFile ? GlobalSettings.LocalFilePathComparison : StringComparison.Ordinal;
 
@@ -72,7 +73,7 @@ namespace Bicep.IO.Abstraction
 
         public static IOUri FromLocalFilePath(string filePath)
         {
-            if (!LocalFilePath.IsPathFullyQualified(filePath) && !(filePath.StartsWith('/') || filePath.StartsWith('\\')))
+            if (!FilePath.IsPathFullyQualified(filePath) && !(filePath.StartsWith('/') || filePath.StartsWith('\\')))
             {
                 // Technically speaking, /foo/bar is not a fully qualified file path on Windows. However, our tests use MockFileSystem,
                 // which normalizes it to C:\foo\bar, so we allow it in this context. In non-test scenarios, file I/O with such paths
@@ -88,31 +89,30 @@ namespace Bicep.IO.Abstraction
                 }
             }
 
-            // System.Uri is RFC compliant when it comes to handle file URIs.
-            // It handles all sorts of OS specific edge cases and normalizes path separators.
-            filePath = filePath.Replace("%", "%25");
-            var fileUri = new UriBuilder { Scheme = IOUriScheme.File, Host = "", Path = filePath }.Uri;
+            // UriBuilder handles most OS-specific edge cases and normalizes path separators.
+            // The remaining cases we handle ourselves are % escaping and UNC path normalization (in IOUri.Resolve).
+            var fileUri = new UriBuilder { Scheme = IOUriScheme.File, Host = null, Path = filePath.Replace("%", "%25") }.Uri;
 
-            if (fileUri.IsUnc)
+            if (!OperatingSystem.IsWindows() && fileUri.IsUnc)
             {
-                throw new IOException("Unsupported UNC path.");
+                throw new IOException("UNC paths are only supported on Windows.");
             }
 
             var uriPath = Uri.UnescapeDataString(fileUri.AbsolutePath);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !uriPath.StartsWith('/'))
+            if (OperatingSystem.IsWindows() && !uriPath.StartsWith('/'))
             {
                 uriPath = "/" + uriPath;
             }
 
-            return new IOUri(IOUriScheme.File, "", uriPath);
+            return new IOUri(IOUriScheme.File, fileUri.Host, uriPath);
         }
 
         public override string ToString() => this.TryGetLocalFilePath() ?? this.ToUriString();
 
         // See: The "file" URI Scheme (https://datatracker.ietf.org/doc/html/rfc8089).
         // Note that we don't handle user info and the case where the host IP resolves to the local machine.
-        public string? TryGetLocalFilePath() => this.IsLocalFile ? new UriBuilder { Scheme = this.Scheme, Host = "", Path = EscapePercentSign(this.Path) }.Uri.LocalPath : null;
+        public string? TryGetLocalFilePath() => this.IsLocalFile ? this.ToUri().LocalPath : null;
 
         public string GetLocalFilePath() => TryGetLocalFilePath() ?? throw new InvalidOperationException("The URI is not a local file path.");
 
@@ -124,8 +124,8 @@ namespace Bicep.IO.Abstraction
             return this.Authority is null ? $"{Scheme}:{escapedPath}" : $"{Scheme}://{Authority}{escapedPath}";
         }
 
-        // TODO: Remove after file abstraction migration is complete.
-        public Uri ToUri() => new UriBuilder { Scheme = this.Scheme, Host = "", Path = Path.Replace("%", "%25") }.Uri;
+        // TODO: Convert to private after file abstraction migration is complete.
+        public Uri ToUri() => new UriBuilder { Scheme = this.Scheme, Host = this.Authority, Path = EscapePercentSign(this.Path) }.Uri;
 
         public static bool operator ==(IOUri left, IOUri right) => left.Equals(right);
 
@@ -237,13 +237,47 @@ namespace Bicep.IO.Abstraction
 
         public IOUri Resolve(string path)
         {
-            if (!path.StartsWith('/'))
+            if (this.IsUnc)
             {
-                // Relative path.
-                path = this.Path.EndsWith('/') ? this.Path + path : this.Path + "/../" + path;
+                return this.ResolveUncPath(path);
             }
 
-            return this.IsLocalFile ? FromLocalFilePath(path) : new IOUri(this.Scheme, this.Authority, path, this.Query, this.Fragment);
+            if (!path.StartsWith('/') && !(OperatingSystem.IsWindows() && path.StartsWith('\\')))
+            {
+                // Relative path.
+                path = this.Path.EndsWith('/')
+                    ? this.Path + path           // Append to directory.
+                    : this.Path + "/../" + path; // Append to file's parent directory.
+            }
+
+            if (!this.IsLocalFile)
+            {
+                return new IOUri(this.Scheme, this.Authority, path, this.Query, this.Fragment);
+            }
+
+            return FromLocalFilePath(path);
+        }
+
+        private IOUri ResolveUncPath(string path)
+        {
+            // We rely on UriBuilder to normalize file paths, but it does not guarantee semantically UNC paths When resolving "..".
+            // For example, "\\server\share\.." resolves to "\\server\", not "\\server\share\".  We need to preserve the share
+            // and restore it later.
+            var share = '/' + this.PathSegments[0];
+
+            if (!path.StartsWith('/') && !(OperatingSystem.IsWindows() && path.StartsWith('\\')))
+            {
+                var currentPathAfterShare = this.Path[share.Length..]; // Remove /<share>
+                path = currentPathAfterShare.EndsWith('/')
+                    ? currentPathAfterShare + path           // Append to directory.
+                    : currentPathAfterShare + "/../" + path; // Append to file's parent directory.
+            }
+
+            path = FromLocalFilePath(path).Path;
+
+            path = $"{share}{path}"; // Restore /<share>
+
+            return new IOUri(this.Scheme, this.Authority, path);
         }
 
         private static string EscapePercentSign(string value) => value.Replace("%", "%25");
@@ -350,6 +384,56 @@ namespace Bicep.IO.Abstraction
 
             return normalizedPath;
         }
+
+        public static string NormalizeUncPath(string path)
+        {
+            if (!path.StartsWith(@"\\") && !path.StartsWith("//"))
+            {
+                // Not a UNC path, return as is.
+                return path;
+            }
+
+            // Normalize separators
+            path = path.Replace('/', '\\');
+
+            // Split into parts, ignoring empty segments caused by leading '\\'
+            var parts = path.Split(['\\'], StringSplitOptions.RemoveEmptyEntries);
+
+            if (parts.Length < 2)
+            {
+                throw new IOException($"UNC path {path} must have at least a server and share.");
+            }
+
+            string server = parts[0];
+            string share = parts[1];
+
+            var stack = new Stack<string>();
+            stack.Push(share);
+
+            for (int i = 2; i < parts.Length; i++)
+            {
+                var part = parts[i];
+                if (part == "." || part.Length == 0)
+                {
+                    continue;
+                }
+                else if (part == "..")
+                {
+                    if (stack.Count > 1)
+                    {
+                        // Don't pop share
+                        stack.Pop();
+                    }
+                }
+                else
+                {
+                    stack.Push(part);
+                }
+            }
+
+            return $@"\\{server}\{string.Join('\\', stack.Reverse())}";
+        }
+
 
         private bool SchemeEquals(IOUri other) => this.Scheme.Equals(other.Scheme);
 

--- a/src/Bicep.IO/FileSystem/FileSystemDirectoryHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemDirectoryHandle.cs
@@ -55,7 +55,7 @@ namespace Bicep.IO.FileSystem
 
             foreach (var directory in directories)
             {
-                var directoryUri = IOUri.FromLocalFilePath(directory);
+                var directoryUri = IOUri.FromFilePath(directory);
                 yield return new FileSystemDirectoryHandle(this.FileSystem, directoryUri);
             }
         }
@@ -66,7 +66,7 @@ namespace Bicep.IO.FileSystem
 
             foreach (var file in files)
             {
-                var fileUri = IOUri.FromLocalFilePath(file);
+                var fileUri = IOUri.FromFilePath(file);
                 yield return new FileSystemFileHandle(this.FileSystem, fileUri);
             }
         }

--- a/src/Bicep.IO/FileSystem/FileSystemIOHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemIOHandle.cs
@@ -44,7 +44,7 @@ namespace Bicep.IO.FileSystem
                 return false;
             }
 
-            return this.GetType() == other.GetType() && Uri == other.Uri;
+            return this.GetType() == other.GetType() && Uri.Equals(other.Uri);
         }
     }
 }

--- a/src/Bicep.IO/FileSystem/FileSystemIOHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemIOHandle.cs
@@ -19,7 +19,7 @@ namespace Bicep.IO.FileSystem
         protected FileSystemIOHandle(IFileSystem fileSystem, IOUri uri)
         {
             this.FileSystem = fileSystem;
-            this.FilePath = uri.GetLocalFilePath();
+            this.FilePath = uri.GetFilePath();
             this.Uri = uri;
         }
 

--- a/src/Bicep.IO/InMemory/InMemoryFileExplorer.cs
+++ b/src/Bicep.IO/InMemory/InMemoryFileExplorer.cs
@@ -21,7 +21,7 @@ namespace Bicep.IO.InMemory
 
         private static IOUri EnsureLocalFileUri(IOUri uri)
         {
-            if (!uri.IsLocalFile)
+            if (!uri.IsFile)
             {
                 throw new ArgumentException($"The in-memory file explorer only supports local file URIs.");
             }

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -1199,7 +1199,7 @@ AzureMetrics
         private IFeatureProviderFactory GetFeatureProviderFactory(Uri uri, string rootDirectoryPath)
         {
             var features = StrictMock.Of<IFeatureProvider>();
-            var rootDirectory = BicepTestConstants.FileExplorer.GetDirectory(IOUri.FromLocalFilePath(rootDirectoryPath));
+            var rootDirectory = BicepTestConstants.FileExplorer.GetDirectory(IOUri.FromFilePath(rootDirectoryPath));
             features.Setup(m => m.CacheRootDirectory).Returns(rootDirectory);
 
             var featureProviderFactory = StrictMock.Of<IFeatureProviderFactory>();

--- a/src/Bicep.LangServer/Utils/HandlerHelper.cs
+++ b/src/Bicep.LangServer/Utils/HandlerHelper.cs
@@ -13,7 +13,7 @@ public static class HandlerHelper
 {
     public static string ValidateLocalFilePath(DocumentUri documentUri)
     {
-        if (documentUri.ToIOUri().TryGetLocalFilePath() is not { } localPath)
+        if (documentUri.ToIOUri().TryGetFilePath() is not { } localPath)
         {
             throw new ArgumentException($"Invalid input URI: {documentUri}. Expected a file URI.");
         }

--- a/src/Bicep.Local.Deploy/Extensibility/GrpcLocalExtension.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/GrpcLocalExtension.cs
@@ -61,7 +61,7 @@ internal class GrpcLocalExtension(
         {
             StartInfo = new ProcessStartInfo
             {
-                FileName = binaryUri.GetLocalFilePath(),
+                FileName = binaryUri.GetFilePath(),
                 Arguments = processArgs,
                 UseShellExecute = false,
                 RedirectStandardError = true,

--- a/src/Bicep.TestFixtures/Bicep.TextFixtures/IO/TestFileUri.cs
+++ b/src/Bicep.TestFixtures/Bicep.TextFixtures/IO/TestFileUri.cs
@@ -10,9 +10,9 @@ namespace Bicep.TextFixtures.IO
     {
         private static readonly MockFileSystem MockFileSystem = new();
 
-        public static IOUri FromInMemoryPath(string path) => IOUri.FromLocalFilePath(NormalizePath(path));
+        public static IOUri FromInMemoryPath(string path) => IOUri.FromFilePath(NormalizePath(path));
 
-        public static IOUri FromMockFileSystemPath(string path) => IOUri.FromLocalFilePath(MockFileSystem.Path.GetFullPath(NormalizePath(path)));
+        public static IOUri FromMockFileSystemPath(string path) => IOUri.FromFilePath(MockFileSystem.Path.GetFullPath(NormalizePath(path)));
 
         // Prepend "/path/to" to enable use of ".." in tests for convenience.
         private static string NormalizePath(string path) => "/path/to/" + path.TrimStart('/');


### PR DESCRIPTION
With `IOUri`, I had intentionally dropped UNC path support, assuming that it wouldn't to be needed because it's Windows specific. However, this support turns out to be essential when invoking the Windows version of Bicep from WSL, since resolved file paths are UNC paths (e.g., \\wsl.localhost\Ubuntu-22.04\home\main.bicep). This PR restores UNC path support for `IOUri`.

Closes https://github.com/Azure/bicep/issues/17843.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17902)