### PR TITLE
On force restore continue recursing into local modules

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/RestoreCommandTests.cs
@@ -483,6 +483,102 @@ output o1 string = '${p1}${p2}'");
             }
         }
 
+        [TestMethod]
+        public async Task Restore_With_Force_ShouldRestore_NestedRegistryModules_ReferencedByLocalModule()
+        {
+            var fileSystem = new MockFileSystem();
+            var fileExplorer = new FileSystemFileExplorer(fileSystem);
+
+            var clientFactory = RegistryHelper.CreateMockRegistryClient(
+                new RegistryHelper.RepoDescriptor("mockregistry.io", "bicepmodules/remote-module-01", ["default"]),
+                new RegistryHelper.RepoDescriptor("mockregistry.io", "bicepmodules/remote-module-02", ["default"]));
+
+            await RegistryHelper.PublishModuleToRegistryAsync(
+                new ServiceBuilder(),
+                clientFactory,
+                fileSystem,
+                new("br:mockregistry.io/bicepmodules/remote-module-01:default", "output name string = 'plan'", WithSource: false));
+
+            await RegistryHelper.PublishModuleToRegistryAsync(
+                new ServiceBuilder(),
+                clientFactory,
+                fileSystem,
+                new("br:mockregistry.io/bicepmodules/remote-module-02:default", "output name string = 'kv'", WithSource: false));
+
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            var mainContent = """
+module autoPlan 'br:mockregistry.io/bicepmodules/remote-module-01:default' = {
+  name: 'remote-module-01'
+}
+
+module app './local-module.bicep' = {
+  name: 'local-module'
+}
+""";
+
+            var localModuleContent = """
+module messaging 'br:mockregistry.io/bicepmodules/remote-module-02:default' = {
+  name: 'remote-module-02'
+}
+""";
+
+            var mainPath = $"{outputPath}/main.bicep";
+            var localModulePath = $"{outputPath}/local-module.bicep";
+
+            fileSystem.AddFile(mainPath, mainContent);
+            fileSystem.AddFile(localModulePath, localModuleContent);
+
+            var cacheRoot = fileExplorer.GetDirectory(IOUri.FromFilePath(outputPath));
+
+            var restoreResult = await Bicep(
+                services => services
+                    .WithFeatureOverrides(new(CacheRootDirectory: cacheRoot, RegistryEnabled: true))
+                    .WithContainerRegistryClientFactory(clientFactory)
+                    .WithFileSystem(fileSystem)
+                    .WithFileExplorer(fileExplorer),
+                "restore",
+                mainPath,
+                "--force");
+
+            using (new AssertionScope())
+            {
+                restoreResult.Should().Succeed();
+                restoreResult.Stdout.Should().BeEmpty();
+                restoreResult.Stderr.Should().BeEmpty();
+
+                CachedModules
+                    .GetCachedModules(fileSystem, cacheRoot)
+                    .Should()
+                    .Contain(module =>
+                        module.Registry == "mockregistry.io" &&
+                        module.Repository == "bicepmodules/remote-module-01" &&
+                        module.Tag == "default")
+                    .And
+                    .Contain(module =>
+                        module.Registry == "mockregistry.io" &&
+                        module.Repository == "bicepmodules/remote-module-02" &&
+                        module.Tag == "default");
+            }
+
+            var buildResult = await Bicep(
+                services => services
+                    .WithFeatureOverrides(new(CacheRootDirectory: cacheRoot, RegistryEnabled: true))
+                    .WithContainerRegistryClientFactory(clientFactory)
+                    .WithFileSystem(fileSystem)
+                    .WithFileExplorer(fileExplorer),
+                "build",
+                mainPath,
+                "--no-restore");
+
+            using (new AssertionScope())
+            {
+                buildResult.Should().Succeed();
+                buildResult.Stdout.Should().BeEmpty();
+                buildResult.Stderr.Should().BeEmpty();
+            }
+        }
+
         [DataTestMethod]
         [DataRow(false)]
         [DataRow(true)]

--- a/src/Bicep.Core/SourceGraph/SourceFileGroupingBuilder.cs
+++ b/src/Bicep.Core/SourceGraph/SourceFileGroupingBuilder.cs
@@ -276,7 +276,12 @@ namespace Bicep.Core.SourceGraph
 
             if (forceRestore)
             {
-                //override the status to force restore
+                // keep local modules traversable so nested references can still be discovered during this pass
+                if (string.Equals(artifactReference.Scheme, ArtifactReferenceSchemes.Local, StringComparison.Ordinal))
+                {
+                    return (new(artifactFileHandle), requiresRestore: true);
+                }
+
                 return (new(x => x.ArtifactRequiresRestore(artifactReference.FullyQualifiedReference)), requiresRestore: true);
             }
 


### PR DESCRIPTION
## Description

Fixes #12752

When using `--force` parameter with `bicep restore` command, local module files containing remote modules won't get restored and the whole restore fails due to missing modules.

Originally reported in #12752.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19137)