### PR TITLE
Support load* functions in REPL

### DIFF
--- a/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
+++ b/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
@@ -2,24 +2,27 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
+using System.IO.Abstractions.TestingHelpers;
 using System.Text;
 using Bicep.Cli.Services;
-using Bicep.Core;
 using Bicep.Core.Parsing;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.WindowsAzure.ResourceStack.Common.Json;
 
 namespace Bicep.Cli.UnitTests.Services;
 
 [TestClass]
 public class ReplEnvironmentTests
 {
-    private static ReplEnvironment CreateReplEnvironment()
-        => ServiceBuilder.Create(x => x.AddSingleton<ReplEnvironment>())
+    private static ReplEnvironment CreateReplEnvironment(Action<IServiceCollection>? configure = null)
+        => ServiceBuilder.Create(x =>
+            {
+                x.AddSingleton<ReplEnvironment>();
+                configure?.Invoke(x);
+            })
             .Construct<ReplEnvironment>();
 
     [TestMethod]
@@ -304,6 +307,81 @@ public class ReplEnvironmentTests
         EnsureSingleInput(text);
     }
 
+    [TestMethod]
+    public void LoadFunctions_succeed()
+    {
+        var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/testDir/vnet/vNetSubnet.jsonc"] = new MockFileData("""
+        {
+          "name": "mySubnet",
+          "version": 1.4 // test float handling
+        }
+        """),
+            ["/testDir/config/app1.txt"] = new MockFileData("test content 1"),
+            ["/testDir/config/app2.txt"] = new MockFileData("test content 2"),
+            ["/testDir/test.yaml"] = new MockFileData("""
+        description: "Allows SSH traffic"
+        protocol: "Tcp"
+        """)
+        });
+
+        mockFileSystem.Directory.SetCurrentDirectory("/testDir");
+
+        var outputs = EvaluateInputs([
+            "loadJsonContent('./vnet/vNetSubnet.jsonc')",
+        "loadTextContent('./config/app1.txt')",
+        "loadYamlContent('./test.yaml')",
+        "loadDirectoryFileInfo('./config/', '*.txt')"
+        ], services =>
+        {
+            services.WithFileSystem(mockFileSystem);
+        });
+
+#if WINDOWS_BUILD
+        var pathPrefix = "C:/";
+#else
+var pathPrefix = string.Empty;
+#endif
+
+        outputs.Should().SatisfyRespectively(
+            x => x.Should().BeEquivalentToIgnoringNewlines("""
+          {
+            [DarkYellow]name[Reset]: [Orange]'mySubnet'[Reset]
+            [DarkYellow]version[Reset]: [Orange]'1.4'[Reset]
+          }
+
+          """),
+            x => x.Should().BeEquivalentToIgnoringNewlines("""
+          [Orange]'test content 1'[Reset]
+
+          """),
+
+            x => x.Should().BeEquivalentToIgnoringNewlines("""
+          {
+            [DarkYellow]description[Reset]: [Orange]'Allows SSH traffic'[Reset]
+            [DarkYellow]protocol[Reset]: [Orange]'Tcp'[Reset]
+          }
+
+          """),
+
+            x => x.Should().BeEquivalentToIgnoringNewlines($$"""
+          [
+            {
+              [DarkYellow]relativePath[Reset]: [Orange]'{{pathPrefix}}testDir/config/app1.txt'[Reset]
+              [DarkYellow]baseName[Reset]: [Orange]'app1.txt'[Reset]
+              [DarkYellow]extension[Reset]: [Orange]'.txt'[Reset]
+            }
+            {
+              [DarkYellow]relativePath[Reset]: [Orange]'{{pathPrefix}}testDir/config/app2.txt'[Reset]
+              [DarkYellow]baseName[Reset]: [Orange]'app2.txt'[Reset]
+              [DarkYellow]extension[Reset]: [Orange]'.txt'[Reset]
+            }
+          ]
+
+          """));
+    }
+
     private static void EnsureSingleInput(string text)
     {
         var input = text.NormalizeNewlines().Split('\n');
@@ -316,9 +394,9 @@ public class ReplEnvironmentTests
         }
     }
 
-    private static ImmutableArray<string> EvaluateInputs(IEnumerable<string> input)
+    private static ImmutableArray<string> EvaluateInputs(IEnumerable<string> input, Action<IServiceCollection>? configure = null)
     {
-        var replEnvironment = CreateReplEnvironment();
+        var replEnvironment = CreateReplEnvironment(configure);
         var outputs = new List<string>();
         foreach (var inputBlock in input)
         {

--- a/src/Bicep.Core/Extensions/IDirectoryHandleExtensions.cs
+++ b/src/Bicep.Core/Extensions/IDirectoryHandleExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.SourceGraph;
+using Bicep.IO.Abstraction;
+
+namespace Bicep.Core.Extensions;
+
+public static class IDirectoryHandleExtensions
+{
+    public static ResultWithDiagnosticBuilder<IFileHandle> TryGetRelativeFile(this IDirectoryHandle directoryHandle, RelativePath path)
+    {
+        try
+        {
+            var relativeDirectory = directoryHandle.GetDirectory(path);
+
+            if (relativeDirectory.Exists())
+            {
+                var uri = path.AsSpan()[^1] == '/' ? relativeDirectory.Uri : relativeDirectory.Uri.ToString()[..^1];
+
+                return new(x => x.FoundDirectoryInsteadOfFile(uri));
+            }
+
+            return new(directoryHandle.GetFile(path));
+        }
+        catch (IOException exception)
+        {
+            return new(x => x.ErrorOccurredReadingFile(exception.Message));
+        }
+    }
+}

--- a/src/Bicep.Core/Extensions/IFileHandleExtensions.cs
+++ b/src/Bicep.Core/Extensions/IFileHandleExtensions.cs
@@ -28,16 +28,7 @@ namespace Bicep.Core.Extensions
             try
             {
                 var currentDirectory = fileHandle.GetParent();
-                var relativeDirectory = currentDirectory.GetDirectory(path);
-
-                if (relativeDirectory.Exists())
-                {
-                    var uri = path.AsSpan()[^1] == '/' ? relativeDirectory.Uri : relativeDirectory.Uri.ToString()[..^1];
-
-                    return new(x => x.FoundDirectoryInsteadOfFile(uri));
-                }
-
-                return new(currentDirectory.GetFile(path));
+                return currentDirectory.TryGetRelativeFile(path);
             }
             catch (IOException exception)
             {

--- a/src/Bicep.Core/SourceGraph/BicepReplFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepReplFile.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Features;
-using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
 using Bicep.IO.Abstraction;
 
@@ -15,6 +14,7 @@ public class BicepReplFile : BicepSourceFile
 {
     public BicepReplFile(
         IFileHandle fileHandle,
+        IDirectoryHandle auxiliaryDirectoryHandle,
         ImmutableArray<int> lineStarts,
         ProgramSyntax programSyntax,
         IConfigurationManager configurationManager,
@@ -33,13 +33,19 @@ public class BicepReplFile : BicepSourceFile
             lexingErrorLookup,
             parsingErrorLookup)
     {
+        AuxiliaryDirectoryHandle = auxiliaryDirectoryHandle;
     }
 
     private BicepReplFile(BicepReplFile original) : base(original)
     {
+        AuxiliaryDirectoryHandle = original.AuxiliaryDirectoryHandle;
     }
 
     public override BicepSourceFileKind FileKind => BicepSourceFileKind.ReplFile;
 
+    public IDirectoryHandle AuxiliaryDirectoryHandle { get; }
+
     public override BicepSourceFile ShallowClone() => new BicepReplFile(this);
+
+    protected override IDirectoryHandle GetDirectoryHandle() => this.AuxiliaryDirectoryHandle;
 }

--- a/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
@@ -98,7 +98,7 @@ namespace Bicep.Core.SourceGraph
                 return new(x => x.ErrorOccurredReadingFile("Cannot load auxiliary file from dummy file handle"));
             }
 
-            return this.FileHandle
+            return this.GetDirectoryHandle()
                 .TryGetRelativeFile(relativePath)
                 .Transform(fileHandle =>
                 {
@@ -118,10 +118,10 @@ namespace Bicep.Core.SourceGraph
                 return new(x => x.ErrorOccurredReadingFile("Cannot load auxiliary file from dummy file handle"));
             }
 
-            var directoryHandle = this.FileHandle.GetParent().GetDirectory(relativePath);
+            var directoryHandle = this.GetDirectoryHandle().GetDirectory(relativePath);
             if (!directoryHandle.Exists())
             {
-                if (this.FileHandle.GetParent().GetFile(relativePath).Exists())
+                if (this.GetDirectoryHandle().GetFile(relativePath).Exists())
                 {
                     return new(x => x.FoundFileInsteadOfDirectory(relativePath));
                 }
@@ -143,5 +143,7 @@ namespace Bicep.Core.SourceGraph
         public FrozenSet<IOUri> GetReferencedAuxiliaryFileUris() => this.referencedAuxiliaryFileUris.ToFrozenSet();
 
         public bool IsReferencingAuxiliaryFile(IOUri uri) => this.referencedAuxiliaryFileUris.Contains(uri);
+
+        protected virtual IDirectoryHandle GetDirectoryHandle() => this.FileHandle.GetParent();
     }
 }

--- a/src/Bicep.Core/SourceGraph/ISourceFileFactory.cs
+++ b/src/Bicep.Core/SourceGraph/ISourceFileFactory.cs
@@ -20,7 +20,7 @@ namespace Bicep.Core.SourceGraph
 
         BicepParamFile CreateBicepParamFile(IOUri fileUri, string fileContents);
 
-        BicepReplFile CreateBicepReplFile(IFileHandle fileHandle, string fileContents);
+        BicepReplFile CreateBicepReplFile(IFileHandle fileHandle, IDirectoryHandle auxiliaryDirectoryHandle, string fileContents);
 
         ArmTemplateFile CreateArmTemplateFile(IOUri fileUri, string fileContents);
 

--- a/src/Bicep.Core/SourceGraph/SourceFileFactory.cs
+++ b/src/Bicep.Core/SourceGraph/SourceFileFactory.cs
@@ -111,12 +111,12 @@ namespace Bicep.Core.SourceGraph
             return new(fileHandle, lineStarts, parser.Program(), this.configurationManager, this.featureProviderFactory, this.auxiliaryFileCache, parser.LexingErrorLookup, parser.ParsingErrorLookup);
         }
 
-        public BicepReplFile CreateBicepReplFile(IFileHandle fileHandle, string fileContents)
+        public BicepReplFile CreateBicepReplFile(IFileHandle fileHandle, IDirectoryHandle auxiliaryDirectoryHandle, string fileContents)
         {
             var parser = new ReplParser(fileContents);
             var lineStarts = TextCoordinateConverter.GetLineStarts(fileContents);
 
-            return new(fileHandle, lineStarts, parser.Program(), this.configurationManager, this.featureProviderFactory, this.auxiliaryFileCache, parser.LexingErrorLookup, parser.ParsingErrorLookup);
+            return new(fileHandle, auxiliaryDirectoryHandle, lineStarts, parser.Program(), this.configurationManager, this.featureProviderFactory, this.auxiliaryFileCache, parser.LexingErrorLookup, parser.ParsingErrorLookup);
         }
 
         public ArmTemplateFile CreateArmTemplateFile(IOUri fileUri, string fileContents) =>


### PR DESCRIPTION
## Description
Fixes #18371.

**Why this wasn't working before:**
The REPL utilizes an ephemeral in-memory file system rather than the "disk" to persist user input. The load* functions were didn't work because the files don't exist in the in-memory file system.

**Approach:**
Captures the user's current directory (on the real filesystem on disk) from which the `bicep console` command is invoked, and then uses it as the parent URI when loading files via `TryLoadAuxiliaryFile` in `BicepSourceFile`. 

<img width="915" height="796" alt="image" src="https://github.com/user-attachments/assets/3730c465-f86b-44e1-adea-ab2d998eedd5" />


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18413)