### PR TITLE
Add context menu option to generate snapshots for .bicepparam files

### DIFF
--- a/src/Bicep.LangServer/Handlers/BicepSnapshotCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepSnapshotCommandHandler.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Emit;
+using Bicep.Core.Extensions;
+using Bicep.Core.Utils.Snapshots;
+using Bicep.IO.Abstraction;
+using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    // This handler is used to generate a snapshot (.snapshot.json) file for a given bicep parameters file.
+    // It returns snapshot generation succeeded/failed message, which can be displayed appropriately in IDE output window
+    public class BicepSnapshotCommandHandler : ExecuteTypedResponseCommandHandlerBase<DocumentUri, string>
+    {
+        private readonly ICompilationManager compilationManager;
+        private readonly IFileExplorer fileExplorer;
+        private readonly BicepCompiler bicepCompiler;
+
+        public BicepSnapshotCommandHandler(ICompilationManager compilationManager, IFileExplorer fileExplorer, BicepCompiler bicepCompiler, ISerializer serializer)
+            : base(LangServerConstants.SnapshotCommand, serializer)
+        {
+            this.compilationManager = compilationManager;
+            this.fileExplorer = fileExplorer;
+            this.bicepCompiler = bicepCompiler;
+        }
+
+        public override async Task<string> Handle(DocumentUri documentUri, CancellationToken cancellationToken)
+        {
+            string output = await GenerateSnapshotFileAndReturnOutputMessage(documentUri, cancellationToken);
+
+            return output;
+        }
+
+        private async Task<string> GenerateSnapshotFileAndReturnOutputMessage(DocumentUri documentUri, CancellationToken cancellationToken)
+        {
+            var bicepParamFileUri = documentUri.ToIOUri();
+            var snapshotFileUri = bicepParamFileUri.WithExtension(".snapshot.json");
+            var snapshotFile = this.fileExplorer.GetFile(snapshotFileUri);
+
+            var compilation = await new CompilationHelper(bicepCompiler, compilationManager).GetRefreshedCompilation(documentUri);
+            var paramsResult = compilation.Emitter.Parameters();
+
+            if (paramsResult.Success != true || paramsResult.Template?.Template is not { } templateContent || paramsResult.Parameters is not { } parametersContent)
+            {
+                var diagnosticsByFile = compilation.GetAllDiagnosticsByBicepFile();
+
+                return "Generating snapshot file failed. Please fix below errors:\n" + DiagnosticsHelper.GetDiagnosticsMessage(diagnosticsByFile);
+            }
+
+            try
+            {
+                var snapshot = await SnapshotHelper.GetSnapshot(
+                    targetScope: compilation.GetEntrypointSemanticModel().TargetScope,
+                    templateContent: templateContent,
+                    parametersContent: parametersContent,
+                    tenantId: null,
+                    subscriptionId: null,
+                    resourceGroup: null,
+                    location: null,
+                    deploymentName: null,
+                    cancellationToken: cancellationToken,
+                    externalInputs: []);
+
+                if (snapshot.Diagnostics.Length > 0)
+{
+                    var diagnosticsMessage = string.Join("\n", snapshot.Diagnostics.Select(d => $"  {d}"));
+                    return $"Snapshot generation completed with warnings:\n{diagnosticsMessage}\n\nSnapshot file created at {snapshotFileUri}";
+                }
+
+                var contents = SnapshotHelper.Serialize(snapshot);
+                await snapshotFile.WriteAllTextAsync(contents, cancellationToken);
+
+                return $"Snapshot generation succeeded. Created file {snapshotFileUri}";
+            }
+            catch (Exception ex)
+            {
+                return $"Snapshot generation failed: {ex.Message}";
+            }
+        }
+    }
+}

--- a/src/Bicep.LangServer/LangServerConstants.cs
+++ b/src/Bicep.LangServer/LangServerConstants.cs
@@ -12,6 +12,7 @@ namespace Bicep.LanguageServer
         public const string DecompileSaveCommand = "decompileSave";
         public const string GenerateParamsCommand = "generateParams";
         public const string BuildParamsCommand = "buildParams";
+        public const string SnapshotCommand = "snapshot";
         public const string DeployCompleteMethod = "deploymentComplete";
         public const string DeployStartCommand = "deploy/start";
         public const string DeployWaitForCompletionCommand = "deploy/waitForCompletion";

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -56,6 +56,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepBuildCommandHandler>()
                     .WithHandler<BicepGenerateParamsCommandHandler>()
                     .WithHandler<BicepBuildParamsCommandHandler>()
+                    .WithHandler<BicepSnapshotCommandHandler>()
                     .WithHandler<BicepDeploymentStartCommandHandler>()
                     // Base handler (ExecuteTypedResponseCommandHandlerBase) is serial. This blocks other commands on the client side.
                     // To avoid the above issue, we'll change the RequestProcessType to parallel

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -272,6 +272,12 @@
         "icon": "$(output)"
       },
       {
+        "command": "bicep.snapshot",
+        "title": "Generate Snapshot",
+        "category": "Bicep",
+        "icon": "$(file-code)"
+      },
+      {
         "command": "bicep.internal.showModuleSourceFile",
         "title": "(Show a source file from a module)",
         "category": "Bicep Internal"
@@ -426,6 +432,11 @@
           "group": "2_bicep_1_edit"
         },
         {
+          "command": "bicep.snapshot",
+          "when": "resourceLangId == bicep-params",
+          "group": "2_bicep_1_edit"
+        },
+        {
           "command": "bicep.decompileParams",
           "when": "resourceLangId == json || resourceLangId == jsonc",
           "group": "9_bicep_in_json"
@@ -484,6 +495,11 @@
         },
         {
           "command": "bicep.buildParams",
+          "when": "resourceLangId == bicep-params",
+          "group": "2_bicep_1_edit"
+        },
+        {
+          "command": "bicep.snapshot",
           "when": "resourceLangId == bicep-params",
           "group": "2_bicep_1_edit"
         },
@@ -555,6 +571,11 @@
           "group": "2_bicep_1_edit"
         },
         {
+          "command": "bicep.snapshot",
+          "when": "resourceLangId == bicep-params",
+          "group": "2_bicep_1_edit"
+        },
+        {
           "command": "bicep.decompileParams",
           "when": "resourceLangId == json || resourceLangId == jsonc",
           "group": "9_bicep_in_json"
@@ -618,6 +639,10 @@
         },
         {
           "command": "bicep.buildParams",
+          "group": "0_bicep"
+        },
+        {
+          "command": "bicep.snapshot",
           "group": "0_bicep"
         },
         {

--- a/src/vscode-bicep/src/commands/snapshot.ts
+++ b/src/vscode-bicep/src/commands/snapshot.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { IActionContext, parseError } from "@microsoft/vscode-azext-utils";
+import vscode from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { OutputChannelManager } from "../utils/OutputChannelManager";
+import { findOrCreateActiveBicepParamFile } from "./findOrCreateActiveBicepFile";
+import { Command } from "./types";
+
+export class SnapshotCommand implements Command {
+  public readonly id = "bicep.snapshot";
+  public constructor(
+    private readonly client: LanguageClient,
+    private readonly outputChannelManager: OutputChannelManager,
+  ) {}
+
+  public async execute(context: IActionContext, documentUri?: vscode.Uri | undefined): Promise<void> {
+    documentUri = await findOrCreateActiveBicepParamFile(
+      context,
+      documentUri,
+      "Choose which Bicep Parameters file to generate a snapshot from",
+    );
+
+    if (documentUri.scheme.toLowerCase() !== "file") {
+      this.client.error(
+        "Snapshot generation failed. The active file must be saved to your local filesystem.",
+        undefined,
+        true,
+      );
+      return;
+    }
+
+    try {
+      const snapshotOutput: string = await this.client.sendRequest("workspace/executeCommand", {
+        command: "snapshot",
+        arguments: [documentUri.toString()],
+      });
+      this.outputChannelManager.appendToOutputChannel(snapshotOutput);
+    } catch (err) {
+      this.client.error("Snapshot generation failed", parseError(err).message, true);
+    }
+  }
+}

--- a/src/vscode-bicep/src/extension.ts
+++ b/src/vscode-bicep/src/extension.ts
@@ -18,6 +18,7 @@ import * as lsp from "vscode-languageclient/node";
 import { AzureUiManager } from "./azure/AzureUiManager";
 import { BuildCommand } from "./commands/build";
 import { BuildParamsCommand } from "./commands/buildParams";
+import { SnapshotCommand } from "./commands/snapshot";
 import { CommandManager } from "./commands/commandManager";
 import { CreateBicepConfigurationFile } from "./commands/createConfigurationFile";
 import { DecompileCommand } from "./commands/decompile";
@@ -147,6 +148,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
             new BuildCommand(languageClient, outputChannelManager),
             new GenerateParamsCommand(languageClient, outputChannelManager),
             new BuildParamsCommand(languageClient, outputChannelManager),
+            new SnapshotCommand(languageClient, outputChannelManager),
             new CreateBicepConfigurationFile(languageClient),
             new DeployCommand(languageClient, outputChannelManager, azurePickers),
             new DecompileCommand(languageClient, outputChannelManager),


### PR DESCRIPTION
## Description

Added a context menu option to generate snapshots for `.bicepparam` files in VS Code. Users can now right-click a Bicep parameters file and select "Generate Snapshot" to create a `.snapshot.json` file, making the existing `bicep snapshot` CLI command accessible directly from the editor.

Fixes #18861 (only UI, pattern needs to be checked with PG if feature is wanted, i would assume the generate button is already sufficient)


https://github.com/user-attachments/assets/5b50536c-1677-4baf-932c-f795270ae40e



## Example Usage

**Before**: Users had to manually run `bicep snapshot <file>.bicepparam` from the command line.

**After**: Users can right-click any `.bicepparam` file in VS Code and select "Bicep: Generate Snapshot":

**Context Menu Locations:**
- Right-click in File Explorer
- Right-click on editor tab
- Right-click within editor
- Command Palette (Ctrl+Shift+P → "Bicep: Generate Snapshot")

**Example Output:**
Snapshot generation succeeded. Created file c:\path\to\file.snapshot.json
The generated `.snapshot.json` file will appear alongside the `.bicepparam` file.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19024)