### PR TITLE
fix and add tests for quoted property names and enhance symbol resolution

### DIFF
--- a/src/Bicep.Core/Semantics/SymbolHelper.cs
+++ b/src/Bicep.Core/Semantics/SymbolHelper.cs
@@ -63,35 +63,6 @@ namespace Bicep.Core.Semantics
 
             switch (syntax)
             {
-                case StringSyntax stringSyntax:
-                    {
-                        var parent = binder.GetParent(stringSyntax);
-                        if (parent is ObjectPropertySyntax objectProperty && objectProperty.Key == stringSyntax)
-                        {
-                            if (binder.GetParent(objectProperty) is not { } parentSyntax)
-                            {
-                                return null;
-                            }
-
-                            var baseType = getDeclaredTypeFunc(parentSyntax);
-                            if (objectProperty.TryGetKeyText() is not { } property)
-                            {
-                                return null;
-                            }
-
-                            return GetPropertySymbol(baseType, property, true);
-                        }
-                        else if (parent is ObjectTypePropertySyntax objectTypeProperty && objectTypeProperty.Key == stringSyntax)
-                        {
-                            if (objectTypeProperty.TryGetKeyText() is not string propertyName || binder.GetParent(objectTypeProperty) is not SyntaxBase parentSyntax)
-                            {
-                                return null;
-                            }
-
-                            return GetPropertySymbol(getDeclaredTypeFunc(parentSyntax), propertyName, false);
-                        }
-                        break;
-                    }
                 case InstanceFunctionCallSyntax ifc:
                     {
                         var baseType = getDeclaredTypeFunc(ifc.BaseExpression);


### PR DESCRIPTION
## Description

Added support for resolving symbols when hovering over quoted property names in Bicep files. Previously, when users used "string" literals as property keys (e.g., `'propertyName': value`), hovering over the quoted property name would not display type information or descriptions.

This fix extends the `TryGetSymbolInfo` method in `SymbolHelper.cs` to handle `StringSyntax` nodes that serve as keys in both `ObjectPropertySyntax` and `ObjectTypePropertySyntax` contexts.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18509)