### PR TITLE
`bicep console` - improve line break handling

### DIFF
--- a/src/Bicep.Cli.UnitTests/Helpers/Repl/PrintHelperTests.cs
+++ b/src/Bicep.Cli.UnitTests/Helpers/Repl/PrintHelperTests.cs
@@ -81,7 +81,7 @@ public class PrintHelperTests
 
         AnsiHelper.ReplaceCodes(result).Should().Be("""
             [Gray]var[Reset] [Blue]foo[Reset] = {
-                [Orange]~~~ Variable "foo" is declared but never used.[Reset]
+                [DarkYellow]~~~ Variable "foo" is declared but never used.[Reset]
               [DarkYellow]abc[Reset]: [Blue]def[Reset]
                    [Red]~~~ The name "def" does not exist in the current context.[Reset]
               [DarkYellow]ghi[Reset]: [Orange]123[Reset][Reset],[Reset]

--- a/src/Bicep.Cli.UnitTests/Utils/AnsiHelper.cs
+++ b/src/Bicep.Cli.UnitTests/Utils/AnsiHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 using Bicep.Cli.Helpers.Repl;
 using Bicep.Cli.Helpers.WhatIf;
@@ -31,8 +32,14 @@ public static class AnsiHelper
         [nameof(PrintHelper.MoveCursorRight)] = "\u001b\\[(\\d+)C",
     }.ToImmutableDictionary();
 
-    public static string ReplaceCodes(string input)
+    [return: NotNullIfNotNull(nameof(input))]
+    public static string? ReplaceCodes(string? input)
     {
+        if (input is null)
+        {
+            return null;
+        }
+
         foreach (var (name, code) in escapeCodeByName)
         {
             input = input.Replace(code, $"[{name}]");

--- a/src/Bicep.Cli/Helpers/Repl/PrintHelper.cs
+++ b/src/Bicep.Cli/Helpers/Repl/PrintHelper.cs
@@ -77,7 +77,7 @@ public class PrintHelper
                 var color = annotation.Diagnostic.Level switch
                 {
                     DiagnosticLevel.Error => Color.Red,
-                    DiagnosticLevel.Warning => Color.Orange,
+                    DiagnosticLevel.Warning => Color.DarkYellow,
                     _ => Color.Reset,
                 };
 

--- a/src/Bicep.Cli/Services/ReplEnvironment.cs
+++ b/src/Bicep.Cli/Services/ReplEnvironment.cs
@@ -17,11 +17,13 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.Emit;
 using Bicep.Core.Extensions;
 using Bicep.Core.Highlighting;
+using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.PrettyPrintV2;
 using Bicep.Core.Semantics;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
+using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
 using Bicep.IO.Abstraction;
 using Bicep.IO.InMemory;
@@ -85,6 +87,22 @@ public class ReplEnvironment
         return PrintHelper.PrintWithSyntaxHighlighting(model, content);
     }
 
+    public string EvaluateAndGetOutput(string input)
+    {
+        var result = EvaluateInput(input);
+
+        if (result.Value is { } value)
+        {
+            return HighlightSyntax(value) + '\n';
+        }
+        else if (result.AnnotatedDiagnostics.Any())
+        {
+            return PrintHelper.PrintWithAnnotations(input, result.AnnotatedDiagnostics, HighlightSyntax(input));
+        }
+
+        return string.Empty;
+    }
+
     public AnnotatedReplResult EvaluateInput(string input)
     {
         history.Add(input);
@@ -138,31 +156,17 @@ public class ReplEnvironment
 
         var model = compilation.GetEntrypointSemanticModel();
         var diagnostics = model.GetAllDiagnostics().Where(d => d.Source != DiagnosticSource.CoreLinter).ToList();
-        if (diagnostics.Count > 0)
+
+        if (!diagnostics.Where(x => x.IsError()).Any())
         {
-            return new AnnotatedReplResult(null, CreateAnnotatedDiagnostics(diagnostics, declarationText, fullContent.Length));
+            // Persist only after successful evaluation.
+            declarationLines.Clear();
+            declarationLines.AddRange(workingLines);
+            declarationLines.Add(declarationText);
+            declarationLookup[declarationName] = declarationText;
         }
 
-        ExpressionEvaluationResult? evalResult = null;
-        if (model.GetSymbolInfo(declaration) is VariableSymbol variableSymbol)
-        {
-            // Find and evaluate the newly declared variable symbol.
-            var evaluator = new ParameterAssignmentEvaluator(model);
-            evalResult = evaluator.EvaluateExpression(variableSymbol.DeclaringVariable.Value);
-        }
-
-        if (evalResult?.Diagnostics.Any() == true)
-        {
-            return new AnnotatedReplResult(null, CreateAnnotatedDiagnostics(evalResult.Diagnostics, declarationText, fullContent.Length));
-        }
-
-        // Persist only after successful evaluation.
-        declarationLines.Clear();
-        declarationLines.AddRange(workingLines);
-        declarationLines.Add(declarationText);
-        declarationLookup[declarationName] = declarationText;
-
-        return new AnnotatedReplResult(ParseJToken(evalResult?.Value), []);
+        return new AnnotatedReplResult(null, CreateAnnotatedDiagnostics(diagnostics, declarationText, fullContent.Length));
     }
 
     private AnnotatedReplResult EvaluateExpression(SyntaxBase expressionSyntax)
@@ -185,10 +189,9 @@ public class ReplEnvironment
         var model = compilation.GetEntrypointSemanticModel();
 
         var diagnostics = model.GetAllDiagnostics().Where(d => d.Source != DiagnosticSource.CoreLinter).ToList();
-
-        if (diagnostics.Count > 0)
+        if (diagnostics.Any(x => x.IsError()))
         {
-            return new AnnotatedReplResult(null, CreateAnnotatedDiagnostics(diagnostics, userExpression, fullContent.Length));
+            return new(null, CreateAnnotatedDiagnostics(diagnostics, userExpression, fullContent.Length));
         }
 
         var evaluator = new ParameterAssignmentEvaluator(model);
@@ -198,12 +201,7 @@ public class ReplEnvironment
         var boundVariable = model.Root.VariableDeclarations.First(v => v.Name == tempVarName);
 
         var expressionEvalResult = evaluator.EvaluateExpression(boundVariable.DeclaringVariable.Value);
-        if (expressionEvalResult.Diagnostics.Any())
-        {
-            return new AnnotatedReplResult(null, CreateAnnotatedDiagnostics(expressionEvalResult.Diagnostics, userExpression, fullContent.Length));
-        }
-
-        return new AnnotatedReplResult(ParseJToken(expressionEvalResult.Value), []);
+        return new(ParseJToken(expressionEvalResult.Value), CreateAnnotatedDiagnostics(expressionEvalResult.Diagnostics, userExpression, fullContent.Length));
     }
 
     public string? TryGetHistory(bool backwards)
@@ -294,6 +292,27 @@ public class ReplEnvironment
         => SyntaxFactory.CreateObject(
             jObject.Properties()
                 .Select(x => SyntaxFactory.CreateObjectProperty(x.Name, ParseJToken(x.Value))));
+
+    /// <summary>
+    /// Heuristic structural completeness check: ensures bracket/brace/paren balance
+    /// and not inside (multi-line) string or interpolation expression.
+    /// Not a full parse; parse errors still reported by real parser.
+    /// </summary>
+    public static bool ShouldSubmitBuffer(string text, string currentLine)
+    {
+        // If line is blank, submit - even if structurally incomplete.
+        // This avoids trapping the user in a state where they cannot recover.
+        if (currentLine.Length == 0)
+        {
+            return true;
+        }
+
+        var program = new ReplParser(text).Program();
+
+        // Use the existence of skipped trivia to determine whether we have a complete structure.
+        var allNodes = SyntaxAggregator.Aggregate(program, x => x is not Token, useCst: true);
+        return allNodes.Last() is not SkippedTriviaSyntax;
+    }
 }
 
 public record AnnotatedReplResult(SyntaxBase? Value, IEnumerable<PrintHelper.AnnotatedDiagnostic> AnnotatedDiagnostics);


### PR DESCRIPTION
* Avoid submitting the buffer for line breaks inside function arguments
* Move more logic into the `ReplEnvironment` class for more thorough unit testing, add unit tests
* Change warning color from Orange -> DarkYellow

Closes #18316