### PR TITLE
fix: update completion to correctly suggest imported types in bicepparam files

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -4852,7 +4852,7 @@ param p validRecursiveObjectType = {
         }
 
         [TestMethod]
-        public async Task Compile_time_imports_do_not_offer_types_as_imported_symbol_list_item_completions_in_bicepparam_files()
+        public async Task Compile_time_imports_offer_types_as_imported_symbol_list_item_completions_in_bicepparam_files()
         {
             var modContent = """
               @export()
@@ -4883,7 +4883,7 @@ param p validRecursiveObjectType = {
             var file = new FileRequestHelper(helper.Client, bicepFile);
 
             var completions = await file.RequestAndResolveCompletions(cursors[0]);
-            completions.Should().NotContain(c => c.Label == "foo");
+            completions.Should().Contain(c => c.Label == "foo");
             completions.Should().Contain(c => c.Label == "bar");
         }
 

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -2168,12 +2168,6 @@ namespace Bicep.LanguageServer.Completions
 
                         foreach (var exported in importedModel.Exports)
                         {
-                            if (exported.Value.Kind == ExportMetadataKind.Type && model.SourceFileKind == BicepSourceFileKind.ParamsFile)
-                            {
-                                // types cannot be imported into .bicepparam files, so don't propose them as completions
-                                continue;
-                            }
-
                             var edit = exported.Key switch
                             {
                                 string key when !Lexer.IsValidIdentifier(key) => $"'{key.Replace("'", @"\'")}' as ",


### PR DESCRIPTION
## Description

Fixes #17955

The fix removes the filter condition in [BicepCompletionProvider.cs](https://github.com/Azure/bicep/blob/e94c8679935990e72883f1feaaef617787e68de5/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs#L2171) (around line 2171) that was explicitly skipping type exports when the source file kind was `BicepSourceFileKind.ParamsFile`.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18523)