### PR TITLE
DSC requires the `apiVersion` field and it's no longer being emitted

### DIFF
--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -1255,6 +1255,7 @@ namespace Bicep.Core.Emit
                 }
 
                 if (metadata.IsAzResource ||
+                    Context.SemanticModel.TargetScope == ResourceScope.DesiredStateConfiguration ||
                     this.Context.SemanticModel.Features.ModuleExtensionConfigsEnabled)
                 {
                     emitter.EmitProperty("type", metadata.TypeReference.FormatType());


### PR DESCRIPTION
So check if that's the scope, and if so, emit it and the type, instead of the formatted name.

I tested that this reverts to the necessary behavior for DSC's expectations by using `"moduleExtensionConfigs": true`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18365)