### PR TITLE
Add snapshot command help documentation to RootCommand

### DIFF
--- a/src/Bicep.Cli/Commands/RootCommand.cs
+++ b/src/Bicep.Cli/Commands/RootCommand.cs
@@ -251,6 +251,28 @@ Usage:
       bicep jsonrpc --socket 9853
       bicep jsonrpc --stdio
 
+  {exeName} snapshot [options] <file>
+    [Experimental] Generates or validates a deployment snapshot from a .bicepparam file.
+
+    Arguments:
+      <file>        The input .bicepparam file
+
+    Options:
+      --mode <mode>              Sets the snapshot mode. Valid values are ( Overwrite | Validate ).
+                                   Overwrite: Generates a new snapshot and saves it to <file>.snapshot.json.
+                                   Validate: Compares the generated snapshot against an existing snapshot file.
+      --tenant-id <id>           The tenant ID to use for the deployment.
+      --subscription-id <id>     The subscription ID to use for the deployment.
+      --resource-group <name>    The resource group name to use for the deployment.
+      --location <location>      The location to use for the deployment.
+      --deployment-name <name>   The deployment name to use.
+
+    Examples:
+      bicep snapshot params.bicepparam
+      bicep snapshot params.bicepparam --mode Overwrite
+      bicep snapshot params.bicepparam --mode Validate
+      bicep snapshot params.bicepparam --subscription-id 00000000-0000-0000-0000-000000000000 --resource-group my-rg
+
 "; // this newline is intentional
 
             io.Output.Writer.Write(output);


### PR DESCRIPTION
## Description

Add inline help documentation for the experimental `snapshot` command in `RootCommand.cs`, including argument descriptions, all supported options (`--mode`, `--tenant-id`, `--subscription-id`, `--resource-group`, `--location`, `--deployment-name`), and usage examples. The help text was derived from the existing `SnapshotArguments.cs` and `SnapshotCommand.cs` implementations to ensure accuracy.

## Example Usage

```
bicep snapshot params.bicepparam
bicep snapshot params.bicepparam --mode Overwrite
bicep snapshot params.bicepparam --mode Validate
bicep snapshot params.bicepparam --subscription-id 00000000-0000-0000-0000-000000000000 --resource-group my-rg
```

## Checklist
- [x] I have read and adhere to the [[contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md)](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18988)