### PR TITLE
chore: updating rollForward to latestPatch

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,6 +5,6 @@
   "sdk": {
     "allowPrerelease": false,
     "version": "8.0.414",
-    "rollForward": "disable"
+    "rollForward": "latestpatch"
   }
 }


### PR DESCRIPTION
_TL;DR;_

- Keeps us secure (we automatically pick up bugfixes/security patches).
- Makes life easier for developers and CI (no more “SDK not installed” errors).
- Doesn’t roll forward to new feature bands or majors, so behavior stays consistent.

## Description

Right now, our [global.json](https://github.com/Azure/bicep/blob/main/global.json) has `sdk.rollForward` set to `disable`. That means the build will only succeed if the `exact` SDK version we list is installed.

If it’s missing, the build just fails. This makes things very brittle, every dev box, CI agent, and container image has to have that SDK version pinned and present.

By switching to `latestPatch`, we loosen that restriction just enough to be practical.

- We still stay locked to the same major, minor, and feature band (so, no breaking changes).

- But instead of failing if _8.0.412_ isn’t installed, the resolver will happily use a later patch in the same band (like _8.0.413_ or _8.0.499_).

Patches are only bug fixes and security updates, so, they’re safe by design.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18098)