### PR TITLE
fix: handling registry module resource derived types in params file

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Semantics/ParamsSemanticModelTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Semantics/ParamsSemanticModelTests.cs
@@ -78,6 +78,44 @@ namespace Bicep.Core.IntegrationTests.Semantics
             data.Symbols.ShouldHaveExpectedValue();
         }
 
+        [TestMethod]
+        public async Task Params_file_should_handle_registry_module_resource_derived_types()
+        {
+            const string moduleRef = "br:mockregistry.io/route/table:v1";
+
+            const string moduleContent = """
+                param routes resourceInput<'Microsoft.Network/routeTables@2024-07-01'>.properties.routes?
+            """;
+
+            const string paramsContent = $@"using '{moduleRef}'
+                param routes = [
+                    {{
+                        id: 'myroute'
+                        properties: {{
+                            addressPrefix: '0.0.0.0/0'
+                            nextHopType: 'Internet'
+                        }}
+                    }}
+                ]
+            ";
+
+            var artifactManager = await MockRegistry.CreateDefaultExternalArtifactManager(TestContext);
+            await artifactManager.PublishRegistryModule(moduleRef, moduleContent);
+
+            var paramsFilePath = FileHelper.SaveResultFile(TestContext, "main.bicepparam", paramsContent);
+            var fileUri = PathHelper.FilePathToFileUrl(paramsFilePath);
+
+            var services = await CreateServicesAsync();
+            services = services.WithTestArtifactManager(artifactManager);
+
+            var compiler = services.Build().GetCompiler();
+            var compilation = await compiler.CreateCompilation(fileUri.ToIOUri());
+
+            var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics().ExcludingLinterDiagnostics();
+
+            diagnostics.Should().BeEmpty();
+        }
+
         private async Task<ServiceBuilder> CreateServicesAsync()
             => new ServiceBuilder()
                 .WithFeatureOverrides(new(TestContext))

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -245,7 +245,9 @@ namespace Bicep.Core.TypeSystem
 
             if (semanticModel.Parameters.TryGetValue(syntax.Name.IdentifierName, out var parameterMetadata))
             {
-                return parameterMetadata.TypeReference.Type;
+                var type = parameterMetadata.TypeReference.Type;
+
+                return resourceDerivedTypeResolver.ResolveResourceDerivedTypes(type);
             }
 
             return null;


### PR DESCRIPTION
Fixes #18420 

## Description

This change ensures `bicepparam` files honor resource-derived parameter types when consuming OCI or template-spec modules by resolving any unresolved resource-derived metadata from compiled module parameters through the local `ResourceDerivedTypeResolver`, eliminating BCP033 diagnostics for patterns like `resourceInput<'Microsoft.Network/routeTables'>.properties.routes?`.

The fix is implemented in `DeclaredTypeManager` so parameter assignment types pulled via using benefit from the same resource-derived resolution as in-module consumption, and I added an integration test that publishes a mock registry module with a resource-derived parameter, consumes it from a params file, and asserts no diagnostics to prevent regressions.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18661)