### PR TITLE
Deploy command: Disable live table rendering if ANSI disabled

### DIFF
--- a/src/Bicep.Cli/Helpers/Deploy/DeploymentRenderer.cs
+++ b/src/Bicep.Cli/Helpers/Deploy/DeploymentRenderer.cs
@@ -148,7 +148,7 @@ public partial class DeploymentRenderer(IAnsiConsole console)
     {
         // Only support live updates in interactive consoles
         // This should allow this to render tables correctly in CI/CD pipelines where you can't ovewrite output
-        if (console.Profile.Capabilities.Interactive)
+        if (console.Profile.Capabilities.Interactive && console.Profile.Capabilities.Ansi)
         {
             await console.Live(table)
                 .AutoClear(false)


### PR DESCRIPTION
Fix the following error:
```
 Process stderr: Unhandled exception. System.IO.IOException: The handle is invalid.
   at System.ConsolePal.set_CursorVisible(Boolean)
   at System.Console.set_CursorVisible(Boolean)
   at Spectre.Console.LegacyConsoleCursor.Show(Boolean) in /_/src/Spectre.Console/Internal/Backends/Legacy/LegacyConsoleCursor.cs:line 7
   at Spectre.Console.CursorExtensions.Hide(IAnsiConsoleCursor) in /_/src/Spectre.Console/Extensions/CursorExtensions.cs:line 33
   at Spectre.Console.LiveDisplayRenderer.Started() in /_/src/Spectre.Console/Live/LiveDisplayRenderer.cs:line 15
   at Spectre.Console.LiveDisplay.<>c__DisplayClass18_0`1.<<StartAsync>b__0>d.MoveNext() in /_/src/Spectre.Console/Live/LiveDisplay.cs:line 104
--- End of stack trace from previous location ---
   at Spectre.Console.Internal.DefaultExclusivityMode.RunAsync[T](Func`1) in /_/src/Spectre.Console/Internal/DefaultExclusivityMode.cs:line 40
   at Spectre.Console.LiveDisplay.StartAsync[T](Func`2) in /_/src/Spectre.Console/Live/LiveDisplay.cs:line 98
   at Spectre.Console.LiveDisplay.StartAsync(Func`2) in /_/src/Spectre.Console/Live/LiveDisplay.cs:line 78
   at Bicep.Cli.Helpers.Deploy.DeploymentRenderer.RenderLive(TimeSpan refreshInterval, Table table, Func`1 refreshFunc, CancellationToken cancellationToken)
   at Bicep.Cli.Helpers.Deploy.DeploymentRenderer.RenderDeployment(TimeSpan refreshInterval, Func`2 executeFunc, DeploymentOutputFormat outputFormat, CancellationToken cancellationToken)
   at Bicep.Cli.Commands.LocalDeployCommand.RunAsync(LocalDeployArguments args, CancellationToken cancellationToken)
```