### PR TITLE
Enhance error messages for ArgumentException

### DIFF
--- a/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeFactory.cs
@@ -104,7 +104,7 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
             {
                 if (value.Type.Type is not Azure.Bicep.Types.Concrete.FunctionType functionType)
                 {
-                    throw new ArgumentException();
+                    throw new ArgumentException($"Expected a FunctionType for function '{key}', but got '{value.Type.Type?.GetType().Name}'.");
                 }
 
                 var builder = new FunctionOverloadBuilder(key);
@@ -234,7 +234,7 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.Array => LanguageConstants.Array,
                         Azure.Bicep.Types.Concrete.BuiltInTypeKind.ResourceRef => LanguageConstants.ResourceRef,
 #pragma warning restore 618
-                        _ => throw new ArgumentException(),
+                        _ => throw new ArgumentException($"Unhandled BuiltInTypeKind '{builtInType.Kind}'."),
                     };
                 case Azure.Bicep.Types.Concrete.ObjectType objectType:
                     {
@@ -260,7 +260,7 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
                         return new DiscriminatedObjectType(discriminatedObjectType.Name, GetValidationFlags(isResourceBodyType, isSensitive: false), discriminatedObjectType.Discriminator, elementReferences);
                     }
                 default:
-                    throw new ArgumentException();
+                    throw new ArgumentException($"Unsupported type: {typeBase.GetType().FullName}");
             }
         }
 
@@ -268,7 +268,7 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
         {
             if (!(extendedType.Type is Azure.Bicep.Types.Concrete.ObjectType objectType))
             {
-                throw new ArgumentException();
+                throw new ArgumentException($"Expected an ObjectType for the extended type in '{name}', but got '{extendedType.Type?.GetType().Name}'.");
             }
 
             var additionalProperties = objectType.AdditionalProperties != null ? GetTypeReference(objectType.AdditionalProperties, isResourceBodyType) : null;


### PR DESCRIPTION
Our current stack trace is not very helpful for debugging issues:

```
  Message: Internal Error - System.ArgumentException: Value does not fall within the expected range.
   at Bicep.Core.TypeSystem.Providers.Extensibility.ExtensionResourceTypeFactory.ToTypeSymbol(TypeBase typeBase, Boolean isResourceBodyType) in C:\__w\1\s\bicep\src\Bicep.Core\TypeSystem\Providers\Extensibility\ExtensionResourceTypeFactory.cs:line 263
   at Bicep.Core.TypeSystem.Providers.Extensibility.ExtensionResourceTypeFactory.<>c__DisplayClass7_0.<GetTypeSymbol>b__0(TypeBase serializedType) in C:\__w\1\s\bicep\src\Bicep.Core\TypeSystem\Providers\Extensibility\ExtensionResourceTypeFactory.cs:line 132
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at Bicep.Core.TypeSystem.Providers.Extensibility.ExtensionResourceTypeFactory.GetTypeSymbol(TypeBase serializedType, Boolean isResourceBodyType) in C:\__w\1\s\bicep\src\Bicep.Core\TypeSystem\Providers\Extensibility\ExtensionResourceTypeFactory.cs:line 132
   at Bicep.Core.TypeSystem.Providers.Extensibility.ExtensionResourceTypeFactory.<>c__DisplayClass8_0.<GetTypeReference>b__0() in 
...
```