### PR TITLE
Release multi-line interpolated strings as a GA feature

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -38,23 +38,6 @@ Enables Bicep to run deployments locally, so that you can run Bicep extensions w
 Moves defining extension configurations to the module level rather than from within a template. The feature also
 includes enhancements for Deployment stacks extensibility integration. This feature is not ready for use.
 
-### `multilineStringInterpolation`
-
-Adds an optional `$` prefix to the current multiline opening syntax `'''`, which enables interpolation using standard `${...}` Bicep interpolation. To permit a `${...}` literal value without escaping requirements, you can specify the number of `$` characters required for interpolation by repeating the `$` prefix.
-
-Basic example:
-```bicep
-var s = $'''
-this is ${interpolated}'''
-```
-
-With multiple `$` characters:
-```bicep
-var s = $$'''
-this is $${interpolated}
-this is not ${interpolated}'''
-```
-
 ### `resourceInfoCodegen`
 
 Enables the 'resourceInfo' function for simplified code generation.

--- a/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Emit/TemplateEmitterTests.cs
@@ -310,7 +310,7 @@ Hello $${name}!
 '''
 ";
 
-            var (template, _, _) = CompilationHelper.Compile(ServiceBuilder.CreateWithFeatures(new(MultilineStringInterpolationEnabled: true)), StringUtils.ReplaceNewlines(inputFile, newlineSequence));
+            var (template, _, _) = CompilationHelper.Compile(StringUtils.ReplaceNewlines(inputFile, newlineSequence));
 
             var expected1 = string.Join(newlineSequence, ["[format('Hello {0}!", "', variables('name'))]"]);
             template.Should().HaveValueAtPath("$.variables.multiline", expected1);

--- a/src/Bicep.Core.IntegrationTests/EvaluationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/EvaluationTests.cs
@@ -93,7 +93,7 @@ output multiline string = multiline
     [TestMethod]
     public void Multiline_interpolation_is_evaluated_successfully()
     {
-        var result = CompilationHelper.Compile(ServiceBuilder.CreateWithFeatures(new(MultilineStringInterpolationEnabled: true)), """
+        var result = CompilationHelper.Compile("""
 var intVal = 12345
 output multiline string = $'''
 >${intVal}<
@@ -112,28 +112,6 @@ output multiline2 string = $$'''
             evaluated.Should().HaveValueAtPath("$.outputs['multiline'].value", ">12345<\n>$12345<\n");
             evaluated.Should().HaveValueAtPath("$.outputs['multiline2'].value", ">${intVal}<\n>12345<\n");
         }
-    }
-
-    [TestMethod]
-    public void Multiline_interpolation_is_blocked_without_feature_flag()
-    {
-        var result = CompilationHelper.Compile("""
-var intVal = 12345
-output multiline string = $'''
->${intVal}<
->$${intVal}<
-'''
-output multiline2 string = $$'''
->${intVal}<
->$${intVal}<
-'''
-""");
-
-        result.Should().HaveDiagnostics(new[]
-        {
-            ("BCP442", DiagnosticLevel.Error, """Using multiline string interpolation requires enabling EXPERIMENTAL feature "MultilineStringInterpolation"."""),
-            ("BCP442", DiagnosticLevel.Error, """Using multiline string interpolation requires enabling EXPERIMENTAL feature "MultilineStringInterpolation"."""),
-        });
     }
 
     [TestMethod]

--- a/src/Bicep.Core.Samples/Files/baselines/MultilineStrings_LF/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/baselines/MultilineStrings_LF/bicepconfig.json
@@ -1,5 +1,0 @@
-{
-  "experimentalFeaturesEnabled": {
-    "multilineStringInterpolation": true
-  }
-}

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -113,7 +113,6 @@ namespace Bicep.Core.UnitTests.Configuration
           "desiredStateConfiguration": false,
           "userDefinedConstraints": false,
           "deployCommands": false,
-          "multilineStringInterpolation": false,
           "thisNamespace": false
         },
         "formatting": {
@@ -198,7 +197,6 @@ namespace Bicep.Core.UnitTests.Configuration
           "desiredStateConfiguration": false,
           "userDefinedConstraints": false,
           "deployCommands": false,
-          "multilineStringInterpolation": false,
           "thisNamespace": false
         },
         "formatting": {
@@ -305,7 +303,6 @@ namespace Bicep.Core.UnitTests.Configuration
           "desiredStateConfiguration": false,
           "userDefinedConstraints": false,
           "deployCommands": false,
-          "multilineStringInterpolation": false,
           "thisNamespace": false
         },
         "formatting": {
@@ -393,7 +390,6 @@ namespace Bicep.Core.UnitTests.Configuration
                 DesiredStateConfiguration: false,
                 UserDefinedConstraints: false,
                 DeployCommands: false,
-                MultilineStringInterpolation: false,
                 ThisNamespace: false);
 
             configuration.WithExperimentalFeaturesEnabled(experimentalFeaturesEnabled).Should().HaveContents(/*lang=json,strict*/ """
@@ -479,7 +475,6 @@ namespace Bicep.Core.UnitTests.Configuration
                 "desiredStateConfiguration": false,
                 "userDefinedConstraints": false,
                 "deployCommands": false,
-                "multilineStringInterpolation": false,
                 "thisNamespace": false
             },
             "formatting": {
@@ -832,7 +827,6 @@ namespace Bicep.Core.UnitTests.Configuration
                     "desiredStateConfiguration": false,
                     "userDefinedConstraints": false,
                     "deployCommands": false,
-                    "multilineStringInterpolation": false,
                     "thisNamespace": false
                   },
                   "formatting": {

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -26,7 +26,6 @@ public record FeatureProviderOverrides(
     bool? DesiredStateConfigurationEnabled = default,
     bool? UserDefinedConstraintsEnabled = default,
     bool? DeployCommandsEnabled = default,
-    bool? MultilineStringInterpolationEnabled = default,
     bool? ThisNamespaceEnabled = default)
 {
     public FeatureProviderOverrides(
@@ -48,7 +47,6 @@ public record FeatureProviderOverrides(
         bool? DesiredStateConfigurationEnabled = default,
         bool? UserDefinedConstraintsEnabled = default,
         bool? DeployCommandsEnabled = default,
-        bool? MultilineStringInterpolationEnabled = default,
         bool? ThisNamespaceEnabled = default) : this(
             FileHelper.GetCacheRootDirectory(testContext),
             RegistryEnabled,
@@ -68,7 +66,6 @@ public record FeatureProviderOverrides(
             DesiredStateConfigurationEnabled,
             UserDefinedConstraintsEnabled,
             DeployCommandsEnabled,
-            MultilineStringInterpolationEnabled,
             ThisNamespaceEnabled)
     { }
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -49,7 +49,5 @@ public class OverriddenFeatureProvider : IFeatureProvider
 
     public bool DeployCommandsEnabled => overrides.DeployCommandsEnabled ?? features.DeployCommandsEnabled;
 
-    public bool MultilineStringInterpolationEnabled => overrides.MultilineStringInterpolationEnabled ?? features.MultilineStringInterpolationEnabled;
-
     public bool ThisNamespaceEnabled => overrides.ThisNamespaceEnabled ?? features.ThisNamespaceEnabled;
 }

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -24,7 +24,6 @@ public record ExperimentalFeaturesEnabled(
     bool DesiredStateConfiguration,
     bool UserDefinedConstraints,
     bool DeployCommands,
-    bool MultilineStringInterpolation,
     bool ThisNamespace)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
@@ -47,6 +46,5 @@ public record ExperimentalFeaturesEnabled(
         DesiredStateConfiguration: false,
         UserDefinedConstraints: false,
         DeployCommands: false,
-        MultilineStringInterpolation: false,
         ThisNamespace: false);
 }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -2009,10 +2009,6 @@ namespace Bicep.Core.Diagnostics
                 "BCP441",
                 $"Resource type \"{resourceTypeReference.FormatName()}\" cannot be used with the 'existing' keyword.");
 
-            public Diagnostic MultilineStringRequiresExperimentalFeature() => CoreError(
-                "BCP442",
-                $"Using multiline string interpolation requires enabling EXPERIMENTAL feature \"{nameof(ExperimentalFeaturesEnabled.MultilineStringInterpolation)}\".");
-
             public Diagnostic UsingWithClauseRequiredIfExperimentalFeatureEnabled() => CoreError(
                 "BCP443",
                 $"""The "{LanguageConstants.UsingKeyword}" statement requires a "{LanguageConstants.WithKeyword}" clause if the EXPERIMENTAL feature "{nameof(ExperimentalFeaturesEnabled.DeployCommands)}" is enabled.""");

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -60,7 +60,6 @@ namespace Bicep.Core.Emit
             BlockExtendsWithoutFeatureFlagEnabled(model, diagnostics);
             BlockExplicitDependenciesInOrOnInlinedExistingResources(model, resourceTypeResolver, diagnostics);
             ValidateUsingWithClauseMatchesExperimentalFeatureEnablement(model, diagnostics);
-            BlockMultilineStringInterpolationWithoutFeatureFlagEnabled(model, diagnostics);
 
             var paramAssignmentEvaluator = new ParameterAssignmentEvaluator(model);
             var (paramAssignments, usingConfig) = CalculateParameterAssignments(model, paramAssignmentEvaluator, diagnostics);
@@ -1056,20 +1055,6 @@ namespace Bicep.Core.Emit
                 {
                     yield return body;
                 }
-            }
-        }
-
-        private static void BlockMultilineStringInterpolationWithoutFeatureFlagEnabled(SemanticModel model, IDiagnosticWriter diagnostics)
-        {
-            if (model.Features.MultilineStringInterpolationEnabled)
-            {
-                return;
-            }
-
-            foreach (var @string in SyntaxAggregator.AggregateByType<StringSyntax>(model.Root.Syntax)
-                .Where(x => x.IsMultiLineString() && !x.IsVerbatimString()))
-            {
-                diagnostics.Write(@string, x => x.MultilineStringRequiresExperimentalFeature());
             }
         }
     }

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -56,8 +56,6 @@ namespace Bicep.Core.Features
 
         public bool DeployCommandsEnabled => configuration.ExperimentalFeaturesEnabled.DeployCommands;
 
-        public bool MultilineStringInterpolationEnabled => configuration.ExperimentalFeaturesEnabled.MultilineStringInterpolation;
-
         public bool ThisNamespaceEnabled => configuration.ExperimentalFeaturesEnabled.ThisNamespace;
 
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -39,8 +39,6 @@ public interface IFeatureProvider
 
     bool DeployCommandsEnabled { get; }
 
-    bool MultilineStringInterpolationEnabled { get; }
-
     bool ThisNamespaceEnabled { get; }
 
     IEnumerable<(string name, bool impactsCompilation, bool usesExperimentalArmEngineFeature)> EnabledFeatureMetadata
@@ -64,7 +62,6 @@ public interface IFeatureProvider
                 (DesiredStateConfigurationEnabled, "Enable defining Desired State Configuration documents", true, false),
                 (UserDefinedConstraintsEnabled, "Enable @validate() decorator", true, true),
                 (DeployCommandsEnabled, "Enable deploy commands", true, true),
-                (MultilineStringInterpolationEnabled, "Enable multiline string interpolation", false, false),
                 (ThisNamespaceEnabled, "Enable 'this' namespace", true, true),
             })
             {

--- a/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
+++ b/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
@@ -26,7 +26,6 @@ namespace Bicep.Core.Features
         public bool DesiredStateConfigurationEnabled => features.DesiredStateConfiguration;
         public bool UserDefinedConstraintsEnabled => features.UserDefinedConstraints;
         public bool DeployCommandsEnabled => features.DeployCommands;
-        public bool MultilineStringInterpolationEnabled => features.MultilineStringInterpolation;
         public bool ThisNamespaceEnabled => features.ThisNamespace;
     }
 }

--- a/src/highlightjs/test/baselines/bicepconfig.json
+++ b/src/highlightjs/test/baselines/bicepconfig.json
@@ -1,5 +1,0 @@
-{
-  "experimentalFeaturesEnabled": {
-    "multilineStringInterpolation": true
-  }
-}

--- a/src/monarch/test/baselines/bicepconfig.json
+++ b/src/monarch/test/baselines/bicepconfig.json
@@ -1,5 +1,0 @@
-{
-  "experimentalFeaturesEnabled": {
-    "multilineStringInterpolation": true
-  }
-}

--- a/src/textmate/test/baselines/bicepconfig.json
+++ b/src/textmate/test/baselines/bicepconfig.json
@@ -1,5 +1,0 @@
-{
-  "experimentalFeaturesEnabled": {
-    "multilineStringInterpolation": true
-  }
-}

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -904,10 +904,6 @@
           "type": "boolean",
           "description": "Allows you to access the 'deploy', 'what-if' and 'teardown' commands. See https://aka.ms/bicep/experimental-features#deploycommands"
         },
-        "multilineStringInterpolation": {
-          "type": "boolean",
-          "description": "Enables support for multiline string interpolation. See https://aka.ms/bicep/experimental-features#multilinestringinterpolation"
-        },
         "thisNamespace": {
           "type": "boolean",
           "description": "Allows you to use this namespace to modify resource properties based on whether the resource already exists. Ex. this.exists() and this.existingResource(). See https://aka.ms/bicep/experimental-features#thisnamespace"


### PR DESCRIPTION
Remove the experimental feature flag for multi-line interpolated strings.

Description of the feature:
> Adds an optional `$` prefix to the current multiline opening syntax `'''`, which enables interpolation using standard `${...}` Bicep interpolation. To permit a `${...}` literal value > without escaping requirements, you can specify the number of `$` characters required for interpolation by repeating the `$` prefix.
> 
> Basic example:
> ```bicep
> var s = $'''
> this is ${interpolated}'''
> ```
> 
> With multiple `$` characters:
> ```bicep
> var s = $$'''
> this is $${interpolated}
> this is not ${interpolated}'''
> ```

Original PR: #18324
Closes #3389