### PR TITLE
Add support for inline() parameter overrides in .bicepparam files

### DIFF
--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -2012,6 +2012,18 @@ namespace Bicep.Core.Diagnostics
             public Diagnostic MultilineStringRequiresExperimentalFeature() => CoreError(
                 "BCP442",
                 $"Using multiline string interpolation requires enabling EXPERIMENTAL feature \"{nameof(ExperimentalFeaturesEnabled.MultilineStringInterpolation)}\".");
+
+            public Diagnostic InlineFunctionNotValidInVariables() => CoreError(
+                "BCP443",
+                $"The '{LanguageConstants.InlineKeyword}()' function cannot be used in variable declarations. It is only valid in parameter assignments in .bicepparam files.");
+
+            public Diagnostic InlineFunctionNotValidInStringInterpolation() => CoreError(
+                "BCP444",
+                $"The '{LanguageConstants.InlineKeyword}()' function cannot be used in string interpolation.");
+
+            public Diagnostic MissingInlineParameterOverride(string parameterName) => CoreError(
+                "BCP445",
+                $"The parameter \"{parameterName}\" uses the '{LanguageConstants.InlineKeyword}()' function but no value was provided via the '--parameters' argument. Please provide a value using: '--parameters {parameterName}=<value>'");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -11,6 +11,7 @@ using Bicep.Core.Intermediate;
 using Bicep.Core.Navigation;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Metadata;
+using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
 using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
@@ -38,6 +39,7 @@ namespace Bicep.Core.Emit
             FunctionPlacementValidatorVisitor.Validate(model, diagnostics);
             IntegerValidatorVisitor.Validate(model, diagnostics);
             ExtensionReferenceValidatorVisitor.Validate(model, diagnostics);
+            InlineFunctionValidator.Validate(model, diagnostics);
 
             DetectDuplicateNames(model, diagnostics, resourceScopeData, moduleScopeData);
             DetectIncorrectlyFormattedNames(model, diagnostics);

--- a/src/Bicep.Core/LanguageConstants.cs
+++ b/src/Bicep.Core/LanguageConstants.cs
@@ -74,6 +74,7 @@ namespace Bicep.Core
         public const string FunctionKeyword = "func";
         public const string ExistingKeyword = "existing";
         public const string ImportKeyword = "import";
+        public const string InlineKeyword = "inline";
         public const string ExtensionKeyword = "extension";
         public const string ExtensionConfigKeyword = "extensionConfig";
         public const string AssertKeyword = "assert";

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1308,6 +1308,11 @@ namespace Bicep.Core.Semantics.Namespaces
                         return new(LanguageConstants.Any);
                     }, LanguageConstants.Any)
                     .Build();
+
+                yield return new FunctionOverloadBuilder(LanguageConstants.InlineKeyword)
+                    .WithGenericDescription("Placeholder for parameter values provided at deployment time via CLI arguments.")
+                    .WithReturnType(LanguageConstants.Any)
+                    .Build();
             }
 
             foreach (var overload in GetAlwaysPermittedOverloads())

--- a/src/Bicep.Core/TypeSystem/InlineFunctionValidator.cs
+++ b/src/Bicep.Core/TypeSystem/InlineFunctionValidator.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
+using Bicep.Core.SourceGraph;
+using Bicep.Core.Syntax;
+
+namespace Bicep.Core.TypeSystem
+{
+    /// <summary>
+    /// InlineFunctionValidator is used to validate that the inline() function is only used in valid contexts.
+    /// The inline() function is only allowed in parameter assignments in .bicepparam files,
+    /// and is not permitted in variables, string interpolation, or decorators.
+    /// </summary>
+    public sealed class InlineFunctionValidator : AstVisitor
+    {
+        private enum ValidationContext
+        {
+            ParameterValue,
+            VariableValue,
+            StringInterpolation,
+            Other
+        }
+
+        private readonly SemanticModel semanticModel;
+        private readonly IDiagnosticWriter diagnosticWriter;
+        private ValidationContext currentContext = ValidationContext.Other;
+        private string? currentParameterName;
+        private string? currentPropertyName;
+
+        private InlineFunctionValidator(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        {
+            this.semanticModel = semanticModel;
+            this.diagnosticWriter = diagnosticWriter;
+        }
+
+        public static void Validate(SemanticModel semanticModel, IDiagnosticWriter diagnosticWriter)
+        {
+            if (semanticModel.SourceFile is not BicepParamFile)
+            {
+                return;
+            }
+
+            var visitor = new InlineFunctionValidator(semanticModel, diagnosticWriter);
+            visitor.Visit(semanticModel.SourceFile.ProgramSyntax);
+        }
+
+        public override void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
+        {
+            var previousContext = currentContext;
+            var previousParameterName = currentParameterName;
+
+            currentContext = ValidationContext.ParameterValue;
+            currentParameterName = syntax.Name.IdentifierName;
+
+            base.VisitParameterAssignmentSyntax(syntax);
+
+            currentContext = previousContext;
+            currentParameterName = previousParameterName;
+        }
+
+        public override void VisitVariableDeclarationSyntax(VariableDeclarationSyntax syntax)
+        {
+            var previousContext = currentContext;
+            currentContext = ValidationContext.VariableValue;
+
+            base.VisitVariableDeclarationSyntax(syntax);
+
+            currentContext = previousContext;
+        }
+
+        public override void VisitStringSyntax(StringSyntax syntax)
+        {
+            if (syntax.IsInterpolated())
+            {
+                var previousContext = currentContext;
+                currentContext = ValidationContext.StringInterpolation;
+
+                foreach (var expression in syntax.Expressions)
+                {
+                    Visit(expression);
+                }
+
+                currentContext = previousContext;
+            }
+            else
+            {
+                base.VisitStringSyntax(syntax);
+            }
+        }
+
+        public override void VisitObjectPropertySyntax(ObjectPropertySyntax syntax)
+        {
+            var previousPropertyName = currentPropertyName;
+
+            // Extract property name from the key
+            currentPropertyName = syntax.Key switch
+            {
+                StringSyntax stringSyntax when stringSyntax.TryGetLiteralValue() is string literal => literal,
+                IdentifierSyntax identifier => identifier.IdentifierName,
+                _ => null
+            };
+
+            base.VisitObjectPropertySyntax(syntax);
+
+            currentPropertyName = previousPropertyName;
+        }
+
+        public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
+        {
+            if (syntax.Name.IdentifierName == LanguageConstants.InlineKeyword)
+            {
+                ValidateInlineUsage(syntax);
+            }
+
+            base.VisitFunctionCallSyntax(syntax);
+        }
+
+        private void ValidateInlineUsage(FunctionCallSyntax syntax)
+        {
+            switch (currentContext)
+            {
+                case ValidationContext.VariableValue:
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax).InlineFunctionNotValidInVariables());
+                    break;
+
+                case ValidationContext.StringInterpolation:
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax).InlineFunctionNotValidInStringInterpolation());
+                    break;
+
+                case ValidationContext.ParameterValue:
+                    var overrideKey = currentPropertyName ?? currentParameterName ?? "parameter";
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax).MissingInlineParameterOverride(overrideKey));
+                    break;
+
+                case ValidationContext.Other:
+                    diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax).InlineFunctionNotValidInVariables());
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding an `inline()` function to `.bicepparam` files that allows parameter values to be provided at deployment time through the `BICEP_PARAMETERS_OVERRIDES` environment variable (populated by Azure CLI from command-line arguments).

The function acts as a placeholder during authoring but gets replaced with actual values during compilation.

```shell
az deployment sub create --location eastus \
  --template-file main.bicep \
  --parameters @prod.bicepparam sku=Basic location=westus
```

The CLI passes these overrides (`sku=Basic` and `location=westus`) to the Bicep compiler through the `BICEP_PARAMETERS_OVERRIDES` environment variable as json.

## Example usage

```bicep
param <name> = inline()
```

The `inline()` function:

- Takes zero arguments
- Returns type any during static analysis
- Is only valid in parameter assignment expressions in `.bicepparam` files
- Acts as a marker/placeholder for runtime replacement

## Implementation details;

Direct assignment (_Parameter name_)
`param foo = inline()` → uses `foo` from overrides

Object property (_Property name_)
`param foo = { key1: inline() }` → uses `key1` from overrides

Array element (_Parameter name_)
`param foo = [inline()]` → uses `foo` from overrides

Nested objects (_Property chain_)
`param foo = { nested: { key: inline() } }` → uses `nested.key` from overrides

## Details

- Implement InlineFunctionValidator to validate inline() usage (allowed only in parameter assignments in .bicepparam; errors for variables, string interpolation, and missing overrides)
- Add LanguageConstants.InlineKeyword and register inline() function in the system namespace
- Implement InlineReplacementRewriter in ParamsFileHelper to replace inline() with CLI-provided parameter overrides when building params
- Hook inline function validation into EmitLimitationCalculator
- Add diagnostics for BCP442/BCP443/BCP444 with clear error messages
- Add integration tests covering inline() success and failure scenarios (inline in params, objects, arrays; and invalid usages)
- Minor whitespace/newline fixes in several test and extension files

Fixes #10454 

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18374)