### PR TITLE
Draft PR: Implement fixed scope parameter serializer and remove bandaid

### DIFF
--- a/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeFactory.cs
@@ -253,12 +253,6 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
             var readableScopes = ToResourceScope(resourceType.ReadableScopes);
             var writableScopes = ToResourceScope(resourceType.WritableScopes);
 
-            if (readableScopes == ResourceScope.None && writableScopes == ResourceScope.None)
-            {
-                readableScopes = ToResourceScope(Azure.Bicep.Types.Concrete.ScopeType.All);
-                writableScopes = ToResourceScope(Azure.Bicep.Types.Concrete.ScopeType.All);
-            }
-
             return (readableScopes, writableScopes);
         }
 


### PR DESCRIPTION
## Description
Removed the temporary bandaid to handle 3 failing LocalDeployCommand tests. These tests were initially failing because when ResourceType was serialized with modern scope properties, the serializer incorrectly included null legacy scope properties. 

This causes extension resources like request@v1 to be incorrectly flagged as ReadOnly, triggering BCP245 errors: 
"Resource type 'request@v1' can only be used with the 'existing' keyword" in LocalDeployCommand tests.

The serializer was fixed in bicep-types and this PR also makes the update to that newest version. 

<!-- Provide a 1-2 sentence description of your change -->

## Example Usage

<!-- Provide example usage if you are making syntax or CLI changes. 
     Provide screenshots if you are making changes to editor user experience.
     Delete this section if it doesn't apply to your change. -->

## Checklist

- [ ] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18268)