### PR TITLE
Always use named pipes on Windows for gRPC

### DIFF
--- a/src/Bicep.Local.Deploy/Extensibility/GrpcLocalExtension.cs
+++ b/src/Bicep.Local.Deploy/Extensibility/GrpcLocalExtension.cs
@@ -36,7 +36,8 @@ internal class GrpcLocalExtension(
         Func<GrpcChannel> channelBuilder;
         GrpcChannel? channel = null;
 
-        if (!OperatingSystem.IsWindows())
+        // While modern Windows technically supports UDS, many libraries (like Rust's Tokio) do not
+        if (Socket.OSSupportsUnixDomainSockets && !OperatingSystem.IsWindows())
         {
             var socketName = $"{Guid.NewGuid()}.tmp";
             var socketPath = Path.Combine(Path.GetTempPath(), socketName);


### PR DESCRIPTION
While modern Windows technically supports UDS, many libraries (like Rust's Tokio) do not. So unfortunately is much more straightforward to always use named pipes on Windows.

## Description

<!-- Provide a 1-2 sentence description of your change -->

## Example Usage
https://github.com/PowerShell/DSC/pull/1330

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18712)