### PR TITLE
File I/O abstraction part 21: Migrate IConfigurationManager and IFeatureProvider

### DIFF
--- a/src/Bicep.Cli/Commands/TestCommand.cs
+++ b/src/Bicep.Cli/Commands/TestCommand.cs
@@ -44,7 +44,7 @@ namespace Bicep.Cli.Commands
         {
             var inputUri = this.inputOutputArgumentsResolver.ResolveInputArguments(args);
             ArgumentHelper.ValidateBicepFile(inputUri);
-            var features = featureProviderFactory.GetFeatureProvider(inputUri.ToUri());
+            var features = featureProviderFactory.GetFeatureProvider(inputUri);
 
             if (!features.TestFrameworkEnabled)
             {

--- a/src/Bicep.Core.IntegrationTests/Decorators/DecoratorTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Decorators/DecoratorTests.cs
@@ -6,6 +6,7 @@ using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.TextFixtures.Utils;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -39,6 +40,8 @@ namespace Bicep.Core.IntegrationTests.Decorators
         [TestMethod]
         public void ParameterDecorator_AttachedToOtherKindsOfDeclarations_CannotBeUsedAsDecoratorSpecificToTheDeclarations()
         {
+            var testCompiler = TestCompiler.ForMockFileSystemCompilation();
+
             var mainUri = new Uri("file:///main.bicep");
             var moduleUri = new Uri("file:///module.bicep");
 

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -8,7 +8,10 @@ using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Mock;
+using Bicep.IO.Abstraction;
 using Bicep.IO.FileSystem;
+using Bicep.IO.InMemory;
+using Bicep.TextFixtures.IO;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -311,9 +314,9 @@ namespace Bicep.Core.UnitTests.Configuration
         public void GetConfiguration_CustomConfigurationNotFound_ReturnsBuiltInConfiguration()
         {
             // Arrange.
-            var fileExplorer = new FileSystemFileExplorer(new OnDiskFileSystem());
+            var fileExplorer = new InMemoryFileExplorer();
             var sut = new ConfigurationManager(fileExplorer);
-            var sourceFileUri = new Uri(this.CreatePath("foo/bar/main.bicep"));
+            var sourceFileUri = TestFileUri.FromInMemoryPath("path/to/nonexistent/main.bicep");
 
             // Act.
             var configuration = sut.GetConfiguration(sourceFileUri);
@@ -326,45 +329,38 @@ namespace Bicep.Core.UnitTests.Configuration
         public void GetConfiguration_InvalidCustomConfiguration_PropagatesFailedToParseConfigurationDiagnostic()
         {
             // Arrange.
-            var configurationPath = CreatePath("path/to/bicepconfig.json");
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                [configurationPath] = "",
-            });
-            var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var sut = new ConfigurationManager(fileExplorer);
-            var sourceFileUri = new Uri(CreatePath("path/to/main.bicep"));
+            var fileSet = InMemoryTestFileSet.Create(("bicepconfig.json", ""));
+            var sut = new ConfigurationManager(fileSet.FileExplorer);
 
             // Act & Assert.
-            var diagnostics = sut.GetConfiguration(sourceFileUri).Diagnostics;
+            var diagnostics = sut.GetConfiguration(fileSet.GetUri("main.bicep")).Diagnostics;
             diagnostics.Length.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
-            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\" as valid JSON: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.");
+            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{fileSet.GetUri("bicepconfig.json")}\" as valid JSON: The input does not contain any JSON tokens. Expected the input to start with a valid JSON token, when isFinalBlock is true. LineNumber: 0 | BytePositionInLine: 0.");
         }
 
         [TestMethod]
         public void GetConfiguration_ConfigurationFileNotReadable_PropagatesCouldNotLoadConfigurationDiagnostic()
         {
             // Arrange.
-            var configurationPath = CreatePath("path/to/bicepconfig.json");
-            var configFileData = new MockFileData("")
-            {
-                AllowedFileShare = FileShare.None,
-            };
+            var configFileUri = TestFileUri.FromMockFileSystemPath("bicepconfig.json");
+            var mainFileUri = TestFileUri.FromMockFileSystemPath("main.bicep");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                [configurationPath] = configFileData,
+                [configFileUri.GetFilePath()] = new MockFileData("")
+                {
+                    AllowedFileShare = FileShare.None,
+                },
             });
 
-            var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var sut = new ConfigurationManager(fileExplorer);
-            var sourceFileUri = new Uri(CreatePath("path/to/main.bicep"));
+            var fileSet = new MockFileSystemTestFileSet(fileSystem);
+            var sut = new ConfigurationManager(fileSet.FileExplorer);
 
             // Act & Assert.
-            var diagnostics = sut.GetConfiguration(sourceFileUri).Diagnostics;
+            var diagnostics = sut.GetConfiguration(mainFileUri).Diagnostics;
             diagnostics.Length.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
-            diagnostics[0].Message.Should().StartWith($"Could not load the Bicep configuration file \"{configurationPath}\":");
+            diagnostics[0].Message.Should().StartWith($"Could not load the Bicep configuration file \"{configFileUri}\":");
         }
 
         [TestMethod]
@@ -498,7 +494,7 @@ namespace Bicep.Core.UnitTests.Configuration
 
             var fileExplorer = new FileSystemFileExplorer(fileSystemMock.Object);
             var sut = new ConfigurationManager(fileExplorer);
-            var configuration = sut.GetConfiguration(new Uri("file:///foo/bar/main.bicep"));
+            var configuration = sut.GetConfiguration(new IOUri(IOUriScheme.File, "", "/foo/bar/main.bicep"));
 
             // Act & Assert.
             var diagnostics = configuration.Diagnostics;
@@ -510,148 +506,136 @@ namespace Bicep.Core.UnitTests.Configuration
 
         [DataTestMethod]
         [DataRow("""
-    {
-      "cloud": {
-        "currentProfile": "MyCloud"
-      }
-    }
-    """, @"The cloud profile ""MyCloud"" does not exist. Available profiles include ""AzureChinaCloud"", ""AzureCloud"", ""AzureUSGovernment"".")]
+            {
+              "cloud": {
+                "currentProfile": "MyCloud"
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" does not exist. Available profiles include ""AzureChinaCloud"", ""AzureCloud"", ""AzureUSGovernment"".")]
         [DataRow("""
-    {
-      "cloud": {
-        "currentProfile": "MyCloud",
-        "profiles": {
-          "MyCloud": {
-          }
-        }
-      }
-    }
-    """, @"The cloud profile ""MyCloud"" is invalid. The ""resourceManagerEndpoint"" property cannot be null or undefined.")]
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The ""resourceManagerEndpoint"" property cannot be null or undefined.")]
         [DataRow("""
-    {
-      "cloud": {
-        "currentProfile": "MyCloud",
-        "profiles": {
-          "MyCloud": {
-            "resourceManagerEndpoint": "Not and URL"
-          }
-        }
-      }
-    }
-    """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""resourceManagerEndpoint"" property ""Not and URL"" is not a valid URL.")]
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                    "resourceManagerEndpoint": "Not and URL"
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""resourceManagerEndpoint"" property ""Not and URL"" is not a valid URL.")]
         [DataRow("""
-    {
-      "cloud": {
-        "currentProfile": "MyCloud",
-        "profiles": {
-          "MyCloud": {
-            "resourceManagerEndpoint": "https://example.invalid"
-          }
-        }
-      }
-    }
-    """, @"The cloud profile ""MyCloud"" is invalid. The ""activeDirectoryAuthority"" property cannot be null or undefined.")]
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                    "resourceManagerEndpoint": "https://example.invalid"
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The ""activeDirectoryAuthority"" property cannot be null or undefined.")]
         [DataRow("""
-    {
-      "cloud": {
-        "currentProfile": "MyCloud",
-        "profiles": {
-          "MyCloud": {
-            "resourceManagerEndpoint": "https://example.invalid",
-            "activeDirectoryAuthority": "Not an URL"
-          }
-        }
-      }
-    }
-    """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""activeDirectoryAuthority"" property ""Not an URL"" is not a valid URL.")]
+            {
+              "cloud": {
+                "currentProfile": "MyCloud",
+                "profiles": {
+                  "MyCloud": {
+                    "resourceManagerEndpoint": "https://example.invalid",
+                    "activeDirectoryAuthority": "Not an URL"
+                  }
+                }
+              }
+            }
+            """, @"The cloud profile ""MyCloud"" is invalid. The value of the ""activeDirectoryAuthority"" property ""Not an URL"" is not a valid URL.")]
         public void GetConfiguration_InvalidCurrentCloudProfile_PropagatesConfigurationDiagnostic(string configurationContents, string expectedExceptionMessage)
         {
             // Arrange.
-            var configurationPath = CreatePath("path/to/bicepconfig.json");
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                [configurationPath] = configurationContents,
-            });
-
-            var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var sut = new ConfigurationManager(fileExplorer);
-            var sourceFileUri = new Uri(CreatePath("path/to/main.bicep"));
+            var fileSet = InMemoryTestFileSet.Create(("bicepconfig.json", configurationContents));
+            var sut = new ConfigurationManager(fileSet.FileExplorer);
 
             // Act & Assert.
-            var diagnostics = sut.GetConfiguration(sourceFileUri).Diagnostics;
+            var diagnostics = sut.GetConfiguration(fileSet.GetUri("main.bicep")).Diagnostics;
             diagnostics.Length.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
-            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\": {expectedExceptionMessage}");
+            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{fileSet.GetUri("bicepconfig.json")}\": {expectedExceptionMessage}");
         }
 
         [TestMethod]
         [DataRow("""
-    {
-      "cloud": {
-        "credentialOptions": {
-            "managedIdentity": {
-                "type": "UserAssigned"
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned"
+                    }
+                }
+              }
             }
-        }
-      }
-    }
-    """, @"The managed-identity configuration is invalid. Either ""clientId"" or ""resourceId"" must be set for user-assigned identity.")]
+            """, @"The managed-identity configuration is invalid. Either ""clientId"" or ""resourceId"" must be set for user-assigned identity.")]
         [DataRow("""
-    {
-      "cloud": {
-        "credentialOptions": {
-            "managedIdentity": {
-                "type": "UserAssigned",
-                "clientId": "foo",
-                "resourceId": "bar"
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned",
+                        "clientId": "foo",
+                        "resourceId": "bar"
+                    }
+                }
+              }
             }
-        }
-      }
-    }
-    """, @"The managed-identity configuration is invalid. ""clientId"" and ""resourceId"" cannot be set at the same time for user-assigned identity.")]
+            """, @"The managed-identity configuration is invalid. ""clientId"" and ""resourceId"" cannot be set at the same time for user-assigned identity.")]
         [DataRow("""
-    {
-      "cloud": {
-        "credentialOptions": {
-            "managedIdentity": {
-                "type": "UserAssigned",
-                "clientId": "foo"
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned",
+                        "clientId": "foo"
+                    }
+                }
+              }
             }
-        }
-      }
-    }
-    """, @"The managed-identity configuration is invalid. ""clientId"" must be a GUID.")]
+            """, @"The managed-identity configuration is invalid. ""clientId"" must be a GUID.")]
         [DataRow("""
-    {
-      "cloud": {
-        "credentialOptions": {
-            "managedIdentity": {
-                "type": "UserAssigned",
-                "resourceId": "bar"
+            {
+              "cloud": {
+                "credentialOptions": {
+                    "managedIdentity": {
+                        "type": "UserAssigned",
+                        "resourceId": "bar"
+                    }
+                }
+              }
             }
-        }
-      }
-    }
-    """, @"The managed-identity configuration is invalid. ""resourceId"" must be a valid Azure resource identifier.")]
+            """, @"The managed-identity configuration is invalid. ""resourceId"" must be a valid Azure resource identifier.")]
         public void GetConfiguration_InvalidUserAssignedIdentityOptions_PropagatesConfigurationDiagnostic(string configurationContents, string expectedExceptionMessage)
         {
             // Arrange.
-            var configurationPath = CreatePath("path/to/bicepconfig.json");
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                [configurationPath] = configurationContents,
-            });
-            var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var sut = new ConfigurationManager(fileExplorer);
-            var sourceFileUri = new Uri(CreatePath("path/to/main.bicep"));
+            var fileSet = InMemoryTestFileSet.Create(("bicepconfig.json", configurationContents));
+            var sut = new ConfigurationManager(fileSet.FileExplorer);
+
 
             // Act.
-            var diagnostics = sut.GetConfiguration(sourceFileUri).Diagnostics;
+            var diagnostics = sut.GetConfiguration(fileSet.GetUri("main.bicep")).Diagnostics;
 
             // Assert.
             diagnostics.Length.Should().Be(1);
             diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
-            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{configurationPath}\": {expectedExceptionMessage}");
+            diagnostics[0].Message.Should().Be($"Failed to parse the contents of the Bicep configuration file \"{fileSet.GetUri("bicepconfig.json")}\": {expectedExceptionMessage}");
         }
 
         [DataTestMethod]
@@ -660,194 +644,188 @@ namespace Bicep.Core.UnitTests.Configuration
         public void GetConfiguration_ValidCustomConfiguration_OverridesBuiltInConfiguration(string root)
         {
             // Arrange.
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                [CreatePath(root)] = new MockDirectoryData(),
-                [CreatePath($"{root}/modules")] = new MockDirectoryData(),
-                [CreatePath($"{root}/bicepconfig.json")] = /*lang=json,strict*/ """
-        {
-          "cloud": {
-            "currentProfile": "MyCloud",
-            "profiles": {
-              "MyCloud": {
-                "resourceManagerEndpoint": "https://bicep.example.com",
-                "activeDirectoryAuthority": "https://login.bicep.example.com"
-              }
-            },
-            "credentialPrecedence": [
-                "AzurePowerShell",
-                "VisualStudioCode"
-            ],
-            "credentialOptions": {
-              "managedIdentity": {
-                "type": "UserAssigned",
-                "clientId": "00000000-0000-0000-0000-000000000000"
-              }
-            }
-          },
-          "moduleAliases": {
-            "ts": {
-              "mySpecPath": {
-                "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
-              }
-            },
-            "br": {
-              "myRegistry": {
-                "registry": "localhost:8000"
-              },
-              "myModulePath": {
-                "registry": "test.invalid",
-                "modulePath": "root/modules"
-              }
-            }
-          },
-        "analyzers": {
-        "core": {
-            "enabled": false,
-            "rules": {
-            "no-hardcoded-env-urls": {
-                "level": "warning",
-                "disallowedhosts": [
-                "datalake.azure.net",
-                "azuredatalakestore.net",
-                "azuredatalakeanalytics.net",
-                "vault.azure.net",
-                "asazure.windows.net",
-                "batch.core.windows.net"
-                ]
-            }
-            }
-        }
-        },
-        "cacheRootDirectory": "/home/username/.bicep/cache",
-        "experimentalFeaturesEnabled": {
-        },
-        "formatting": {
-        "indentKind": "Space",
-        "newlineKind": "LF",
-        "insertFinalNewline": true,
-        "indentSize": 2,
-        "width": 80
-        }
-    }
-    """
-            });
-            var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var sut = new ConfigurationManager(fileExplorer);
-            var sourceFileUri = new Uri(this.CreatePath($"{root}/modules/vnet.bicep"));
+            var fileSet = InMemoryTestFileSet.Create(
+                ("modules", TestFileData.Directory),
+                ("bicepconfig.json", """
+                    {
+                      "cloud": {
+                        "currentProfile": "MyCloud",
+                        "profiles": {
+                          "MyCloud": {
+                            "resourceManagerEndpoint": "https://bicep.example.com",
+                            "activeDirectoryAuthority": "https://login.bicep.example.com"
+                          }
+                        },
+                        "credentialPrecedence": [
+                          "AzurePowerShell",
+                          "VisualStudioCode"
+                        ],
+                        "credentialOptions": {
+                          "managedIdentity": {
+                            "type": "UserAssigned",
+                            "clientId": "00000000-0000-0000-0000-000000000000"
+                          }
+                        }
+                      },
+                      "moduleAliases": {
+                        "ts": {
+                          "mySpecPath": {
+                            "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
+                          }
+                        },
+                        "br": {
+                          "myRegistry": {
+                            "registry": "localhost:8000"
+                          },
+                          "myModulePath": {
+                            "registry": "test.invalid",
+                            "modulePath": "root/modules"
+                          }
+                        }
+                      },
+                      "analyzers": {
+                        "core": {
+                          "enabled": false,
+                          "rules": {
+                            "no-hardcoded-env-urls": {
+                              "level": "warning",
+                              "disallowedhosts": [
+                                "datalake.azure.net",
+                                "azuredatalakestore.net",
+                                "azuredatalakeanalytics.net",
+                                "vault.azure.net",
+                                "asazure.windows.net",
+                                "batch.core.windows.net"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "cacheRootDirectory": "/home/username/.bicep/cache",
+                      "experimentalFeaturesEnabled": {},
+                      "formatting": {
+                        "indentKind": "Space",
+                        "newlineKind": "LF",
+                        "insertFinalNewline": true,
+                        "indentSize": 2,
+                        "width": 80
+                      }
+                    }
+                    """));
+            var sut = new ConfigurationManager(fileSet.FileExplorer);
 
             // Act.
-            var configuration = sut.GetConfiguration(sourceFileUri);
+            var configuration = sut.GetConfiguration(fileSet.GetUri("modules/vnet.bicep"));
 
             // Assert.
-            configuration.Should().HaveContents(/*lang=json,strict*/ """
-      {
-        "cloud": {
-          "currentProfile": "MyCloud",
-          "profiles": {
-            "AzureChinaCloud": {
-              "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
-              "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
-            },
-            "AzureCloud": {
-              "resourceManagerEndpoint": "https://management.azure.com",
-              "activeDirectoryAuthority": "https://login.microsoftonline.com"
-            },
-            "AzureUSGovernment": {
-              "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
-              "activeDirectoryAuthority": "https://login.microsoftonline.us"
-            },
-            "MyCloud": {
-              "resourceManagerEndpoint": "https://bicep.example.com",
-              "activeDirectoryAuthority": "https://login.bicep.example.com"
-            }
-          },
-          "credentialPrecedence": [
-            "AzurePowerShell",
-            "VisualStudioCode"
-          ],
-          "credentialOptions": {
-            "managedIdentity": {
-              "type": "UserAssigned",
-              "clientId": "00000000-0000-0000-0000-000000000000"
-            }
-          }
-        },
-        "moduleAliases": {
-          "ts": {
-            "mySpecPath": {
-              "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
-            }
-          },
-          "br": {
-            "myModulePath": {
-              "registry": "test.invalid",
-              "modulePath": "root/modules"
-            },
-            "myRegistry": {
-              "registry": "localhost:8000"
-            },
-            "public": {
-              "registry": "mcr.microsoft.com",
-              "modulePath": "bicep"
-            }
-          }
-        },
-        "extensions": {
-            "az": "builtin:",
-            "kubernetes": "builtin:"
-        },
-        "implicitExtensions": [
-            "az"
-        ],
-        "analyzers": {
-          "core": {
-            "verbose": false,
-            "enabled": false,
-            "rules": {
-              "no-hardcoded-env-urls": {
-                "level": "warning",
-                "disallowedhosts": [
-                  "datalake.azure.net",
-                  "azuredatalakestore.net",
-                  "azuredatalakeanalytics.net",
-                  "vault.azure.net",
-                  "asazure.windows.net",
-                  "batch.core.windows.net"
-                ],
-                "excludedhosts": [
-                  "schema.management.azure.com"
-                ]
-              }
-            }
-          }
-        },
-        "cacheRootDirectory": "/home/username/.bicep/cache",
-        "experimentalFeaturesEnabled": {
-          "extendableParamFiles": false,
-          "symbolicNameCodegen": false,
-          "resourceTypedParamsAndOutputs": false,
-          "sourceMapping": false,
-          "legacyFormatter": false,
-          "testFramework": false,
-          "assertions": false,
-          "waitAndRetry": false,
-          "localDeploy": false,
-          "resourceInfoCodegen": false,
-          "moduleExtensionConfigs": false,
-          "desiredStateConfiguration": false,
-          "onlyIfNotExists": false,
-          "moduleIdentity": false
-        },
-        "formatting": {
-          "indentKind": "Space",
-          "newlineKind": "LF",
-          "insertFinalNewline": true,
-          "indentSize": 2,
-          "width": 80
-        }
-      }
-      """);
+            configuration.Should().HaveContents("""
+                {
+                  "cloud": {
+                    "currentProfile": "MyCloud",
+                    "profiles": {
+                      "AzureChinaCloud": {
+                        "resourceManagerEndpoint": "https://management.chinacloudapi.cn",
+                        "activeDirectoryAuthority": "https://login.chinacloudapi.cn"
+                      },
+                      "AzureCloud": {
+                        "resourceManagerEndpoint": "https://management.azure.com",
+                        "activeDirectoryAuthority": "https://login.microsoftonline.com"
+                      },
+                      "AzureUSGovernment": {
+                        "resourceManagerEndpoint": "https://management.usgovcloudapi.net",
+                        "activeDirectoryAuthority": "https://login.microsoftonline.us"
+                      },
+                      "MyCloud": {
+                        "resourceManagerEndpoint": "https://bicep.example.com",
+                        "activeDirectoryAuthority": "https://login.bicep.example.com"
+                      }
+                    },
+                    "credentialPrecedence": [
+                      "AzurePowerShell",
+                      "VisualStudioCode"
+                    ],
+                    "credentialOptions": {
+                      "managedIdentity": {
+                        "type": "UserAssigned",
+                        "clientId": "00000000-0000-0000-0000-000000000000"
+                      }
+                    }
+                  },
+                  "moduleAliases": {
+                    "ts": {
+                      "mySpecPath": {
+                        "subscription": "B34C8680-F688-48C2-A44F-E1EFF5E01173"
+                      }
+                    },
+                    "br": {
+                      "myModulePath": {
+                        "registry": "test.invalid",
+                        "modulePath": "root/modules"
+                      },
+                      "myRegistry": {
+                        "registry": "localhost:8000"
+                      },
+                      "public": {
+                        "registry": "mcr.microsoft.com",
+                        "modulePath": "bicep"
+                      }
+                    }
+                  },
+                  "extensions": {
+                    "az": "builtin:",
+                    "kubernetes": "builtin:"
+                  },
+                  "implicitExtensions": [
+                    "az"
+                  ],
+                  "analyzers": {
+                    "core": {
+                      "verbose": false,
+                      "enabled": false,
+                      "rules": {
+                        "no-hardcoded-env-urls": {
+                          "level": "warning",
+                          "disallowedhosts": [
+                            "datalake.azure.net",
+                            "azuredatalakestore.net",
+                            "azuredatalakeanalytics.net",
+                            "vault.azure.net",
+                            "asazure.windows.net",
+                            "batch.core.windows.net"
+                          ],
+                          "excludedhosts": [
+                            "schema.management.azure.com"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "cacheRootDirectory": "/home/username/.bicep/cache",
+                  "experimentalFeaturesEnabled": {
+                    "extendableParamFiles": false,
+                    "symbolicNameCodegen": false,
+                    "resourceTypedParamsAndOutputs": false,
+                    "sourceMapping": false,
+                    "legacyFormatter": false,
+                    "testFramework": false,
+                    "assertions": false,
+                    "waitAndRetry": false,
+                    "localDeploy": false,
+                    "resourceInfoCodegen": false,
+                    "moduleExtensionConfigs": false,
+                    "desiredStateConfiguration": false,
+                    "onlyIfNotExists": false,
+                    "moduleIdentity": false
+                  },
+                  "formatting": {
+                    "indentKind": "Space",
+                    "newlineKind": "LF",
+                    "insertFinalNewline": true,
+                    "indentSize": 2,
+                    "width": 80
+                  }
+                }
+                """);
         }
 
         [TestMethod]
@@ -857,39 +835,31 @@ namespace Bicep.Core.UnitTests.Configuration
             // > The configuration file closest to the Bicep file in the directory hierarchy is used.
 
             // Arrange.
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-            {
-                [CreatePath("repo")] = new MockDirectoryData(),
-                [CreatePath("repo/bicepconfig.json")] = """
-        {
-          "moduleAliases": {
-            "br": {
-              "public": {
-                "registry": "main.microsoft.com",
-                "modulePath": "bicep"
-              }
-            }
-          }
-        }
-        """,
-                [CreatePath("repo/modules")] = new MockDirectoryData(),
-                [CreatePath("repo/modules/bicepconfig.json")] = """
-        {
-        }
-        """
-            });
+            var fileSet = InMemoryTestFileSet.Create(
+                ("repo/modules/bicepconfig.json", """
+                    {}
+                    """),
+                ("repo/bicepconfig.json", """
+                    {
+                      "moduleAliases": {
+                        "br": {
+                          "public": {
+                            "registry": "main.microsoft.com",
+                            "modulePath": "bicep"
+                          }
+                        }
+                      }
+                    }
+                    """));
 
-            var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var sut = new ConfigurationManager(fileExplorer);
-            var sourceFileUri = new Uri(this.CreatePath("repo/modules/vnet.bicep"));
+            var sut = new ConfigurationManager(fileSet.FileExplorer);
 
             // Act.
-            var configuration = sut.GetConfiguration(sourceFileUri);
+            var configuration = sut.GetConfiguration(fileSet.GetUri("repo/modules/bicepconfig.json"));
 
             // Assert.
             configuration.ModuleAliases.TryGetOciArtifactModuleAlias("public").IsSuccess(out var moduleAlias).Should().BeTrue();
             moduleAlias!.Registry.Should().Be("mcr.microsoft.com");
         }
-        private string CreatePath(string path) => Path.Combine(this.TestContext.ResultsDirectory!, path.Replace('/', Path.DirectorySeparatorChar));
     }
 }

--- a/src/Bicep.Core.UnitTests/Configuration/PatchingConfigurationManager.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/PatchingConfigurationManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Configuration;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.UnitTests.Configuration;
 
@@ -16,5 +17,5 @@ public class PatchingConfigurationManager : IConfigurationManager
         this.patchFunc = patchFunc;
     }
 
-    public RootConfiguration GetConfiguration(Uri sourceFileUri) => patchFunc(configurationManager.GetConfiguration(sourceFileUri));
+    public RootConfiguration GetConfiguration(IOUri sourceFileUri) => patchFunc(configurationManager.GetConfiguration(sourceFileUri));
 }

--- a/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
@@ -8,6 +8,7 @@ using Bicep.Core.Json;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.IO.Abstraction;
 using Bicep.IO.FileSystem;
+using Bicep.TextFixtures.IO;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -66,23 +67,18 @@ public class ExtensionsConfigurationTests
     [TestMethod]
     public void ExtensionConfiguration_user_provided_configuration_overrides_default_configuration()
     {
-        var bicepConfigFileName = "bicepconfig.json";
-        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
-        {
-            [bicepConfigFileName] = new("""
+        var fileSet = InMemoryTestFileSet.Create(("bicepconfig.json", """
             {
-                "extensions": {
-                    "foo": "br:example.azurecr.io/some/fake/path:1.0.0",
-                    "az": "br:mcr.microsoft.com/bicep/extensions/az:0.2.3"
-                }
+              "extensions": {
+                "foo": "br:example.azurecr.io/some/fake/path:1.0.0",
+                "az": "br:mcr.microsoft.com/bicep/extensions/az:0.2.3"
+              }
             }
-            """)
-        });
+            """));
 
-        var fileExplorer = new FileSystemFileExplorer(fs);
-        var configManager = new ConfigurationManager(fileExplorer);
-        var testFilePath = fs.Path.GetFullPath(bicepConfigFileName);
-        var config = configManager.GetConfiguration(PathHelper.FilePathToFileUrl(testFilePath));
+        var configManager = new ConfigurationManager(fileSet.FileExplorer);
+        var config = configManager.GetConfiguration(fileSet.GetUri("main.bicep"));
+
         config.Diagnostics.Should().BeEmpty();
         config.Should().NotBeNull();
         config!.Extensions.Should().NotBeNull();

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
@@ -32,8 +32,8 @@ public class FeatureProviderTests
         var configuration = configManager.GetConfiguration(fileSet.GetUri("repo/main.bicep"));
         var fpm = new FeatureProviderFactory(configManager, fileSet.FileExplorer);
 
-        var control = fpm.GetFeatureProvider(fileSet.GetUri("main.bicep").ToUri());
-        var sut = fpm.GetFeatureProvider(fileSet.GetUri("repo/main.bicep").ToUri());
+        var control = fpm.GetFeatureProvider(fileSet.GetUri("main.bicep"));
+        var sut = fpm.GetFeatureProvider(fileSet.GetUri("repo/main.bicep"));
         sut.SymbolicNameCodegenEnabled.Should().Be(control.SymbolicNameCodegenEnabled);
     }
 
@@ -58,11 +58,11 @@ public class FeatureProviderTests
         var configuration = configManager.GetConfiguration(fileSet.GetUri("repo/main.bicep"));
         var fpm = new FeatureProviderFactory(configManager, fileSet.FileExplorer);
 
-        var control = fpm.GetFeatureProvider(fileSet.GetUri("main.bicep").ToUri());
+        var control = fpm.GetFeatureProvider(fileSet.GetUri("main.bicep"));
         control.SymbolicNameCodegenEnabled.Should().BeFalse();
-        var mainDirFeatures = fpm.GetFeatureProvider(fileSet.GetUri("repo/main.bicep").ToUri());
+        var mainDirFeatures = fpm.GetFeatureProvider(fileSet.GetUri("repo/main.bicep"));
         mainDirFeatures.SymbolicNameCodegenEnabled.Should().BeFalse();
-        var subDirFeatures = fpm.GetFeatureProvider(fileSet.GetUri("repo/subdir/module.bicep").ToUri());
+        var subDirFeatures = fpm.GetFeatureProvider(fileSet.GetUri("repo/subdir/module.bicep"));
         subDirFeatures.SymbolicNameCodegenEnabled.Should().BeTrue();
     }
 }

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
@@ -7,6 +7,7 @@ using Bicep.Core.Configuration;
 using Bicep.Core.Features;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.IO.FileSystem;
+using Bicep.TextFixtures.IO;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,44 +22,47 @@ public class FeatureProviderTests
     [TestMethod]
     public void PropertyLookup_WithNothingConfigured_ReturnsDefault()
     {
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-        {
-            [CreatePath("repo")] = new MockDirectoryData(),
-            [CreatePath("repo/bicepconfig.json")] = @"{""experimentalFeaturesEnabled"": {}}",
-        });
+        var fileSet = InMemoryTestFileSet.Create(("repo/bicepconfig.json", """
+            {
+              "experimentalFeaturesEnabled": {}
+            }
+            """));
 
-        var fileExplorer = new FileSystemFileExplorer(fileSystem);
-        var configManager = new ConfigurationManager(fileExplorer);
-        var configuration = configManager.GetConfiguration(new Uri(this.CreatePath("repo/main.bicep")));
-        var fpm = new FeatureProviderFactory(configManager, fileExplorer);
+        var configManager = new ConfigurationManager(fileSet.FileExplorer);
+        var configuration = configManager.GetConfiguration(fileSet.GetUri("repo/main.bicep"));
+        var fpm = new FeatureProviderFactory(configManager, fileSet.FileExplorer);
 
-        var control = fpm.GetFeatureProvider(new Uri("file:///main.bicep"));
-        var sut = fpm.GetFeatureProvider(new Uri(this.CreatePath("repo/main.bicep")));
+        var control = fpm.GetFeatureProvider(fileSet.GetUri("main.bicep").ToUri());
+        var sut = fpm.GetFeatureProvider(fileSet.GetUri("repo/main.bicep").ToUri());
         sut.SymbolicNameCodegenEnabled.Should().Be(control.SymbolicNameCodegenEnabled);
     }
 
     [TestMethod]
     public void PropertyLookup_WithFeatureEnabledViaBicepConfig_ReturnsTrue()
     {
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-        {
-            [CreatePath("repo")] = new MockDirectoryData(),
-            [CreatePath("repo/bicepconfig.json")] = @"{""experimentalFeaturesEnabled"": {}}",
-            [CreatePath("repo/subdir")] = new MockDirectoryData(),
-            [CreatePath("repo/subdir/bicepconfig.json")] = @"{""experimentalFeaturesEnabled"": {""symbolicNameCodegen"": true}}",
-        });
-        var fileExplorer = new FileSystemFileExplorer(fileSystem);
-        var configManager = new ConfigurationManager(fileExplorer);
-        var configuration = configManager.GetConfiguration(new Uri(this.CreatePath("repo/main.bicep")));
-        var fpm = new FeatureProviderFactory(configManager, fileExplorer);
+        var fileSet = InMemoryTestFileSet.Create(
+            ("repo/bicepconfig.json", """
+                {
+                  "experimentalFeaturesEnabled": {}
+                }
+                """),
+            ("repo/subdir/bicepconfig.json", """
+                {
+                  "experimentalFeaturesEnabled": {
+                    "symbolicNameCodegen": true
+                  }
+                }
+                """));
 
-        var control = fpm.GetFeatureProvider(new Uri("file:///main.bicep"));
+        var configManager = new ConfigurationManager(fileSet.FileExplorer);
+        var configuration = configManager.GetConfiguration(fileSet.GetUri("repo/main.bicep"));
+        var fpm = new FeatureProviderFactory(configManager, fileSet.FileExplorer);
+
+        var control = fpm.GetFeatureProvider(fileSet.GetUri("main.bicep").ToUri());
         control.SymbolicNameCodegenEnabled.Should().BeFalse();
-        var mainDirFeatures = fpm.GetFeatureProvider(new Uri(this.CreatePath("repo/main.bicep")));
+        var mainDirFeatures = fpm.GetFeatureProvider(fileSet.GetUri("repo/main.bicep").ToUri());
         mainDirFeatures.SymbolicNameCodegenEnabled.Should().BeFalse();
-        var subDirFeatures = fpm.GetFeatureProvider(new Uri(this.CreatePath("repo/subdir/module.bicep")));
+        var subDirFeatures = fpm.GetFeatureProvider(fileSet.GetUri("repo/subdir/module.bicep").ToUri());
         subDirFeatures.SymbolicNameCodegenEnabled.Should().BeTrue();
     }
-
-    private string CreatePath(string path) => Path.Combine(this.TestContext.ResultsDirectory!, path.Replace('/', Path.DirectorySeparatorChar));
 }

--- a/src/Bicep.Core.UnitTests/Features/OverridableFeatureProviderFactory.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverridableFeatureProviderFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Features;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.UnitTests.Features;
 
@@ -16,6 +17,6 @@ public class OverriddenFeatureProviderFactory : IFeatureProviderFactory
         this.overrides = overrides;
     }
 
-    public IFeatureProvider GetFeatureProvider(Uri templateUri)
-        => new OverriddenFeatureProvider(factory.GetFeatureProvider(templateUri), overrides);
+    public IFeatureProvider GetFeatureProvider(IOUri sourceFileUri)
+        => new OverriddenFeatureProvider(factory.GetFeatureProvider(sourceFileUri), overrides);
 }

--- a/src/Bicep.Core.UnitTests/Registry/ArtifactDispatcherTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/ArtifactDispatcherTests.cs
@@ -138,7 +138,7 @@ namespace Bicep.Core.UnitTests.Registry
         {
             // Arrange.
             var configManagerMock = StrictMock.Of<IConfigurationManager>();
-            configManagerMock.SetupSequence(m => m.GetConfiguration(It.IsAny<Uri>()))
+            configManagerMock.SetupSequence(m => m.GetConfiguration(It.IsAny<IOUri>()))
                 .Returns(BicepTestConstants.CreateMockConfiguration())
                 .Returns(BicepTestConstants.CreateMockConfiguration())
                 .Returns(changedConfiguration);

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -668,7 +668,7 @@ namespace Bicep.Core.UnitTests.Registry
             var template = BinaryData.FromString(jsonContentsV1);
 
             var featureProviderFactoryMock = StrictMock.Of<IFeatureProviderFactory>();
-            featureProviderFactoryMock.Setup(x => x.GetFeatureProvider(bicepFile.Uri)).Returns(bicepFile.Features);
+            featureProviderFactoryMock.Setup(x => x.GetFeatureProvider(bicepFile.FileHandle.Uri)).Returns(bicepFile.Features);
 
             SourceArchive? sourceArchive = null;
             if (publishSource)
@@ -746,7 +746,7 @@ namespace Bicep.Core.UnitTests.Registry
             featureProviderMock.Setup(m => m.CacheRootDirectory).Returns(cacheRootDirectory);
 
             var featureProviderFactoryMock = StrictMock.Of<IFeatureProviderFactory>();
-            featureProviderFactoryMock.Setup(m => m.GetFeatureProvider(parentModuleUri)).Returns(featureProviderMock.Object);
+            featureProviderFactoryMock.Setup(m => m.GetFeatureProvider(parentModuleUri.ToIOUri())).Returns(featureProviderMock.Object);
 
             var parentModuleFile = new BicepFile(
                 BicepTestConstants.FileExplorer.GetFile(parentModuleUri.ToIOUri()),

--- a/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
@@ -90,10 +90,7 @@ namespace Bicep.Core.UnitTests.Utils
             clientFactory.Setup(m => m.CreateAuthenticatedBlobClient(It.IsAny<CloudConfiguration>(), registryUri, repository)).Returns(client);
 
             var containerRegistryManager = new AzureContainerRegistryManager(clientFactory.Object);
-            var configurationManager = BicepTestConstants.ConfigurationManager;
-
-            var parentUri = new Uri("http://test.bicep", UriKind.Absolute);
-            var configuration = configurationManager.GetConfiguration(parentUri);
+            var configuration = IConfigurationManager.GetBuiltInConfiguration();
 
             using var compiledStream = new BufferedMemoryStream();
 

--- a/src/Bicep.Core/Configuration/ConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/ConfigurationManager.cs
@@ -28,15 +28,14 @@ namespace Bicep.Core.Configuration
             this.fileExplorer = fileExplorer;
         }
 
-        public RootConfiguration GetConfiguration(Uri sourceFileUri)
+        public RootConfiguration GetConfiguration(IOUri sourceFileUri)
         {
             if (!sourceFileUri.IsFile)
             {
                 return GetDefaultConfiguration();
             }
 
-            var sourceFileIOUri = sourceFileUri.ToIOUri();
-            var sourceDirectory = this.fileExplorer.GetFile(sourceFileIOUri).GetParent();
+            var sourceDirectory = this.fileExplorer.GetFile(sourceFileUri).GetParent();
 
             if (!configFileLookupCache.GetOrAdd(sourceDirectory, LookupConfigurationFile).IsSuccess(out var configFileHandle, out var lookupDiagnostic))
             {
@@ -81,9 +80,9 @@ namespace Bicep.Core.Configuration
             return returnVal;
         }
 
-        public void RemoveConfigCacheEntry(IOUri identifier)
+        public void RemoveConfigCacheEntry(IOUri configFileUri)
         {
-            var configFileHandle = this.fileExplorer.GetFile(identifier);
+            var configFileHandle = this.fileExplorer.GetFile(configFileUri);
             if (loadedConfigCache.TryRemove(configFileHandle, out _))
             {
                 // If a config file has been removed from a workspace, the lookup cache is no longer valid.

--- a/src/Bicep.Core/Configuration/IConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/IConfigurationManager.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Text.Json;
 using Bicep.Core.Json;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Configuration
 {
@@ -17,7 +18,7 @@ namespace Bicep.Core.Configuration
         /// </summary>
         /// <param name="sourceFileUri">The URI of the source file to get configuration for.</param>
         /// <returns>The configuration for the source file.</returns>
-        RootConfiguration GetConfiguration(Uri sourceFileUri);
+        RootConfiguration GetConfiguration(IOUri sourceFileUri);
 
         /// <summary>
         /// Gets the built-in configuration.
@@ -54,7 +55,7 @@ namespace Bicep.Core.Configuration
                 this.configuration = configuration;
             }
 
-            public RootConfiguration GetConfiguration(Uri sourceFileUri) => configuration;
+            public RootConfiguration GetConfiguration(IOUri sourceFileUri) => configuration;
         }
     }
 }

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -1463,9 +1463,9 @@ namespace Bicep.Core.Emit
                     jsonWriter.AddNestedSourceMap(moduleJsonWriter.TrackingJsonWriter);
                     emitter.EmitProperty("template", moduleTextWriter.ToString());
 
-                    if (moduleBicepFile?.Uri is { } sourceUri)
+                    if (moduleBicepFile?.FileHandle.Uri is { } sourceUri)
                     {
-                        emitter.EmitProperty("sourceUri", sourceUri.AbsoluteUri);
+                        emitter.EmitProperty("sourceUri", sourceUri.ToUriString());
                     }
                 });
 

--- a/src/Bicep.Core/Features/FeatureProviderFactory.cs
+++ b/src/Bicep.Core/Features/FeatureProviderFactory.cs
@@ -17,5 +17,5 @@ public class FeatureProviderFactory : IFeatureProviderFactory
         this.fileExplorer = fileExplorer;
     }
 
-    public IFeatureProvider GetFeatureProvider(Uri templateUri) => new FeatureProvider(configurationManager.GetConfiguration(templateUri.ToIOUri()), this.fileExplorer);
+    public IFeatureProvider GetFeatureProvider(IOUri sourceFileUri) => new FeatureProvider(configurationManager.GetConfiguration(sourceFileUri), this.fileExplorer);
 }

--- a/src/Bicep.Core/Features/FeatureProviderFactory.cs
+++ b/src/Bicep.Core/Features/FeatureProviderFactory.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Bicep.Core.Configuration;
+using Bicep.Core.Extensions;
 using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Features;
@@ -16,5 +17,5 @@ public class FeatureProviderFactory : IFeatureProviderFactory
         this.fileExplorer = fileExplorer;
     }
 
-    public IFeatureProvider GetFeatureProvider(Uri templateUri) => new FeatureProvider(configurationManager.GetConfiguration(templateUri), this.fileExplorer);
+    public IFeatureProvider GetFeatureProvider(Uri templateUri) => new FeatureProvider(configurationManager.GetConfiguration(templateUri.ToIOUri()), this.fileExplorer);
 }

--- a/src/Bicep.Core/Features/IFeatureProviderFactory.cs
+++ b/src/Bicep.Core/Features/IFeatureProviderFactory.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using Bicep.IO.Abstraction;
+
 namespace Bicep.Core.Features;
 
 public interface IFeatureProviderFactory
 {
-    IFeatureProvider GetFeatureProvider(Uri templateUri);
+    IFeatureProvider GetFeatureProvider(IOUri sourceFileUri);
 
     static IFeatureProviderFactory WithStaticFeatureProvider(IFeatureProvider featureProvider)
         => new ConstantFeatureProviderFactory(featureProvider);
@@ -18,6 +20,6 @@ public interface IFeatureProviderFactory
             this.features = features;
         }
 
-        public IFeatureProvider GetFeatureProvider(Uri templateUri) => features;
+        public IFeatureProvider GetFeatureProvider(IOUri sourceFileUri) => features;
     }
 }

--- a/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
@@ -80,7 +80,7 @@ namespace Bicep.Core.SourceGraph
 
         public RootConfiguration Configuration => this.configurationManager.GetConfiguration(this.FileHandle.Uri);
 
-        public IFeatureProvider Features => this.featureProviderFactory.GetFeatureProvider(this.Uri);
+        public IFeatureProvider Features => this.featureProviderFactory.GetFeatureProvider(this.FileHandle.Uri);
 
         public IDiagnosticLookup LexingErrorLookup { get; }
 

--- a/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
@@ -78,7 +78,7 @@ namespace Bicep.Core.SourceGraph
 
         public ISyntaxHierarchy Hierarchy { get; }
 
-        public RootConfiguration Configuration => this.configurationManager.GetConfiguration(this.Uri);
+        public RootConfiguration Configuration => this.configurationManager.GetConfiguration(this.FileHandle.Uri);
 
         public IFeatureProvider Features => this.featureProviderFactory.GetFeatureProvider(this.Uri);
 

--- a/src/Bicep.Core/SourceGraph/SourceFileFactory.cs
+++ b/src/Bicep.Core/SourceGraph/SourceFileFactory.cs
@@ -88,7 +88,7 @@ namespace Bicep.Core.SourceGraph
 
         public BicepParamFile CreateBicepParamFile(IOUri fileUri, string fileContents)
         {
-            var parser = new ParamsParser(fileContents, this.featureProviderFactory.GetFeatureProvider(fileUri.ToUri()));
+            var parser = new ParamsParser(fileContents, this.featureProviderFactory.GetFeatureProvider(fileUri));
             var lineStarts = TextCoordinateConverter.GetLineStarts(fileContents);
             var fileHandle = this.CreateFileHandle(fileUri);
 

--- a/src/Bicep.IO/Abstraction/IFileHandle.cs
+++ b/src/Bicep.IO/Abstraction/IFileHandle.cs
@@ -22,11 +22,11 @@ namespace Bicep.IO.Abstraction
 
         string ReadAllText();
 
-        Task<string> ReadAllTextAsync();
+        Task<string> ReadAllTextAsync(CancellationToken cancellationToken = default);
 
         void WriteAllText(string text);
 
-        Task WriteAllTextAsync(string text);
+        Task WriteAllTextAsync(string text, CancellationToken cancellationToken = default);
 
         void Delete();
 

--- a/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
+++ b/src/Bicep.IO/FileSystem/FileSystemFileHandle.cs
@@ -45,7 +45,8 @@ namespace Bicep.IO.FileSystem
 
         public string ReadAllText() => this.FileSystem.File.ReadAllText(this.FilePath);
 
-        public Task<string> ReadAllTextAsync() => this.FileSystem.File.ReadAllTextAsync(this.FilePath);
+        public Task<string> ReadAllTextAsync(CancellationToken cancellationToken = default) =>
+            this.FileSystem.File.ReadAllTextAsync(this.FilePath, cancellationToken);
 
         public void WriteAllText(string text)
         {
@@ -53,11 +54,11 @@ namespace Bicep.IO.FileSystem
             this.FileSystem.File.WriteAllText(this.FilePath, text);
         }
 
-        public async Task WriteAllTextAsync(string text)
+        public async Task WriteAllTextAsync(string text, CancellationToken cancellationToken = default)
         {
             this.GetParent().EnsureExists();
 
-            await this.FileSystem.File.WriteAllTextAsync(this.FilePath, text);
+            await this.FileSystem.File.WriteAllTextAsync(this.FilePath, text, cancellationToken);
         }
 
         public void Delete() => this.FileSystem.File.Delete(this.FilePath);

--- a/src/Bicep.IO/InMemory/DummyFileHandle.cs
+++ b/src/Bicep.IO/InMemory/DummyFileHandle.cs
@@ -35,11 +35,11 @@ namespace Bicep.IO.InMemory
 
         public string ReadAllText() => throw new UnreachableException();
 
-        public Task<string> ReadAllTextAsync() => throw new UnreachableException();
+        public Task<string> ReadAllTextAsync(CancellationToken cancellationToken = default) => throw new UnreachableException();
 
         public void WriteAllText(string text) => throw new UnreachableException();
 
-        public Task WriteAllTextAsync(string text) => throw new UnreachableException();
+        public Task WriteAllTextAsync(string text, CancellationToken cancellationToken = default) => throw new UnreachableException();
 
         public IFileLock? TryLock() => throw new UnreachableException();
     }

--- a/src/Bicep.IO/InMemory/InMemoryFileHandle.cs
+++ b/src/Bicep.IO/InMemory/InMemoryFileHandle.cs
@@ -52,12 +52,19 @@ namespace Bicep.IO.InMemory
 
         public string ReadAllText() => this.FileStore.ReadFile(this).ToString();
 
-        public Task<string> ReadAllTextAsync() => Task.FromResult(this.ReadAllText());
+        public Task<string> ReadAllTextAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(this.ReadAllText());
+        }
 
         public void WriteAllText(string text) => this.FileStore.WriteFile(this, text);
 
-        public Task WriteAllTextAsync(string text)
+        public Task WriteAllTextAsync(string text, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             this.WriteAllText(text);
 
             return Task.CompletedTask;

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -4321,7 +4321,6 @@ var file = " + functionName + @"(templ|)
         {
             var extension = kind == BicepSourceFileKind.ParamsFile ? "bicepparam" : "bicep";
             var (fileText, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursors, '|');
-            var fileUri = new Uri($"file:///{Guid.NewGuid():D}/{TestContext.TestName}/main.{extension}");
 
             var settingsProvider = StrictMock.Of<ISettingsProvider>();
             settingsProvider.Setup(x => x.GetSetting(LangServerConstants.GetAllAzureContainerRegistriesForCompletionsSetting)).Returns(false);
@@ -4338,17 +4337,18 @@ var file = " + functionName + @"(templ|)
 
             var configurationManager = StrictMock.Of<IConfigurationManager>();
             var moduleAliasesConfiguration = BicepTestConstants.BuiltInConfiguration.With(
-                    moduleAliases: RegistryCatalogMocks.ModuleAliases(
-                        """
-                        {
-                            "br": {
-                                "contoso": {
-                                    "registry": "private.contoso.com"
-                                }
+                moduleAliases: RegistryCatalogMocks.ModuleAliases(
+                    """
+                    {
+                        "br": {
+                            "contoso": {
+                                "registry": "private.contoso.com"
                             }
                         }
-                        """));
-            configurationManager.Setup(x => x.GetConfiguration(fileUri)).Returns(moduleAliasesConfiguration);
+                    }
+                    """));
+            var fileUri = DocumentUri.From($"file:///{Guid.NewGuid():D}/{TestContext.TestName}/main.{extension}");
+            configurationManager.Setup(x => x.GetConfiguration(fileUri.ToIOUri())).Returns(moduleAliasesConfiguration);
 
             using var helper = await MultiFileLanguageServerHelper.StartLanguageServer(
                 TestContext,
@@ -4441,7 +4441,6 @@ var file = " + functionName + @"(templ|)
             var extension = kind == BicepSourceFileKind.ParamsFile ? "bicepparam" : "bicep";
             var (fileText, cursor) = ParserHelper.GetFileWithSingleCursor(text, '|');
             var baseFolder = $"{Guid.NewGuid():D}";
-            var fileUri = new Uri($"file:///{baseFolder}/{TestContext.TestName}/main.{extension}");
 
             var configurationManager = StrictMock.Of<IConfigurationManager>();
             var moduleAliasesConfiguration = BicepTestConstants.BuiltInConfiguration.With(
@@ -4460,7 +4459,8 @@ var file = " + functionName + @"(templ|)
                     }
                     """),
                 null));
-            configurationManager.Setup(x => x.GetConfiguration(fileUri)).Returns(moduleAliasesConfiguration);
+            var fileUri = DocumentUri.From($"file:///{baseFolder}/{TestContext.TestName}/main.{extension}");
+            configurationManager.Setup(x => x.GetConfiguration(fileUri.ToIOUri())).Returns(moduleAliasesConfiguration);
 
             var settingsProvider = StrictMock.Of<ISettingsProvider>();
             settingsProvider.Setup(x => x.GetSetting(LangServerConstants.GetAllAzureContainerRegistriesForCompletionsSetting)).Returns(false);
@@ -4511,7 +4511,6 @@ var file = " + functionName + @"(templ|)
         {
             var (fileText, cursor) = ParserHelper.GetFileWithSingleCursor(text, '|');
             var baseFolder = $"{Guid.NewGuid():D}";
-            var fileUri = new Uri($"file:///{baseFolder}/{TestContext.TestName}/main.bicep");
 
             var configurationManager = StrictMock.Of<IConfigurationManager>();
             var moduleAliasesConfiguration = BicepTestConstants.BuiltInConfiguration.With(
@@ -4534,7 +4533,8 @@ var file = " + functionName + @"(templ|)
                       }
                     """),
                 null));
-            configurationManager.Setup(x => x.GetConfiguration(fileUri)).Returns(moduleAliasesConfiguration);
+            var fileUri = DocumentUri.From($"file:///{baseFolder}/{TestContext.TestName}/main.bicep");
+            configurationManager.Setup(x => x.GetConfiguration(fileUri.ToIOUri())).Returns(moduleAliasesConfiguration);
 
             var settingsProvider = StrictMock.Of<ISettingsProvider>();
             settingsProvider.Setup(x => x.GetSetting(LangServerConstants.GetAllAzureContainerRegistriesForCompletionsSetting)).Returns(false);

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -1188,58 +1188,6 @@ AzureMetrics
             return multiFileLanguageServerHelper;
         }
 
-        private ICompilationManager GetBicepCompilationManager(DocumentUri documentUri, CompilationContext compilationContext)
-        {
-            var bicepCompilationManager = StrictMock.Of<ICompilationManager>();
-            bicepCompilationManager.Setup(m => m.GetCompilation(documentUri)).Returns(compilationContext);
-
-            return bicepCompilationManager.Object;
-        }
-
-        private IFeatureProviderFactory GetFeatureProviderFactory(Uri uri, string rootDirectoryPath)
-        {
-            var features = StrictMock.Of<IFeatureProvider>();
-            var rootDirectory = BicepTestConstants.FileExplorer.GetDirectory(IOUri.FromFilePath(rootDirectoryPath));
-            features.Setup(m => m.CacheRootDirectory).Returns(rootDirectory);
-
-            var featureProviderFactory = StrictMock.Of<IFeatureProviderFactory>();
-            featureProviderFactory.Setup(m => m.GetFeatureProvider(uri)).Returns(features.Object);
-
-            return featureProviderFactory.Object;
-        }
-
-        private IModuleDispatcher GetModuleDispatcher(
-            BicepSourceFile parentModuleFile,
-            string manifestFileContents,
-            string testOutputPath,
-            string registry,
-            string repository,
-            string? digest,
-            string? tag)
-        {
-            var moduleDeclarationSyntax = parentModuleFile.ProgramSyntax.Declarations.OfType<ModuleDeclarationSyntax>().Single();
-
-            OciRegistryHelper.SaveManifestFileToModuleRegistryCache(
-                TestContext,
-                registry,
-                repository,
-                manifestFileContents,
-                testOutputPath,
-                digest,
-                tag);
-            ArtifactReference? ociArtifactModuleReference = OciRegistryHelper.CreateModuleReferenceMock(
-                parentModuleFile,
-                registry,
-                repository,
-                digest,
-                tag);
-
-            var moduleDispatcher = StrictMock.Of<IModuleDispatcher>();
-            moduleDispatcher.Setup(m => m.TryGetArtifactReference(parentModuleFile, moduleDeclarationSyntax)).Returns(ResultHelper.Create(ociArtifactModuleReference, null));
-
-            return moduleDispatcher.Object;
-        }
-
         private static void ValidateHover(Hover? hover, Symbol symbol)
         {
             hover.Should().NotBeNull();

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -537,7 +537,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             featureProviderMock.Setup(x => x.CacheRootDirectory).Returns(cacheRootDirectoryMock.Object);
 
             var featureProviderFactoryMock = StrictMock.Of<IFeatureProviderFactory>();
-            featureProviderFactoryMock.Setup(x => x.GetFeatureProvider(It.IsAny<Uri>())).Returns(featureProviderMock.Object);
+            featureProviderFactoryMock.Setup(x => x.GetFeatureProvider(It.IsAny<IOUri>())).Returns(featureProviderMock.Object);
 
             var sourceFileFactory = new SourceFileFactory(BicepTestConstants.ConfigurationManager, featureProviderFactoryMock.Object, BicepTestConstants.AuxiliaryFileCache, BicepTestConstants.FileExplorer);
 

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepExternalSourceDocumentLinkHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepExternalSourceDocumentLinkHandlerTests.cs
@@ -56,7 +56,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var mockConfigurationManager = new ConfigurationManager(mockFileExplorer);
             var featureProviderFactory = new FeatureProviderFactory(mockConfigurationManager, mockFileExplorer);
 
-            this.CacheRootDirectory = featureProviderFactory.GetFeatureProvider(new Uri("file:///no-file")).CacheRootDirectory;
+            this.CacheRootDirectory = featureProviderFactory.GetFeatureProvider(new IOUri("file", "", "/dummy.bicep")).CacheRootDirectory;
         }
 
         private void ResetModuleCache()

--- a/src/Bicep.Local.Deploy/Extensibility/NestedDeploymentExtension.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/NestedDeploymentExtension.cs
@@ -13,6 +13,7 @@ using Azure.Deployments.Extensibility.Core.V2.Models;
 using Azure.Deployments.Extensibility.Data;
 using Azure.Deployments.Extensibility.Messages;
 using Bicep.Core.Configuration;
+using Bicep.Core.Extensions;
 using Bicep.Core.Registry.Auth;
 using Bicep.Local.Deploy.Azure;
 using Bicep.Local.Deploy.Engine;
@@ -113,7 +114,7 @@ internal class NestedDeploymentExtension(
             try
             {
                 GuardHelper.ArgumentNotNull(identifiers.SourceUri);
-                var configuration = configurationManager.GetConfiguration(new Uri(identifiers.SourceUri));
+                var configuration = configurationManager.GetConfiguration(new Uri(identifiers.SourceUri).ToIOUri());
                 DeploymentLocator locator = new("", null, identifiers.SubscriptionId, identifiers.ResourceGroup, identifiers.Name);
 
                 await armDeploymentProvider.StartDeployment(configuration, locator, template, parameters.ToJsonString(), cancellationToken);
@@ -148,7 +149,7 @@ internal class NestedDeploymentExtension(
             try
             {
                 GuardHelper.ArgumentNotNull(identifiers.SourceUri);
-                var configuration = configurationManager.GetConfiguration(new Uri(identifiers.SourceUri));
+                var configuration = configurationManager.GetConfiguration(new Uri(identifiers.SourceUri).ToIOUri());
                 DeploymentLocator locator = new("", null, identifiers.SubscriptionId, identifiers.ResourceGroup, identifiers.Name);
 
                 var result = await armDeploymentProvider.CheckDeployment(configuration, locator, cancellationToken);


### PR DESCRIPTION
Refactored `IConfigurationManager` and `IFeatureProvider` (along with their implementations and tests) to use the Bicep.IO APIs.