### PR TITLE
Add dependency installation tasks before building VSCode components

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,10 +66,29 @@
                 "cwd": "${workspaceFolder}/src/vscode-bicep"
             },
             "dependsOn": [
+                "Install VSCode Extension Dependencies",
                 "Build Language Server for VSIX",
                 "Build MCP Server for VSIX",
                 "Build VSCode UI"
             ]
+        },
+        {
+            "label": "Install VSCode Extension Dependencies",
+            "command": "npm",
+            "args": ["install"],
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/src/vscode-bicep"
+            }
+        },
+        {
+            "label": "Install VSCode UI Dependencies",
+            "command": "npm",
+            "args": ["install"],
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}/src/vscode-bicep-ui"
+            }
         },
         {
             "label": "Build VSCode UI",
@@ -79,7 +98,10 @@
             "problemMatcher": "$tsc-watch",
             "options": {
                 "cwd": "${workspaceFolder}/src/vscode-bicep-ui"
-            }
+            },
+            "dependsOn": [
+                "Install VSCode UI Dependencies"
+            ]
         },
         {
             "label": "Build WASM for Playground",


### PR DESCRIPTION
## Description

Added npm install dependency tasks to the VS Code development workflow so that npm install runs automatically before building the extension projects. This fixes F5 debugging failures when node_modules are not present.

## Example Usage

When pressing F5 to debug the VS Code Extension, the following tasks now run automatically in order:


1. Install VSCode Extension Dependencies (npm install in src/vscode-bicep)
2. Install VSCode UI Dependencies (npm install in src/vscode-bicep-ui)
3. Build tasks (Language Server, MCP Server, VSCode UI)
4. Build VSIX

No manual `npm install` is required before first debug session.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18989)