### PR TITLE
`bicep deploy`: Use Spectre for rendering information

### DIFF
--- a/src/Bicep.Cli/Bicep.Cli.csproj
+++ b/src/Bicep.Cli/Bicep.Cli.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Sarif.Sdk" />
+    <PackageReference Include="Spectre.Console" />
     <PackageReference Include="StreamJsonRpc" />
     <PackageReference Include="Azure.Deployments.ClientTools" />
   </ItemGroup>

--- a/src/Bicep.Cli/Commands/DeployCommand.cs
+++ b/src/Bicep.Cli/Commands/DeployCommand.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Immutable;
 using Bicep.Cli.Arguments;
-using Bicep.Cli.Commands.Helpers.Deploy;
+using Bicep.Cli.Helpers.Deploy;
 using Bicep.Cli.Logging;
 using Bicep.Core;
 using Bicep.Core.AzureApi;
@@ -15,7 +14,7 @@ using Microsoft.Extensions.Logging;
 namespace Bicep.Cli.Commands;
 
 public class DeployCommand(
-    IOContext io,
+    DeploymentRenderer deploymentRenderer,
     ILogger logger,
     IEnvironment environment,
     IArmClientProvider armClientProvider,
@@ -27,56 +26,26 @@ public class DeployCommand(
     {
         var config = await DeploymentProcessor.GetDeployCommandsConfig(environment, args.AdditionalArguments, result);
 
-        DeploymentState state = new(Deployments: [], IsActive: true);
-        await Task.WhenAll([
-            RenderLoop(TimeSpan.FromMilliseconds(50), () => state, cancellationToken),
-            ProcessDeployment(model, config, newState => state = newState, cancellationToken),
-        ]);
+        var success = await deploymentRenderer.RenderDeployment(
+            TimeSpan.FromMilliseconds(50),
+            (onUpdate) => ProcessDeployment(model, config, onUpdate, cancellationToken),
+            cancellationToken);
 
-        return DeploymentProcessor.IsSuccess(state.Deployments) ? 0 : 1;
+        return success ? 0 : 1;
     }
 
-    private record DeploymentState(ImmutableArray<DeploymentView> Deployments, bool IsActive);
-
-    private async Task ProcessDeployment(SemanticModel model, DeployCommandsConfig config, Action<DeploymentState> onUpdate, CancellationToken cancellationToken)
+    private async Task ProcessDeployment(SemanticModel model, DeployCommandsConfig config, Action<DeploymentWrapperView> onUpdate, CancellationToken cancellationToken)
     {
-        var armClient = armClientProvider.CreateArmClient(model.Configuration, null);
-        var processor = new DeploymentProcessor(armClient);
-
-        ImmutableArray<DeploymentView> currentDeployments = [];
         try
         {
-            await processor.Deploy(config, deployments =>
-            {
-                currentDeployments = deployments;
-                onUpdate(new(Deployments: currentDeployments, IsActive: true));
-            }, cancellationToken);
-        }
-        finally
-        {
-            // ensure we always set IsActive to false, so that the render loop exits even on error
-            onUpdate(new(Deployments: currentDeployments, IsActive: false));
-        }
-    }
+            var armClient = armClientProvider.CreateArmClient(model.Configuration, null);
+            var processor = new DeploymentProcessor(armClient);
 
-    private async Task RenderLoop(TimeSpan refreshInterval, Func<DeploymentState> getCurrentState, CancellationToken cancellationToken)
-    {
-        var lineCount = 0;
-        var isActive = true;
-        while (isActive)
-        {
-            (var deployments, isActive) = getCurrentState();
-            var output = DeploymentRenderer.Format(DateTime.UtcNow, deployments, lineCount);
-            lineCount = output.Count(c => c == '\n');
-            await io.Output.WriteAsync(output);
-            await Task.Delay(refreshInterval, cancellationToken);
+            await processor.Deploy(config, deployment => onUpdate(deployment), cancellationToken);
         }
-
+        catch (Exception exception)
         {
-            // Always render the final state before exiting
-            (var deployments, _) = getCurrentState();
-            var finalOutput = DeploymentRenderer.Format(DateTime.UtcNow, deployments, lineCount);
-            await io.Output.WriteAsync(finalOutput);
+            onUpdate(new(null, exception.Message));
         }
     }
 }

--- a/src/Bicep.Cli/Commands/LocalDeployCommand.cs
+++ b/src/Bicep.Cli/Commands/LocalDeployCommand.cs
@@ -1,22 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.Deployments.Core.Definitions;
-using Azure.Deployments.Core.Json;
 using Bicep.Cli.Arguments;
 using Bicep.Cli.Helpers;
+using Bicep.Cli.Helpers.Deploy;
 using Bicep.Cli.Logging;
 using Bicep.Core;
+using Bicep.Core.Semantics;
 using Bicep.Core.TypeSystem;
-using Bicep.Local.Deploy;
 using Bicep.Local.Deploy.Extensibility;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Bicep.Cli.Commands;
 
 public class LocalDeployCommand(
-    IOContext io,
+    DeploymentRenderer deploymentRenderer,
     ILogger logger,
     DiagnosticLogger diagnosticLogger,
     BicepCompiler compiler,
@@ -53,42 +51,26 @@ public class LocalDeployCommand(
             return 1;
         }
 
+        var success = await deploymentRenderer.RenderDeployment(
+            TimeSpan.FromMilliseconds(50),
+            (onUpdate) => ProcessDeployment(compilation, templateString, parametersString, onUpdate, cancellationToken),
+            cancellationToken);
 
-        // this using block is intentional to ensure that the dispatcher completes running before we write the summary
-        LocalDeploymentResult result;
-        await using (var dispatcher = dispatcherFactory.Create())
-        {
-            await dispatcher.InitializeExtensions(compilation);
-            result = await dispatcher.Deploy(templateString, parametersString, cancellationToken);
-        }
-
-        await WriteSummary(result);
-        return result.Deployment.Properties.ProvisioningState == ProvisioningState.Succeeded ? 0 : 1;
+        return success ? 0 : 1;
     }
 
-    private async Task WriteSummary(LocalDeploymentResult result)
+    private async Task ProcessDeployment(Compilation compilation, string templateString, string parametersString, Action<DeploymentWrapperView> onUpdate, CancellationToken cancellationToken)
     {
-        if (result.Deployment.Properties.Outputs is { } outputs)
+        try
         {
-            foreach (var output in outputs)
-            {
-                await io.Output.WriteLineAsync($"Output {output.Key}: {JsonConvert.SerializeObject(output.Value.Value, Formatting.Indented, SerializerSettings.SerializerObjectTypeSettings)}");
-            }
-        }
+            await using var dispatcher = dispatcherFactory.Create();
 
-        if (result.Deployment.Properties.Error is { } error)
+            await dispatcher.InitializeExtensions(compilation);
+            await dispatcher.Deploy(templateString, parametersString, result => onUpdate(new(DeploymentProcessor.GetDeploymentView(result.Deployment, result.Operations), null)), cancellationToken);
+        }
+        catch (Exception exception)
         {
-            foreach (var subError in error.Details)
-            {
-                await io.Output.WriteLineAsync($"Error: {subError.Code} - {subError.Message}");
-            }
+            onUpdate(new(null, exception.Message));
         }
-
-        foreach (var operation in result.Operations)
-        {
-            await io.Output.WriteLineAsync($"Resource {operation.Properties.TargetResource.SymbolicName} ({operation.Properties.ProvisioningOperation}): {operation.Properties.ProvisioningState}");
-        }
-
-        await io.Output.WriteLineAsync($"Result: {result.Deployment.Properties.ProvisioningState}");
     }
 }

--- a/src/Bicep.Cli/Commands/WhatIfCommand.cs
+++ b/src/Bicep.Cli/Commands/WhatIfCommand.cs
@@ -8,7 +8,7 @@ using Azure.ResourceManager;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
 using Bicep.Cli.Arguments;
-using Bicep.Cli.Commands.Helpers.Deploy;
+using Bicep.Cli.Helpers.Deploy;
 using Bicep.Cli.Helpers.WhatIf;
 using Bicep.Cli.Logging;
 using Bicep.Core;

--- a/src/Bicep.Cli/Helpers/Deploy/DeploymentView.cs
+++ b/src/Bicep.Cli/Helpers/Deploy/DeploymentView.cs
@@ -4,7 +4,16 @@
 using System.Collections.Immutable;
 using System.Text.Json.Nodes;
 
-namespace Bicep.Cli.Commands.Helpers.Deploy;
+namespace Bicep.Cli.Helpers.Deploy;
+
+public record GeneralOperationView(
+    string Name,
+    string State,
+    string? Error);
+
+public record DeploymentWrapperView(
+    DeploymentView? Deployment,
+    string? Error);
 
 public record DeploymentView(
     string Id,
@@ -13,13 +22,13 @@ public record DeploymentView(
     DateTime StartTime,
     DateTime? EndTime,
     ImmutableArray<DeploymentOperationView> Operations,
-    bool IsEntryPoint,
     string? Error,
     ImmutableDictionary<string, JsonNode> Outputs);
 
 public record DeploymentOperationView(
     string Id,
     string Name,
+    string? SymbolicName,
     string Type,
     string State,
     DateTime StartTime,

--- a/src/Bicep.Cli/Program.cs
+++ b/src/Bicep.Cli/Program.cs
@@ -4,9 +4,11 @@
 using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Runtime;
+using Azure.Deployments.Engine.Workers;
 using Bicep.Cli.Arguments;
 using Bicep.Cli.Commands;
 using Bicep.Cli.Helpers;
+using Bicep.Cli.Helpers.Deploy;
 using Bicep.Cli.Logging;
 using Bicep.Cli.Services;
 using Bicep.Core.Emit;
@@ -16,6 +18,7 @@ using Bicep.Core.Tracing;
 using Bicep.Core.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 namespace Bicep.Cli
 {
@@ -180,6 +183,13 @@ namespace Bicep.Cli
                 .AddSingleton<DiagnosticLogger>()
                 .AddSingleton<OutputWriter>()
                 .AddSingleton<PlaceholderParametersWriter>()
-                .AddSingleton(io);
+                .AddSingleton(io)
+                .AddSingleton(AnsiConsole.Create(new AnsiConsoleSettings
+                {
+                    Ansi = AnsiSupport.Detect,
+                    ColorSystem = ColorSystemSupport.Detect,
+                    Interactive = InteractionSupport.Detect,
+                }))
+                .AddSingleton<DeploymentRenderer>();
     }
 }

--- a/src/Bicep.Local.Deploy/Extensibility/LocalExtensionDispatcher.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/LocalExtensionDispatcher.cs
@@ -206,7 +206,7 @@ public class LocalExtensionDispatcher : IAsyncDisposable
         }
     }
 
-    public async Task<LocalDeploymentResult> Deploy(string templateString, string parametersString, CancellationToken cancellationToken)
+    public async Task<LocalDeploymentResult> Deploy(string templateString, string parametersString, Action<LocalDeploymentResult> onUpdate, CancellationToken cancellationToken)
     {
         var name = Guid.NewGuid().ToString();
         await localDeploymentEngine.StartDeployment(name, templateString, parametersString, cancellationToken);
@@ -214,8 +214,9 @@ public class LocalExtensionDispatcher : IAsyncDisposable
         var result = await localDeploymentEngine.CheckDeployment(name);
         while (result.Deployment.Properties.ProvisioningState?.IsTerminal() != true)
         {
-            await Task.Delay(20, cancellationToken);
+            await Task.Delay(50, cancellationToken);
             result = await localDeploymentEngine.CheckDeployment(name);
+            onUpdate(result);
         }
 
         return result;

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -89,6 +89,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.TextWriter" Version="3.0.0" />
     <PackageVersion Include="SharpYaml" Version="2.1.1" />
+    <PackageVersion Include="Spectre.Console" Version="0.51.1" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.20" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />


### PR DESCRIPTION
Removed custom code for rendering information, and replaced it with [Spectre](https://spectreconsole.net/).

Examples of results returned:
<img width="355" height="82" alt="image" src="https://github.com/user-attachments/assets/1adcd6a7-da44-4d47-bdcc-6e5df1861ed4" />

<img width="773" height="376" alt="image" src="https://github.com/user-attachments/assets/5c23d20b-95ac-4ec5-b52a-6f8252382358" />

<img width="973" height="111" alt="image" src="https://github.com/user-attachments/assets/78b8e409-38ab-45f3-8dca-087246037a68" />
