### PR TITLE
Install mono on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,9 +463,13 @@ jobs:
           name: bicep-nupkg-any
           path: ./src/Bicep.MSBuild.E2eTests/examples/local-packages
 
-      - name: Install mono
+      - name: Install mono (Mac)
+        if: runner.os == 'macOS'
+        run: brew install mono
+
+      - name: Install mono (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt update && sudo apt install mono-complete
-        if: ${{ matrix.rid == 'linux-x64' || matrix.rid == 'linux-arm64' }}
 
       - name: Build CLI Package
         run: dotnet build --configuration Release /p:RuntimeSuffix=${{ matrix.rid }} ./src/Bicep.Cli.Nuget/nuget.proj


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/12705, mono is no longer present by default on the Mac runner images
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/17914)