### PR TITLE
enable `build-params` evaluation of `for-expressions` in `.bicepparam`

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -328,6 +328,36 @@ namespace Bicep.Cli.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Build_params_inline_for_expression_parameter_should_succeed()
+        {
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            _ = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                "param p int[]",
+                outputPath);
+
+            var paramsPath = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+
+                param p = [for item in range(0, 4): item * 2]
+                """,
+                outputPath);
+
+            var result = await Bicep(CreateDefaultSettings(), "build-params", paramsPath, "--stdout");
+
+            result.Should().Succeed();
+
+            var parametersStdout = result.Stdout.FromJson<BuildParamsStdout>();
+            var paramsObject = parametersStdout.parametersJson.FromJson<JToken>();
+            paramsObject.Should().HaveValueAtPath("parameters.p.value", JToken.Parse("[0, 2, 4, 6]"));
+        }
+
+        [TestMethod]
         public async Task Build_params_for_expression_variable_should_succeed()
         {
             var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);

--- a/src/Bicep.Core.UnitTests/Emit/ParameterAssignmentEvaluatorTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/ParameterAssignmentEvaluatorTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.UnitTests.Emit;
+
+[TestClass]
+public class ParameterAssignmentEvaluatorTests
+{
+    [TestMethod]
+    public void BuildParams_ForExpressionVariable_EvaluatesToValue()
+    {
+        var services = new ServiceBuilder().WithEmptyAzResources();
+
+        var result = CompilationHelper.CompileParams(
+            services,
+            ("main.bicep", "param p int[]"),
+            ("parameters.bicepparam", """
+            using 'main.bicep'
+
+            var x = [for item in [1, 2]: item * 2]
+            param p = x
+            """));
+
+        result.Should().NotHaveAnyDiagnostics();
+        result.Parameters.Should().HaveValueAtPath("parameters.p.value", JToken.Parse("[2, 4]"));
+    }
+}

--- a/src/Bicep.Core.UnitTests/Emit/ParameterAssignmentEvaluatorTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/ParameterAssignmentEvaluatorTests.cs
@@ -12,6 +12,24 @@ namespace Bicep.Core.UnitTests.Emit;
 public class ParameterAssignmentEvaluatorTests
 {
     [TestMethod]
+    public void BuildParams_ForExpressionParameter_EvaluatesToValue()
+    {
+        var services = new ServiceBuilder().WithEmptyAzResources();
+
+        var result = CompilationHelper.CompileParams(
+            services,
+            ("main.bicep", "param p int[]"),
+            ("parameters.bicepparam", """
+            using 'main.bicep'
+
+            param p = [for item in range(0, 4): item * 2]
+            """));
+
+        result.Should().NotHaveAnyDiagnostics();
+        result.Parameters.Should().HaveValueAtPath("parameters.p.value", JToken.Parse("[0, 2, 4, 6]"));
+    }
+
+    [TestMethod]
     public void BuildParams_ForExpressionVariable_EvaluatesToValue()
     {
         var services = new ServiceBuilder().WithEmptyAzResources();

--- a/src/Bicep.Core/Emit/ForSyntaxValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/ForSyntaxValidatorVisitor.cs
@@ -160,6 +160,15 @@ namespace Bicep.Core.Emit
             }
         }
 
+        public override void VisitParameterAssignmentSyntax(ParameterAssignmentSyntax syntax)
+        {
+            this.activeLoopCapableTopLevelDeclaration = syntax;
+
+            base.VisitParameterAssignmentSyntax(syntax);
+
+            this.activeLoopCapableTopLevelDeclaration = null;
+        }
+
         public override void VisitOutputDeclarationSyntax(OutputDeclarationSyntax syntax)
         {
             this.activeLoopCapableTopLevelDeclaration = syntax;
@@ -387,9 +396,11 @@ namespace Bicep.Core.Emit
             }
 
             // not a top-level loop
-            if (this.activeLoopCapableTopLevelDeclaration is OutputDeclarationSyntax || this.activeLoopCapableTopLevelDeclaration is VariableDeclarationSyntax)
+            if (this.activeLoopCapableTopLevelDeclaration is OutputDeclarationSyntax ||
+                this.activeLoopCapableTopLevelDeclaration is VariableDeclarationSyntax ||
+                this.activeLoopCapableTopLevelDeclaration is ParameterAssignmentSyntax)
             {
-                // output and variable loops are only supported in the values due to runtime limitations
+                // output, variable, and parameter assignment loops are only supported in the values due to runtime limitations
                 return false;
             }
 
@@ -451,6 +462,7 @@ namespace Bicep.Core.Emit
                 case ModuleDeclarationSyntax module when ReferenceEquals(module.Value, syntax):
                 case OutputDeclarationSyntax output when ReferenceEquals(output.Value, syntax):
                 case VariableDeclarationSyntax variable when ReferenceEquals(variable.Value, syntax):
+                case ParameterAssignmentSyntax parameterAssignment when ReferenceEquals(parameterAssignment.Value, syntax):
                     return true;
 
                 default:

--- a/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
+++ b/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
@@ -26,6 +26,24 @@ namespace Bicep.Core.Emit;
 
 public class ParameterAssignmentEvaluator
 {
+    private sealed class ForLoopIndexRewriter : ExpressionRewriteVisitor
+    {
+        private readonly long index;
+
+        private ForLoopIndexRewriter(long index)
+        {
+            this.index = index;
+        }
+
+        public static Expression Rewrite(Expression expression, long index)
+        {
+            return new ForLoopIndexRewriter(index).Replace(expression);
+        }
+
+        public override Expression ReplaceCopyIndexExpression(CopyIndexExpression expression) => new IntegerLiteralExpression(expression.SourceSyntax, index);
+
+        public override Expression ReplaceForLoopExpression(ForLoopExpression expression) => expression;
+    }
     private class ParameterAssignmentEvaluationContext : IEvaluationContext
     {
         private readonly TemplateExpressionEvaluationHelper evaluationHelper;
@@ -432,7 +450,7 @@ public class ParameterAssignmentEvaluator
 
                 try
                 {
-                    return Result.For(parameterConverter.ConvertExpression(intermediate).EvaluateExpression(context));
+                    return Result.For(EvaluateExpression(parameterConverter, intermediate, context));
                 }
                 catch (Exception ex)
                 {
@@ -488,7 +506,7 @@ public class ParameterAssignmentEvaluator
                     {
                         try
                         {
-                            propertyResult = Result.For(converter.ConvertExpression(intermediate).EvaluateExpression(context));
+                            propertyResult = Result.For(EvaluateExpression(converter, intermediate, context));
                         }
                         catch (Exception ex)
                         {
@@ -547,7 +565,7 @@ public class ParameterAssignmentEvaluator
                     var variableConverter = GetConverterForVariable(variable);
                     var intermediate = variableConverter.ConvertToIntermediateExpression(variable.DeclaringVariable.Value);
 
-                    return Result.For(variableConverter.ConvertExpression(intermediate).EvaluateExpression(context));
+                    return Result.For(EvaluateExpression(variableConverter, intermediate, context));
                 }
                 catch (Exception ex)
                 {
@@ -565,7 +583,7 @@ public class ParameterAssignmentEvaluator
                 {
                     var evalContext = GetExpressionEvaluationContextForModel(model);
                     var exprConverter = converterCache.GetOrAdd(model, m => new ExpressionConverter(new EmitterContext(m)));
-                    return Result.For(exprConverter.ConvertExpression(expression).EvaluateExpression(evalContext));
+                    return Result.For(EvaluateExpression(exprConverter, expression, evalContext));
                 }
                 catch (Exception e)
                 {
@@ -795,7 +813,7 @@ public class ParameterAssignmentEvaluator
         {
             var context = GetExpressionEvaluationContext();
             var intermediate = converter.ConvertToIntermediateExpression(expressionSyntax);
-            var result = converter.ConvertExpression(intermediate).EvaluateExpression(context);
+            var result = EvaluateExpression(converter, intermediate, context);
             return ExpressionEvaluationResult.For(result);
         }
         catch (Exception ex)
@@ -807,6 +825,34 @@ public class ParameterAssignmentEvaluator
 
     // TODO: Should look into using ITemplateLanguageExpression for ParameterAssignmentEvaluator
     // which would probably simplify a lot of this logic.
+
+    private JToken EvaluateExpression(ExpressionConverter expressionConverter, Expression expression, ParameterAssignmentEvaluationContext context)
+    {
+        if (expression is ForLoopExpression forLoop)
+        {
+            return EvaluateForLoopExpression(expressionConverter, forLoop, context);
+        }
+
+        return expressionConverter.ConvertExpression(expression).EvaluateExpression(context);
+    }
+
+    private JToken EvaluateForLoopExpression(ExpressionConverter expressionConverter, ForLoopExpression forLoop, ParameterAssignmentEvaluationContext context)
+    {
+        var source = EvaluateExpression(expressionConverter, forLoop.Expression, context);
+        if (source is not JArray sourceArray)
+        {
+            throw new InvalidOperationException("For-expression source must be an array.");
+        }
+
+        var results = new JArray();
+        for (var i = 0; i < sourceArray.Count; i++)
+        {
+            results.Add(EvaluateExpression(expressionConverter, ForLoopIndexRewriter.Rewrite(forLoop.Body, i), context));
+        }
+
+        return results;
+    }
+
     /// <summary>
     /// Rewrites intermediate expressions by replacing variable references, parameter assignment references,
     /// and user-defined function calls with their evaluated literal values. This is used for parameter

--- a/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
+++ b/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
@@ -916,43 +916,4 @@ public class ParameterAssignmentEvaluator
         };
     }
 
-    /// <summary>
-    /// Rewrites the external input function calls to use the externalInputs function with the index of the external input.
-    /// e.g. externalInput('sys.cli', 'foo') becomes externalInputs('0')
-    /// </summary>
-    private class ExternalInputExpressionRewriter : ExpressionRewriteVisitor
-    {
-        private readonly ExternalInputReferences externalInputReferences;
-
-        private ExternalInputExpressionRewriter(
-            ExternalInputReferences externalInputReferences)
-        {
-            this.externalInputReferences = externalInputReferences;
-        }
-
-        public static Expression Rewrite(
-            Expression expression,
-            ExternalInputReferences externalInputReferences)
-        {
-            var visitor = new ExternalInputExpressionRewriter(externalInputReferences);
-            var rewritten = visitor.Replace(expression);
-            return rewritten;
-        }
-
-        public override Expression ReplaceFunctionCallExpression(FunctionCallExpression expression)
-        {
-            if (expression.SourceSyntax is FunctionCallSyntaxBase functionCallSyntax &&
-                externalInputReferences.InfoBySyntax.TryGetValue(functionCallSyntax, out var info) &&
-                info.Length > 0)
-            {
-                return new FunctionCallExpression(
-                    functionCallSyntax,
-                    LanguageConstants.ExternalInputsArmFunctionName,
-                    [ExpressionFactory.CreateStringLiteral(info[0].DefinitionKey)]
-                );
-            }
-
-            return base.ReplaceFunctionCallExpression(expression);
-        }
-    }
 }

--- a/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
+++ b/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
@@ -915,4 +915,44 @@ public class ParameterAssignmentEvaluator
             _ => throw new ExpressionException($"Unsupported JToken type: {token.Type}"),
         };
     }
+
+    /// <summary>
+    /// Rewrites the external input function calls to use the externalInputs function with the index of the external input.
+    /// e.g. externalInput('sys.cli', 'foo') becomes externalInputs('0')
+    /// </summary>
+    private class ExternalInputExpressionRewriter : ExpressionRewriteVisitor
+    {
+        private readonly ExternalInputReferences externalInputReferences;
+
+        private ExternalInputExpressionRewriter(
+            ExternalInputReferences externalInputReferences)
+        {
+            this.externalInputReferences = externalInputReferences;
+        }
+
+        public static Expression Rewrite(
+            Expression expression,
+            ExternalInputReferences externalInputReferences)
+        {
+            var visitor = new ExternalInputExpressionRewriter(externalInputReferences);
+            var rewritten = visitor.Replace(expression);
+            return rewritten;
+        }
+
+        public override Expression ReplaceFunctionCallExpression(FunctionCallExpression expression)
+        {
+            if (expression.SourceSyntax is FunctionCallSyntaxBase functionCallSyntax &&
+                externalInputReferences.InfoBySyntax.TryGetValue(functionCallSyntax, out var info) &&
+                info.Length > 0)
+            {
+                return new FunctionCallExpression(
+                    functionCallSyntax,
+                    LanguageConstants.ExternalInputsArmFunctionName,
+                    [ExpressionFactory.CreateStringLiteral(info[0].DefinitionKey)]
+                );
+            }
+
+            return base.ReplaceFunctionCallExpression(expression);
+        }
+    }
 }

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -1174,6 +1174,9 @@ public class ExpressionBuilder
             // variable copy index has the name of the variable
             VariableDeclarationSyntax variable when variable.Name.IsValid => variable.Name.IdentifierName,
 
+            // parameter assignment copy index has the name of the parameter
+            ParameterAssignmentSyntax parameter when parameter.Name.IsValid => parameter.Name.IdentifierName,
+
             // output loops are only allowed at the top level and don't have names, either
             OutputDeclarationSyntax => null,
 


### PR DESCRIPTION
Fixes #14722 

## Description

`build-params` now evaluates `for-expressions` in parameter assignments by expanding them at compile time, avoiding `variables()` runtime evaluation errors.

I also added coverage for this scenario in both CLI integration tests and core unit tests.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18949)