### PR TITLE
Added the grace period to delay recommending the latest API version

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
@@ -38,7 +38,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             }
         }
 
-        private static void CompileAndTestWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, string[] expectedMessagesForCode, OnCompileErrors onCompileErrors = OnCompileErrors.IncludeErrors, int? maxAgeInDays = null, int? newVersionGracePeriodInDays = null)
+        private static void CompileAndTestWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, string[] expectedMessagesForCode, OnCompileErrors onCompileErrors = OnCompileErrors.IncludeErrors, int? maxAgeInDays = null, int? gracePeriodInDays = null)
         {
             VerifyAllTypesAndDatesAreFake(bicep, string.Join(", ", resourceTypes), fakeToday, string.Join(", ", expectedMessagesForCode));
 
@@ -48,13 +48,13 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors: onCompileErrors,
                     IncludePosition.LineNumber,
-                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodInDays),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, gracePeriodInDays),
                     // Test with the linter thinking today's date is fakeToday and also fake resource types from FakeResourceTypes
                     // Note: The compiler does not know about these fake types, only the linter.
                     AzResourceTypeLoader: resourceTypes.Any() ? FakeResourceTypes.GetAzResourceTypeLoaderWithInjectedTypes(resourceTypes).Object : null));
         }
 
-        private static void CompileAndTestFixWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, DiagnosticAndFixes[] expectedDiagnostics, int? maxAgeInDays = null, int? newVersionGracePeriodInDays = null)
+        private static void CompileAndTestFixWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, DiagnosticAndFixes[] expectedDiagnostics, int? maxAgeInDays = null, int? gracePeriodInDays = null)
         {
             VerifyAllTypesAndDatesAreFake(bicep);
             VerifyAllTypesAndDatesAreFake(resourceTypes);
@@ -92,13 +92,13 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors.IncludeErrors,
                     IncludePosition.LineNumber,
-                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodInDays),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, gracePeriodInDays),
                     // Test with the linter thinking today's date is fakeToday and also fake resource types from FakeResourceTypes
                     // Note: The compiler does not know about these fake types, only the linter.
                     AzResourceTypeLoader: FakeResourceTypes.GetAzResourceTypeLoaderWithInjectedTypes(resourceTypes).Object));
         }
 
-        private static RootConfiguration CreateConfigurationWithFakeToday(RootConfiguration original, string today, int? maxAgeInDays = null, int? newVersionGracePeriodInDays = null)
+        private static RootConfiguration CreateConfigurationWithFakeToday(RootConfiguration original, string today, int? maxAgeInDays = null, int? gracePeriodInDays = null)
         {
             VerifyAllTypesAndDatesAreFake(today);
 
@@ -126,7 +126,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         """
                             .Replace("<TESTING_TODAY_DATE>", today)
                             .Replace("<MAX_AGE_PROP>", maxAgeInDays.HasValue ? $", \"maxAgeInDays\": {maxAgeInDays}" : "")
-                            .Replace("<GRACE_PERIOD_PROP>", newVersionGracePeriodInDays.HasValue ? $", \"newVersionGracePeriodInDays\": {newVersionGracePeriodInDays}" : ""))),
+                            .Replace("<GRACE_PERIOD_PROP>", gracePeriodInDays.HasValue ? $", \"gracePeriodInDays\": {gracePeriodInDays}" : ""))),
                 original.CacheRootDirectory,
                 original.ExperimentalFeaturesWarning,
                 original.ExperimentalFeaturesEnabled with
@@ -141,7 +141,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         [TestClass]
         public class GetAcceptableApiVersionsTests
         {
-            private static void TestGetAcceptableApiVersions(string fullyQualifiedResourceType, ResourceScope scope, string resourceTypes, string today, string[] expectedApiVersions, int maxAgeInDays = UseRecentApiVersionRule.DefaultMaxAgeInDays, int newVersionGracePeriodInDays = 0)
+            private static void TestGetAcceptableApiVersions(string fullyQualifiedResourceType, ResourceScope scope, string resourceTypes, string today, string[] expectedApiVersions, int maxAgeInDays = UseRecentApiVersionRule.DefaultMaxAgeInDays, int gracePeriodInDays = 0)
             {
                 VerifyAllTypesAndDatesAreFake(fullyQualifiedResourceType, today);
                 VerifyAllTypesAndDatesAreFake(resourceTypes);
@@ -149,7 +149,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 
                 var apiVersionProvider = new ApiVersionProvider(BicepTestConstants.Features, []);
                 apiVersionProvider.InjectTypeReferences(scope, FakeResourceTypes.GetFakeResourceTypeReferences(resourceTypes));
-                var (_, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(apiVersionProvider, AzureResourceApiVersion.Parse(today).Date, maxAgeInDays, newVersionGracePeriodInDays, scope, fullyQualifiedResourceType);
+                var (_, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(apiVersionProvider, AzureResourceApiVersion.Parse(today).Date, maxAgeInDays, gracePeriodInDays, scope, fullyQualifiedResourceType);
                 var allowedVersionsStrings = allowedVersions.Select(v => v.ToString()).ToArray();
                 allowedVersionsStrings.Should().BeEquivalentTo(expectedApiVersions, options => options.WithStrictOrdering());
             }
@@ -737,7 +737,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-04-01",
                         "2421-03-01",
                     ],
-                    newVersionGracePeriodInDays: 90);
+                    gracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -760,7 +760,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-04-01",
                         "2421-03-01",
                     ],
-                    newVersionGracePeriodInDays: 0);
+                    gracePeriodInDays: 0);
             }
 
             [TestMethod]
@@ -783,7 +783,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-02-01-preview",
                         "2421-01-01", // Stable version
                     ],
-                    newVersionGracePeriodInDays: 90);
+                    gracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -805,7 +805,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-04-01", // Most recent stable outside grace period (90 days from 2421-07-07 = before 2421-04-09)
                         "2421-01-01",
                     ],
-                    newVersionGracePeriodInDays: 90);
+                    gracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -832,7 +832,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-03-01", // Most recent stable outside grace period
                         "2421-01-01", // Older stable
                     ],
-                    newVersionGracePeriodInDays: 90);
+                    gracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -856,7 +856,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-06-15",
                         "2421-06-01",
                     ],
-                    newVersionGracePeriodInDays: 90);
+                    gracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -881,7 +881,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-05-01", // Older stable
                         // Note: 2421-06-01-preview is not included because it's not newer than the most recent stable (2421-06-15)
                     ],
-                    newVersionGracePeriodInDays: 90);
+                    gracePeriodInDays: 90);
             }
         }
 
@@ -992,7 +992,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             [DynamicData(nameof(GetTestData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(TestData), DynamicDataDisplayName = nameof(TestData.GetDisplayName))]
             public void InvariantsTest(TestData data)
             {
-                var (allVersions, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(RealApiVersionProvider, data.Today, data.MaxAgeInDays, UseRecentApiVersionRule.DefaultNewVersionGracePeriodInDays, data.ResourceScope, data.FullyQualifiedResourceType);
+                var (allVersions, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(RealApiVersionProvider, data.Today, data.MaxAgeInDays, UseRecentApiVersionRule.DefaultGracePeriodInDays, data.ResourceScope, data.FullyQualifiedResourceType);
 
                 allVersions.Should().NotBeNull();
                 allowedVersions.Should().NotBeNull();
@@ -1095,7 +1095,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     apiVersionProvider,
                     GetToday(),
                     maxAllowedAgeInDays,
-                    UseRecentApiVersionRule.DefaultNewVersionGracePeriodInDays,
+                    UseRecentApiVersionRule.DefaultGracePeriodInDays,
                     new TextSpan(17, 47),
                     new TextSpan(17, 47),
                     ResourceScope.ResourceGroup,

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
@@ -38,7 +38,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             }
         }
 
-        private static void CompileAndTestWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, string[] expectedMessagesForCode, OnCompileErrors onCompileErrors = OnCompileErrors.IncludeErrors, int? maxAgeInDays = null, int? newVersionGracePeriodDays = null)
+        private static void CompileAndTestWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, string[] expectedMessagesForCode, OnCompileErrors onCompileErrors = OnCompileErrors.IncludeErrors, int? maxAgeInDays = null, int? newVersionGracePeriodInDays = null)
         {
             VerifyAllTypesAndDatesAreFake(bicep, string.Join(", ", resourceTypes), fakeToday, string.Join(", ", expectedMessagesForCode));
 
@@ -48,13 +48,13 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors: onCompileErrors,
                     IncludePosition.LineNumber,
-                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodDays),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodInDays),
                     // Test with the linter thinking today's date is fakeToday and also fake resource types from FakeResourceTypes
                     // Note: The compiler does not know about these fake types, only the linter.
                     AzResourceTypeLoader: resourceTypes.Any() ? FakeResourceTypes.GetAzResourceTypeLoaderWithInjectedTypes(resourceTypes).Object : null));
         }
 
-        private static void CompileAndTestFixWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, DiagnosticAndFixes[] expectedDiagnostics, int? maxAgeInDays = null, int? newVersionGracePeriodDays = null)
+        private static void CompileAndTestFixWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, DiagnosticAndFixes[] expectedDiagnostics, int? maxAgeInDays = null, int? newVersionGracePeriodInDays = null)
         {
             VerifyAllTypesAndDatesAreFake(bicep);
             VerifyAllTypesAndDatesAreFake(resourceTypes);
@@ -92,13 +92,13 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors.IncludeErrors,
                     IncludePosition.LineNumber,
-                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodDays),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodInDays),
                     // Test with the linter thinking today's date is fakeToday and also fake resource types from FakeResourceTypes
                     // Note: The compiler does not know about these fake types, only the linter.
                     AzResourceTypeLoader: FakeResourceTypes.GetAzResourceTypeLoaderWithInjectedTypes(resourceTypes).Object));
         }
 
-        private static RootConfiguration CreateConfigurationWithFakeToday(RootConfiguration original, string today, int? maxAgeInDays = null, int? newVersionGracePeriodDays = null)
+        private static RootConfiguration CreateConfigurationWithFakeToday(RootConfiguration original, string today, int? maxAgeInDays = null, int? newVersionGracePeriodInDays = null)
         {
             VerifyAllTypesAndDatesAreFake(today);
 
@@ -126,7 +126,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         """
                             .Replace("<TESTING_TODAY_DATE>", today)
                             .Replace("<MAX_AGE_PROP>", maxAgeInDays.HasValue ? $", \"maxAgeInDays\": {maxAgeInDays}" : "")
-                            .Replace("<GRACE_PERIOD_PROP>", newVersionGracePeriodDays.HasValue ? $", \"newVersionGracePeriodDays\": {newVersionGracePeriodDays}" : ""))),
+                            .Replace("<GRACE_PERIOD_PROP>", newVersionGracePeriodInDays.HasValue ? $", \"newVersionGracePeriodInDays\": {newVersionGracePeriodInDays}" : ""))),
                 original.CacheRootDirectory,
                 original.ExperimentalFeaturesWarning,
                 original.ExperimentalFeaturesEnabled with
@@ -141,7 +141,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         [TestClass]
         public class GetAcceptableApiVersionsTests
         {
-            private static void TestGetAcceptableApiVersions(string fullyQualifiedResourceType, ResourceScope scope, string resourceTypes, string today, string[] expectedApiVersions, int maxAgeInDays = UseRecentApiVersionRule.DefaultMaxAgeInDays, int newVersionGracePeriodDays = 0)
+            private static void TestGetAcceptableApiVersions(string fullyQualifiedResourceType, ResourceScope scope, string resourceTypes, string today, string[] expectedApiVersions, int maxAgeInDays = UseRecentApiVersionRule.DefaultMaxAgeInDays, int newVersionGracePeriodInDays = 0)
             {
                 VerifyAllTypesAndDatesAreFake(fullyQualifiedResourceType, today);
                 VerifyAllTypesAndDatesAreFake(resourceTypes);
@@ -149,7 +149,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 
                 var apiVersionProvider = new ApiVersionProvider(BicepTestConstants.Features, []);
                 apiVersionProvider.InjectTypeReferences(scope, FakeResourceTypes.GetFakeResourceTypeReferences(resourceTypes));
-                var (_, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(apiVersionProvider, AzureResourceApiVersion.Parse(today).Date, maxAgeInDays, newVersionGracePeriodDays, scope, fullyQualifiedResourceType);
+                var (_, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(apiVersionProvider, AzureResourceApiVersion.Parse(today).Date, maxAgeInDays, newVersionGracePeriodInDays, scope, fullyQualifiedResourceType);
                 var allowedVersionsStrings = allowedVersions.Select(v => v.ToString()).ToArray();
                 allowedVersionsStrings.Should().BeEquivalentTo(expectedApiVersions, options => options.WithStrictOrdering());
             }
@@ -737,7 +737,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-04-01",
                         "2421-03-01",
                     ],
-                    newVersionGracePeriodDays: 90);
+                    newVersionGracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -760,7 +760,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-04-01",
                         "2421-03-01",
                     ],
-                    newVersionGracePeriodDays: 0);
+                    newVersionGracePeriodInDays: 0);
             }
 
             [TestMethod]
@@ -783,7 +783,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-02-01-preview",
                         "2421-01-01", // Stable version
                     ],
-                    newVersionGracePeriodDays: 90);
+                    newVersionGracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -805,7 +805,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-04-01", // Most recent stable outside grace period (90 days from 2421-07-07 = before 2421-04-09)
                         "2421-01-01",
                     ],
-                    newVersionGracePeriodDays: 90);
+                    newVersionGracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -832,7 +832,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-03-01", // Most recent stable outside grace period
                         "2421-01-01", // Older stable
                     ],
-                    newVersionGracePeriodDays: 90);
+                    newVersionGracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -856,7 +856,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-06-15",
                         "2421-06-01",
                     ],
-                    newVersionGracePeriodDays: 90);
+                    newVersionGracePeriodInDays: 90);
             }
 
             [TestMethod]
@@ -881,7 +881,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-05-01", // Older stable
                         // Note: 2421-06-01-preview is not included because it's not newer than the most recent stable (2421-06-15)
                     ],
-                    newVersionGracePeriodDays: 90);
+                    newVersionGracePeriodInDays: 90);
             }
         }
 
@@ -992,7 +992,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             [DynamicData(nameof(GetTestData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(TestData), DynamicDataDisplayName = nameof(TestData.GetDisplayName))]
             public void InvariantsTest(TestData data)
             {
-                var (allVersions, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(RealApiVersionProvider, data.Today, data.MaxAgeInDays, UseRecentApiVersionRule.DefaultNewVersionGracePeriodDays, data.ResourceScope, data.FullyQualifiedResourceType);
+                var (allVersions, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(RealApiVersionProvider, data.Today, data.MaxAgeInDays, UseRecentApiVersionRule.DefaultNewVersionGracePeriodInDays, data.ResourceScope, data.FullyQualifiedResourceType);
 
                 allVersions.Should().NotBeNull();
                 allowedVersions.Should().NotBeNull();
@@ -1095,7 +1095,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     apiVersionProvider,
                     GetToday(),
                     maxAllowedAgeInDays,
-                    UseRecentApiVersionRule.DefaultNewVersionGracePeriodDays,
+                    UseRecentApiVersionRule.DefaultNewVersionGracePeriodInDays,
                     new TextSpan(17, 47),
                     new TextSpan(17, 47),
                     ResourceScope.ResourceGroup,

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
@@ -38,7 +38,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             }
         }
 
-        private static void CompileAndTestWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, string[] expectedMessagesForCode, OnCompileErrors onCompileErrors = OnCompileErrors.IncludeErrors, int? maxAgeInDays = null)
+        private static void CompileAndTestWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, string[] expectedMessagesForCode, OnCompileErrors onCompileErrors = OnCompileErrors.IncludeErrors, int? maxAgeInDays = null, int? newVersionGracePeriodDays = null)
         {
             VerifyAllTypesAndDatesAreFake(bicep, string.Join(", ", resourceTypes), fakeToday, string.Join(", ", expectedMessagesForCode));
 
@@ -48,13 +48,13 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors: onCompileErrors,
                     IncludePosition.LineNumber,
-                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodDays),
                     // Test with the linter thinking today's date is fakeToday and also fake resource types from FakeResourceTypes
                     // Note: The compiler does not know about these fake types, only the linter.
                     AzResourceTypeLoader: resourceTypes.Any() ? FakeResourceTypes.GetAzResourceTypeLoaderWithInjectedTypes(resourceTypes).Object : null));
         }
 
-        private static void CompileAndTestFixWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, DiagnosticAndFixes[] expectedDiagnostics, int? maxAgeInDays = null)
+        private static void CompileAndTestFixWithFakeDateAndTypes(string bicep, ResourceScope scope, string[] resourceTypes, string fakeToday, DiagnosticAndFixes[] expectedDiagnostics, int? maxAgeInDays = null, int? newVersionGracePeriodDays = null)
         {
             VerifyAllTypesAndDatesAreFake(bicep);
             VerifyAllTypesAndDatesAreFake(resourceTypes);
@@ -92,13 +92,13 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                 new Options(
                     OnCompileErrors.IncludeErrors,
                     IncludePosition.LineNumber,
-                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays),
+                    ConfigurationPatch: c => CreateConfigurationWithFakeToday(c, fakeToday, maxAgeInDays, newVersionGracePeriodDays),
                     // Test with the linter thinking today's date is fakeToday and also fake resource types from FakeResourceTypes
                     // Note: The compiler does not know about these fake types, only the linter.
                     AzResourceTypeLoader: FakeResourceTypes.GetAzResourceTypeLoaderWithInjectedTypes(resourceTypes).Object));
         }
 
-        private static RootConfiguration CreateConfigurationWithFakeToday(RootConfiguration original, string today, int? maxAgeInDays = null)
+        private static RootConfiguration CreateConfigurationWithFakeToday(RootConfiguration original, string today, int? maxAgeInDays = null, int? newVersionGracePeriodDays = null)
         {
             VerifyAllTypesAndDatesAreFake(today);
 
@@ -118,13 +118,15 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                                         "test-today": "<TESTING_TODAY_DATE>",
                                         "test-warn-not-found": true
                                         <MAX_AGE_PROP>
+                                        <GRACE_PERIOD_PROP>
                                     }
                                 }
                             }
                         }
                         """
                             .Replace("<TESTING_TODAY_DATE>", today)
-                            .Replace("<MAX_AGE_PROP>", maxAgeInDays.HasValue ? $", \"maxAgeInDays\": {maxAgeInDays}" : ""))),
+                            .Replace("<MAX_AGE_PROP>", maxAgeInDays.HasValue ? $", \"maxAgeInDays\": {maxAgeInDays}" : "")
+                            .Replace("<GRACE_PERIOD_PROP>", newVersionGracePeriodDays.HasValue ? $", \"newVersionGracePeriodDays\": {newVersionGracePeriodDays}" : ""))),
                 original.CacheRootDirectory,
                 original.ExperimentalFeaturesWarning,
                 original.ExperimentalFeaturesEnabled with
@@ -139,7 +141,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         [TestClass]
         public class GetAcceptableApiVersionsTests
         {
-            private static void TestGetAcceptableApiVersions(string fullyQualifiedResourceType, ResourceScope scope, string resourceTypes, string today, string[] expectedApiVersions, int maxAgeInDays = UseRecentApiVersionRule.DefaultMaxAgeInDays)
+            private static void TestGetAcceptableApiVersions(string fullyQualifiedResourceType, ResourceScope scope, string resourceTypes, string today, string[] expectedApiVersions, int maxAgeInDays = UseRecentApiVersionRule.DefaultMaxAgeInDays, int newVersionGracePeriodDays = 0)
             {
                 VerifyAllTypesAndDatesAreFake(fullyQualifiedResourceType, today);
                 VerifyAllTypesAndDatesAreFake(resourceTypes);
@@ -147,7 +149,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 
                 var apiVersionProvider = new ApiVersionProvider(BicepTestConstants.Features, []);
                 apiVersionProvider.InjectTypeReferences(scope, FakeResourceTypes.GetFakeResourceTypeReferences(resourceTypes));
-                var (_, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(apiVersionProvider, AzureResourceApiVersion.Parse(today).Date, maxAgeInDays, scope, fullyQualifiedResourceType);
+                var (_, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(apiVersionProvider, AzureResourceApiVersion.Parse(today).Date, maxAgeInDays, newVersionGracePeriodDays, scope, fullyQualifiedResourceType);
                 var allowedVersionsStrings = allowedVersions.Select(v => v.ToString()).ToArray();
                 allowedVersionsStrings.Should().BeEquivalentTo(expectedApiVersions, options => options.WithStrictOrdering());
             }
@@ -712,6 +714,175 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                         "2421-02-01", // No previews older than this allowed, even if < 2 years old
                     ]);
             }
+
+            [TestMethod]
+            public void GracePeriod_FiltersOutVersionsWithinGracePeriod()
+            {
+                // Today is 2421-07-07, grace period is 90 days
+                // Versions from 2421-04-09 onwards (within 90 days) should be filtered out
+                TestGetAcceptableApiVersions(
+                    "Fake.Kusto/clusters",
+                    ResourceScope.ResourceGroup,
+                    @"
+                        Fake.Kusto/clusters@2421-03-01
+                        Fake.Kusto/clusters@2421-04-01
+                        Fake.Kusto/clusters@2421-04-08
+                        Fake.Kusto/clusters@2421-04-09
+                        Fake.Kusto/clusters@2421-05-01
+                        Fake.Kusto/clusters@2421-06-01
+                    ",
+                    "2421-07-07",
+                    [
+                        "2421-04-08", // Most recent outside grace period
+                        "2421-04-01",
+                        "2421-03-01",
+                    ],
+                    newVersionGracePeriodDays: 90);
+            }
+
+            [TestMethod]
+            public void GracePeriod_Zero_RecommendsAllVersions()
+            {
+                // With grace period of 0, all versions should be considered
+                TestGetAcceptableApiVersions(
+                    "Fake.Kusto/clusters",
+                    ResourceScope.ResourceGroup,
+                    @"
+                        Fake.Kusto/clusters@2421-03-01
+                        Fake.Kusto/clusters@2421-04-01
+                        Fake.Kusto/clusters@2421-05-01
+                        Fake.Kusto/clusters@2421-06-01
+                    ",
+                    "2421-07-07",
+                    [
+                        "2421-06-01", // Most recent (no grace period filtering)
+                        "2421-05-01",
+                        "2421-04-01",
+                        "2421-03-01",
+                    ],
+                    newVersionGracePeriodDays: 0);
+            }
+
+            [TestMethod]
+            public void GracePeriod_FiltersPreviewVersionsWithinGracePeriod()
+            {
+                // Grace period should apply to preview versions too
+                TestGetAcceptableApiVersions(
+                    "Fake.Kusto/clusters",
+                    ResourceScope.ResourceGroup,
+                    @"
+                        Fake.Kusto/clusters@2421-01-01
+                        Fake.Kusto/clusters@2421-02-01-preview
+                        Fake.Kusto/clusters@2421-03-01-preview
+                        Fake.Kusto/clusters@2421-05-01-preview
+                        Fake.Kusto/clusters@2421-06-01-preview
+                    ",
+                    "2421-07-07",
+                    [
+                        "2421-03-01-preview", // Most recent preview outside grace period (90 days)
+                        "2421-02-01-preview",
+                        "2421-01-01", // Stable version
+                    ],
+                    newVersionGracePeriodDays: 90);
+            }
+
+            [TestMethod]
+            public void GracePeriod_MostRecentVersionWithinGracePeriod_ReturnsNextMostRecent()
+            {
+                // If the most recent version is within grace period, should return the most recent version outside grace period
+                TestGetAcceptableApiVersions(
+                    "Fake.Kusto/clusters",
+                    ResourceScope.ResourceGroup,
+                    @"
+                        Fake.Kusto/clusters@2421-01-01
+                        Fake.Kusto/clusters@2421-04-01
+                        Fake.Kusto/clusters@2421-06-01
+                        Fake.Kusto/clusters@2421-06-15
+                        Fake.Kusto/clusters@2421-07-01
+                    ",
+                    "2421-07-07",
+                    [
+                        "2421-04-01", // Most recent stable outside grace period (90 days from 2421-07-07 = before 2421-04-09)
+                        "2421-01-01",
+                    ],
+                    newVersionGracePeriodDays: 90);
+            }
+
+            [TestMethod]
+            public void GracePeriod_WithMixedStableAndPreview()
+            {
+                // Verify grace period works correctly with mixed stable and preview versions
+                // Today is 2421-07-07, grace period is 90 days
+                // Grace period threshold: 2421-07-07 - 90 days = 2421-04-08
+                // Versions from 2421-04-09 onwards are filtered out
+                TestGetAcceptableApiVersions(
+                    "Fake.Kusto/clusters",
+                    ResourceScope.ResourceGroup,
+                    @"
+                        Fake.Kusto/clusters@2421-01-01
+                        Fake.Kusto/clusters@2421-02-01-preview
+                        Fake.Kusto/clusters@2421-03-01
+                        Fake.Kusto/clusters@2421-04-01-preview
+                        Fake.Kusto/clusters@2421-05-01
+                        Fake.Kusto/clusters@2421-06-01-preview
+                    ",
+                    "2421-07-07",
+                    [
+                        "2421-04-01-preview", // Preview after most recent stable outside grace period (2421-03-01)
+                        "2421-03-01", // Most recent stable outside grace period
+                        "2421-01-01", // Older stable
+                    ],
+                    newVersionGracePeriodDays: 90);
+            }
+
+            [TestMethod]
+            public void GracePeriod_AllVersionsWithinGracePeriod_FallsBackToMostRecent()
+            {
+                // Edge case: All API versions are very new (within 90 days)
+                // Should fall back to recommending the most recent versions despite being in grace period
+                // Today is 2421-07-07, grace period is 90 days
+                // All versions are from 2421-06-01 onwards (within last ~36 days)
+                TestGetAcceptableApiVersions(
+                    "Fake.Kusto/clusters",
+                    ResourceScope.ResourceGroup,
+                    @"
+                        Fake.Kusto/clusters@2421-06-01
+                        Fake.Kusto/clusters@2421-06-15
+                        Fake.Kusto/clusters@2421-07-01
+                    ",
+                    "2421-07-07",
+                    [
+                        "2421-07-01", // Should still recommend most recent as fallback
+                        "2421-06-15",
+                        "2421-06-01",
+                    ],
+                    newVersionGracePeriodDays: 90);
+            }
+
+            [TestMethod]
+            public void GracePeriod_AllVersionsWithinGracePeriod_MixedStableAndPreview_FallsBackCorrectly()
+            {
+                // Edge case with mixed stable and preview versions, all within grace period
+                // Today is 2421-07-07, grace period is 90 days (so versions after 2421-04-08 are filtered)
+                // Fallback logic applies: use all unfiltered versions
+                TestGetAcceptableApiVersions(
+                    "Fake.Kusto/clusters",
+                    ResourceScope.ResourceGroup,
+                    @"
+                        Fake.Kusto/clusters@2421-05-01
+                        Fake.Kusto/clusters@2421-06-01-preview
+                        Fake.Kusto/clusters@2421-06-15
+                        Fake.Kusto/clusters@2421-07-01-preview
+                    ",
+                    "2421-07-07",
+                    [
+                        "2421-07-01-preview", // Most recent preview (after most recent stable)
+                        "2421-06-15", // Most recent stable
+                        "2421-05-01", // Older stable
+                        // Note: 2421-06-01-preview is not included because it's not newer than the most recent stable (2421-06-15)
+                    ],
+                    newVersionGracePeriodDays: 90);
+            }
         }
 
         [TestClass]
@@ -821,7 +992,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             [DynamicData(nameof(GetTestData), DynamicDataSourceType.Method, DynamicDataDisplayNameDeclaringType = typeof(TestData), DynamicDataDisplayName = nameof(TestData.GetDisplayName))]
             public void InvariantsTest(TestData data)
             {
-                var (allVersions, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(RealApiVersionProvider, data.Today, data.MaxAgeInDays, data.ResourceScope, data.FullyQualifiedResourceType);
+                var (allVersions, allowedVersions) = UseRecentApiVersionRule.GetAcceptableApiVersions(RealApiVersionProvider, data.Today, data.MaxAgeInDays, UseRecentApiVersionRule.DefaultNewVersionGracePeriodDays, data.ResourceScope, data.FullyQualifiedResourceType);
 
                 allVersions.Should().NotBeNull();
                 allowedVersions.Should().NotBeNull();
@@ -924,6 +1095,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     apiVersionProvider,
                     GetToday(),
                     maxAllowedAgeInDays,
+                    UseRecentApiVersionRule.DefaultNewVersionGracePeriodDays,
                     new TextSpan(17, 47),
                     new TextSpan(17, 47),
                     ResourceScope.ResourceGroup,
@@ -1699,11 +1871,11 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     "2422-07-04",
                     [
                         "[7] Use more recent API version for 'fake.Resources/resourceGroups'. '2419-05-10' is 1151 days old, should be no more than 730 days old, or the most recent. Acceptable versions: 2421-05-01, 2421-04-01, 2421-01-01, 2420-10-01, 2420-08-01"
-                    ]);
-            }
+                                      ]);
+                             }
 
-            [TestMethod]
-            public void SubscriptionDeployment_Pass()
+                             [TestMethod]
+                             public void SubscriptionDeployment_Pass()
             {
                 CompileAndTestWithFakeDateAndTypes(@"
                         targetScope='subscription'

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
@@ -29,6 +29,10 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public const int DefaultMaxAgeInDays = 365 * 2;
         private const int MinimumValidMaxAgeInDays = 0; // Zero means all apiVersions must be the most recent possible
 
+        private const string NewVersionGracePeriodDaysKey = "newVersionGracePeriodDays";
+        public const int DefaultNewVersionGracePeriodDays = 90;
+        private const int MinimumValidNewVersionGracePeriodDays = 0;
+
         private static readonly Regex resourceTypeRegex = new(
             "^ [a-z]+\\.[a-z]+ (\\/ [a-z]+)+ $",
             RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
@@ -79,6 +83,18 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 maxAgeInDays = DefaultMaxAgeInDays;
             }
 
+            int newVersionGracePeriodDays = GetConfigurationValue(model.Configuration.Analyzers, NewVersionGracePeriodDaysKey, DefaultNewVersionGracePeriodDays);
+            if (newVersionGracePeriodDays < MinimumValidNewVersionGracePeriodDays)
+            {
+                yield return CreateDiagnosticForSpan(
+                    diagnosticLevel,
+                    new TextSpan(),
+                    $"{Code}: Configuration value for {NewVersionGracePeriodDaysKey} is not valid: {newVersionGracePeriodDays}",
+                    Array.Empty<AzureResourceApiVersion>());
+
+                newVersionGracePeriodDays = DefaultNewVersionGracePeriodDays;
+            }
+
             var today = DateOnly.FromDateTime(DateTime.Today);
             // Today's date can be changed to enable testing/debug scenarios
             if (GetConfigurationValue<string?>(model.Configuration.Analyzers, "test-today", null) is string testToday)
@@ -90,7 +106,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             foreach (var resource in model.DeclaredResources.Where(r => r.IsAzResource))
             {
-                if (AnalyzeResource(model, today, maxAgeInDays, resource.Symbol, warnIfNotFound: warnIfNotFound) is Failure failure)
+                if (AnalyzeResource(model, today, maxAgeInDays, newVersionGracePeriodDays, resource.Symbol, warnIfNotFound: warnIfNotFound) is Failure failure)
                 {
                     yield return CreateFixableDiagnosticForSpan(
                         diagnosticLevel,
@@ -103,7 +119,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             foreach (var callInfo in GetFunctionCallInfos(model))
             {
-                if (AnalyzeFunctionCall(model, today, maxAgeInDays, callInfo) is Failure failure)
+                if (AnalyzeFunctionCall(model, today, maxAgeInDays, newVersionGracePeriodDays, callInfo) is Failure failure)
                 {
                     yield return CreateFixableDiagnosticForSpan(
                         diagnosticLevel,
@@ -115,7 +131,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private static Failure? AnalyzeFunctionCall(SemanticModel model, DateOnly today, int maxAgeInDays, FunctionCallInfo functionCallInfo)
+        private static Failure? AnalyzeFunctionCall(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, FunctionCallInfo functionCallInfo)
         {
             if (functionCallInfo.ApiVersion.HasValue && functionCallInfo.ResourceType is not null)
             {
@@ -123,6 +139,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     model.ApiVersionProvider,
                     today,
                     maxAgeInDays,
+                    newVersionGracePeriodDays,
                     errorSpan: functionCallInfo.FunctionCallSyntax.Span,
                     replacementSpan: TextSpan.Nil,
                     model.TargetScope,
@@ -308,7 +325,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return mostRecentValid;
         }
 
-        private static Failure? AnalyzeResource(SemanticModel model, DateOnly today, int maxAgeInDays, ResourceSymbol resourceSymbol, bool warnIfNotFound)
+        private static Failure? AnalyzeResource(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, ResourceSymbol resourceSymbol, bool warnIfNotFound)
         {
             if (resourceSymbol.TryGetResourceTypeReference() is ResourceTypeReference resourceTypeReference &&
                 resourceTypeReference.ApiVersion is string apiVersionString &&
@@ -321,6 +338,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                         model.ApiVersionProvider,
                         today,
                         maxAgeInDays,
+                        newVersionGracePeriodDays,
                         replacementSpan,
                         replacementSpan,
                         model.TargetScope,
@@ -333,9 +351,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return null;
         }
 
-        public static Failure? AnalyzeApiVersion(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, TextSpan errorSpan, TextSpan replacementSpan, ResourceScope scope, string fullyQualifiedResourceType, AzureResourceApiVersion actualApiVersion, bool returnNotFoundDiagnostics)
+        public static Failure? AnalyzeApiVersion(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, TextSpan errorSpan, TextSpan replacementSpan, ResourceScope scope, string fullyQualifiedResourceType, AzureResourceApiVersion actualApiVersion, bool returnNotFoundDiagnostics)
         {
-            var (allApiVersions, acceptableApiVersions) = GetAcceptableApiVersions(apiVersionProvider, today, maxAgeInDays, scope, fullyQualifiedResourceType);
+            var (allApiVersions, acceptableApiVersions) = GetAcceptableApiVersions(apiVersionProvider, today, maxAgeInDays, newVersionGracePeriodDays, scope, fullyQualifiedResourceType);
             if (!allApiVersions.Any())
             {
                 // Resource type not recognized
@@ -414,7 +432,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 acceptableApiVersions);
         }
 
-        public static (AzureResourceApiVersion[] allApiVersions, AzureResourceApiVersion[] acceptableVersions) GetAcceptableApiVersions(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, ResourceScope scope, string fullyQualifiedResourceType)
+        public static (AzureResourceApiVersion[] allApiVersions, AzureResourceApiVersion[] acceptableVersions) GetAcceptableApiVersions(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, ResourceScope scope, string fullyQualifiedResourceType)
         {
             var allVersions = apiVersionProvider.GetApiVersions(scope, fullyQualifiedResourceType).ToArray();
             if (!allVersions.Any())
@@ -423,8 +441,20 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 return (allVersions, Array.Empty<AzureResourceApiVersion>());
             }
 
-            var stableVersionsSorted = FilterStable(allVersions).OrderBy(v => v.Date).ToArray();
-            var previewVersionsSorted = FilterPreview(allVersions).OrderBy(v => v.Date).ToArray();
+            // Filter out versions that are too new (within grace period)
+            var allVersionsExcludingGracePeriod = FilterExcludingGracePeriod(allVersions, today, newVersionGracePeriodDays).ToArray();
+
+            // Use filtered versions for the rest of the logic to avoid recommending versions within the grace period
+            var stableVersionsSorted = FilterStable(allVersionsExcludingGracePeriod).OrderBy(v => v.Date).ToArray();
+            var previewVersionsSorted = FilterPreview(allVersionsExcludingGracePeriod).OrderBy(v => v.Date).ToArray();
+
+            // If grace period filtering removed everything, fall back to using all versions
+            // (This is an edge case where the grace period is too aggressive)
+            if (!stableVersionsSorted.Any() && !previewVersionsSorted.Any())
+            {
+                stableVersionsSorted = FilterStable(allVersions).OrderBy(v => v.Date).ToArray();
+                previewVersionsSorted = FilterPreview(allVersions).OrderBy(v => v.Date).ToArray();
+            }
 
             var recentStableVersionsSorted = FilterRecent(stableVersionsSorted, today, maxAgeInDays).ToArray();
             var recentPreviewVersionsSorted = FilterRecent(previewVersionsSorted, today, maxAgeInDays).ToArray();
@@ -554,6 +584,17 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         private static bool IsMoreRecentThan(DateOnly date, DateOnly other)
         {
             return date.CompareTo(other) > 0;
+        }
+
+        private static IEnumerable<AzureResourceApiVersion> FilterExcludingGracePeriod(IEnumerable<AzureResourceApiVersion> apiVersions, DateOnly today, int newVersionGracePeriodDays)
+        {
+            if (newVersionGracePeriodDays == 0)
+            {
+                return apiVersions; // No grace period
+            }
+
+            var gracePeriodThreshold = today.AddDays(-newVersionGracePeriodDays);
+            return apiVersions.Where(v => v.Date <= gracePeriodThreshold);
         }
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
@@ -395,6 +395,14 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 return null;
             }
 
+            // Check if version is within grace period - if so, accept it without warning
+            // Grace period is for RECOMMENDATIONS (don't suggest it), not VALIDATION (it's still valid to use)
+            if (newVersionGracePeriodDays > 0 && IsWithinGracePeriod(actualApiVersion, today, newVersionGracePeriodDays))
+            {
+                // Version exists and is too new to recommend to others, but valid for current use - pass
+                return null;
+            }
+
             // At this point, the rule has failed. Just need to determine reason for failure, for the message.
             string? failureReason = null;
 
@@ -565,6 +573,18 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return apiVersion.Date >= today.AddDays(-maxAgeInDays);
         }
 
+        // Check if an API version is within the grace period (too new to recommend)
+        private static bool IsWithinGracePeriod(AzureResourceApiVersion apiVersion, DateOnly today, int gracePeriodDays)
+        {
+            if (gracePeriodDays == 0)
+            {
+                return false; // No grace period
+            }
+
+            var gracePeriodThreshold = today.AddDays(-gracePeriodDays);
+            return apiVersion.Date > gracePeriodThreshold;
+        }
+
         // Recent meaning < maxAgeInDays old
         private static IEnumerable<AzureResourceApiVersion> FilterRecent(IEnumerable<AzureResourceApiVersion> apiVersions, DateOnly today, int maxAgeInDays)
         {
@@ -593,8 +613,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 return apiVersions; // No grace period
             }
 
-            var gracePeriodThreshold = today.AddDays(-newVersionGracePeriodDays);
-            return apiVersions.Where(v => v.Date <= gracePeriodThreshold);
+            return apiVersions.Where(v => !IsWithinGracePeriod(v, today, newVersionGracePeriodDays));
         }
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
@@ -29,9 +29,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public const int DefaultMaxAgeInDays = 365 * 2;
         private const int MinimumValidMaxAgeInDays = 0; // Zero means all apiVersions must be the most recent possible
 
-        private const string NewVersionGracePeriodInDaysKey = "newVersionGracePeriodInDays";
-        public const int DefaultNewVersionGracePeriodInDays = 90;
-        private const int MinimumValidNewVersionGracePeriodInDays = 0;
+        private const string GracePeriodInDaysKey = "gracePeriodInDays";
+        public const int DefaultGracePeriodInDays = 90;
+        private const int MinimumValidGracePeriodInDays = 0;
 
         private static readonly Regex resourceTypeRegex = new(
             "^ [a-z]+\\.[a-z]+ (\\/ [a-z]+)+ $",
@@ -83,16 +83,16 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 maxAgeInDays = DefaultMaxAgeInDays;
             }
 
-            int newVersionGracePeriodInDays = GetConfigurationValue(model.Configuration.Analyzers, NewVersionGracePeriodInDaysKey, DefaultNewVersionGracePeriodInDays);
-            if (newVersionGracePeriodInDays < MinimumValidNewVersionGracePeriodInDays)
+            int gracePeriodInDays = GetConfigurationValue(model.Configuration.Analyzers, GracePeriodInDaysKey, DefaultGracePeriodInDays);
+            if (gracePeriodInDays < MinimumValidGracePeriodInDays)
             {
                 yield return CreateDiagnosticForSpan(
                     diagnosticLevel,
                     new TextSpan(),
-                    $"{Code}: Configuration value for {NewVersionGracePeriodInDaysKey} is not valid: {newVersionGracePeriodInDays}",
+                    $"{Code}: Configuration value for {GracePeriodInDaysKey} is not valid: {gracePeriodInDays}",
                     Array.Empty<AzureResourceApiVersion>());
 
-                newVersionGracePeriodInDays = DefaultNewVersionGracePeriodInDays;
+                gracePeriodInDays = DefaultGracePeriodInDays;
             }
 
             var today = DateOnly.FromDateTime(DateTime.Today);
@@ -106,7 +106,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             foreach (var resource in model.DeclaredResources.Where(r => r.IsAzResource))
             {
-                if (AnalyzeResource(model, today, maxAgeInDays, newVersionGracePeriodInDays, resource.Symbol, warnIfNotFound: warnIfNotFound) is Failure failure)
+                if (AnalyzeResource(model, today, maxAgeInDays, gracePeriodInDays, resource.Symbol, warnIfNotFound: warnIfNotFound) is Failure failure)
                 {
                     yield return CreateFixableDiagnosticForSpan(
                         diagnosticLevel,
@@ -119,7 +119,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             foreach (var callInfo in GetFunctionCallInfos(model))
             {
-                if (AnalyzeFunctionCall(model, today, maxAgeInDays, newVersionGracePeriodInDays, callInfo) is Failure failure)
+                if (AnalyzeFunctionCall(model, today, maxAgeInDays, gracePeriodInDays, callInfo) is Failure failure)
                 {
                     yield return CreateFixableDiagnosticForSpan(
                         diagnosticLevel,
@@ -131,7 +131,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private static Failure? AnalyzeFunctionCall(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, FunctionCallInfo functionCallInfo)
+        private static Failure? AnalyzeFunctionCall(SemanticModel model, DateOnly today, int maxAgeInDays, int gracePeriodInDays, FunctionCallInfo functionCallInfo)
         {
             if (functionCallInfo.ApiVersion.HasValue && functionCallInfo.ResourceType is not null)
             {
@@ -139,7 +139,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     model.ApiVersionProvider,
                     today,
                     maxAgeInDays,
-                    newVersionGracePeriodInDays,
+                    gracePeriodInDays,
                     errorSpan: functionCallInfo.FunctionCallSyntax.Span,
                     replacementSpan: TextSpan.Nil,
                     model.TargetScope,
@@ -325,7 +325,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return mostRecentValid;
         }
 
-        private static Failure? AnalyzeResource(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, ResourceSymbol resourceSymbol, bool warnIfNotFound)
+        private static Failure? AnalyzeResource(SemanticModel model, DateOnly today, int maxAgeInDays, int gracePeriodInDays, ResourceSymbol resourceSymbol, bool warnIfNotFound)
         {
             if (resourceSymbol.TryGetResourceTypeReference() is ResourceTypeReference resourceTypeReference &&
                 resourceTypeReference.ApiVersion is string apiVersionString &&
@@ -338,7 +338,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                         model.ApiVersionProvider,
                         today,
                         maxAgeInDays,
-                        newVersionGracePeriodInDays,
+                        gracePeriodInDays,
                         replacementSpan,
                         replacementSpan,
                         model.TargetScope,
@@ -351,9 +351,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return null;
         }
 
-        public static Failure? AnalyzeApiVersion(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, TextSpan errorSpan, TextSpan replacementSpan, ResourceScope scope, string fullyQualifiedResourceType, AzureResourceApiVersion actualApiVersion, bool returnNotFoundDiagnostics)
+        public static Failure? AnalyzeApiVersion(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int gracePeriodInDays, TextSpan errorSpan, TextSpan replacementSpan, ResourceScope scope, string fullyQualifiedResourceType, AzureResourceApiVersion actualApiVersion, bool returnNotFoundDiagnostics)
         {
-            var (allApiVersions, acceptableApiVersions) = GetAcceptableApiVersions(apiVersionProvider, today, maxAgeInDays, newVersionGracePeriodInDays, scope, fullyQualifiedResourceType);
+            var (allApiVersions, acceptableApiVersions) = GetAcceptableApiVersions(apiVersionProvider, today, maxAgeInDays, gracePeriodInDays, scope, fullyQualifiedResourceType);
             if (!allApiVersions.Any())
             {
                 // Resource type not recognized
@@ -397,7 +397,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             // Check if version is within grace period - if so, accept it without warning
             // Grace period is for RECOMMENDATIONS (don't suggest it), not VALIDATION (it's still valid to use)
-            if (newVersionGracePeriodInDays > 0 && IsWithinGracePeriod(actualApiVersion, today, newVersionGracePeriodInDays))
+            if (gracePeriodInDays > 0 && IsWithinGracePeriod(actualApiVersion, today, gracePeriodInDays))
             {
                 // Version exists and is too new to recommend to others, but valid for current use - pass
                 return null;
@@ -440,7 +440,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 acceptableApiVersions);
         }
 
-        public static (AzureResourceApiVersion[] allApiVersions, AzureResourceApiVersion[] acceptableVersions) GetAcceptableApiVersions(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, ResourceScope scope, string fullyQualifiedResourceType)
+        public static (AzureResourceApiVersion[] allApiVersions, AzureResourceApiVersion[] acceptableVersions) GetAcceptableApiVersions(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int gracePeriodInDays, ResourceScope scope, string fullyQualifiedResourceType)
         {
             var allVersions = apiVersionProvider.GetApiVersions(scope, fullyQualifiedResourceType).ToArray();
             if (!allVersions.Any())
@@ -450,49 +450,49 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
 
             // Filter out versions that are too new (within grace period)
-            var allVersionsExcludingGracePeriod = FilterExcludingGracePeriod(allVersions, today, newVersionGracePeriodInDays).ToArray();
+            var allVersionsExcludingGracePeriod = FilterExcludingGracePeriod(allVersions, today, gracePeriodInDays).ToArray();
 
             // Use filtered versions for the rest of the logic to avoid recommending versions within the grace period
-            var stableVersionsSorted = FilterStable(allVersionsExcludingGracePeriod).OrderBy(v => v.Date).ToArray();
-            var previewVersionsSorted = FilterPreview(allVersionsExcludingGracePeriod).OrderBy(v => v.Date).ToArray();
+            var stableVersions = FilterStable(allVersionsExcludingGracePeriod).ToArray();
+            var previewVersions = FilterPreview(allVersionsExcludingGracePeriod).ToArray();
 
             // If grace period filtering removed everything, fall back to using all versions
             // (This is an edge case where the grace period is too aggressive)
-            if (!stableVersionsSorted.Any() && !previewVersionsSorted.Any())
+            if (!stableVersions.Any() && !previewVersions.Any())
             {
-                stableVersionsSorted = FilterStable(allVersions).OrderBy(v => v.Date).ToArray();
-                previewVersionsSorted = FilterPreview(allVersions).OrderBy(v => v.Date).ToArray();
+                stableVersions = FilterStable(allVersions).ToArray();
+                previewVersions = FilterPreview(allVersions).ToArray();
             }
 
-            var recentStableVersionsSorted = FilterRecent(stableVersionsSorted, today, maxAgeInDays).ToArray();
-            var recentPreviewVersionsSorted = FilterRecent(previewVersionsSorted, today, maxAgeInDays).ToArray();
+            var recentStableVersions = FilterRecent(stableVersions, today, maxAgeInDays).ToArray();
+            var recentPreviewVersions = FilterRecent(previewVersions, today, maxAgeInDays).ToArray();
 
             // Start with all recent stable versions
-            List<AzureResourceApiVersion> acceptableVersions = [.. recentStableVersionsSorted];
+            List<AzureResourceApiVersion> acceptableVersions = [.. recentStableVersions];
 
             // If no recent stable versions, add the most recent stable version, if any
             if (!acceptableVersions.Any())
             {
-                acceptableVersions.AddRange(FilterMostRecentApiVersion(stableVersionsSorted));
+                acceptableVersions.AddRange(FilterMostRecentApiVersion(stableVersions));
             }
 
             // Add any recent (not old) preview versions that are newer than the newest stable version
-            var mostRecentStableDate = GetNewestDateOrNull(stableVersionsSorted);
+            var mostRecentStableDate = GetNewestDateOrNull(stableVersions);
             if (mostRecentStableDate != null)
             {
-                Debug.Assert(stableVersionsSorted.Any(), "There should have been at least one stable version since mostRecentStableDate != null");
-                var previewsNewerThanMostRecentStable = recentPreviewVersionsSorted.Where(v => IsMoreRecentThan(v.Date, mostRecentStableDate.Value));
+                Debug.Assert(stableVersions.Any(), "There should have been at least one stable version since mostRecentStableDate != null");
+                var previewsNewerThanMostRecentStable = recentPreviewVersions.Where(v => IsMoreRecentThan(v.Date, mostRecentStableDate.Value));
                 acceptableVersions.AddRange(previewsNewerThanMostRecentStable);
             }
             else
             {
                 // There are no stable versions available at all - add all preview versions that are recent enough
-                acceptableVersions.AddRange(recentPreviewVersionsSorted);
+                acceptableVersions.AddRange(recentPreviewVersions);
 
                 // If there are no recent preview versions, add the newest preview only
                 if (!acceptableVersions.Any())
                 {
-                    acceptableVersions.AddRange(FilterMostRecentApiVersion(previewVersionsSorted));
+                    acceptableVersions.AddRange(FilterMostRecentApiVersion(previewVersions));
                     Debug.Assert(acceptableVersions.Any(), "There should have been at least one preview version available to add");
                 }
             }
@@ -606,14 +606,14 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return date.CompareTo(other) > 0;
         }
 
-        private static IEnumerable<AzureResourceApiVersion> FilterExcludingGracePeriod(IEnumerable<AzureResourceApiVersion> apiVersions, DateOnly today, int newVersionGracePeriodInDays)
+        private static IEnumerable<AzureResourceApiVersion> FilterExcludingGracePeriod(IEnumerable<AzureResourceApiVersion> apiVersions, DateOnly today, int gracePeriodInDays)
         {
-            if (newVersionGracePeriodInDays == 0)
+            if (gracePeriodInDays == 0)
             {
                 return apiVersions; // No grace period
             }
 
-            return apiVersions.Where(v => !IsWithinGracePeriod(v, today, newVersionGracePeriodInDays));
+            return apiVersions.Where(v => !IsWithinGracePeriod(v, today, gracePeriodInDays));
         }
     }
 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
@@ -29,9 +29,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         public const int DefaultMaxAgeInDays = 365 * 2;
         private const int MinimumValidMaxAgeInDays = 0; // Zero means all apiVersions must be the most recent possible
 
-        private const string NewVersionGracePeriodDaysKey = "newVersionGracePeriodDays";
-        public const int DefaultNewVersionGracePeriodDays = 90;
-        private const int MinimumValidNewVersionGracePeriodDays = 0;
+        private const string NewVersionGracePeriodInDaysKey = "newVersionGracePeriodInDays";
+        public const int DefaultNewVersionGracePeriodInDays = 90;
+        private const int MinimumValidNewVersionGracePeriodInDays = 0;
 
         private static readonly Regex resourceTypeRegex = new(
             "^ [a-z]+\\.[a-z]+ (\\/ [a-z]+)+ $",
@@ -83,16 +83,16 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 maxAgeInDays = DefaultMaxAgeInDays;
             }
 
-            int newVersionGracePeriodDays = GetConfigurationValue(model.Configuration.Analyzers, NewVersionGracePeriodDaysKey, DefaultNewVersionGracePeriodDays);
-            if (newVersionGracePeriodDays < MinimumValidNewVersionGracePeriodDays)
+            int newVersionGracePeriodInDays = GetConfigurationValue(model.Configuration.Analyzers, NewVersionGracePeriodInDaysKey, DefaultNewVersionGracePeriodInDays);
+            if (newVersionGracePeriodInDays < MinimumValidNewVersionGracePeriodInDays)
             {
                 yield return CreateDiagnosticForSpan(
                     diagnosticLevel,
                     new TextSpan(),
-                    $"{Code}: Configuration value for {NewVersionGracePeriodDaysKey} is not valid: {newVersionGracePeriodDays}",
+                    $"{Code}: Configuration value for {NewVersionGracePeriodInDaysKey} is not valid: {newVersionGracePeriodInDays}",
                     Array.Empty<AzureResourceApiVersion>());
 
-                newVersionGracePeriodDays = DefaultNewVersionGracePeriodDays;
+                newVersionGracePeriodInDays = DefaultNewVersionGracePeriodInDays;
             }
 
             var today = DateOnly.FromDateTime(DateTime.Today);
@@ -106,7 +106,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             foreach (var resource in model.DeclaredResources.Where(r => r.IsAzResource))
             {
-                if (AnalyzeResource(model, today, maxAgeInDays, newVersionGracePeriodDays, resource.Symbol, warnIfNotFound: warnIfNotFound) is Failure failure)
+                if (AnalyzeResource(model, today, maxAgeInDays, newVersionGracePeriodInDays, resource.Symbol, warnIfNotFound: warnIfNotFound) is Failure failure)
                 {
                     yield return CreateFixableDiagnosticForSpan(
                         diagnosticLevel,
@@ -119,7 +119,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             foreach (var callInfo in GetFunctionCallInfos(model))
             {
-                if (AnalyzeFunctionCall(model, today, maxAgeInDays, newVersionGracePeriodDays, callInfo) is Failure failure)
+                if (AnalyzeFunctionCall(model, today, maxAgeInDays, newVersionGracePeriodInDays, callInfo) is Failure failure)
                 {
                     yield return CreateFixableDiagnosticForSpan(
                         diagnosticLevel,
@@ -131,7 +131,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
         }
 
-        private static Failure? AnalyzeFunctionCall(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, FunctionCallInfo functionCallInfo)
+        private static Failure? AnalyzeFunctionCall(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, FunctionCallInfo functionCallInfo)
         {
             if (functionCallInfo.ApiVersion.HasValue && functionCallInfo.ResourceType is not null)
             {
@@ -139,7 +139,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                     model.ApiVersionProvider,
                     today,
                     maxAgeInDays,
-                    newVersionGracePeriodDays,
+                    newVersionGracePeriodInDays,
                     errorSpan: functionCallInfo.FunctionCallSyntax.Span,
                     replacementSpan: TextSpan.Nil,
                     model.TargetScope,
@@ -325,7 +325,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return mostRecentValid;
         }
 
-        private static Failure? AnalyzeResource(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, ResourceSymbol resourceSymbol, bool warnIfNotFound)
+        private static Failure? AnalyzeResource(SemanticModel model, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, ResourceSymbol resourceSymbol, bool warnIfNotFound)
         {
             if (resourceSymbol.TryGetResourceTypeReference() is ResourceTypeReference resourceTypeReference &&
                 resourceTypeReference.ApiVersion is string apiVersionString &&
@@ -338,7 +338,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                         model.ApiVersionProvider,
                         today,
                         maxAgeInDays,
-                        newVersionGracePeriodDays,
+                        newVersionGracePeriodInDays,
                         replacementSpan,
                         replacementSpan,
                         model.TargetScope,
@@ -351,9 +351,9 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return null;
         }
 
-        public static Failure? AnalyzeApiVersion(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, TextSpan errorSpan, TextSpan replacementSpan, ResourceScope scope, string fullyQualifiedResourceType, AzureResourceApiVersion actualApiVersion, bool returnNotFoundDiagnostics)
+        public static Failure? AnalyzeApiVersion(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, TextSpan errorSpan, TextSpan replacementSpan, ResourceScope scope, string fullyQualifiedResourceType, AzureResourceApiVersion actualApiVersion, bool returnNotFoundDiagnostics)
         {
-            var (allApiVersions, acceptableApiVersions) = GetAcceptableApiVersions(apiVersionProvider, today, maxAgeInDays, newVersionGracePeriodDays, scope, fullyQualifiedResourceType);
+            var (allApiVersions, acceptableApiVersions) = GetAcceptableApiVersions(apiVersionProvider, today, maxAgeInDays, newVersionGracePeriodInDays, scope, fullyQualifiedResourceType);
             if (!allApiVersions.Any())
             {
                 // Resource type not recognized
@@ -397,7 +397,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
 
             // Check if version is within grace period - if so, accept it without warning
             // Grace period is for RECOMMENDATIONS (don't suggest it), not VALIDATION (it's still valid to use)
-            if (newVersionGracePeriodDays > 0 && IsWithinGracePeriod(actualApiVersion, today, newVersionGracePeriodDays))
+            if (newVersionGracePeriodInDays > 0 && IsWithinGracePeriod(actualApiVersion, today, newVersionGracePeriodInDays))
             {
                 // Version exists and is too new to recommend to others, but valid for current use - pass
                 return null;
@@ -440,7 +440,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 acceptableApiVersions);
         }
 
-        public static (AzureResourceApiVersion[] allApiVersions, AzureResourceApiVersion[] acceptableVersions) GetAcceptableApiVersions(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodDays, ResourceScope scope, string fullyQualifiedResourceType)
+        public static (AzureResourceApiVersion[] allApiVersions, AzureResourceApiVersion[] acceptableVersions) GetAcceptableApiVersions(IApiVersionProvider apiVersionProvider, DateOnly today, int maxAgeInDays, int newVersionGracePeriodInDays, ResourceScope scope, string fullyQualifiedResourceType)
         {
             var allVersions = apiVersionProvider.GetApiVersions(scope, fullyQualifiedResourceType).ToArray();
             if (!allVersions.Any())
@@ -450,7 +450,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             }
 
             // Filter out versions that are too new (within grace period)
-            var allVersionsExcludingGracePeriod = FilterExcludingGracePeriod(allVersions, today, newVersionGracePeriodDays).ToArray();
+            var allVersionsExcludingGracePeriod = FilterExcludingGracePeriod(allVersions, today, newVersionGracePeriodInDays).ToArray();
 
             // Use filtered versions for the rest of the logic to avoid recommending versions within the grace period
             var stableVersionsSorted = FilterStable(allVersionsExcludingGracePeriod).OrderBy(v => v.Date).ToArray();
@@ -606,14 +606,14 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             return date.CompareTo(other) > 0;
         }
 
-        private static IEnumerable<AzureResourceApiVersion> FilterExcludingGracePeriod(IEnumerable<AzureResourceApiVersion> apiVersions, DateOnly today, int newVersionGracePeriodDays)
+        private static IEnumerable<AzureResourceApiVersion> FilterExcludingGracePeriod(IEnumerable<AzureResourceApiVersion> apiVersions, DateOnly today, int newVersionGracePeriodInDays)
         {
-            if (newVersionGracePeriodDays == 0)
+            if (newVersionGracePeriodInDays == 0)
             {
                 return apiVersions; // No grace period
             }
 
-            return apiVersions.Where(v => !IsWithinGracePeriod(v, today, newVersionGracePeriodDays));
+            return apiVersions.Where(v => !IsWithinGracePeriod(v, today, newVersionGracePeriodInDays));
         }
     }
 }

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -722,6 +722,12 @@
                           "type": "integer",
                           "default": 730,
                           "minimum": 0
+                        },
+                        "newVersionGracePeriodDays": {
+                          "description": "Number of days to wait after an API version is published before recommending it, to allow time for regional deployment (default is 90 days)",
+                          "type": "integer",
+                          "default": 90,
+                          "minimum": 0
                         }
                       }
                     },

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -723,7 +723,7 @@
                           "default": 730,
                           "minimum": 0
                         },
-                        "newVersionGracePeriodInDays": {
+                        "gracePeriodInDays": {
                           "description": "Number of days to wait after an API version is published before recommending it, to allow time for regional deployment (default is 90 days)",
                           "type": "integer",
                           "default": 90,

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -723,7 +723,7 @@
                           "default": 730,
                           "minimum": 0
                         },
-                        "newVersionGracePeriodDays": {
+                        "newVersionGracePeriodInDays": {
                           "description": "Number of days to wait after an API version is published before recommending it, to allow time for regional deployment (default is 90 days)",
                           "type": "integer",
                           "default": 90,


### PR DESCRIPTION
## Description

This PR is to add a grace period of 90 days to delay recommending the latest API version to users from Swagger. This is added to give RP team to finish deploying the new API version to all ARM regions.

Previously customer took the recommended latest API version but faced deployment failure because RP's latest API version wasn't deployed to all ARM regions.

This only affects the recommended API version. It's still allowed if customer keeps using the API version in grace period.

## Example Usage

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19205)