### PR TITLE
[bicep console] Use visitor pattern to handle multi-line inputs

### DIFF
--- a/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
+++ b/src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj
@@ -21,8 +21,4 @@
   <ItemGroup>
     <PackageReference Update="Nerdbank.GitVersioning" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Helpers\" />
-  </ItemGroup>
 </Project>

--- a/src/Bicep.Cli.UnitTests/Helpers/Repl/StructuralCompletenessHelperTests.cs
+++ b/src/Bicep.Cli.UnitTests/Helpers/Repl/StructuralCompletenessHelperTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Bicep.Cli.Helpers.Repl;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Cli.UnitTests.Helpers.Repl;
+
+[TestClass]
+public class StructuralCompletenessHelperTests
+{
+    [DataTestMethod]
+    [DataRow("42", true)]
+    [DataRow("'hello'", true)]
+    [DataRow("true", true)]
+    [DataRow("items([1, 2, 3])", true)]
+    [DataRow("var a = 'complete'", true)]
+    [DataRow("length(['a', 'b'])", true)]
+    [DataRow(
+"""
+'''
+Hello
+World
+'''
+""", true)]
+    [DataRow("items({", false)]
+    [DataRow("var a = items({", false)]
+    [DataRow("var b = length([", false)]
+    [DataRow("[", false)]
+    [DataRow("{", false)]
+    [DataRow("(length(", false)]
+    [DataRow("filter(map([1,2],", false)]
+    [DataRow(
+"""
+filter(map([1,2],
+x => x + 1),
+y => y % 2 == 0
+""", false)]
+    [DataRow(
+"""
+'''
+Hello
+World
+""", false)]
+    public void IsStructurallyComplete_CompleteExpressions_ReturnsExpectedResult(string text, bool expected)
+    {
+        StructuralCompletenessHelper.IsStructurallyComplete(text).Should().Be(expected);
+    }
+}

--- a/src/Bicep.Cli/Helpers/Repl/StructuralCompletenessHelper.cs
+++ b/src/Bicep.Cli/Helpers/Repl/StructuralCompletenessHelper.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Bicep.Core.Parsing;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Cli.Helpers.Repl;
+
+public static class StructuralCompletenessHelper
+{
+    public static bool IsStructurallyComplete(string text)
+    {
+        var program = new ReplParser(text).Program();
+        var completenessVisitor = new StructuralCompletenessVisitor();
+        program.Accept(completenessVisitor);
+        return completenessVisitor.IsComplete;
+    }
+
+    private sealed class StructuralCompletenessVisitor : CstVisitor
+    {
+        public bool IsComplete { get; private set; } = true;
+
+        public override void VisitSkippedTriviaSyntax(SkippedTriviaSyntax syntax)
+        {
+            IsComplete = false;
+            // don't visit children - we already know it's incomplete
+        }
+
+        public override void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
+        {
+            if (syntax.Value is SkippedTriviaSyntax)
+            {
+                IsComplete = false;
+                return;
+            }
+
+            base.VisitVariableDeclarationSyntax(syntax);
+        }
+
+        public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
+        {
+            if (syntax.CloseParen is SkippedTriviaSyntax)
+            {
+                IsComplete = false;
+                return;
+            }
+
+            base.VisitFunctionCallSyntax(syntax);
+        }
+
+        public override void VisitParenthesizedExpressionSyntax(ParenthesizedExpressionSyntax syntax)
+        {
+            if (syntax.CloseParen is SkippedTriviaSyntax)
+            {
+                IsComplete = false;
+                return;
+            }
+
+            base.VisitParenthesizedExpressionSyntax(syntax);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Use visitor pattern to handle more multi-line input scenarios, including standalone expressions with no variable assignment.

## Example Usage

https://github.com/user-attachments/assets/aaf05b0b-32e9-4ed5-891e-d53eb6c475b8

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
