### PR TITLE
Remove comment-test-summary job from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -720,36 +720,6 @@ jobs:
           path: ./TestResults/*.trx
           if-no-files-found: error
 
-  comment-test-summary:
-    name: "PR Comment: Dotnet Tests Summary"
-    needs: test-dotnet
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
-    if: always()
-
-    steps:
-      - name: Merge Test Results into Single Artifact (fewer artifacts to deal with in build)
-        uses: actions/upload-artifact/merge@v6
-        with:
-          name: TestResults
-          pattern: TestResults-*
-          delete-merged: true
-
-      - name: Download Test Results Artifact
-        uses: actions/download-artifact@v7
-        with:
-          pattern: TestResults
-          path: TestResults
-          merge-multiple: true
-
-      - name: Publish Dotnet Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          check_name: Dotnet Test Results
-          files: "TestResults/**/*.trx"
-
   comment-preview-links:
     name: "PR Comment: Preview Links"
     needs: [build-vscode-ext, build-cli]


### PR DESCRIPTION
The results returned by this summary are completely inaccurate:

<img width="901" height="323" alt="image" src="https://github.com/user-attachments/assets/ec391c20-4adb-4ef4-9afa-f291d1d13e88" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18708)