### PR TITLE
`bicep deploy` - support `using` `with` completions

### DIFF
--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -188,6 +188,9 @@ namespace Bicep.Core.TypeSystem
 
                 case VariableDeclarationSyntax variableDeclaration:
                     return GetVariableTypeIfDefined(variableDeclaration);
+
+                case UsingWithClauseSyntax usingWithClause:
+                    return GetUsingConfigAssignmentType(usingWithClause);
             }
 
             return null;
@@ -1218,6 +1221,13 @@ namespace Bicep.Core.TypeSystem
             return extMetadata.ConfigAssignmentDeclaredType;
         }
 
+        private DeclaredTypeAssignment? GetUsingConfigAssignmentType(UsingWithClauseSyntax syntax)
+        {
+            var usingConfigType = LanguageConstants.CreateUsingConfigType();
+
+            return TryCreateAssignment(usingConfigType, syntax);
+        }
+
         private DeclaredTypeAssignment? GetExtensionConfigAssignmentType(ExtensionConfigAssignmentSyntax extConfigAssignment)
         {
             if (GetDeclaredExtensionConfigAssignmentType(extConfigAssignment) is { } configType)
@@ -1825,21 +1835,11 @@ namespace Bicep.Core.TypeSystem
                     // the object is an item in an array
                     // use the item's type and propagate flags
                     return TryCreateAssignment(ResolveDiscriminatedObjects(configType.Type, syntax), syntax, extensionAssignment.Flags);
-                case UsingWithClauseSyntax:
-                    parent = this.binder.GetParent(parent) ?? throw new InvalidOperationException($"Expected {nameof(UsingWithClauseSyntax)} to have a parent.");
-                    if (!binder.FileSymbol.TryGetBicepFileSemanticModelViaUsing().IsSuccess(out var semanticModel))
-                    {
-                        // this error will have already been surfaced elsewhere
-                        return null;
-                    }
-
-                    var usingConfigType = LanguageConstants.CreateUsingConfigType();
-
-                    return TryCreateAssignment(usingConfigType, syntax);
 
                 case FunctionArgumentSyntax:
                 case OutputDeclarationSyntax parentOutput when syntax == parentOutput.Value:
                 case VariableDeclarationSyntax parentVariable when syntax == parentVariable.Value:
+                case UsingWithClauseSyntax usingWith when syntax == usingWith.Config:
                     if (GetNonNullableTypeAssignment(parent) is not { } parentAssignment)
                     {
                         return null;
@@ -2011,7 +2011,7 @@ namespace Bicep.Core.TypeSystem
             return null;
         }
 
-        private static TypeSymbol? ResolveDiscriminatedObjects(TypeSymbol type, ObjectSyntax syntax)
+        private static TypeSymbol ResolveDiscriminatedObjects(TypeSymbol type, ObjectSyntax syntax)
         {
             if (type is not DiscriminatedObjectType discriminated)
             {
@@ -2053,7 +2053,7 @@ namespace Bicep.Core.TypeSystem
             var matchingObjectType = discriminated.UnionMembersByKey.TryGetValue(StringUtils.EscapeBicepString(discriminatorValue));
 
             // return the match if we have it
-            return matchingObjectType?.Type;
+            return matchingObjectType?.Type ?? type;
         }
 
         // references to symbols can be involved in cycles

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -242,7 +242,9 @@ namespace Bicep.LanguageServer.Completions
                 ConvertFlag(ExpectingExtensionSpecification.TailMatch(pattern), BicepCompletionContextKind.ExpectingExtensionSpecification) |
                 ConvertFlag(ExpectingExtensionWithOrAsKeyword.TailMatch(pattern), BicepCompletionContextKind.ExpectingExtensionWithOrAsKeyword) |
                 ConvertFlag(ExpectingExtensionConfig.TailMatch(pattern), BicepCompletionContextKind.ExpectingExtensionConfig) |
-                ConvertFlag(ExpectingExtensionAsKeyword.TailMatch(pattern), BicepCompletionContextKind.ExpectingExtensionAsKeyword);
+                ConvertFlag(ExpectingExtensionAsKeyword.TailMatch(pattern), BicepCompletionContextKind.ExpectingExtensionAsKeyword) |
+                ConvertFlag(IsUsingFollowerContext(matchingNodes, offset), BicepCompletionContextKind.UsingFollower) |
+                ConvertFlag(IsUsingWithFollowerContext(matchingNodes, offset), BicepCompletionContextKind.UsingWithFollower);
 
             if (bicepFile.Features.AssertsEnabled)
             {
@@ -465,6 +467,20 @@ namespace Bicep.LanguageServer.Completions
             SyntaxMatcher.IsTailMatch<TargetScopeSyntax, Token>(matchingNodes, (targetScope, token) =>
                 token.Type == TokenType.Assignment &&
                 ReferenceEquals(targetScope.Assignment, token));
+
+        private static bool IsUsingFollowerContext(List<SyntaxBase> matchingNodes, int offset) =>
+            // using 'main.bicep' |
+            SyntaxMatcher.IsTailMatch<UsingDeclarationSyntax>(matchingNodes, syntax =>
+                offset > syntax.Path.GetEndPosition() &&
+                syntax.WithClause is SkippedTriviaSyntax &&
+                offset <= syntax.WithClause.Span.Position);
+
+        private static bool IsUsingWithFollowerContext(List<SyntaxBase> matchingNodes, int offset) =>
+            // using 'main.bicep' with |
+            SyntaxMatcher.IsTailMatch<UsingWithClauseSyntax>(matchingNodes, syntax =>
+                offset > syntax.Keyword.GetEndPosition() &&
+                syntax.Config is SkippedTriviaSyntax &&
+                offset <= syntax.Config.Span.Position);
 
         private static bool IsTopLevelDeclarationStartContext(List<SyntaxBase> matchingNodes, int offset)
         {

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -263,5 +263,15 @@ namespace Bicep.LanguageServer.Completions
         /// The location immediately after a name in a variable declaration.
         /// </summary>
         VariableNameFollower = 1UL << 48,
+
+        /// <summary>
+        /// We're at this place: 'using 'main.bicep' |'
+        /// </summary>
+        UsingFollower = 1UL << 49,
+
+        /// <summary>
+        /// We're at this place: 'using 'main.bicep' with |'
+        /// </summary>
+        UsingWithFollower = 1UL << 50,
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -86,6 +86,7 @@ namespace Bicep.LanguageServer.Completions
                 .Concat(GetParamValueCompletions(model, context))
                 .Concat(GetAssertValueCompletions(model, context))
                 .Concat(GetTypeArgumentCompletions(model, context))
+                .Concat(GetUsingWithCompletions(model,context))
                 .Concat(await moduleReferenceCompletionProvider.GetFilteredCompletions(model.SourceFile, context, cancellationToken));
         }
 
@@ -2107,6 +2108,30 @@ namespace Bicep.LanguageServer.Completions
             if (context.Kind.HasFlag(BicepCompletionContextKind.ExpectingExtensionAsKeyword))
             {
                 yield return CreateKeywordCompletion(LanguageConstants.AsKeyword, "As keyword", context.ReplacementRange);
+            }
+        }
+
+        private IEnumerable<CompletionItem> GetUsingWithCompletions(SemanticModel model, BicepCompletionContext context)
+        {
+            if (!model.Features.DeployCommandsEnabled)
+            {
+                yield break;
+            }
+
+            if (context.Kind.HasFlag(BicepCompletionContextKind.UsingFollower))
+            {
+                yield return CreateKeywordCompletion(LanguageConstants.WithKeyword, "With keyword", context.ReplacementRange);
+            }
+
+            if (context.Kind.HasFlag(BicepCompletionContextKind.UsingWithFollower) &&
+                context.EnclosingDeclaration is UsingDeclarationSyntax usingDeclaration &&
+                usingDeclaration.WithClause is UsingWithClauseSyntax usingWithClause)
+            {
+                var configType = model.GetDeclaredType(usingWithClause);
+                foreach (var completion in GetValueCompletionsForType(model, context, configType, usingWithClause.Config, loopsAllowed: false))
+                {
+                    yield return completion;
+                }
             }
         }
 


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18104)