### PR TITLE
jsonrpc: fix TCP startup, update helptext

### DIFF
--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -246,12 +246,13 @@ Usage:
     Runs a JSONRPC server for interacting with Bicep programmatically.
 
     Options:
-      --pipe <name>   Runs the JSONRPC server using a named pipe.
-      --socket <dir>  Runs the JSONRPC server on a specific port.
-      --stdio         Runs the JSONRPC server over stdin/stdout.
+      --pipe <name>    Runs the JSONRPC server using a named pipe.
+      --socket <port>  Runs the JSONRPC server on a specific port.
+      --stdio          Runs the JSONRPC server over stdin/stdout.
 
     Examples:
       bicep jsonrpc --pipe /path/to/pipe.sock
+      bicep jsonrpc --socket 12345
       bicep jsonrpc --stdio
 
 "; // this newline is intentional


### PR DESCRIPTION
The `bicep jsonrpc --socket` flow was incorrectly trying to start a TCP client connection, instead of a server connection. CLI helptext for the flag was also misleading.

Fixes #18099 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18102)