### PR TITLE
DRAFT - Remove scope deserialization bandaid after Bicep.Type 0.6.27 update

### DIFF
--- a/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeFactory.cs
@@ -253,12 +253,6 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
             var readableScopes = ToResourceScope(resourceType.ReadableScopes);
             var writableScopes = ToResourceScope(resourceType.WritableScopes);
 
-            if (readableScopes == ResourceScope.None && writableScopes == ResourceScope.None)
-            {
-                readableScopes = ToResourceScope(Azure.Bicep.Types.Concrete.ScopeType.All);
-                writableScopes = ToResourceScope(Azure.Bicep.Types.Concrete.ScopeType.All);
-            }
-
             return (readableScopes, writableScopes);
         }
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Bicep.Internal.RoslynAnalyzers" Version="0.1.45" />
-    <PackageVersion Include="Azure.Bicep.Types" Version="0.6.12" />
+    <PackageVersion Include="Azure.Bicep.Types" Version="0.6.27" />
     <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.803" />
     <PackageVersion Include="Azure.Bicep.Types.K8s" Version="0.1.644" />
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.1.1" />


### PR DESCRIPTION
## Description

This removes the temporary bandaid fix from `ExtensionResourceTypeFactory.cs` after updating Bicep.Types to version 0.6.27 which [includes this fix](https://github.com/Azure/bicep-types/pull/756).

The bandaid was added to work around a serialization bug where extension resource types with `readableScopes=All` and `writableScopes=All` were being incorrectly deserialized as `ScopeType.None`, causing them to be flagged as ReadOnly.

The root cause was that `TypeSerializer` was writing null legacy properties `scopeType: null`, `readOnlyScopes: null` alongside the correct modern properties, and the deserializer prioritized the null legacy values. This has been fixed upstream in Bicep.Types 0.6.27 by adding `DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull` to the serializer options.

With the fix in place, the bandaid is no longer needed and the 3 failing LocalDeployCommand tests now pass.

Removes this band aid: https://github.com/Azure/bicep/pull/17849#discussion_r2355719102
