### PR TITLE
Visualizer Migration Step 3: Integrate ELK.js Auto-Layout

### DIFF
--- a/src/vscode-bicep-ui/apps/visual-designer/package.json
+++ b/src/vscode-bicep-ui/apps/visual-designer/package.json
@@ -21,6 +21,7 @@
     "@react-hook/resize-observer": "^2.0.2",
     "@vscode-bicep-ui/components": "^0.0.0",
     "@vscode-bicep-ui/messaging": "^0.0.0",
+    "elkjs": "^0.11.0",
     "jotai": "^2.13.1",
     "motion": "^12.23.3",
     "react": "^18.3.1",

--- a/src/vscode-bicep-ui/apps/visual-designer/src/App.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/App.tsx
@@ -22,6 +22,7 @@ import {
   nodesAtom,
 } from "./features/graph-engine/atoms";
 import { Canvas, Graph } from "./features/graph-engine/components";
+import { runLayout } from "./features/graph-engine/layout/elk-layout";
 
 const store = getDefaultStore();
 const nodeConfig = store.get(nodeConfigAtom);
@@ -68,7 +69,20 @@ export function App() {
     addEdge("E->D", "E", "D");
     addEdge("C->B", "C", "B");
 
+    // Wait for DOM measurement (two frames) then run auto-layout
+    const frame1 = requestAnimationFrame(() => {
+      const frame2 = requestAnimationFrame(() => {
+        void runLayout(store);
+      });
+
+      cleanup = () => cancelAnimationFrame(frame2);
+    });
+
+    let cleanup: (() => void) | undefined;
+
     return () => {
+      cancelAnimationFrame(frame1);
+      cleanup?.();
       setEdgesAtom([]);
       setNodesAtom({});
     };

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/design-view/components/GraphControlBar.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/design-view/components/GraphControlBar.tsx
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 import { Codicon, useGetPanZoomDimensions, usePanZoomControl } from "@vscode-bicep-ui/components";
+import { useStore } from "jotai";
 import { useAtomCallback } from "jotai/utils";
 import { useCallback } from "react";
 import { styled } from "styled-components";
 import { nodesAtom } from "../../graph-engine/atoms";
+import { runLayout } from "../../graph-engine/layout/elk-layout";
 
 const $GraphControlBar = styled.div`
   display: flex;
@@ -52,17 +54,11 @@ const $ControlButton = styled.button`
 export function GraphControlBar() {
   const getPanZoomDimensions = useGetPanZoomDimensions();
   const { zoomIn, zoomOut, transform } = usePanZoomControl();
+  const store = useStore();
 
-  const resetLayout = useAtomCallback(
-    useCallback((get, set) => {
-      const nodes = get(nodesAtom);
-      for (const node of Object.values(nodes)) {
-        if (node.kind === "atomic") {
-          set(node.originAtom, { ...get(node.originAtom) });
-        }
-      }
-    }, []),
-  );
+  const resetLayout = useCallback(async () => {
+    await runLayout(store);
+  }, [store]);
 
   const fitView = useAtomCallback(
     useCallback(

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/graph-engine/layout/elk-layout.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/graph-engine/layout/elk-layout.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { ElkExtendedEdge, ElkNode } from "elkjs/lib/elk.bundled.js";
+
+import ELK from "elkjs/lib/elk.bundled.js";
+import { getDefaultStore } from "jotai";
+import { nodesAtom, edgesAtom } from "../atoms";
+
+type Store = ReturnType<typeof getDefaultStore>;
+
+const elk = new ELK();
+
+const ELK_OPTIONS: Record<string, string> = {
+  "elk.algorithm": "layered",
+  "elk.direction": "DOWN",
+  "elk.aspectRatio": "2.5",
+  "elk.layered.layering.strategy": "INTERACTIVE",
+  "elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
+  "elk.layered.cycleBreaking.strategy": "DEPTH_FIRST",
+  "elk.spacing.nodeNode": "120",
+  "elk.layered.spacing.nodeNodeBetweenLayers": "80",
+  "elk.spacing.componentComponent": "100",
+};
+
+function buildElkGraph(store: Store): ElkNode {
+  const nodes = store.get(nodesAtom);
+  const edges = store.get(edgesAtom);
+
+  // Build parent lookup: childId → parentId
+  const childToParent = new Map<string, string>();
+  for (const node of Object.values(nodes)) {
+    if (node.kind === "compound") {
+      const childIds = store.get(node.childIdsAtom);
+      for (const childId of childIds) {
+        childToParent.set(childId, node.id);
+      }
+    }
+  }
+
+  // Convert a node to an ElkNode
+  function toElkNode(node: (typeof nodes)[string]): ElkNode {
+    if (!node) {
+      return { id: "unknown" };
+    }
+
+    const box = store.get(node.boxAtom);
+    const width = Math.max(box.max.x - box.min.x, 1);
+    const height = Math.max(box.max.y - box.min.y, 1);
+
+    if (node.kind === "compound") {
+      const childIds = store.get(node.childIdsAtom);
+      const children = childIds
+        .map((id) => nodes[id])
+        .filter((child): child is NonNullable<typeof child> => child !== undefined)
+        .map(toElkNode);
+
+      // Don't pass explicit width/height for compound nodes — ELK computes them
+      // based on children + padding. Pass padding so ELK reserves space for the label.
+      return {
+        id: node.id,
+        children,
+        layoutOptions: {
+          ...ELK_OPTIONS,
+          "elk.padding": "[top=50,left=40,bottom=40,right=40]",
+        },
+      };
+    }
+
+    return { id: node.id, width, height };
+  }
+
+  // Build top-level children (nodes not contained by any compound)
+  const topLevelNodes = Object.values(nodes)
+    .filter((n) => !childToParent.has(n.id))
+    .map(toElkNode);
+
+  // All edges go at root level (ELK handles cross-hierarchy edges)
+  const elkEdges: ElkExtendedEdge[] = edges.map((edge) => ({
+    id: edge.id,
+    sources: [edge.fromId],
+    targets: [edge.toId],
+  }));
+
+  return {
+    id: "root",
+    children: topLevelNodes,
+    edges: elkEdges,
+    layoutOptions: ELK_OPTIONS,
+  };
+}
+
+function applyElkLayout(store: Store, elkRoot: ElkNode, offsetX = 0, offsetY = 0): void {
+  const nodes = store.get(nodesAtom);
+
+  for (const elkNode of elkRoot.children ?? []) {
+    const node = nodes[elkNode.id];
+    if (!node) continue;
+
+    const x = (elkNode.x ?? 0) + offsetX;
+    const y = (elkNode.y ?? 0) + offsetY;
+
+    if (node.kind === "atomic") {
+      // Setting originAtom triggers spring animation in AtomicNode
+      store.set(node.originAtom, { x, y });
+    } else if (node.kind === "compound") {
+      // For compound nodes, position their children relative to
+      // the compound node's position. ELK gives children positions
+      // relative to their parent.
+      applyElkLayout(store, elkNode, x, y);
+    }
+  }
+}
+
+export async function runLayout(store: Store): Promise<void> {
+  const elkGraph = buildElkGraph(store);
+  const layoutResult = await elk.layout(elkGraph);
+  applyElkLayout(store, layoutResult);
+}

--- a/src/vscode-bicep-ui/package-lock.json
+++ b/src/vscode-bicep-ui/package-lock.json
@@ -81,6 +81,7 @@
         "@react-hook/resize-observer": "^2.0.2",
         "@vscode-bicep-ui/components": "^0.0.0",
         "@vscode-bicep-ui/messaging": "^0.0.0",
+        "elkjs": "^0.11.0",
         "jotai": "^2.13.1",
         "motion": "^12.23.3",
         "react": "^18.3.1",
@@ -603,6 +604,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -842,6 +844,7 @@
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -899,6 +902,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -2619,6 +2623,7 @@
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -3303,6 +3308,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3378,6 +3384,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3627,6 +3634,7 @@
       "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3642,6 +3650,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3745,6 +3754,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -4376,6 +4386,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4852,6 +4863,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5172,7 +5184,6 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5182,7 +5193,6 @@
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5206,7 +5216,6 @@
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5216,7 +5225,6 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -5239,7 +5247,6 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5249,7 +5256,6 @@
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -5646,6 +5652,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/elkjs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.0.tgz",
+      "integrity": "sha512-u4J8h9mwEDaYMqo0RYJpqNMFDoMK7f+pu4GjcV+N8jIC7TRdORgzkfSjTJemhqONFfH6fBI3wpysgWbhgVWIXw==",
+      "license": "EPL-2.0"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -5867,6 +5879,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5944,6 +5957,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7570,6 +7584,7 @@
       "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.17.1.tgz",
       "integrity": "sha512-TFNZZDa/0ewCLQyRC/Sq9crtixNj/Xdf/wmj9631xxMuKToVJZDbqcHIYN0OboH+7kh6P6tpIK7uKWClj86PKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -8628,6 +8643,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8717,6 +8733,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8795,6 +8812,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8952,6 +8970,7 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9366,6 +9385,7 @@
       "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -9662,6 +9682,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.9.tgz",
       "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "@emotion/unitless": "0.10.0",
@@ -9886,7 +9907,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/turbo": {
       "version": "2.8.3",
@@ -10087,6 +10109,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10245,6 +10268,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10926,6 +10950,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/visualizer-migration/README.md
+++ b/visualizer-migration/README.md
@@ -42,7 +42,7 @@ The migration is split into 7 incremental PRs, each self-contained and shippable
 
 1. ~~**[Expand Azure Icon Coverage](./step-1-icons.md)** — Migrate ~80+ resource type→SVG mappings to `@vscode-bicep-ui/components`~~ ✅
 2. ~~**[Add Theming Support](./step-2-theming.md)** — Theme the visual designer using styled-components ThemeProvider~~ ✅
-3. **[Integrate ELK.js Auto-Layout](./step-3-elk-layout.md)** — Add automatic graph layout to the new engine
+3. ~~**[Integrate ELK.js Auto-Layout](./step-3-elk-layout.md)** — Add automatic graph layout to the new engine~~ ✅
 4. **[Wire Up LSP Data Source](./step-4-data-source.md)** — Connect to `textDocument/deploymentGraph` via shared messaging
 5. **[Integrate into VS Code Extension](./step-5-extension-integration.md)** — Load the visual designer in a webview panel
 6. **[Achieve Full Feature Parity](./step-6-feature-parity.md)** — Double-click navigation, status bar, error indicators, etc.


### PR DESCRIPTION
## Description

This PR adds automatic graph layout to the new visual designer using ELK.js, replacing the need for manual node positioning. This is step 3 of the visualizer migration plan.

### Changes

- **Added \elkjs\** dependency to the visual designer package
- **Created \elk-layout.ts\** — ELK integration module that:
  - Converts Jotai graph state into ELK's hierarchical input format
  - Handles compound nodes with proper parent-child hierarchy and padding
  - Runs ELK layered layout with the same options as the old Cytoscape-based visualizer
  - Maps ELK output positions back to each atomic node's \originAtom\, triggering spring animations
- **Updated \GraphControlBar.tsx\** — Reset Layout button now runs ELK layout
- **Updated \App.tsx\** — Auto-layout runs after initial node setup (two-frame RAF delay for DOM measurement)

### Verification

- npm run build succeeds in the visual designer
- Nodes appear in a clean layered arrangement on load
- Reset Layout button re-computes and animates nodes to ELK positions
- Compound nodes properly contain their children with padding
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18992)