### PR TITLE
Add `resourceInput` integration tests and unify param diagnostics

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -1119,5 +1119,169 @@ param objParam object
             error.Should().Contain("Error BCP033: Expected a value of type \"bool\" but the provided value is of type \"<empty array>\".");
             result.Should().Be(1);
         }
+
+        [TestMethod]
+        public async Task BuildParams_ResourceInputType_WithValidObject_Succeeds()
+        {
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+            FileHelper.SaveResultFile(TestContext, "main.bicep", """
+            @description('Parameter with resourceInput type')
+            param storageConfig resourceInput<'Microsoft.Storage/storageAccounts@2022-09-01'>.properties.encryption
+
+            output test string = 'success'
+            """, outputPath);
+
+            var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicepparam", """
+            using './main.bicep'
+
+            param storageConfig = {
+              services: {
+                blob: {
+                  enabled: true
+                }
+                file: {
+                  enabled: true
+                }
+              }
+              keySource: 'Microsoft.Storage'
+            }
+            """, outputPath);
+
+            var expectedOutputFile = FileHelper.GetResultFilePath(TestContext, "main.json", outputPath);
+            File.Exists(expectedOutputFile).Should().BeFalse();
+
+            var (output, error, result) = await Bicep(["build-params", inputFile]);
+
+            result.Should().Be(0);
+            error.Should().NotContain("Error");
+            File.Exists(expectedOutputFile).Should().BeTrue();
+
+            var parametersFile = File.ReadAllText(expectedOutputFile);
+            var parametersObject = JObject.Parse(parametersFile);
+            ((JToken)parametersObject).Should().NotBeNull();
+            var storageConfigValue = parametersObject["parameters"]?["storageConfig"]?["value"];
+            storageConfigValue.Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public async Task BuildParams_ResourceInputType_NestedProperty_Succeeds()
+        {
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+            FileHelper.SaveResultFile(TestContext, "main.bicep", """
+            @description('Parameter with nested resourceInput type')
+            param encryptionServices resourceInput<'Microsoft.Storage/storageAccounts@2022-09-01'>.properties.encryption.services
+
+            output test string = 'success'
+            """, outputPath);
+
+            var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicepparam", """
+            using './main.bicep'
+
+            param encryptionServices = {
+              blob: {
+                enabled: true
+                keyType: 'Account'
+              }
+              file: {
+                enabled: false
+              }
+            }
+            """, outputPath);
+
+            var expectedOutputFile = FileHelper.GetResultFilePath(TestContext, "main.json", outputPath);
+            File.Exists(expectedOutputFile).Should().BeFalse();
+
+            var (output, error, result) = await Bicep(["build-params", inputFile]);
+
+            result.Should().Be(0);
+            error.Should().NotContain("Error");
+            File.Exists(expectedOutputFile).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public async Task BuildParams_ResourceInputType_ArrayOfResources_Succeeds()
+        {
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+            FileHelper.SaveResultFile(TestContext, "main.bicep", """
+            @description('Parameter with array of resourceInput type')
+            param subnets resourceInput<'Microsoft.Network/virtualNetworks/subnets@2023-09-01'>.properties[]
+
+            output test string = 'success'
+            """, outputPath);
+
+            var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicepparam", """
+            using './main.bicep'
+
+            param subnets = [
+              {
+                addressPrefix: '10.0.1.0/24'
+                privateEndpointNetworkPolicies: 'Disabled'
+              }
+              {
+                addressPrefix: '10.0.2.0/24'
+                delegations: []
+              }
+            ]
+            """, outputPath);
+
+            var expectedOutputFile = FileHelper.GetResultFilePath(TestContext, "main.json", outputPath);
+            File.Exists(expectedOutputFile).Should().BeFalse();
+
+            var (output, error, result) = await Bicep(["build-params", inputFile]);
+
+            result.Should().Be(0);
+            error.Should().NotContain("Error");
+            File.Exists(expectedOutputFile).Should().BeTrue();
+
+            var parametersFile = File.ReadAllText(expectedOutputFile);
+            var parametersObject = JObject.Parse(parametersFile);
+            var subnetsArray = parametersObject["parameters"]?["subnets"]?["value"] as JArray;
+            subnetsArray.Should().NotBeNull();
+            subnetsArray!.Count.Should().Be(2);
+        }
+
+        [TestMethod]
+        public async Task BuildParams_ResourceInputType_ComplexNestedObject_Succeeds()
+        {
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+            FileHelper.SaveResultFile(TestContext, "main.bicep", """
+            @description('Parameter with complex resourceInput type')
+            param organizationProfile resourceInput<'Microsoft.DevOpsInfrastructure/pools@2024-10-19'>.properties.organizationProfile
+
+            output test string = 'success'
+            """, outputPath);
+
+            var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicepparam", """
+            using './main.bicep'
+
+            param organizationProfile = {
+              kind: 'AzureDevOps'
+              organizations: [
+                {
+                  url: 'https://dev.azure.com/my-org'
+                  projects: []
+                  parallelism: 1
+                }
+              ]
+              permissionProfile: {
+                kind: 'CreatorOnly'
+              }
+            }
+            """, outputPath);
+
+            var expectedOutputFile = FileHelper.GetResultFilePath(TestContext, "main.json", outputPath);
+            File.Exists(expectedOutputFile).Should().BeFalse();
+
+            var (output, error, result) = await Bicep(["build-params", inputFile]);
+
+            result.Should().Be(0);
+            error.Should().NotContain("Error");
+            File.Exists(expectedOutputFile).Should().BeTrue();
+
+            var parametersFile = File.ReadAllText(expectedOutputFile);
+            var parametersObject = JObject.Parse(parametersFile);
+            var kindValue = parametersObject["parameters"]?["organizationProfile"]?["value"]?["kind"]?.ToString();
+            kindValue.Should().Be("AzureDevOps");
+        }
     }
 }


### PR DESCRIPTION
## Description

- Refactor SemanticModel diagnostics collection for parameter assignments:
  - Create the diagnostics writer once and use TypeValidator.NarrowTypeAndCollectDiagnostics for both same-file and cross-file assignments.
  - Use assignmentSymbol.Context to access TypeManager, Binder, and ParsingErrorLookup for the cross-file path.
  - Yield collected diagnostics after the validation call to keep behavior consistent and consolidate logic.
- Add integration tests for build-params handling of resourceInput parameter types

Fixes #17900 

Fixes #17947

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18376)