### PR TITLE
Add test for building parameters with extends and base merging using interpolation

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -1094,6 +1094,8 @@ param objParam object
 
             result.Should().Succeed();
             result.Stdout.Should().NotBeEmpty();
+            var parameters = result.Stdout.FromJson<BuildParamsStdout>().parametersJson.FromJson<JToken>();
+            parameters.Should().HaveValueAtPath("parameters.bar.value", "my-value-foo");
             result.Stderr.Should().Contain("WARNING: The following experimental Bicep features have been enabled: Enable extendable parameters. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.");
             result.ExitCode.Should().Be(0);
         }


### PR DESCRIPTION
## Description

Closes #18272 

Added a new integration test for `build-params` that covers extendable parameter files where the base file contains interpolated values.

The test provisions `base.bicepparam`, `main.bicepparam`, `main.bicep` under the _extendable params_ feature flag and runs `build-params --stdout`.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18660)