### PR TITLE
Improve F12 UX for using declaration in .bicepparam

### DIFF
--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -109,6 +109,17 @@ namespace Bicep.LanguageServer.Handlers
                     return HandleModuleReference(context, stringToken, sourceFile, moduleReference);
                 }
             }
+            {
+                // Handle using '<module_path>'
+                if (SyntaxMatcher.IsTailMatch<UsingDeclarationSyntax, StringSyntax, Token>(matchingNodes, (usingDeclaration, usingPath, token) => token.Type == TokenType.StringComplete) &&
+                    matchingNodes[^3] is UsingDeclarationSyntax usingDeclaration &&
+                    matchingNodes[^2] is StringSyntax stringSyntax &&
+                    context.Compilation.SourceFileGrouping.TryGetSourceFile(usingDeclaration).IsSuccess(out var sourceFile) &&
+                    moduleDispatcher.TryGetArtifactReference(context.Compilation.SourceFileGrouping.EntryPoint, usingDeclaration).IsSuccess(out var moduleReference))
+                {
+                    return HandleModuleReference(context, stringSyntax, sourceFile, moduleReference);
+                }
+            }
             { // Definition handler for a non symbol bound to implement import path goto.
                 // try to resolve import path syntax from given offset using tail matching.
                 if (SyntaxMatcher.IsTailMatch<CompileTimeImportDeclarationSyntax, CompileTimeImportFromClauseSyntax, StringSyntax, Token>(


### PR DESCRIPTION
Updated `BicepDefinitionHandler` to handle `UsingDeclarationSyntax`, ensuring that Bicep source files instead of ARM template files for remote modules are opened (if Bicep source is available). This aligns the user experience with the behavior of Go to Definition for module paths in Bicep files.

Closes https://github.com/Azure/bicep/issues/17859.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18372)