### PR TITLE
fix: update .NET version in devcontainer configuration from 8.0 to 10.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "8.0"
+      "version": "10.0"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "latest"


### PR DESCRIPTION
## Description

Updated the repo’s default .NET SDK from 8.0 to 10.0, so the `devcontainer` matches `global.json`.

This prevents the recurring “SDK 10.0.100 not found” errors that showed up whenever we ran `dotnet` commands inside Codespaces or CI but the container still shipped 8.x.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18518)