### PR TITLE
improve syntax handling and update diagnostics for decorators in parameter files

### DIFF
--- a/src/Bicep.Cli/Helpers/ParamsFileHelper.cs
+++ b/src/Bicep.Cli/Helpers/ParamsFileHelper.cs
@@ -49,6 +49,7 @@ public static class ParamsFileHelper
                 var replacementValue = ConvertJsonToBicepSyntax(overrideValue);
 
                 return new ParameterAssignmentSyntax(
+                    paramSyntax.LeadingNodes,
                     paramSyntax.Keyword,
                     paramSyntax.Name,
                     paramSyntax.Assignment,

--- a/src/Bicep.Core/Emit/PlaceholderParametersBicepParamWriter.cs
+++ b/src/Bicep.Core/Emit/PlaceholderParametersBicepParamWriter.cs
@@ -31,12 +31,12 @@ namespace Bicep.Core.Emit
 
             var result = filteredParameterDeclarations
                             .OfType<ParameterDeclarationSyntax>()
-                            .Select(e => new ParameterAssignmentSyntax(e.Keyword, e.Name, SyntaxFactory.AssignmentToken, this.GetValueForParameter(e)))
+                            .Select(e => new ParameterAssignmentSyntax([], e.Keyword, e.Name, SyntaxFactory.AssignmentToken, this.GetValueForParameter(e)))
                             .SelectMany(e => new List<SyntaxBase>() { e, SyntaxFactory.NewlineToken });
 
             var processedSyntaxList = new List<SyntaxBase>()
             {
-                new UsingDeclarationSyntax(SyntaxFactory.UsingKeywordToken, SyntaxFactory.CreateStringLiteral($"./{bicepFileName}"), SyntaxFactory.EmptySkippedTrivia),
+                new UsingDeclarationSyntax([], SyntaxFactory.UsingKeywordToken, SyntaxFactory.CreateStringLiteral($"./{bicepFileName}"), SyntaxFactory.EmptySkippedTrivia),
                 SyntaxFactory.NewlineToken,
                 SyntaxFactory.NewlineToken
             }.Concat(result);

--- a/src/Bicep.Core/Parsing/ParamsParser.cs
+++ b/src/Bicep.Core/Parsing/ParamsParser.cs
@@ -60,9 +60,9 @@ namespace Bicep.Core.Parsing
                     {
                         TokenType.Identifier => ValidateKeyword(current.Text) switch
                         {
-                            LanguageConstants.UsingKeyword => this.UsingDeclaration(),
-                            LanguageConstants.ExtendsKeyword => this.ExtendsDeclaration(),
-                            LanguageConstants.ParameterKeyword => this.ParameterAssignment(),
+                            LanguageConstants.UsingKeyword => this.UsingDeclaration(leadingNodes),
+                            LanguageConstants.ExtendsKeyword => this.ExtendsDeclaration(leadingNodes),
+                            LanguageConstants.ParameterKeyword => this.ParameterAssignment(leadingNodes),
                             LanguageConstants.VariableKeyword => this.VariableDeclaration(leadingNodes),
                             LanguageConstants.ImportKeyword => this.CompileTimeImportDeclaration(ExpectKeyword(LanguageConstants.ImportKeyword), leadingNodes),
                             LanguageConstants.ExtensionConfigKeyword => this.ExtensionConfigAssignment(leadingNodes),
@@ -79,7 +79,7 @@ namespace Bicep.Core.Parsing
                 RecoveryFlags.None,
                 TokenType.NewLine);
 
-        private UsingDeclarationSyntax UsingDeclaration()
+        private UsingDeclarationSyntax UsingDeclaration(ImmutableArray<SyntaxBase> leadingNodes)
         {
             var keyword = ExpectKeyword(LanguageConstants.UsingKeyword);
 
@@ -98,10 +98,10 @@ namespace Bicep.Core.Parsing
                 _ => this.WithRecovery(this.UsingWithClause, GetSuppressionFlag(expression), TokenType.NewLine),
             };
 
-            return new(keyword, expression, withClause);
+            return new(leadingNodes, keyword, expression, withClause);
         }
 
-        private ExtendsDeclarationSyntax ExtendsDeclaration()
+        private ExtendsDeclarationSyntax ExtendsDeclaration(ImmutableArray<SyntaxBase> leadingNodes)
         {
             var keyword = ExpectKeyword(LanguageConstants.ExtendsKeyword);
             var path = this.WithRecovery(
@@ -109,17 +109,17 @@ namespace Bicep.Core.Parsing
                 GetSuppressionFlag(keyword),
                 TokenType.NewLine);
 
-            return new ExtendsDeclarationSyntax(keyword, path);
+            return new ExtendsDeclarationSyntax(leadingNodes, keyword, path);
         }
 
-        private SyntaxBase ParameterAssignment()
+        private SyntaxBase ParameterAssignment(ImmutableArray<SyntaxBase> leadingNodes)
         {
             var keyword = ExpectKeyword(LanguageConstants.ParameterKeyword);
             var name = this.IdentifierWithRecovery(b => b.ExpectedParameterIdentifier(), RecoveryFlags.None, TokenType.Identifier, TokenType.NewLine);
             var assignment = this.WithRecovery(this.Assignment, GetSuppressionFlag(name), TokenType.NewLine);
             var value = this.WithRecovery(() => this.Expression(ExpressionFlags.AllowComplexLiterals), GetSuppressionFlag(assignment), TokenType.NewLine);
 
-            return new ParameterAssignmentSyntax(keyword, name, assignment, value);
+            return new ParameterAssignmentSyntax(leadingNodes, keyword, name, assignment, value);
         }
 
         private ExtensionConfigAssignmentSyntax ExtensionConfigAssignment(IEnumerable<SyntaxBase> leadingNodes)

--- a/src/Bicep.Core/Syntax/ExtendsDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/ExtendsDeclarationSyntax.cs
@@ -10,8 +10,8 @@ namespace Bicep.Core.Syntax
 {
     public class ExtendsDeclarationSyntax : StatementSyntax, ITopLevelDeclarationSyntax, IArtifactReferenceSyntax
     {
-        public ExtendsDeclarationSyntax(Token keyword, SyntaxBase path)
-            : base([])
+        public ExtendsDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, SyntaxBase path)
+            : base(leadingNodes)
         {
             AssertKeyword(keyword, nameof(keyword), LanguageConstants.ExtendsKeyword);
             AssertSyntaxType(path, nameof(path), typeof(StringSyntax), typeof(SkippedTriviaSyntax));

--- a/src/Bicep.Core/Syntax/ParameterAssignmentSyntax.cs
+++ b/src/Bicep.Core/Syntax/ParameterAssignmentSyntax.cs
@@ -9,8 +9,8 @@ namespace Bicep.Core.Syntax
 {
     public class ParameterAssignmentSyntax : StatementSyntax, ITopLevelNamedDeclarationSyntax
     {
-        public ParameterAssignmentSyntax(Token keyword, IdentifierSyntax name, SyntaxBase assignment, SyntaxBase value)
-            : base([])
+        public ParameterAssignmentSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, IdentifierSyntax name, SyntaxBase assignment, SyntaxBase value)
+            : base(leadingNodes)
         {
             AssertKeyword(keyword, nameof(keyword), LanguageConstants.ParameterKeyword);
             AssertSyntaxType(name, nameof(name), typeof(IdentifierSyntax));

--- a/src/Bicep.Core/Syntax/SyntaxFactory.cs
+++ b/src/Bicep.Core/Syntax/SyntaxFactory.cs
@@ -409,6 +409,7 @@ namespace Bicep.Core.Syntax
 
         public static ParameterAssignmentSyntax CreateParameterAssignmentSyntax(string name, SyntaxBase value)
             => new(
+                [],
                 ParameterKeywordToken,
                 CreateIdentifierWithTrailingSpace(name),
                 AssignmentToken,

--- a/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
+++ b/src/Bicep.Core/Syntax/SyntaxRewriteVisitor.cs
@@ -168,7 +168,8 @@ namespace Bicep.Core.Syntax
 
         protected virtual SyntaxBase VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
         {
-            var hasChanges = TryRewriteStrict(syntax.Keyword, out var keyword);
+            var hasChanges = TryRewriteStrict(syntax.LeadingNodes, out var leadingNodes);
+            hasChanges |= TryRewriteStrict(syntax.Keyword, out var keyword);
             hasChanges |= TryRewriteStrict(syntax.Name, out var name);
             hasChanges |= TryRewriteStrict(syntax.Assignment, out var assignment);
             hasChanges |= TryRewriteStrict(syntax.Value, out var value);
@@ -178,13 +179,14 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new ParameterAssignmentSyntax(keyword, name, assignment, value);
+            return new ParameterAssignmentSyntax(leadingNodes, keyword, name, assignment, value);
         }
         void ISyntaxVisitor.VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax) => ReplaceCurrent(syntax, VisitParameterAssignmentSyntax);
 
         protected virtual SyntaxBase VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax)
         {
-            var hasChanges = TryRewriteStrict(syntax.Keyword, out var keyword);
+            var hasChanges = TryRewriteStrict(syntax.LeadingNodes, out var leadingNodes);
+            hasChanges |= TryRewriteStrict(syntax.Keyword, out var keyword);
             hasChanges |= TryRewriteStrict(syntax.Path, out var path);
             hasChanges |= TryRewriteStrict(syntax.WithClause, out var withClause);
 
@@ -193,7 +195,7 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new UsingDeclarationSyntax(keyword, path, withClause);
+            return new UsingDeclarationSyntax(leadingNodes, keyword, path, withClause);
         }
         void ISyntaxVisitor.VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax) => ReplaceCurrent(syntax, VisitUsingDeclarationSyntax);
 
@@ -213,7 +215,8 @@ namespace Bicep.Core.Syntax
 
         protected virtual SyntaxBase ReplaceExtendsDeclarationSyntax(ExtendsDeclarationSyntax syntax)
         {
-            var hasChanges = TryRewriteStrict(syntax.Keyword, out var keyword);
+            var hasChanges = TryRewriteStrict(syntax.LeadingNodes, out var leadingNodes);
+            hasChanges |= TryRewriteStrict(syntax.Keyword, out var keyword);
             hasChanges |= TryRewriteStrict(syntax.Path, out var path);
 
             if (!hasChanges)
@@ -221,7 +224,7 @@ namespace Bicep.Core.Syntax
                 return syntax;
             }
 
-            return new ExtendsDeclarationSyntax(keyword, path);
+            return new ExtendsDeclarationSyntax(leadingNodes, keyword, path);
         }
         void ISyntaxVisitor.VisitExtendsDeclarationSyntax(ExtendsDeclarationSyntax syntax) => ReplaceCurrent(syntax, ReplaceExtendsDeclarationSyntax);
 

--- a/src/Bicep.Core/Syntax/UsingDeclarationSyntax.cs
+++ b/src/Bicep.Core/Syntax/UsingDeclarationSyntax.cs
@@ -10,8 +10,8 @@ namespace Bicep.Core.Syntax
 {
     public class UsingDeclarationSyntax : StatementSyntax, ITopLevelDeclarationSyntax, IArtifactReferenceSyntax
     {
-        public UsingDeclarationSyntax(Token keyword, SyntaxBase path, SyntaxBase withClause)
-            : base([])
+        public UsingDeclarationSyntax(IEnumerable<SyntaxBase> leadingNodes, Token keyword, SyntaxBase path, SyntaxBase withClause)
+            : base(leadingNodes)
         {
             AssertKeyword(keyword, nameof(keyword), LanguageConstants.UsingKeyword);
             AssertSyntaxType(path, nameof(path), typeof(StringSyntax), typeof(SkippedTriviaSyntax), typeof(NoneLiteralSyntax));

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Intermediate;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
 using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
@@ -498,6 +499,11 @@ namespace Bicep.Core.TypeSystem
         public override void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
             => AssignTypeWithDiagnostics(syntax, diagnostics =>
             {
+                if (this.model.SourceFile is BicepParamFile && syntax.Decorators.Any())
+                {
+                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Decorators.First().At).DecoratorsNotAllowed());
+                }
+
                 var errors = new List<IDiagnostic>();
 
                 var valueType = this.typeManager.GetTypeInfo(syntax.Value);
@@ -509,6 +515,32 @@ namespace Bicep.Core.TypeSystem
                 }
 
                 return valueType;
+            });
+
+        public override void VisitUsingDeclarationSyntax(UsingDeclarationSyntax syntax)
+            => AssignTypeWithDiagnostics(syntax, diagnostics =>
+            {
+                if (this.model.SourceFile is BicepParamFile && syntax.Decorators.Any())
+                {
+                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Decorators.First().At).DecoratorsNotAllowed());
+                }
+
+                base.VisitUsingDeclarationSyntax(syntax);
+
+                return LanguageConstants.Any;
+            });
+
+        public override void VisitExtendsDeclarationSyntax(ExtendsDeclarationSyntax syntax)
+            => AssignTypeWithDiagnostics(syntax, diagnostics =>
+            {
+                if (this.model.SourceFile is BicepParamFile && syntax.Decorators.Any())
+                {
+                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax.Decorators.First().At).DecoratorsNotAllowed());
+                }
+
+                base.VisitExtendsDeclarationSyntax(syntax);
+
+                return LanguageConstants.Any;
             });
 
         public override void VisitTypeDeclarationSyntax(TypeDeclarationSyntax syntax)

--- a/src/Bicep.Decompiler/BicepDecompiler.cs
+++ b/src/Bicep.Decompiler/BicepDecompiler.cs
@@ -86,6 +86,7 @@ public class BicepDecompiler
         {
             var bicepPath = bicepFileUri?.GetPathRelativeTo(entryBicepparamUri);
             statements.Add(new UsingDeclarationSyntax(
+                [],
                 SyntaxFactory.UsingKeywordToken,
                 bicepPath is not null
                     ? SyntaxFactory.CreateStringLiteral(bicepPath)


### PR DESCRIPTION
## Description

This PR adds validation to raise `BCP130` diagnostic errors when decorators are used on `param`, `using`, and `extends` statements in `.bicepparam` files, where they have no effect and are not supported.

The implementation correctly handles .bicepparam files (where decorators on these statements are invalid) and .bicep files (where decorators on parameter declarations remain valid and supported).

New visitor methods added in `VisitParameterAssignmentSyntax` to validate if the `using`, `extends`, `params` keywords have `leadingNodes` (_decorators_) in `.bicepparam` files.

Tests added to ensure the validation works correctly, throws `BCP130` only in `.bicepparam` files, not in `.bicep` files.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18274)