### PR TITLE
Improve BCP081 diagnostic message and update corresponding unit tests

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecureParamsInNestedDeploymentsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecureParamsInNestedDeploymentsRuleTests.cs
@@ -405,37 +405,38 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         {
             // https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-test-cases#use-inner-scope-for-nested-deployment-secure-parameters
             CompileAndTest(@"
-                @secure()
-                #disable-next-line secure-parameter-default
-                param stgAccountName string
+                      @secure()
+                      #disable-next-line secure-parameter-default
+                      param stgAccountName string
 
-                resource nested 'Microsoft.Resources/notDeployments@2021-04-01' = {
-                    name: 'nested'
-                    properties: {
-                        mode: 'Incremental'
-                        template: {
-                            '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-                            contentVersion: '1.0.0.0'
-                            resources: [
-                                {
-                                    name: stgAccountName
-                                    type: 'Microsoft.Storage/storageAccounts'
-                                    apiVersion: '2021-04-01'
-                                    #disable-next-line no-loc-expr-outside-params
-                                    location: resourceGroup().location
-                                    kind: 'StorageV2'
-                                    sku: {
-                                        name: 'Premium_LRS'
-                                        tier: 'Premium'
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                }",
-                [
-                    "[6] Resource type \"Microsoft.Resources/notDeployments@2021-04-01\" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed."
-                ]);
+                      resource nested 'Microsoft.Resources/notDeployments@2021-04-01' = {
+                          name: 'nested'
+                          properties: {
+                              mode: 'Incremental'
+                              template: {
+                                  '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+                                  contentVersion: '1.0.0.0'
+                                  resources: [
+                                      {
+                                          name: stgAccountName
+                                          type: 'Microsoft.Storage/storageAccounts'
+                                          apiVersion: '2021-04-01'
+                                          #disable-next-line no-loc-expr-outside-params
+                                          location: resourceGroup().location
+                                          kind: 'StorageV2'
+                                          sku: {
+                                              name: 'Premium_LRS'
+                                              tier: 'Premium'
+                                          }
+                                      }
+                                  ]
+                              }
+                          }
+                      }",
+                      [
+                          "[6] Resource type \"Microsoft.Resources/notDeployments@2021-04-01\" does not have type definitions available. Bicep cannot validate properties or provide IntelliSense for this resource; deployment will still be attempted by Azure Resource Manager. See https://learn.microsoft.com/azure/azure-resource-manager/bicep/diagnostics/bcp081 for details."
+                      ]);
+
         }
 
         [TestMethod]

--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
@@ -163,8 +163,9 @@ resource missingResource 'Mock.Rp/madeUpResourceType@2020-01-01' = {
 }
 ");
             compilation.Should().HaveDiagnostics(new[] {
-                ("BCP081", DiagnosticLevel.Warning, "Resource type \"Mock.Rp/madeUpResourceType@2020-01-01\" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed.")
-            });
+            ("BCP081", DiagnosticLevel.Warning, "Resource type \"Mock.Rp/madeUpResourceType@2020-01-01\" does not have type definitions available. Bicep cannot validate properties or provide IntelliSense for this resource; deployment will still be attempted by Azure Resource Manager. See https://learn.microsoft.com/azure/azure-resource-manager/bicep/diagnostics/bcp081 for details.")
+});
+
         }
 
         [TestMethod]

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -484,7 +484,10 @@ namespace Bicep.Core.Diagnostics
 
             public Diagnostic ResourceTypesUnavailable(ResourceTypeReference resourceTypeReference) => CoreWarning(
                 "BCP081",
-                $"Resource type \"{resourceTypeReference.FormatName()}\" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed.");
+                $"Resource type \"{resourceTypeReference.FormatName()}\" does not have type definitions available. " +
+                "Bicep cannot validate properties or provide IntelliSense for this resource; deployment will still be attempted by Azure Resource Manager. " +
+                "See https://learn.microsoft.com/azure/azure-resource-manager/bicep/diagnostics/bcp081 for details.");
+
 
             public Diagnostic SymbolicNameDoesNotExistWithSuggestion(string name, string suggestedName) => CoreError(
                 "BCP082",

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -484,8 +484,8 @@ namespace Bicep.Core.Diagnostics
 
             public Diagnostic ResourceTypesUnavailable(ResourceTypeReference resourceTypeReference) => CoreWarning(
                 "BCP081",
-                "Property type validations and code completions are not available for this resource type, but the resource update operation will still be attempted if this file is deployed. " +
-                "See https://learn.microsoft.com/azure/azure-resource-manager/bicep/diagnostics/bcp081 for details.");
+                $"Bicep does not have type definitions available for resource type \"{resourceTypeReference.FormatName()}\". " +
+                "Property type validations and code completions are not available for this resource type, but the resource update operation will still be attempted if this file is deployed.");
 
 
             public Diagnostic SymbolicNameDoesNotExistWithSuggestion(string name, string suggestedName) => CoreError(

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -484,7 +484,6 @@ namespace Bicep.Core.Diagnostics
 
             public Diagnostic ResourceTypesUnavailable(ResourceTypeReference resourceTypeReference) => CoreWarning(
                 "BCP081",
-                $"Resource type \"{resourceTypeReference.FormatName()}\" does not have type definitions available. " +
                 "Bicep cannot validate properties or provide IntelliSense for this resource; deployment will still be attempted by Azure Resource Manager. " +
                 "See https://learn.microsoft.com/azure/azure-resource-manager/bicep/diagnostics/bcp081 for details.");
 

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -484,7 +484,7 @@ namespace Bicep.Core.Diagnostics
 
             public Diagnostic ResourceTypesUnavailable(ResourceTypeReference resourceTypeReference) => CoreWarning(
                 "BCP081",
-                "Bicep cannot validate properties or provide IntelliSense for this resource; deployment will still be attempted by Azure Resource Manager. " +
+                "Property type validations and code completions are not available for this resource type, but the resource update operation will still be attempted if this file is deployed. " +
                 "See https://learn.microsoft.com/azure/azure-resource-manager/bicep/diagnostics/bcp081 for details.");
 
 


### PR DESCRIPTION
## Description

This PR improves the BCP081 diagnostic message to make it clearer:

- Clarifies that missing resource type definitions affect IntelliSense and property validation
- States that deployment is still handled by Azure Resource Manager
- Adds a link to the official documentation

All unit tests that reference BCP081 have been updated to match the new message.

Fixes #13287

## Checklist

- [ X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18860)