### PR TITLE
Generate VS Code extension manifest for signing

### DIFF
--- a/src/vscode-bicep/.gitignore
+++ b/src/vscode-bicep/.gitignore
@@ -9,3 +9,5 @@ syntaxes/language-configuration.json
 bicepLanguageServer
 bicepMcpServer
 ThirdPartyNotices.txt
+vscode-bicep.manifest
+vscode-bicep.p7s

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -750,7 +750,7 @@
     "test:update-snapshot": "jest --config jest.config.snapshot.js --updateSnapshot",
     "testlocal:e2e": "(export BICEP_LANGUAGE_SERVER_PATH=${INIT_CWD}/../Bicep.LangServer/bin/Debug/net10.0/Bicep.LangServer.dll || set BICEP_LANGUAGE_SERVER_PATH=%INIT_CWD%/../Bicep.LangServer/bin/Debug/net10.0/Bicep.LangServer.dll) && npm run build && npm run build:e2e && npm run test:e2e",
     "clean": "rimraf ./out ./coverage",
-    "package": "npm run clean && nbgv-setversion && vsce package --no-dependencies --githubBranch main --out ./vscode-bicep.vsix && nbgv-setversion --reset",
+    "package": "npm run clean && nbgv-setversion && vsce package --no-dependencies --githubBranch main --out ./vscode-bicep.vsix && nbgv-setversion --reset && vsce generate-manifest -i ./vscode-bicep.vsix -o ./vscode-bicep.manifest",
     "package:local": "rimraf ./bicepLanguageServer && cp -r ../Bicep.LangServer/bin/Debug/net10.0 ./bicepLanguageServer && rimraf ./bicepMcpServer && cp -r ../Bicep.McpServer/bin/Debug/net10.0 ./bicepMcpServer && npm run package"
   },
   "devDependencies": {


### PR DESCRIPTION
The `package` script now also generates a manifest for signing the VS Code extension in the official build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/18996)