### PR TITLE
Added ability to promote info diagnostics to warning in msbuild

### DIFF
--- a/Bicep.sln
+++ b/Bicep.sln
@@ -117,6 +117,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.RpcClient", "src\Bice
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.RpcClient.Tests", "src\Bicep.RpcClient.Tests\Bicep.RpcClient.Tests.csproj", "{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.MSBuild.UnitTests", "src\Bicep.MSBuild.UnitTests\Bicep.MSBuild.UnitTests.csproj", "{64F80A63-FF29-4B66-89EB-3F94A0F33E3B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -255,6 +257,10 @@ Global
 		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64F80A63-FF29-4B66-89EB-3F94A0F33E3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64F80A63-FF29-4B66-89EB-3F94A0F33E3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64F80A63-FF29-4B66-89EB-3F94A0F33E3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64F80A63-FF29-4B66-89EB-3F94A0F33E3B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -293,6 +299,7 @@ Global
 		{8585C44C-5093-4A32-AABA-9EC7B8A6118C} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
 		{EFC27293-4DBB-4D58-85E4-4B94A8F50C8B} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
 		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
+		{64F80A63-FF29-4B66-89EB-3F94A0F33E3B} = {38A0A11F-72BD-4512-A4A9-AC953936C09F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {21F77282-91E7-4304-B1EF-FADFA4F39E37}

--- a/scripts/SetupMsBuildTests.ps1
+++ b/scripts/SetupMsBuildTests.ps1
@@ -1,0 +1,100 @@
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrWhiteSpace()]
+  [ValidateSet(
+    'Debug',
+    'Release'
+  )]
+  [string]
+  $Configuration,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrWhiteSpace()]
+  [ValidateSet(
+    'win-x64',
+    'linux-x64',
+    'linux-musl-x64',
+    'osx-x64',
+    'linux-arm64',
+    'win-arm64',
+    'osx-arm64'
+  )]
+  [string]
+  $RuntimeIdentifier
+)
+
+function CopyFilesToDirectory($sourceDir, $fileNameFilter, $destinationDir) {
+  New-Item -ItemType Directory -Path $destinationDir -Force | Out-Null;
+  $files = Get-ChildItem -Path $sourceDir -Filter $fileNameFilter -File;
+  foreach ($file in $files) {
+    $sourceFile = $file.FullName;
+    $destinationFile = Join-Path -Path $destinationDir -ChildPath $file.Name;
+    Write-Output "  Copying file from '$sourceFile' to '$destinationFile'..."
+    Copy-Item -Path $sourceFile -Destination $destinationFile -Force;
+  }
+}
+
+function RemoveFilesFromDirectory($dir, $fileNameFilter) {
+  if( -not (Test-Path -Path $dir)) {
+    Write-Output "  Directory '$dir' does not exist. Skipping removal of files matching '$fileNameFilter'."
+    return;
+  }
+
+  $files = Get-ChildItem -Path $dir -Filter $fileNameFilter -File;
+  foreach ($file in $files) {
+    $fileToRemove = $file.FullName;
+    Write-Output "  Removing file '$fileToRemove'..."
+    Remove-Item -Path $fileToRemove -Force;
+  }
+}
+
+$ErrorActionPreference = 'Stop';
+$TargetFramework = 'net8.0';
+
+$msbuildNuGetFileGlob = "Azure.Bicep.MSBuild.*.nupkg";
+$bicepCliNuGetFileGlob = "Azure.Bicep.CommandLine.$RuntimeIdentifier.*.nupkg";
+
+$repoRoot = Join-Path -Path $PSScriptRoot -ChildPath '..';
+Write-Output "Repo root = $repoRoot";
+Write-Output "Configuration = $Configuration";
+Write-Output "RuntimeIdentifier = $RuntimeIdentifier";
+
+$bicepCliProjectDir = Join-Path -Path $repoRoot -ChildPath 'src' -AdditionalChildPath 'Bicep.Cli';
+$bicepCliProjectFile = Join-Path -Path $bicepCliProjectDir -ChildPath 'Bicep.Cli.csproj';
+$bicepCliPublishDir = Join-Path -Path $bicepCliProjectDir -ChildPath 'bin' -AdditionalChildPath @($Configuration, $TargetFramework, $RuntimeIdentifier, 'publish');
+
+$bicepCliNugetProjectDir = Join-Path -Path $repoRoot -ChildPath 'src' -AdditionalChildPath 'Bicep.Cli.NuGet';
+$bicepCliNugetProjectFile = Join-Path -Path $bicepCliNugetProjectDir -ChildPath 'nuget.proj';
+$bicepCliNugetProjectToolsDir = Join-Path -Path $bicepCliNugetProjectDir -ChildPath 'tools';
+
+$msbuildProjectDir = Join-Path -Path $repoRoot -ChildPath 'src' -AdditionalChildPath 'Bicep.MSBuild';
+$msbuildProjectFile = Join-Path -Path $msbuildProjectDir -ChildPath 'Bicep.MSBuild.csproj';
+$msbuildProjectOutputDir = Join-Path $repoRoot -ChildPath 'out';
+
+$e2eTestProjectDir = Join-Path -Path $repoRoot -ChildPath 'src' -AdditionalChildPath 'Bicep.MSBuild.E2eTests';
+$e2eTestProjectPackageDir = Join-Path -Path $e2eTestProjectDir -ChildPath 'examples' -AdditionalChildPath 'local-packages';
+
+Write-Output "Cleaning old NuGet packages...";
+RemoveFilesFromDirectory -dir $msbuildProjectOutputDir -fileNameFilter $msbuildNuGetFileGlob;
+RemoveFilesFromDirectory -dir $bicepCliNugetProjectDir -fileNameFilter $bicepCliNuGetFileGlob;
+
+RemoveFilesFromDirectory -dir $e2eTestProjectPackageDir -fileNameFilter '*.nupkg';
+
+Write-Output "Publishing Bicep CLI...";
+dotnet publish --configuration $Configuration --self-contained true -r $RuntimeIdentifier $bicepCliProjectFile
+
+Write-Output "Building and packing Bicep MSBuild package...";
+dotnet build --configuration $Configuration $msbuildProjectFile
+dotnet pack --configuration $Configuration $msbuildProjectFile
+
+Write-Output "Preparing Bicep CLI package prerequisites...";
+CopyFilesToDirectory -sourceDir $bicepCliPublishDir -fileNameFilter 'bicep*' -destinationDir $bicepCliNugetProjectToolsDir;
+
+Write-Output "Creating Bicep CLI NuGet package...";
+dotnet build --configuration $Configuration /p:RuntimeSuffix=$RuntimeIdentifier $bicepCliNugetProjectFile
+
+Write-Output "Setting up Bicep MSBuild E2E test prerequisites...";
+CopyFilesToDirectory -sourceDir $msbuildProjectOutputDir -fileNameFilter $msbuildNuGetFileGlob -destinationDir $e2eTestProjectPackageDir;
+CopyFilesToDirectory -sourceDir $bicepCliNugetProjectDir -fileNameFilter $bicepCliNuGetFileGlob -destinationDir $e2eTestProjectPackageDir;
+

--- a/src/Bicep.MSBuild.E2eTests/Bicep.MSBuild.E2eTests.sln
+++ b/src/Bicep.MSBuild.E2eTests/Bicep.MSBuild.E2eTests.sln
@@ -1,0 +1,36 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "csharp", "examples\csharp\csharp.csproj", "{F79AC5B1-7565-02FE-B53D-781B9950650D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "csharp-recursive", "examples\csharp-recursive\csharp-recursive.csproj", "{D362AF50-8ACC-851F-E6BE-C2E7811F0624}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F79AC5B1-7565-02FE-B53D-781B9950650D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F79AC5B1-7565-02FE-B53D-781B9950650D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F79AC5B1-7565-02FE-B53D-781B9950650D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F79AC5B1-7565-02FE-B53D-781B9950650D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D362AF50-8ACC-851F-E6BE-C2E7811F0624}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D362AF50-8ACC-851F-E6BE-C2E7811F0624}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D362AF50-8ACC-851F-E6BE-C2E7811F0624}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D362AF50-8ACC-851F-E6BE-C2E7811F0624}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F79AC5B1-7565-02FE-B53D-781B9950650D} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
+		{D362AF50-8ACC-851F-E6BE-C2E7811F0624} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D5F074BC-7882-4477-A4F5-940378CE0A7F}
+	EndGlobalSection
+EndGlobal

--- a/src/Bicep.MSBuild.E2eTests/examples/info-to-warning/bicepconfig.json
+++ b/src/Bicep.MSBuild.E2eTests/examples/info-to-warning/bicepconfig.json
@@ -1,0 +1,13 @@
+{
+  // See https://aka.ms/bicep/config for more information on Bicep configuration options
+  // Press CTRL+SPACE at any location to see Intellisense suggestions
+  "analyzers": {
+    "core": {
+      "rules": {
+        "no-unused-vars": {
+          "level": "info"
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.MSBuild.E2eTests/examples/info-to-warning/info-to-warning.proj
+++ b/src/Bicep.MSBuild.E2eTests/examples/info-to-warning/info-to-warning.proj
@@ -1,0 +1,21 @@
+<!--
+  Do not include this project in the solution. It is intended to validate our MSBuild task.
+-->
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <BicepTreatInfoAsWarnings>true</BicepTreatInfoAsWarnings>
+  </PropertyGroup>
+
+  <!--
+    Pickup latest available packages (including prerelease) from local feed configured in NuGet.config.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Bicep.CommandLine.$(RuntimeSuffix)" Version="*-*" />
+    <PackageReference Include="Azure.Bicep.MSBuild" Version="*-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Bicep Include="main.bicep"/>
+  </ItemGroup>
+</Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/info-to-warning/main.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/info-to-warning/main.bicep
@@ -1,0 +1,3 @@
+
+// intentionally unused
+var unused = 42

--- a/src/Bicep.MSBuild.E2eTests/examples/info/bicepconfig.json
+++ b/src/Bicep.MSBuild.E2eTests/examples/info/bicepconfig.json
@@ -1,0 +1,13 @@
+{
+  // See https://aka.ms/bicep/config for more information on Bicep configuration options
+  // Press CTRL+SPACE at any location to see Intellisense suggestions
+  "analyzers": {
+    "core": {
+      "rules": {
+        "no-unused-vars": {
+          "level": "info"
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.MSBuild.E2eTests/examples/info/info.proj
+++ b/src/Bicep.MSBuild.E2eTests/examples/info/info.proj
@@ -1,0 +1,20 @@
+<!--
+  Do not include this project in the solution. It is intended to validate our MSBuild task.
+-->
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <!--
+    Pickup latest available packages (including prerelease) from local feed configured in NuGet.config.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Azure.Bicep.CommandLine.$(RuntimeSuffix)" Version="*-*" />
+    <PackageReference Include="Azure.Bicep.MSBuild" Version="*-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Bicep Include="main.bicep"/>
+  </ItemGroup>
+</Project>

--- a/src/Bicep.MSBuild.E2eTests/examples/info/main.bicep
+++ b/src/Bicep.MSBuild.E2eTests/examples/info/main.bicep
@@ -1,0 +1,3 @@
+
+// intentionally unused
+var unused = 42

--- a/src/Bicep.MSBuild.E2eTests/package-lock.json
+++ b/src/Bicep.MSBuild.E2eTests/package-lock.json
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2031,9 +2031,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3165,9 +3165,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.20",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
-      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/Bicep.MSBuild.E2eTests/src/info.test.ts
+++ b/src/Bicep.MSBuild.E2eTests/src/info.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, expect, it } from "vitest";
+import * as asserts from "./asserts";
+import { Example } from "./example";
+
+describe("msbuild", () => {
+  it("should promote info diagnostic to warning", () => {
+    const example = new Example("info-to-warning");
+    example.cleanProjectDir();
+
+    const result = example.build(false);
+    asserts.expectLinesInLog(result.stdout, [
+          '1 Warning(s)',
+          '0 Error(s)',
+          'main.bicep(3,5): warning no-unused-vars: Variable "unused" is declared but never used.',
+        ]);
+  });
+
+  it("should promote info diagnostic to error", () => {
+    const example = new Example("info");
+    example.cleanProjectDir();
+
+    const result = example.build(false);
+    asserts.expectLinesInLog(result.stdout, [
+          '0 Warning(s)',
+          '0 Error(s)',
+        ]);
+  });
+});

--- a/src/Bicep.MSBuild.E2eTests/src/info.test.ts
+++ b/src/Bicep.MSBuild.E2eTests/src/info.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 import * as asserts from "./asserts";
 import { Example } from "./example";
 

--- a/src/Bicep.MSBuild.UnitTests/Bicep.MSBuild.UnitTests.csproj
+++ b/src/Bicep.MSBuild.UnitTests/Bicep.MSBuild.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Bicep.MSBuild/Bicep.MSBuild.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Bicep.MSBuild.UnitTests/BicepDiagnosticParserTests.cs
+++ b/src/Bicep.MSBuild.UnitTests/BicepDiagnosticParserTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Bicep.MSBuild;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.MSBuild.UnitTests;
+
+[TestClass]
+public class BicepDiagnosticParserTests
+{
+    [DataRow("main.bicep(4,23) : Error BCP079: This expression is referencing its own declaration, which is not allowed. [https://aka.ms/bicep/core-diagnostics#BCP079]", "main.bicep(4,23)", "Error", "BCP079", "This expression is referencing its own declaration, which is not allowed. [https://aka.ms/bicep/core-diagnostics#BCP079]")]
+    [DataRow("C:\\main.bicep(4,23) : Error BCP079: This expression is referencing its own declaration, which is not allowed. [https://aka.ms/bicep/core-diagnostics#BCP079]", "C:\\main.bicep(4,23)", "Error", "BCP079", "This expression is referencing its own declaration, which is not allowed. [https://aka.ms/bicep/core-diagnostics#BCP079]")]
+    [DataRow("X:\\hello\\there\\main.bicep(1,12) : Warning use-recent-module-versions: Use a more recent version of module 'fake/avm/res/app/container-app1a'. The most recent version is 0.2.0. *", "X:\\hello\\there\\main.bicep(1,12)", "Warning", "use-recent-module-versions", "Use a more recent version of module 'fake/avm/res/app/container-app1a'. The most recent version is 0.2.0. *")]
+    [DataRow("/users/test/subdir/main.bicep(1,12) : Warning use-recent-module-versions: Use a more recent version of module 'fake/avm/res/app/container-app1a'. The most recent version is 0.2.0. *", "/users/test/subdir/main.bicep(1,12)", "Warning", "use-recent-module-versions", "Use a more recent version of module 'fake/avm/res/app/container-app1a'. The most recent version is 0.2.0. *")]
+    [DataRow("main.bicep(2,2) : Info FAKE: Made up informational diagnostic.", "main.bicep(2,2)", "Info", "FAKE", "Made up informational diagnostic.")]
+    [DataTestMethod]
+    public void ParserCanParseAndReconstructBicepDiagnostics(string line, string expectedOrigin, string expectedCategory, string expectedCode, string expectedText)
+    {
+        var result = BicepDiagnosticParser.TryParseDiagnostic(line);
+        result.Should().NotBeNull();
+
+        result.Origin.Should().Be(expectedOrigin);
+        result.Category.Should().Be(expectedCategory);
+        result.Code.Should().Be(expectedCode);
+        result.Text.Should().Be(expectedText);
+
+        BicepDiagnosticParser.ReconstructDiagnostic(result).Should().Be(line);
+    }
+}

--- a/src/Bicep.MSBuild/BicepDiagnosticParser.cs
+++ b/src/Bicep.MSBuild/BicepDiagnosticParser.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace Azure.Bicep.MSBuild;
+
+public record BicepDiagnostic(string Origin, string Category, string Code, string Text);
+
+/// <summary>
+/// Parses and reconstructs Bicep diagnostics in canonical MSBuild format.
+/// </summary>
+/// <remarks>This class does not handle the full msbuild canonical diagnostic format. It also extends the msbuild diagnostic format to support info levels.</remarks>
+public static class BicepDiagnosticParser
+{
+    private static readonly Regex DiagnosticFormatRegex = new(@"^(?<origin>(((\d+>)?\s*[a-zA-Z]?:[^:]*)|([^:]*))) : (?<category>error|warning|info) (?<code>[^: ]+): (?<text>.+)$", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+
+    public static BicepDiagnostic? TryParseDiagnostic(string line)
+    {
+        var match = DiagnosticFormatRegex.Match(line);
+        if (!match.Success)
+        {
+            return null;
+        }
+        return new BicepDiagnostic(
+            match.Groups["origin"].Value,
+            match.Groups["category"].Value,
+            match.Groups["code"].Value,
+            match.Groups["text"].Value);
+    }
+
+    public static string ReconstructDiagnostic(BicepDiagnostic diagnostic)
+        => ReconstructDiagnostic(diagnostic.Origin, diagnostic.Category, diagnostic.Code, diagnostic.Text);
+
+    public static string ReconstructDiagnostic(string origin, string category, string code, string text)
+        => $"{origin} : {category} {code}: {text}";
+}

--- a/src/Bicep.MSBuild/Polyfills/IsExternalInit.cs
+++ b/src/Bicep.MSBuild/Polyfills/IsExternalInit.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Class required for C# 9.0 record types.
+    /// </summary>
+    internal static class IsExternalInit
+    {
+    }
+}
+#endif

--- a/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.targets
+++ b/src/Bicep.MSBuild/build/Azure.Bicep.MSBuild.targets
@@ -8,6 +8,9 @@
     <BicepOutputPath Condition=" $(BicepOutputPath) == '' ">$(OutputPath)</BicepOutputPath>
     <!-- all files by default will get dumped into the configured output path -->
     <BicepOutputStyle Condition=" $(BicepOutputStyle) == '' ">Flat</BicepOutputStyle>
+
+    <!-- disable promoting info diagnostics to warnings by default -->
+    <BicepTreatInfoAsWarnings Condition=" $(BicepTreatInfoAsWarnings) == '' ">false</BicepTreatInfoAsWarnings>
   </PropertyGroup>
 
   <Target Name="BeforeBicepCompileCommon">
@@ -32,7 +35,7 @@
       <!-- collect all the files with NoBuild metadata set -->
       <_BicepSkipped Include="@(Bicep)" Condition=" %(Bicep.NoBuild) == 'true' " />
     </ItemGroup>
-    
+
     <!-- pre-create directories for all the outputs in case they don't exist -->
     <MakeDir Directories=" %(_BicepOutputFile.RootDir)%(Directory)" />
     <Error Text="The path to the Bicep compiler is not set. Reference the appropriate Azure.Bicep.CommandLine.* package for your runtime or set the BicepPath property." Condition=" $(BicepPath) == '' " />
@@ -56,14 +59,14 @@
       <!-- collect all the files with NoBuild metadata set -->
       <_BicepParamSkipped Include="@(BicepParam)" Condition=" %(BicepParam.NoBuild) == 'true' " />
     </ItemGroup>
-    
+
     <!-- pre-create directories for all the outputs in case they don't exist -->
     <MakeDir Directories=" %(_BicepOutputFile.RootDir)%(Directory)" />
     <Error Text="The path to the Bicep compiler is not set. Reference the appropriate Azure.Bicep.CommandLine.* package for your runtime or set the BicepPath property." Condition=" $(BicepPath) == '' " />
   </Target>
 
   <Target Name="BicepCompile" Inputs="@(_BicepResolved);@(_BicepSkipped)" Outputs="%(_BicepResolved.OutputFile)" DependsOnTargets="$(BicepCompileDependsOn)" AfterTargets="$(BicepCompileAfterTargets)" BeforeTargets="$(BicepCompileBeforeTargets)">
-    <Bicep SourceFile="%(_BicepResolved.FullPath)" OutputFile="%(OutputFile)" ToolExe="$(BicepPath)" YieldDuringToolExecution="true" />
+    <Bicep SourceFile="%(_BicepResolved.FullPath)" OutputFile="%(OutputFile)" ToolExe="$(BicepPath)" YieldDuringToolExecution="true" BicepTreatInfoAsWarnings="$(BicepTreatInfoAsWarnings)" />
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; %(_BicepResolved.OutputFile)" />
 
     <ItemGroup>
@@ -72,7 +75,7 @@
   </Target>
 
   <Target Name="BicepParamCompile" Inputs="@(_BicepParamResolved);@(_BicepParamSkipped)" Outputs="%(_BicepParamResolved.OutputFile)" DependsOnTargets="$(BicepParamCompileDependsOn)" AfterTargets="$(BicepParamCompileAfterTargets)" BeforeTargets="$(BicepParamCompileBeforeTargets)">
-    <BicepParam SourceFile="%(_BicepParamResolved.FullPath)" OutputFile="%(OutputFile)" ToolExe="$(BicepPath)" YieldDuringToolExecution="true" />
+    <BicepParam SourceFile="%(_BicepParamResolved.FullPath)" OutputFile="%(OutputFile)" ToolExe="$(BicepPath)" YieldDuringToolExecution="true" BicepTreatInfoAsWarnings="$(BicepTreatInfoAsWarnings)" />
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; %(_BicepParamResolved.OutputFile)" />
 
     <ItemGroup>


### PR DESCRIPTION
This fixes #17517. I also added a script that simplifies the setup of prereqs for the MSBuild E2E tests. Tested it on Windows and a Mac.