### PR TITLE
`bicep deploy` - flush terminal after writing

### DIFF
--- a/src/Bicep.Cli/Commands/DeployCommand.cs
+++ b/src/Bicep.Cli/Commands/DeployCommand.cs
@@ -70,6 +70,7 @@ public class DeployCommand(
             lineCount = output.Count(c => c == '\n');
             await io.Output.WriteAsync(output);
             await Task.Delay(refreshInterval, cancellationToken);
+            await io.Output.FlushAsync(cancellationToken);
         }
 
         {
@@ -77,6 +78,7 @@ public class DeployCommand(
             (var deployments, _) = getCurrentState();
             var finalOutput = DeploymentRenderer.Format(DateTime.UtcNow, deployments, lineCount);
             await io.Output.WriteAsync(finalOutput);
+            await io.Output.FlushAsync(cancellationToken);
         }
     }
 }


### PR DESCRIPTION
The behavior actually seemed fine without this, but I wanted to include it just in case.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18052)