### PR TITLE
Add library for interacting with Bicep CLI via JSONRPC

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -277,3 +277,8 @@ dotnet_diagnostic.CA1851.severity = warning
 # Override code quality rules for test projects
 [{src/Bicep.Core.Samples/*.cs,src/*Test*/*.cs}]
 dotnet_diagnostic.CA1851.severity = suggestion
+
+# This library is intended to be consumed by other .NET applications, so re-enable best-practice for threading
+[src/Bicep.RpcClient/**/*.cs]
+# Do not directly await a Task
+dotnet_diagnostic.CA2007.severity = warning

--- a/Bicep.sln
+++ b/Bicep.sln
@@ -113,6 +113,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.McpServer.UnitTests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.Local.Rpc", "src\Bicep.Local.Rpc\Bicep.Local.Rpc.csproj", "{8585C44C-5093-4A32-AABA-9EC7B8A6118C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.RpcClient", "src\Bicep.RpcClient\Bicep.RpcClient.csproj", "{EFC27293-4DBB-4D58-85E4-4B94A8F50C8B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.RpcClient.Tests", "src\Bicep.RpcClient.Tests\Bicep.RpcClient.Tests.csproj", "{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +247,14 @@ Global
 		{8585C44C-5093-4A32-AABA-9EC7B8A6118C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8585C44C-5093-4A32-AABA-9EC7B8A6118C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8585C44C-5093-4A32-AABA-9EC7B8A6118C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFC27293-4DBB-4D58-85E4-4B94A8F50C8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFC27293-4DBB-4D58-85E4-4B94A8F50C8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFC27293-4DBB-4D58-85E4-4B94A8F50C8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFC27293-4DBB-4D58-85E4-4B94A8F50C8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -279,6 +291,8 @@ Global
 		{83AC12EE-E6B5-45FA-AADF-68AB652CC804} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
 		{46780AD4-62F3-4AB4-9B3C-6A8AB305C260} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
 		{8585C44C-5093-4A32-AABA-9EC7B8A6118C} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
+		{EFC27293-4DBB-4D58-85E4-4B94A8F50C8B} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
+		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {21F77282-91E7-4304-B1EF-FADFA4F39E37}

--- a/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/FileHelper.cs
@@ -29,18 +29,32 @@ namespace Bicep.Core.UnitTests.Utils
 
         public static string SaveResultFile(TestContext testContext, string fileName, string contents, string? testOutputPath = null, Encoding? encoding = null)
         {
-            var filePath = GetResultFilePath(testContext, fileName, testOutputPath);
+            var outputPath = SaveResultFiles(testContext, [new ResultFile(fileName, contents, encoding)], testOutputPath);
 
-            if (encoding is not null)
+            return Path.Combine(outputPath, fileName);
+        }
+        
+        public record ResultFile(string FileName, string Contents, Encoding? Encoding = null);
+
+        public static string SaveResultFiles(TestContext testContext, ResultFile[] files, string? testOutputPath = null)
+        {
+            var outputPath = testOutputPath ?? GetUniqueTestOutputPath(testContext);
+
+            foreach (var (fileName, contents, encoding) in files)
             {
-                File.WriteAllText(filePath, contents, encoding);
-            }
-            else
-            {
-                File.WriteAllText(filePath, contents);
+                var filePath = GetResultFilePath(testContext, fileName, outputPath);
+
+                if (encoding is not null)
+                {
+                    File.WriteAllText(filePath, contents, encoding);
+                }
+                else
+                {
+                    File.WriteAllText(filePath, contents);
+                }
             }
 
-            return filePath;
+            return outputPath;
         }
 
         public static string SaveEmbeddedResourcesWithPathPrefix(TestContext testContext, Assembly containingAssembly, string manifestFilePrefix)

--- a/src/Bicep.RpcClient.Tests/Bicep.RpcClient.Tests.csproj
+++ b/src/Bicep.RpcClient.Tests/Bicep.RpcClient.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="./Files/**/*.*" />
+    <EmbeddedResource Include="./Files/**/*.*" LogicalName="$([System.String]::new('Files/%(RecursiveDir)%(Filename)%(Extension)').Replace('\', '/'))" WithCulture="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="PublicApiGenerator" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj" />
+    <ProjectReference Include="../Bicep.Cli/Bicep.Cli.csproj" />
+    <ProjectReference Include="../Bicep.RpcClient/Bicep.RpcClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <Target Name="PublishCli" AfterTargets="Build">
+    <Exec Command="dotnet publish --no-restore --configuration $(Configuration) --self-contained true ../Bicep.Cli --output $(OutDir)/PublishedCli"
+      WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
+</Project>

--- a/src/Bicep.RpcClient.Tests/BicepClientTests.cs
+++ b/src/Bicep.RpcClient.Tests/BicepClientTests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using Bicep.RpcClient.Helpers;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.Core.FileSystem;
+using RichardSzalay.MockHttp;
+
+namespace Bicep.RpcClient.Tests;
+
+[TestClass]
+public class BicepClientTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    public required IBicepClient Bicep { get; set; }
+
+    [TestInitialize]
+    public async Task TestInitialize()
+    {
+        MockHttpMessageHandler mockHandler = new();
+
+        mockHandler.When(HttpMethod.Get, "https://downloads.bicep.azure.com/releases/latest")
+            .Respond("application/json", """
+            {
+                "tag_name": "v0.0.0-dev"
+            }
+            """);
+
+        mockHandler.When(HttpMethod.Get, "https://downloads.bicep.azure.com/v0.0.0-dev/bicep-*-*")
+            .Respond(req => {
+                var cliName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "bicep.exe" : "bicep";
+                var cliPath = Path.GetFullPath(Path.Combine(typeof(BicepClientTests).Assembly.Location, $"../PublishedCli/{cliName}"));
+
+                return new(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StreamContent(File.OpenRead(cliPath))
+                };
+            });
+
+        var clientFactory = new BicepClientFactory(new(mockHandler));
+
+        Bicep = await clientFactory.DownloadAndInitialize(new()
+        {
+            InstallPath = FileHelper.GetUniqueTestOutputPath(TestContext),
+        }, null, TestContext.CancellationTokenSource.Token);
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        Bicep.Dispose();
+        if (Directory.Exists(TestContext.TestResultsDirectory))
+        {
+            // This test creates a new Bicep CLI install for each test run, so we need to clean it up afterwards
+            Directory.Delete(TestContext.TestResultsDirectory, true);
+        }
+    }
+
+    [TestMethod]
+    public void BuildDownloadUrlForTag_returns_correct_url()
+    {
+        BicepInstaller.BuildDownloadUrlForTag(OSPlatform.Linux, Architecture.X64, "v0.24.24")
+            .Should().Be("https://downloads.bicep.azure.com/v0.24.24/bicep-linux-x64");
+    }
+
+    [TestMethod]
+    public async Task GetVersion_runs_successfully()
+    {
+        var result = await Bicep.GetVersion();
+
+        result.Should().MatchRegex(@"^\d+\.\d+\.\d+(-.+)?$");
+    }
+
+    [TestMethod]
+    public async Task Compile_runs_successfully()
+    {
+        var bicepFile = FileHelper.SaveResultFile(TestContext, "main.bicep", """
+        param location string
+        """);
+
+        var result = await Bicep.Compile(new(bicepFile));
+
+        result.Success.Should().BeTrue();
+        result.Contents.Should().NotBeNullOrEmpty();
+        result.Diagnostics.Should().Contain(x => x.Code == "no-unused-params");
+    }
+
+    [TestMethod]
+    public async Task CompileParams_runs_successfully()
+    {
+        var outputPath = FileHelper.SaveResultFiles(TestContext, [
+            new("main.bicep", """
+            param location string
+            """),
+            new("main.bicepparam", """
+            using 'main.bicep'
+
+            param location = 'westus'
+            """),
+        ]);
+
+        var result = await Bicep.CompileParams(new(Path.Combine(outputPath, "main.bicepparam"), []));
+
+        result.Success.Should().BeTrue();
+        result.Parameters.Should().NotBeNullOrEmpty();
+        result.Template.Should().NotBeNullOrEmpty();
+        result.Diagnostics.Should().Contain(x => x.Code == "no-unused-params");
+    }
+
+    [TestMethod]
+    public async Task Format_runs_successfully()
+    {
+        var bicepFile = FileHelper.SaveResultFile(TestContext, "main.bicep", """
+        param location      string
+        """);
+
+        var result = await Bicep.Format(new(bicepFile));
+
+        result.Contents.Should().Be("""
+        param location string
+
+        """);
+    }
+    
+    [TestMethod]
+    public async Task GetSnapshot_runs_successfully()
+    {
+        var outputPath = FileHelper.SaveResultFiles(TestContext, [
+            new("main.bicep", """
+            param sku string
+            
+            resource storageaccount 'Microsoft.Storage/storageAccounts@2021-02-01' = {
+              name: 'myStgAct'
+              location: resourceGroup().location
+              kind: 'StorageV2'
+              sku: {
+                name: sku
+              }
+            }
+            """),
+            new("main.bicepparam", """
+            using 'main.bicep'
+            
+            param sku = 'Premium_LRS'
+            """),
+        ]);
+
+        var result = await Bicep.GetSnapshot(new(Path.Combine(outputPath, "main.bicepparam"), new(
+            TenantId: null,
+            SubscriptionId: "0910bc80-1614-479b-a3f4-07178d3ea77b",
+            ResourceGroup: "ant-test",
+            Location: "West US",
+            DeploymentName: "main"), []));
+
+        result.Snapshot.Should().Contain("/subscriptions/0910bc80-1614-479b-a3f4-07178d3ea77b/resourceGroups/ant-test/providers/Microsoft.Storage/storageAccounts/myStgAct");
+    }
+
+    [TestMethod]
+    public async Task GetMetadataResponse_runs_successfully()
+    {
+        var bicepFile = FileHelper.SaveResultFile(TestContext, "main.bicep", """
+            @export()
+            @description('A foo object')
+            type foo = {
+              bar: string
+            }
+            """);
+
+        var result = await Bicep.GetMetadata(new(bicepFile));
+
+        result.Exports[0].Description.Should().Be("A foo object");
+    }
+}

--- a/src/Bicep.RpcClient.Tests/Files/PublicApis/Azure.Bicep.RpcClient.txt
+++ b/src/Bicep.RpcClient.Tests/Files/PublicApis/Azure.Bicep.RpcClient.txt
@@ -3,17 +3,19 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Bicep.RpcClient
 {
-    public class BicepClientConfiguration
+    public class BicepClientConfiguration : System.IEquatable<Bicep.RpcClient.BicepClientConfiguration>
     {
         public BicepClientConfiguration() { }
-        public System.Runtime.InteropServices.Architecture? Architecture { get; set; }
-        public string? InstallPath { get; set; }
-        public System.Runtime.InteropServices.OSPlatform? OsPlatform { get; set; }
+        public System.Runtime.InteropServices.Architecture? Architecture { get; init; }
+        public string? BicepVersion { get; init; }
+        public string? InstallPath { get; init; }
+        public System.Runtime.InteropServices.OSPlatform? OsPlatform { get; init; }
+        public static Bicep.RpcClient.BicepClientConfiguration Default { get; }
     }
     public class BicepClientFactory : Bicep.RpcClient.IBicepClientFactory
     {
         public BicepClientFactory(System.Net.Http.HttpClient httpClient) { }
-        public System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> DownloadAndInitialize(Bicep.RpcClient.BicepClientConfiguration configuration, string? bicepVersion, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> DownloadAndInitialize(Bicep.RpcClient.BicepClientConfiguration configuration, System.Threading.CancellationToken cancellationToken) { }
         public System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> InitializeFromPath(string bicepCliPath, System.Threading.CancellationToken cancellationToken) { }
     }
     public interface IBicepClient : System.IDisposable
@@ -29,7 +31,7 @@ namespace Bicep.RpcClient
     }
     public interface IBicepClientFactory
     {
-        System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> DownloadAndInitialize(Bicep.RpcClient.BicepClientConfiguration configuration, string? bicepVersion, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> DownloadAndInitialize(Bicep.RpcClient.BicepClientConfiguration configuration, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> InitializeFromPath(string bicepCliPath, System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/Bicep.RpcClient.Tests/Files/PublicApis/Azure.Bicep.RpcClient.txt
+++ b/src/Bicep.RpcClient.Tests/Files/PublicApis/Azure.Bicep.RpcClient.txt
@@ -1,0 +1,210 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Azure/bicep")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Bicep.RpcClient.Tests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+namespace Bicep.RpcClient
+{
+    public class BicepClientConfiguration
+    {
+        public BicepClientConfiguration() { }
+        public System.Runtime.InteropServices.Architecture? Architecture { get; set; }
+        public string? InstallPath { get; set; }
+        public System.Runtime.InteropServices.OSPlatform? OsPlatform { get; set; }
+    }
+    public class BicepClientFactory : Bicep.RpcClient.IBicepClientFactory
+    {
+        public BicepClientFactory(System.Net.Http.HttpClient httpClient) { }
+        public System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> DownloadAndInitialize(Bicep.RpcClient.BicepClientConfiguration configuration, string? bicepVersion, System.Threading.CancellationToken cancellationToken) { }
+        public System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> InitializeFromPath(string bicepCliPath, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public interface IBicepClient : System.IDisposable
+    {
+        System.Threading.Tasks.Task<Bicep.RpcClient.Models.CompileResponse> Compile(Bicep.RpcClient.Models.CompileRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.Models.CompileParamsResponse> CompileParams(Bicep.RpcClient.Models.CompileParamsRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.Models.FormatResponse> Format(Bicep.RpcClient.Models.FormatRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.Models.GetDeploymentGraphResponse> GetDeploymentGraph(Bicep.RpcClient.Models.GetDeploymentGraphRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.Models.GetFileReferencesResponse> GetFileReferences(Bicep.RpcClient.Models.GetFileReferencesRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.Models.GetMetadataResponse> GetMetadata(Bicep.RpcClient.Models.GetMetadataRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.Models.GetSnapshotResponse> GetSnapshot(Bicep.RpcClient.Models.GetSnapshotRequest request, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<string> GetVersion(System.Threading.CancellationToken cancellationToken = default);
+    }
+    public interface IBicepClientFactory
+    {
+        System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> DownloadAndInitialize(Bicep.RpcClient.BicepClientConfiguration configuration, string? bicepVersion, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Bicep.RpcClient.IBicepClient> InitializeFromPath(string bicepCliPath, System.Threading.CancellationToken cancellationToken = default);
+    }
+}
+namespace Bicep.RpcClient.Models
+{
+    public class CompileParamsRequest : System.IEquatable<Bicep.RpcClient.Models.CompileParamsRequest>
+    {
+        public CompileParamsRequest(string Path, System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode> ParameterOverrides) { }
+        public System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode> ParameterOverrides { get; init; }
+        public string Path { get; init; }
+    }
+    public class CompileParamsResponse : System.IEquatable<Bicep.RpcClient.Models.CompileParamsResponse>
+    {
+        public CompileParamsResponse(bool Success, System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.DiagnosticDefinition> Diagnostics, string? Parameters, string? Template, string? TemplateSpecId) { }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.DiagnosticDefinition> Diagnostics { get; init; }
+        public string? Parameters { get; init; }
+        public bool Success { get; init; }
+        public string? Template { get; init; }
+        public string? TemplateSpecId { get; init; }
+    }
+    public class CompileRequest : System.IEquatable<Bicep.RpcClient.Models.CompileRequest>
+    {
+        public CompileRequest(string Path) { }
+        public string Path { get; init; }
+    }
+    public class CompileResponse : System.IEquatable<Bicep.RpcClient.Models.CompileResponse>
+    {
+        public CompileResponse(bool Success, System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.DiagnosticDefinition> Diagnostics, string? Contents) { }
+        public string? Contents { get; init; }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.DiagnosticDefinition> Diagnostics { get; init; }
+        public bool Success { get; init; }
+    }
+    public class DiagnosticDefinition : System.IEquatable<Bicep.RpcClient.Models.DiagnosticDefinition>
+    {
+        public DiagnosticDefinition(string Source, Bicep.RpcClient.Models.Range Range, string Level, string Code, string Message) { }
+        public string Code { get; init; }
+        public string Level { get; init; }
+        public string Message { get; init; }
+        public Bicep.RpcClient.Models.Range Range { get; init; }
+        public string Source { get; init; }
+    }
+    public class FormatRequest : System.IEquatable<Bicep.RpcClient.Models.FormatRequest>
+    {
+        public FormatRequest(string Path) { }
+        public string Path { get; init; }
+    }
+    public class FormatResponse : System.IEquatable<Bicep.RpcClient.Models.FormatResponse>
+    {
+        public FormatResponse(string Contents) { }
+        public string Contents { get; init; }
+    }
+    public class GetDeploymentGraphRequest : System.IEquatable<Bicep.RpcClient.Models.GetDeploymentGraphRequest>
+    {
+        public GetDeploymentGraphRequest(string Path) { }
+        public string Path { get; init; }
+    }
+    public class GetDeploymentGraphResponse : System.IEquatable<Bicep.RpcClient.Models.GetDeploymentGraphResponse>
+    {
+        public GetDeploymentGraphResponse(System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetDeploymentGraphResponse.Node> Nodes, System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetDeploymentGraphResponse.Edge> Edges) { }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetDeploymentGraphResponse.Edge> Edges { get; init; }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetDeploymentGraphResponse.Node> Nodes { get; init; }
+        public class Edge : System.IEquatable<Bicep.RpcClient.Models.GetDeploymentGraphResponse.Edge>
+        {
+            public Edge(string Source, string Target) { }
+            public string Source { get; init; }
+            public string Target { get; init; }
+        }
+        public class Node : System.IEquatable<Bicep.RpcClient.Models.GetDeploymentGraphResponse.Node>
+        {
+            public Node(Bicep.RpcClient.Models.Range Range, string Name, string Type, bool IsExisting, string? RelativePath) { }
+            public bool IsExisting { get; init; }
+            public string Name { get; init; }
+            public Bicep.RpcClient.Models.Range Range { get; init; }
+            public string? RelativePath { get; init; }
+            public string Type { get; init; }
+        }
+    }
+    public class GetFileReferencesRequest : System.IEquatable<Bicep.RpcClient.Models.GetFileReferencesRequest>
+    {
+        public GetFileReferencesRequest(string Path) { }
+        public string Path { get; init; }
+    }
+    public class GetFileReferencesResponse : System.IEquatable<Bicep.RpcClient.Models.GetFileReferencesResponse>
+    {
+        public GetFileReferencesResponse(System.Collections.Immutable.ImmutableArray<string> FilePaths) { }
+        public System.Collections.Immutable.ImmutableArray<string> FilePaths { get; init; }
+    }
+    public class GetMetadataRequest : System.IEquatable<Bicep.RpcClient.Models.GetMetadataRequest>
+    {
+        public GetMetadataRequest(string Path) { }
+        public string Path { get; init; }
+    }
+    public class GetMetadataResponse : System.IEquatable<Bicep.RpcClient.Models.GetMetadataResponse>
+    {
+        public GetMetadataResponse(System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.MetadataDefinition> Metadata, System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.SymbolDefinition> Parameters, System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.SymbolDefinition> Outputs, System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.ExportDefinition> Exports) { }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.ExportDefinition> Exports { get; init; }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.MetadataDefinition> Metadata { get; init; }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.SymbolDefinition> Outputs { get; init; }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetMetadataResponse.SymbolDefinition> Parameters { get; init; }
+        public class ExportDefinition : System.IEquatable<Bicep.RpcClient.Models.GetMetadataResponse.ExportDefinition>
+        {
+            public ExportDefinition(Bicep.RpcClient.Models.Range Range, string Name, string Kind, string? Description) { }
+            public string? Description { get; init; }
+            public string Kind { get; init; }
+            public string Name { get; init; }
+            public Bicep.RpcClient.Models.Range Range { get; init; }
+        }
+        public class MetadataDefinition : System.IEquatable<Bicep.RpcClient.Models.GetMetadataResponse.MetadataDefinition>
+        {
+            public MetadataDefinition(string Name, string Value) { }
+            public string Name { get; init; }
+            public string Value { get; init; }
+        }
+        public class SymbolDefinition : System.IEquatable<Bicep.RpcClient.Models.GetMetadataResponse.SymbolDefinition>
+        {
+            public SymbolDefinition(Bicep.RpcClient.Models.Range Range, string Name, Bicep.RpcClient.Models.GetMetadataResponse.TypeDefinition? Type, string? Description) { }
+            public string? Description { get; init; }
+            public string Name { get; init; }
+            public Bicep.RpcClient.Models.Range Range { get; init; }
+            public Bicep.RpcClient.Models.GetMetadataResponse.TypeDefinition? Type { get; init; }
+        }
+        public class TypeDefinition : System.IEquatable<Bicep.RpcClient.Models.GetMetadataResponse.TypeDefinition>
+        {
+            public TypeDefinition(Bicep.RpcClient.Models.Range? Range, string Name) { }
+            public string Name { get; init; }
+            public Bicep.RpcClient.Models.Range? Range { get; init; }
+        }
+    }
+    public class GetSnapshotRequest : System.IEquatable<Bicep.RpcClient.Models.GetSnapshotRequest>
+    {
+        public GetSnapshotRequest(string Path, Bicep.RpcClient.Models.GetSnapshotRequest.MetadataDefinition Metadata, System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetSnapshotRequest.ExternalInputValue>? ExternalInputs) { }
+        public System.Collections.Immutable.ImmutableArray<Bicep.RpcClient.Models.GetSnapshotRequest.ExternalInputValue>? ExternalInputs { get; init; }
+        public Bicep.RpcClient.Models.GetSnapshotRequest.MetadataDefinition Metadata { get; init; }
+        public string Path { get; init; }
+        public class ExternalInputValue : System.IEquatable<Bicep.RpcClient.Models.GetSnapshotRequest.ExternalInputValue>
+        {
+            public ExternalInputValue(string Kind, System.Text.Json.Nodes.JsonNode? Config, System.Text.Json.Nodes.JsonNode Value) { }
+            public System.Text.Json.Nodes.JsonNode? Config { get; init; }
+            public string Kind { get; init; }
+            public System.Text.Json.Nodes.JsonNode Value { get; init; }
+        }
+        public class MetadataDefinition : System.IEquatable<Bicep.RpcClient.Models.GetSnapshotRequest.MetadataDefinition>
+        {
+            public MetadataDefinition(string? TenantId, string? SubscriptionId, string? ResourceGroup, string? Location, string? DeploymentName) { }
+            public string? DeploymentName { get; init; }
+            public string? Location { get; init; }
+            public string? ResourceGroup { get; init; }
+            public string? SubscriptionId { get; init; }
+            public string? TenantId { get; init; }
+        }
+    }
+    public class GetSnapshotResponse : System.IEquatable<Bicep.RpcClient.Models.GetSnapshotResponse>
+    {
+        public GetSnapshotResponse(string Snapshot) { }
+        public string Snapshot { get; init; }
+    }
+    public class Position : System.IEquatable<Bicep.RpcClient.Models.Position>
+    {
+        public Position(int Line, int Char) { }
+        public int Char { get; init; }
+        public int Line { get; init; }
+    }
+    public class Range : System.IEquatable<Bicep.RpcClient.Models.Range>
+    {
+        public Range(Bicep.RpcClient.Models.Position Start, Bicep.RpcClient.Models.Position End) { }
+        public Bicep.RpcClient.Models.Position End { get; init; }
+        public Bicep.RpcClient.Models.Position Start { get; init; }
+    }
+    public class VersionRequest : System.IEquatable<Bicep.RpcClient.Models.VersionRequest>
+    {
+        public VersionRequest() { }
+    }
+    public class VersionResponse : System.IEquatable<Bicep.RpcClient.Models.VersionResponse>
+    {
+        public VersionResponse(string Version) { }
+        public string Version { get; init; }
+    }
+}

--- a/src/Bicep.RpcClient.Tests/PublicApiTests.cs
+++ b/src/Bicep.RpcClient.Tests/PublicApiTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Baselines;
+using FluentAssertions;
+using PublicApiGenerator;
+
+namespace Bicep.RpcClient.Tests;
+
+[TestClass]
+public class PublicApiTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    [TestCategory(BaselineHelper.BaselineTestCategory)]
+    [EmbeddedFilesTestData(@"^Files\/PublicApis\/Azure.Bicep.RpcClient.txt$")]
+    public void PublicApi_should_be_up_to_date(EmbeddedFile publicApiFile)
+    {
+        // This test just asserts that the public API surface of the assembly as defined in Azure.Bicep.RpcClient.txt is up to date.
+        // This ensures that any changes to the public API are reviewed.
+        var baselineFolder = BaselineFolder.BuildOutputFolder(TestContext, publicApiFile);
+        var result = baselineFolder.GetFileOrEnsureCheckedIn(publicApiFile.FileName);
+
+        var publicApi = typeof(BicepClientConfiguration).Assembly.GeneratePublicApi();
+
+        result.WriteToOutputFolder(publicApi);
+        result.ShouldHaveExpectedValue();
+    }
+
+    [TestMethod]
+    public void Dependencies_should_be_minimal()
+    {
+        var referencedAssemblies = typeof(BicepClientConfiguration).Assembly
+            .GetReferencedAssemblies()
+            .OrderBy(x => x.Name)
+            .Select(x => x.Name);
+
+        referencedAssemblies.Except(["netstandard"]).Should().BeEquivalentTo([
+            // Be careful when adding new dependencies to the ClientTools assembly - this assembly is intentionally slim.
+            // The assembly is used in Microsoft internal tools, where dependency management is complex, so we want to avoid transitively depending on ResourceStack
+            "System.Collections.Immutable",
+            "System.Memory",
+            "System.Text.Encodings.Web",
+            "System.Text.Json",
+            "System.Threading.Tasks.Extensions"
+        ]);
+    }
+}

--- a/src/Bicep.RpcClient/Bicep.RpcClient.csproj
+++ b/src/Bicep.RpcClient/Bicep.RpcClient.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Azure.Bicep.RpcClient</AssemblyName>
+    <RootNamespace>Bicep.RpcClient</RootNamespace>
+    <EnableNuget>true</EnableNuget>
+    <!-- intentionally targeting netstandard2.0 for maximum compatibility -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackageTags>Azure;ResourceManager;ARM;Deployments;Templates;Bicep</PackageTags>
+    <Description>
+      Bicep RPC Client. Available to facilitate installation and communication with the Bicep CLI via JSONRPC.
+      The Bicep team has made this NuGet package publicly available on nuget.org. While it is public, it is not a supported package. Any dependency you take on this package will be done at your own risk and we reserve the right to push breaking changes to this package at any time.
+    </Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Bicep.RpcClient.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/src/Bicep.RpcClient/BicepClient.cs
+++ b/src/Bicep.RpcClient/BicepClient.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using Bicep.RpcClient.JsonRpc;
+using Bicep.RpcClient.Models;
+
+namespace Bicep.RpcClient;
+
+internal class BicepClient : IBicepClient
+{
+    private readonly NamedPipeServerStream pipeStream;
+    private readonly Process cliProcess;
+    private readonly JsonRpcClient jsonRpcClient;
+    private readonly Task backgroundTask;
+    private readonly CancellationTokenSource cts;
+
+    private BicepClient(NamedPipeServerStream pipeStream, Process cliProcess, JsonRpcClient jsonRpcClient, CancellationTokenSource cts)
+    {
+        this.pipeStream = pipeStream;
+        this.cliProcess = cliProcess;
+        this.jsonRpcClient = jsonRpcClient;
+        this.backgroundTask = CreateBackgroundTask(pipeStream, cliProcess, jsonRpcClient, cts.Token);
+        this.cts = cts;
+    }
+
+    /// <summary>
+    /// Initializes the Bicep CLI by starting the process and establishing a JSON-RPC connection.
+    /// </summary>
+    public static async Task<IBicepClient> Initialize(string bicepCliPath, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(bicepCliPath))
+        {
+            throw new FileNotFoundException($"The specified Bicep CLI path does not exist: {bicepCliPath}");
+        }
+
+        var pipeName = Guid.NewGuid().ToString();
+        var pipeStream = new NamedPipeServerStream(pipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = bicepCliPath,
+            Arguments = $"jsonrpc --pipe {pipeName}",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+
+        var cliProcess = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start Bicep CLI process");
+
+        await pipeStream.WaitForConnectionAsync(cancellationToken);
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var client = new JsonRpcClient(pipeStream, pipeStream);
+
+        return new BicepClient(pipeStream, cliProcess, client, cts);
+    }
+
+    private static Task CreateBackgroundTask(NamedPipeServerStream pipeStream, Process cliProcess, JsonRpcClient jsonRpcClient, CancellationToken cancellationToken)
+        => Task.Run(async () =>
+        {
+            try
+            {
+                await jsonRpcClient.ReadLoop(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when disposing
+            }
+            finally
+            {
+                pipeStream.Dispose();
+                cliProcess.Dispose();
+            }
+        }, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<CompileResponse> Compile(CompileRequest request, CancellationToken cancellationToken)
+        => jsonRpcClient.SendRequest<CompileRequest, CompileResponse>("bicep/compile", request, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<CompileParamsResponse> CompileParams(CompileParamsRequest request, CancellationToken cancellationToken)
+        => jsonRpcClient.SendRequest<CompileParamsRequest, CompileParamsResponse>("bicep/compileParams", request, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<FormatResponse> Format(FormatRequest request, CancellationToken cancellationToken)
+    {
+        await EnsureMinimumVersion("0.37.1", nameof(Format), cancellationToken);
+        return await jsonRpcClient.SendRequest<FormatRequest, FormatResponse>("bicep/format", request, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public Task<GetDeploymentGraphResponse> GetDeploymentGraph(GetDeploymentGraphRequest request, CancellationToken cancellationToken)
+        => jsonRpcClient.SendRequest<GetDeploymentGraphRequest, GetDeploymentGraphResponse>("bicep/getDeploymentGraph", request, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<GetFileReferencesResponse> GetFileReferences(GetFileReferencesRequest request, CancellationToken cancellationToken)
+        => jsonRpcClient.SendRequest<GetFileReferencesRequest, GetFileReferencesResponse>("bicep/getFileReferences", request, cancellationToken);
+
+    /// <inheritdoc/>
+    public Task<GetMetadataResponse> GetMetadata(GetMetadataRequest request, CancellationToken cancellationToken)
+        => jsonRpcClient.SendRequest<GetMetadataRequest, GetMetadataResponse>("bicep/getMetadata", request, cancellationToken);
+
+    /// <inheritdoc/>
+    public async Task<GetSnapshotResponse> GetSnapshot(GetSnapshotRequest request, CancellationToken cancellationToken)
+    {
+        await EnsureMinimumVersion("0.36.1", nameof(GetSnapshot), cancellationToken);
+        return await jsonRpcClient.SendRequest<GetSnapshotRequest, GetSnapshotResponse>("bicep/getSnapshot", request, cancellationToken);        
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> GetVersion(CancellationToken cancellationToken)
+        => (await jsonRpcClient.SendRequest<VersionRequest, VersionResponse>("bicep/version", new(), cancellationToken)).Version;
+
+    private async Task EnsureMinimumVersion(string requiredVersion, string operationName, CancellationToken cancellationToken)
+    {
+        var actualVersion = await GetVersion(cancellationToken);
+        if (Version.Parse(actualVersion) < Version.Parse(requiredVersion))
+        {
+            throw new InvalidOperationException($"Operation '{operationName}' requires Bicep CLI version '{requiredVersion}' or later, whereas '{actualVersion}' is currently installed.");
+        }
+    }
+
+    public void Dispose()
+    {
+        cts.Cancel();
+        if (!cliProcess.HasExited)
+        {
+            cliProcess.WaitForExit();
+        }
+    }
+}

--- a/src/Bicep.RpcClient/BicepClientConfiguration.cs
+++ b/src/Bicep.RpcClient/BicepClientConfiguration.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+
+namespace Bicep.RpcClient;
+
+public class BicepClientConfiguration
+{
+    public string? InstallPath { get; set; }
+
+    public OSPlatform? OsPlatform { get; set; }
+
+    public Architecture? Architecture { get; set; }
+}

--- a/src/Bicep.RpcClient/BicepClientConfiguration.cs
+++ b/src/Bicep.RpcClient/BicepClientConfiguration.cs
@@ -5,11 +5,16 @@ using System.Runtime.InteropServices;
 
 namespace Bicep.RpcClient;
 
-public class BicepClientConfiguration
+public record BicepClientConfiguration
 {
-    public string? InstallPath { get; set; }
+    public string? InstallPath { get; init; }
 
-    public OSPlatform? OsPlatform { get; set; }
+    public OSPlatform? OsPlatform { get; init; }
 
-    public Architecture? Architecture { get; set; }
+    public Architecture? Architecture { get; init; }
+
+    public string? BicepVersion { get; init; }
+
+    public static BicepClientConfiguration Default
+        => new();
 }

--- a/src/Bicep.RpcClient/BicepClientFactory.cs
+++ b/src/Bicep.RpcClient/BicepClientFactory.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Bicep.RpcClient.Helpers;
+
+namespace Bicep.RpcClient;
+
+public class BicepClientFactory(HttpClient httpClient) : IBicepClientFactory
+{
+    private static readonly string DefaultInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".bicep", "bin");
+    private static readonly OSPlatform CurrentOsPlatform = BicepInstaller.DetectCurrentOSPlatform();
+    private static readonly Architecture CurrentArchitecture = RuntimeInformation.OSArchitecture;
+
+    private readonly HttpClient httpClient = httpClient;
+
+    public async Task<IBicepClient> DownloadAndInitialize(BicepClientConfiguration configuration, string? bicepVersion, CancellationToken cancellationToken)
+    {
+        var osPlatform = configuration.OsPlatform ?? CurrentOsPlatform;
+        var architecture = configuration.Architecture ?? CurrentArchitecture;
+        var baseDownloadPath = configuration.InstallPath ?? DefaultInstallPath;
+
+        var versionTag = bicepVersion is { } ? $"v{bicepVersion}" : await BicepInstaller.ResolveBicepVersionTagAsync(httpClient, bicepVersion, cancellationToken).ConfigureAwait(false);
+
+        var versionedPath = Path.Combine(baseDownloadPath, versionTag);
+        var bicepCliName = osPlatform.Equals(OSPlatform.Windows) ? "bicep.exe" : "bicep";
+        var bicepCliPath = Path.Combine(versionedPath, bicepCliName);
+
+        if (!File.Exists(bicepCliPath))
+        {
+            await BicepInstaller.DownloadAndInstallBicepCliAsync(
+                httpClient: httpClient,
+                bicepCliPath: bicepCliPath,
+                targetOSPlatform: osPlatform,
+                targetOSArchitecture: architecture,
+                versionTag: versionTag,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        return await InitializeFromPath(bicepCliPath, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IBicepClient> InitializeFromPath(string bicepCliPath, CancellationToken cancellationToken)
+    {
+        return await BicepClient.Initialize(bicepCliPath, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Bicep.RpcClient/BicepClientFactory.cs
+++ b/src/Bicep.RpcClient/BicepClientFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Bicep.RpcClient.Helpers;
@@ -13,23 +14,28 @@ namespace Bicep.RpcClient;
 
 public class BicepClientFactory(HttpClient httpClient) : IBicepClientFactory
 {
+    private static readonly Regex VersionRegex = new(@"^\d+\.\d+\.\d+$");
     private static readonly string DefaultInstallPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".bicep", "bin");
     private static readonly OSPlatform CurrentOsPlatform = BicepInstaller.DetectCurrentOSPlatform();
     private static readonly Architecture CurrentArchitecture = RuntimeInformation.OSArchitecture;
 
-    private readonly HttpClient httpClient = httpClient;
-
-    public async Task<IBicepClient> DownloadAndInitialize(BicepClientConfiguration configuration, string? bicepVersion, CancellationToken cancellationToken)
+    public async Task<IBicepClient> DownloadAndInitialize(BicepClientConfiguration configuration, CancellationToken cancellationToken)
     {
+        if (configuration.BicepVersion is { } version && !VersionRegex.IsMatch(version))
+        {
+            throw new ArgumentException($"Invalid Bicep version format '{version}'. Expected format: 'x.y.z' where x, y, and z are integers.");
+        }
+
         var osPlatform = configuration.OsPlatform ?? CurrentOsPlatform;
         var architecture = configuration.Architecture ?? CurrentArchitecture;
         var baseDownloadPath = configuration.InstallPath ?? DefaultInstallPath;
+        var versionTag = configuration.BicepVersion is { } ?
+            $"v{configuration.BicepVersion}" :
+            await BicepInstaller.GetLatestBicepVersion(httpClient, cancellationToken).ConfigureAwait(false);
 
-        var versionTag = bicepVersion is { } ? $"v{bicepVersion}" : await BicepInstaller.ResolveBicepVersionTagAsync(httpClient, bicepVersion, cancellationToken).ConfigureAwait(false);
-
-        var versionedPath = Path.Combine(baseDownloadPath, versionTag);
         var bicepCliName = osPlatform.Equals(OSPlatform.Windows) ? "bicep.exe" : "bicep";
-        var bicepCliPath = Path.Combine(versionedPath, bicepCliName);
+        // E.g. ~/.bicep/bin/v0.37.4/bicep
+        var bicepCliPath = Path.Combine(baseDownloadPath, versionTag, bicepCliName);
 
         if (!File.Exists(bicepCliPath))
         {

--- a/src/Bicep.RpcClient/Helpers/BicepInstaller.cs
+++ b/src/Bicep.RpcClient/Helpers/BicepInstaller.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bicep.RpcClient.Helpers;
+
+internal static class BicepInstaller
+{
+    private const string DownloadBaseUrl = "https://downloads.bicep.azure.com";
+    private const string LatestReleaseUrl = $"{DownloadBaseUrl}/releases/latest";
+    private const string TagNameProperty = "tag_name";
+
+    public static async Task DownloadAndInstallBicepCliAsync(
+        HttpClient httpClient,
+        string bicepCliPath,
+        OSPlatform targetOSPlatform,
+        Architecture targetOSArchitecture,
+        string versionTag,
+        CancellationToken cancellationToken)
+    {
+        var downloadUrl = BuildDownloadUrlForTag(
+            targetOSPlatform: targetOSPlatform,
+            targetOSArchitecture: targetOSArchitecture,
+            versionTag: versionTag);
+
+        if (Path.GetDirectoryName(bicepCliPath) is { } parentPath && !Directory.Exists(parentPath))
+        {
+            Directory.CreateDirectory(parentPath);
+        }
+
+        var response = await httpClient.GetAsync(downloadUrl, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        using var fileStream = File.Create(path: bicepCliPath);
+        await response.Content.CopyToAsync(fileStream).ConfigureAwait(false);
+
+        // Set executable permissions on non-Windows platforms
+        if (!targetOSPlatform.Equals(OSPlatform.Windows))
+        {
+            SetExecutablePermissions(bicepCliPath, cancellationToken);
+        }
+    }
+
+    public static async Task<string> ResolveBicepVersionTagAsync(
+        HttpClient httpClient,
+        string? bicepVersion,
+        CancellationToken cancellationToken)
+    {
+        if (bicepVersion != null)
+        {
+            return $"v{bicepVersion}";
+        }
+
+        var response = await httpClient.GetAsync(LatestReleaseUrl, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var json = JsonSerializer.Deserialize<JsonElement>(responseBody);
+
+        return json.GetProperty(TagNameProperty).GetString()
+            ?? throw new InvalidOperationException("Failed to determine the latest Bicep CLI version from the releases API.");
+    }
+
+    internal static string BuildDownloadUrlForTag(
+        OSPlatform targetOSPlatform,
+        Architecture targetOSArchitecture,
+        string versionTag)
+    {
+        var osPlatformArchitectureMap = new Dictionary<(OSPlatform, Architecture), string>
+        {
+            { (OSPlatform.Windows, Architecture.X64), "bicep-win-x64.exe" },
+            { (OSPlatform.Windows, Architecture.Arm64), "bicep-win-arm64.exe" },
+            { (OSPlatform.Linux, Architecture.X64), "bicep-linux-x64" },
+            { (OSPlatform.Linux, Architecture.Arm64), "bicep-linux-arm64" },
+            { (OSPlatform.OSX, Architecture.X64), "bicep-osx-x64" },
+            { (OSPlatform.OSX, Architecture.Arm64), "bicep-osx-arm64" }
+        };
+
+        if (osPlatformArchitectureMap.TryGetValue((targetOSPlatform, targetOSArchitecture), out var bicepCliArtifactName))
+        {
+            return $"{DownloadBaseUrl}/{versionTag}/{bicepCliArtifactName}";
+        }
+
+        throw new PlatformNotSupportedException(
+            $"The Bicep CLI is not available for the specified platform '{targetOSPlatform}' and architecture '{targetOSArchitecture}'. " +
+            "Supported combinations include Windows (x64, Arm64), Linux (x64, Arm64), and macOS (x64, Arm64).");
+    }
+
+    private static void SetExecutablePermissions(
+        string filePath,
+        CancellationToken cancellationToken)
+    {
+        var chmod = new System.Diagnostics.Process
+        {
+            StartInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "chmod",
+                Arguments = $"+x \"{filePath}\"",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        chmod.Start();
+        chmod.WaitForExit();
+
+        if (chmod.ExitCode != 0)
+        {
+            throw new UnauthorizedAccessException(
+                $"Failed to set executable permissions for the file at '{filePath}'. " +
+                $"The 'chmod' process exited with code {chmod.ExitCode}. Ensure you have sufficient permissions.");
+        }
+    }
+
+    public static OSPlatform DetectCurrentOSPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return OSPlatform.Windows;
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return OSPlatform.Linux;
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return OSPlatform.OSX;
+        }
+        else
+        {
+            throw new PlatformNotSupportedException(
+                "The current operating system platform is not supported. Supported platforms are Windows, Linux, and macOS.");
+        }
+    }
+}

--- a/src/Bicep.RpcClient/Helpers/BicepInstaller.cs
+++ b/src/Bicep.RpcClient/Helpers/BicepInstaller.cs
@@ -50,16 +50,10 @@ internal static class BicepInstaller
         }
     }
 
-    public static async Task<string> ResolveBicepVersionTagAsync(
+    public static async Task<string> GetLatestBicepVersion(
         HttpClient httpClient,
-        string? bicepVersion,
         CancellationToken cancellationToken)
     {
-        if (bicepVersion != null)
-        {
-            return $"v{bicepVersion}";
-        }
-
         var response = await httpClient.GetAsync(LatestReleaseUrl, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 

--- a/src/Bicep.RpcClient/IBicepClient.cs
+++ b/src/Bicep.RpcClient/IBicepClient.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading;
+using Bicep.RpcClient.Models;
+
+namespace Bicep.RpcClient;
+
+public interface IBicepClient : IDisposable
+{
+    /// <summary>
+    /// Compiles a Bicep file into an ARM template.
+    /// </summary>
+    Task<CompileResponse> Compile(CompileRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Compiles a Bicepparam file into an ARM parameters file.
+    /// </summary>
+    Task<CompileParamsResponse> CompileParams(CompileParamsRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Formats a Bicep file.
+    /// </summary>
+    Task<FormatResponse> Format(FormatRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the deployment graph for a Bicep file.
+    /// </summary>
+    Task<GetDeploymentGraphResponse> GetDeploymentGraph(GetDeploymentGraphRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns file references for a Bicep file.
+    /// </summary>
+    Task<GetFileReferencesResponse> GetFileReferences(GetFileReferencesRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns metadata for a Bicep file.
+    /// </summary>
+    Task<GetMetadataResponse> GetMetadata(GetMetadataRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a snapshot of a Bicep parameters file.
+    /// </summary>
+    Task<GetSnapshotResponse> GetSnapshot(GetSnapshotRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the version of the Bicep CLI.
+    /// </summary>
+    Task<string> GetVersion(CancellationToken cancellationToken = default);
+}

--- a/src/Bicep.RpcClient/IBicepClientFactory.cs
+++ b/src/Bicep.RpcClient/IBicepClientFactory.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bicep.RpcClient;
+
+public interface IBicepClientFactory
+{
+    /// <summary>
+    /// Initializes a Bicep client by downloading the specified version of the Bicep CLI.
+    /// </summary>
+    /// <param name="configuration">The configuration for the Bicep client.</param>
+    /// <param name="bicepVersion">The version of the Bicep CLI to download.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<IBicepClient> DownloadAndInitialize(BicepClientConfiguration configuration, string? bicepVersion, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Initializes a Bicep client from a file system path.
+    /// </summary>
+    /// <param name="bicepCliPath">The file system path to the Bicep CLI.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task<IBicepClient> InitializeFromPath(string bicepCliPath, CancellationToken cancellationToken = default);
+}

--- a/src/Bicep.RpcClient/IBicepClientFactory.cs
+++ b/src/Bicep.RpcClient/IBicepClientFactory.cs
@@ -12,9 +12,8 @@ public interface IBicepClientFactory
     /// Initializes a Bicep client by downloading the specified version of the Bicep CLI.
     /// </summary>
     /// <param name="configuration">The configuration for the Bicep client.</param>
-    /// <param name="bicepVersion">The version of the Bicep CLI to download.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    Task<IBicepClient> DownloadAndInitialize(BicepClientConfiguration configuration, string? bicepVersion, CancellationToken cancellationToken = default);
+    Task<IBicepClient> DownloadAndInitialize(BicepClientConfiguration configuration, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Initializes a Bicep client from a file system path.

--- a/src/Bicep.RpcClient/JsonRpc/JsonRpcClient.cs
+++ b/src/Bicep.RpcClient/JsonRpc/JsonRpcClient.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Net.Security;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Bicep.RpcClient.JsonRpc;
+
+internal class JsonRpcClient(Stream reader, Stream writer) : IDisposable
+{
+    private record JsonRpcRequest<T>(
+        string Jsonrpc,
+        string Method,
+        T Params,
+        int Id);
+
+    private record MinimalJsonRpcResponse(
+        string Jsonrpc,
+        int Id);
+
+    private record JsonRpcResponse<T>(
+        string Jsonrpc,
+        T? Result,
+        JsonRpcError? Error,
+        int Id);
+
+    private record JsonRpcError(
+        int Code,
+        string Message,
+        JsonNode? Data);
+
+    private readonly byte[] terminator = "\r\n\r\n"u8.ToArray();
+    private int nextId = 0;
+    private readonly SemaphoreSlim writeSemaphore = new(1, 1);
+    private readonly ConcurrentDictionary<int, TaskCompletionSource<string>> pendingResponses = new();
+
+    private readonly JsonSerializerOptions jsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    public async Task<TResponse> SendRequest<TRequest, TResponse>(string method, TRequest request, CancellationToken cancellationToken)
+    {
+        var currentId = Interlocked.Increment(ref nextId);
+
+        var jsonRpcRequest = new JsonRpcRequest<TRequest>(Jsonrpc: "2.0", Method: method, Params: request, Id: currentId);
+        var requestContent = JsonSerializer.Serialize(jsonRpcRequest, jsonSerializerOptions);
+        var requestLength = Encoding.UTF8.GetByteCount(requestContent);
+        var rawRequest = $"Content-Length: {requestLength}\r\n\r\n{requestContent}";
+        var requestBytes = Encoding.UTF8.GetBytes(rawRequest);
+
+        await writeSemaphore.WaitAsync(cancellationToken);
+        try
+        {
+            await writer.WriteAsync(requestBytes, 0, requestBytes.Length, cancellationToken);
+            await writer.FlushAsync(cancellationToken);
+        }
+        finally
+        {
+            writeSemaphore.Release();
+        }
+
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!pendingResponses.TryAdd(currentId, tcs))
+        {
+            throw new InvalidOperationException($"A request with ID {currentId} is already pending.");
+        }
+
+        var responseContent = await tcs.Task;
+        var jsonRpcResponse = JsonSerializer.Deserialize<JsonRpcResponse<TResponse>>(responseContent, jsonSerializerOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize JSON-RPC response");
+
+        if (jsonRpcResponse.Result is null)
+        {
+            var error = jsonRpcResponse.Error ?? throw new InvalidDataException("Failed to retrieve JSONRPC error");
+            throw new InvalidOperationException(error.Message);
+        }
+
+        return jsonRpcResponse.Result;
+    }
+
+    public async Task ReadLoop(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                var message = await ReadMessage(cancellationToken);
+
+                var response = JsonSerializer.Deserialize<MinimalJsonRpcResponse>(message, jsonSerializerOptions)
+                    ?? throw new InvalidOperationException("Failed to deserialize JSON-RPC response");
+
+                if (pendingResponses.TryRemove(response.Id, out var tcs))
+                {
+                    tcs.SetResult(message);
+                }
+            }
+            catch (Exception) when (cancellationToken.IsCancellationRequested)
+            {
+                reader.Dispose();
+                writer.Dispose();
+                break;
+            }
+        }
+    }
+
+    private async Task<string> ReadUntilTerminator(CancellationToken cancellationToken)
+    {
+        using var outputStream = new MemoryStream();
+        var patternIndex = 0;
+        var byteBuffer = new byte[1];
+
+        while (true)
+        {
+            await ReadExactly(byteBuffer, byteBuffer.Length, cancellationToken);
+
+            await outputStream.WriteAsync(byteBuffer, 0, byteBuffer.Length, cancellationToken);
+            patternIndex = terminator[patternIndex] == byteBuffer[0] ? patternIndex + 1 : 0;
+            if (patternIndex == terminator.Length)
+            {
+                outputStream.Position = 0;
+                outputStream.SetLength(outputStream.Length - terminator.Length);
+                // return stream as string
+                return Encoding.UTF8.GetString(outputStream.ToArray());
+            }
+        }
+    }
+
+    private async Task<string> ReadContent(int length, CancellationToken cancellationToken)
+    {
+        var byteBuffer = new byte[length];
+        await ReadExactly(byteBuffer, length, cancellationToken);
+
+        return Encoding.UTF8.GetString(byteBuffer);
+    }
+
+    private async Task<string> ReadMessage(CancellationToken cancellationToken)
+    {
+        var header = await ReadUntilTerminator(cancellationToken);
+        var parsed = header.Split(':').Select(x => x.Trim()).ToArray();
+
+        if (parsed.Length != 2 ||
+            !parsed[0].Equals("Content-Length", StringComparison.OrdinalIgnoreCase) ||
+            !int.TryParse(parsed[1], out var contentLength) ||
+            contentLength <= 0)
+        {
+            throw new InvalidOperationException($"Invalid header: {header}");
+        }
+
+        return await ReadContent(contentLength, cancellationToken);
+    }
+
+    private async ValueTask ReadExactly(byte[] buffer, int minimumBytes, CancellationToken cancellationToken)
+    {
+        var totalRead = 0;
+        while (totalRead < minimumBytes)
+        {
+            var read = await reader.ReadAsync(buffer, totalRead, minimumBytes - totalRead, cancellationToken);
+            if (read == 0)
+            {
+                throw new EndOfStreamException("Stream closed before reading expected number of bytes");
+            }
+
+            totalRead += read;
+        }
+    }
+
+    public void Dispose()
+    {
+        writer.Dispose();
+        reader.Dispose();
+    }
+}

--- a/src/Bicep.RpcClient/Models/Models.cs
+++ b/src/Bicep.RpcClient/Models/Models.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+
+namespace Bicep.RpcClient.Models;
+
+// Data models for all RPC requests and responses.
+// These models should be kept in sync with the corresponding models in the Bicep CLI, but must also be backwards-compatible,
+// as the JSONRPC client is able to communicate with multiple versions of the Bicep CLI.
+
+public record Position(
+    int Line,
+    int Char);
+
+public record Range(
+    Position Start,
+    Position End);
+
+public record VersionRequest();
+
+public record VersionResponse(
+    string Version);
+
+public record CompileRequest(
+    string Path);
+
+public record CompileResponse(
+    bool Success,
+    ImmutableArray<DiagnosticDefinition> Diagnostics,
+    string? Contents);
+
+public record CompileParamsRequest(
+    string Path,
+    Dictionary<string, JsonNode> ParameterOverrides);
+
+public record CompileParamsResponse(
+    bool Success,
+    ImmutableArray<DiagnosticDefinition> Diagnostics,
+    string? Parameters,
+    string? Template,
+    string? TemplateSpecId);
+
+public record DiagnosticDefinition(
+    string Source,
+    Range Range,
+    string Level,
+    string Code,
+    string Message);
+
+public record GetFileReferencesRequest(
+    string Path);
+
+public record GetFileReferencesResponse(
+    ImmutableArray<string> FilePaths);
+
+public record GetMetadataRequest(
+    string Path);
+
+public record GetSnapshotRequest(
+    string Path,
+    GetSnapshotRequest.MetadataDefinition Metadata,
+    ImmutableArray<GetSnapshotRequest.ExternalInputValue>? ExternalInputs)
+{
+    public record MetadataDefinition(
+        string? TenantId,
+        string? SubscriptionId,
+        string? ResourceGroup,
+        string? Location,
+        string? DeploymentName);
+
+    public record ExternalInputValue(
+        string Kind,
+        JsonNode? Config,
+        JsonNode Value);
+}
+
+public record GetSnapshotResponse(
+    string Snapshot);
+
+public record GetMetadataResponse(
+    ImmutableArray<GetMetadataResponse.MetadataDefinition> Metadata,
+    ImmutableArray<GetMetadataResponse.SymbolDefinition> Parameters,
+    ImmutableArray<GetMetadataResponse.SymbolDefinition> Outputs,
+    ImmutableArray<GetMetadataResponse.ExportDefinition> Exports)
+{
+    public record SymbolDefinition(
+        Range Range,
+        string Name,
+        TypeDefinition? Type,
+        string? Description);
+
+    public record ExportDefinition(
+        Range Range,
+        string Name,
+        string Kind,
+        string? Description);
+
+    public record TypeDefinition(
+        Range? Range,
+        string Name);
+
+    public record MetadataDefinition(
+        string Name,
+        string Value);
+}
+
+public record GetDeploymentGraphRequest(
+    string Path);
+
+public record GetDeploymentGraphResponse(
+    ImmutableArray<GetDeploymentGraphResponse.Node> Nodes,
+    ImmutableArray<GetDeploymentGraphResponse.Edge> Edges)
+{
+    public record Node(
+        Range Range,
+        string Name,
+        string Type,
+        bool IsExisting,
+        string? RelativePath);
+
+    public record Edge(
+        string Source,
+        string Target);
+}
+
+public record FormatRequest(
+    string Path);
+
+public record FormatResponse(
+    string Contents);

--- a/src/Bicep.RpcClient/Polyfills/IsExternalInit.cs
+++ b/src/Bicep.RpcClient/Polyfills/IsExternalInit.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Class required for C# 9.0 record types.
+    /// </summary>
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,14 +5,14 @@
   </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="All" />
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4"  PrivateAssets="All" />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.2" PrivateAssets="All"/>
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" PrivateAssets="All" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.13.2" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Bicep.Internal.RoslynAnalyzers" Version="0.1.45" />
-  <PackageVersion Include="Azure.Bicep.Types" Version="0.6.12" />
-  <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.803" />
+    <PackageVersion Include="Azure.Bicep.Types" Version="0.6.12" />
+    <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.803" />
     <PackageVersion Include="Azure.Bicep.Types.K8s" Version="0.1.644" />
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.1.1" />
     <PackageVersion Include="Azure.Deployments.ClientTools" Version="1.473.0" />
@@ -82,6 +82,7 @@
     <PackageVersion Include="NuGet.CommandLine" Version="6.6.2" />
     <PackageVersion Include="OmniSharp.Extensions.LanguageClient" Version="0.19.9" />
     <PackageVersion Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
+    <PackageVersion Include="PublicApiGenerator" Version="11.4.6" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="Sarif.Sdk" Version="4.5.4" />
     <PackageVersion Include="Semver" Version="3.0.0" />
@@ -96,6 +97,7 @@
     <PackageVersion Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.CommandLine.Rendering" Version="0.4.0-alpha.22272.1" />
+    <PackageVersion Include="System.Collections.Immutable" Version="9.0.9" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.15" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.0.15" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />


### PR DESCRIPTION
Add library for installing and interacting with Bicep CLI via [JSONRPC](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-cli?tabs=bicep-cli#jsonrpc). This provides a unified and efficient interface for calling any version of Bicep programatically.

Features:
* Spawns a single executable to minimize cold-start delays for multiple Bicep requests
* Minimal NuGet dependencies
* Supports caching of binaries under `~/.bicep/bin`
* Supports all JSONRPC methods
* Supports concurrency

Example usage:
```csharp
var clientFactory = new BicepClientFactory(new HttpClient());
using var client = await clientFactory.DownloadAndInitialize(new() { BicepVersion: "0.38.3" }, cancellationToken);

var result = await Bicep.Compile(new("/path/to/main.bicep"));
```