### PR TITLE
Support access token refresh in deploy pane

### DIFF
--- a/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/App.test.tsx
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/App.test.tsx
@@ -8,8 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../components/App";
 import {
   createDeploymentDataMessage,
-  createGetAccessTokenMessage,
-  createGetAccessTokenResultMessage,
   createGetDeploymentScopeMessage,
   createGetDeploymentScopeResultMessage,
   createGetStateMessage,
@@ -77,14 +75,13 @@ describe("App", () => {
   it("runs a deployment", async () => {
     const { container } = render(<App />);
 
-    const scope = await initialize();
+    await initialize();
 
     const deployButton = screen.getByText("Deploy");
     fireEvent.click(deployButton);
 
-    await act(async () => {
-      await waitFor(() => expect(vscode.postMessage).toBeCalledWith(createGetAccessTokenMessage(scope)));
-      sendMessage(getAccessTokenResultMessage());
+    await waitFor(() => {
+      expect(screen.getAllByText('Succeeded')[0]).toBeInTheDocument();
     });
 
     expect(container).toMatchSnapshot();
@@ -93,7 +90,7 @@ describe("App", () => {
   it("handles synchronous deployment failures correctly", async () => {
     const { container } = render(<App />);
 
-    const scope = await initialize();
+    await initialize();
 
     mockClient.deployments.beginCreateOrUpdateAtScope.mockImplementation(async () => {
       throw new Error("Deployment failed");
@@ -102,9 +99,8 @@ describe("App", () => {
     const deployButton = screen.getByText("Deploy");
     fireEvent.click(deployButton);
 
-    await act(async () => {
-      await waitFor(() => expect(vscode.postMessage).toBeCalledWith(createGetAccessTokenMessage(scope)));
-      sendMessage(getAccessTokenResultMessage());
+    await waitFor(() => {
+      expect(screen.getAllByText('Failed')[0]).toBeInTheDocument();
     });
 
     expect(mockClient.deploymentOperations.listAtScope).not.toHaveBeenCalled();
@@ -114,14 +110,13 @@ describe("App", () => {
   it("validates a deployment", async () => {
     const { container } = render(<App />);
 
-    const scope = await initialize();
+    await initialize();
 
     const validateButton = screen.getByText("Validate");
     fireEvent.click(validateButton);
 
-    await act(async () => {
-      await waitFor(() => expect(vscode.postMessage).toBeCalledWith(createGetAccessTokenMessage(scope)));
-      sendMessage(getAccessTokenResultMessage());
+    await waitFor(() => {
+      expect(screen.getAllByText('InvalidTemplate')[0]).toBeInTheDocument();
     });
 
     expect(container).toMatchSnapshot();
@@ -130,14 +125,13 @@ describe("App", () => {
   it("what-ifs a deployment", async () => {
     const { container } = render(<App />);
 
-    const scope = await initialize();
+    await initialize();
 
     const whatIfButton = screen.getByText("What-If");
     fireEvent.click(whatIfButton);
 
-    await act(async () => {
-      await waitFor(() => expect(vscode.postMessage).toBeCalledWith(createGetAccessTokenMessage(scope)));
-      sendMessage(getAccessTokenResultMessage());
+    await waitFor(() => {
+      expect(screen.getAllByText('Succeeded')[0]).toBeInTheDocument();
     });
 
     expect(container).toMatchSnapshot();
@@ -191,12 +185,5 @@ function getDeploymentDataMessage() {
 function getStateResultMessage() {
   return createGetStateResultMessage({
     scope: scope,
-  });
-}
-
-function getAccessTokenResultMessage() {
-  return createGetAccessTokenResultMessage({
-    expiresOnTimestamp: 1737601964200,
-    token: "mockAccessToken",
   });
 }

--- a/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/setupGlobals.ts
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/setupGlobals.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { vi } from "vitest";
-
+import '@testing-library/jest-dom/vitest';
 import "element-internals-polyfill";
 
 global.ResizeObserver = vi.fn(() => ({


### PR DESCRIPTION
Addresses the deploy pane issue in #11892

As per guidance in https://github.com/microsoft/vscode-azuretools/issues/2004, we should just always request a token, and rely on caching.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18326)