### PR TITLE
Bicep.RpcClient - ensure the child process is explicitly killed

### DIFF
--- a/src/Bicep.RpcClient/BicepClient.cs
+++ b/src/Bicep.RpcClient/BicepClient.cs
@@ -130,9 +130,14 @@ internal class BicepClient : IBicepClient
     public void Dispose()
     {
         cts.Cancel();
-        if (!cliProcess.HasExited)
+        jsonRpcClient.Dispose();
+        try
         {
+            cliProcess.Kill();
             cliProcess.WaitForExit();
+        }
+        catch (InvalidOperationException)
+        {
         }
     }
 }


### PR DESCRIPTION
Bicep.RpcClient - ensure the child process is explicitly killed