### PR TITLE
Dont crash on error symbol external input parameters

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -379,6 +379,7 @@ import { foo } from 'main.bicep' // foo doesn't exist in main.bicep
 param bar = '${foo}-${externalInput('test')}'
 var baz = foo('test')
 param qux = externalInput('kind', baz)
+param bar2 = externalInput('kind', foo)
 "));
 
         result.Should().HaveDiagnostics(
@@ -386,8 +387,8 @@ param qux = externalInput('kind', baz)
                 ("BCP360", DiagnosticLevel.Error, "The 'foo' symbol was not found in (or was not exported by) the imported template."),
                 ("BCP063", DiagnosticLevel.Error, "The name \"foo\" is not a parameter, variable, resource or module."),
                 ("BCP059", DiagnosticLevel.Error, "The name \"foo\" is not a function."),
-                ("BCP338", DiagnosticLevel.Error, "Failed to evaluate function \"externalInput('kind', baz)\": Failed to evaluate variable \"baz\": The template function 'foo' is not valid. Please see https://aka.ms/arm-functions for usage details."),
                 ("BCP062", DiagnosticLevel.Error, "The referenced declaration with name \"baz\" is not valid."),
+                ("BCP063", DiagnosticLevel.Error, "The name \"foo\" is not a parameter, variable, resource or module."),
             ]);
 
     }

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.bicepparam
@@ -4,6 +4,8 @@ import { exportedVariable, helperFunction } from 'main.bicep'
 
 param p12 = '${exportedVariable}-${externalInput('custom', helperFunction())}'
 
+param p13 = '${exportedVariable}-${externalInput('custom', exportedVariable)}'
+
 var myVar = 1 + 2
 param p = externalInput('sys.envVar', myVar)
 

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.diagnostics.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.diagnostics.bicepparam
@@ -8,6 +8,10 @@ param p12 = '${exportedVariable}-${externalInput('custom', helperFunction())}'
 //@[15:31) [BCP063 (Error)] The name "exportedVariable" is not a parameter, variable, resource or module. (bicep https://aka.ms/bicep/core-diagnostics#BCP063) |exportedVariable|
 //@[59:73) [BCP059 (Error)] The name "helperFunction" is not a function. (bicep https://aka.ms/bicep/core-diagnostics#BCP059) |helperFunction|
 
+param p13 = '${exportedVariable}-${externalInput('custom', exportedVariable)}'
+//@[15:31) [BCP063 (Error)] The name "exportedVariable" is not a parameter, variable, resource or module. (bicep https://aka.ms/bicep/core-diagnostics#BCP063) |exportedVariable|
+//@[59:75) [BCP063 (Error)] The name "exportedVariable" is not a parameter, variable, resource or module. (bicep https://aka.ms/bicep/core-diagnostics#BCP063) |exportedVariable|
+
 var myVar = 1 + 2
 param p = externalInput('sys.envVar', myVar)
 //@[38:43) [BCP032 (Error)] The value must be a compile-time constant. (bicep https://aka.ms/bicep/core-diagnostics#BCP032) |myVar|

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.formatted.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.formatted.bicepparam
@@ -4,6 +4,8 @@ import { exportedVariable, helperFunction } from 'main.bicep'
 
 param p12 = '${exportedVariable}-${externalInput('custom', helperFunction())}'
 
+param p13 = '${exportedVariable}-${externalInput('custom', exportedVariable)}'
+
 var myVar = 1 + 2
 param p = externalInput('sys.envVar', myVar)
 

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.symbols.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.symbols.bicepparam
@@ -7,6 +7,9 @@ import { exportedVariable, helperFunction } from 'main.bicep'
 param p12 = '${exportedVariable}-${externalInput('custom', helperFunction())}'
 //@[06:09) ParameterAssignment p12. Type: error. Declaration start char: 0, length: 78
 
+param p13 = '${exportedVariable}-${externalInput('custom', exportedVariable)}'
+//@[06:09) ParameterAssignment p13. Type: error. Declaration start char: 0, length: 78
+
 var myVar = 1 + 2
 //@[04:09) Variable myVar. Type: 3. Declaration start char: 0, length: 17
 param p = externalInput('sys.envVar', myVar)

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.syntax.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.syntax.bicepparam
@@ -1,5 +1,5 @@
 using none
-//@[00:838) ProgramSyntax
+//@[00:920) ProgramSyntax
 //@[00:010) ├─UsingDeclarationSyntax
 //@[00:005) | ├─Token(Identifier) |using|
 //@[06:010) | ├─NoneLiteralSyntax
@@ -52,6 +52,34 @@ param p12 = '${exportedVariable}-${externalInput('custom', helperFunction())}'
 //@[59:073) |   | |   | └─Token(Identifier) |helperFunction|
 //@[73:074) |   | |   ├─Token(LeftParen) |(|
 //@[74:075) |   | |   └─Token(RightParen) |)|
+//@[75:076) |   | └─Token(RightParen) |)|
+//@[76:078) |   └─Token(StringRightPiece) |}'|
+//@[78:082) ├─Token(NewLine) |\r\n\r\n|
+
+param p13 = '${exportedVariable}-${externalInput('custom', exportedVariable)}'
+//@[00:078) ├─ParameterAssignmentSyntax
+//@[00:005) | ├─Token(Identifier) |param|
+//@[06:009) | ├─IdentifierSyntax
+//@[06:009) | | └─Token(Identifier) |p13|
+//@[10:011) | ├─Token(Assignment) |=|
+//@[12:078) | └─StringSyntax
+//@[12:015) |   ├─Token(StringLeftPiece) |'${|
+//@[15:031) |   ├─VariableAccessSyntax
+//@[15:031) |   | └─IdentifierSyntax
+//@[15:031) |   |   └─Token(Identifier) |exportedVariable|
+//@[31:035) |   ├─Token(StringMiddlePiece) |}-${|
+//@[35:076) |   ├─FunctionCallSyntax
+//@[35:048) |   | ├─IdentifierSyntax
+//@[35:048) |   | | └─Token(Identifier) |externalInput|
+//@[48:049) |   | ├─Token(LeftParen) |(|
+//@[49:057) |   | ├─FunctionArgumentSyntax
+//@[49:057) |   | | └─StringSyntax
+//@[49:057) |   | |   └─Token(StringComplete) |'custom'|
+//@[57:058) |   | ├─Token(Comma) |,|
+//@[59:075) |   | ├─FunctionArgumentSyntax
+//@[59:075) |   | | └─VariableAccessSyntax
+//@[59:075) |   | |   └─IdentifierSyntax
+//@[59:075) |   | |     └─Token(Identifier) |exportedVariable|
 //@[75:076) |   | └─Token(RightParen) |)|
 //@[76:078) |   └─Token(StringRightPiece) |}'|
 //@[78:082) ├─Token(NewLine) |\r\n\r\n|

--- a/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.tokens.bicepparam
+++ b/src/Bicep.Core.Samples/Files/baselines_bicepparam/Invalid_ExternalInputs/parameters.tokens.bicepparam
@@ -32,6 +32,22 @@ param p12 = '${exportedVariable}-${externalInput('custom', helperFunction())}'
 //@[76:78) StringRightPiece |}'|
 //@[78:82) NewLine |\r\n\r\n|
 
+param p13 = '${exportedVariable}-${externalInput('custom', exportedVariable)}'
+//@[00:05) Identifier |param|
+//@[06:09) Identifier |p13|
+//@[10:11) Assignment |=|
+//@[12:15) StringLeftPiece |'${|
+//@[15:31) Identifier |exportedVariable|
+//@[31:35) StringMiddlePiece |}-${|
+//@[35:48) Identifier |externalInput|
+//@[48:49) LeftParen |(|
+//@[49:57) StringComplete |'custom'|
+//@[57:58) Comma |,|
+//@[59:75) Identifier |exportedVariable|
+//@[75:76) RightParen |)|
+//@[76:78) StringRightPiece |}'|
+//@[78:82) NewLine |\r\n\r\n|
+
 var myVar = 1 + 2
 //@[00:03) Identifier |var|
 //@[04:09) Identifier |myVar|

--- a/src/Bicep.Core/Emit/ExternalInputFunctionReferenceVisitor.cs
+++ b/src/Bicep.Core/Emit/ExternalInputFunctionReferenceVisitor.cs
@@ -102,6 +102,11 @@ public sealed partial class ExternalInputFunctionReferenceVisitor : AstVisitor
             return;
         }
 
+        if (functionCallSyntax.Arguments.Any(arg => semanticModel.GetTypeInfo(arg.Expression).IsError()))
+        {
+            return;
+        }
+
         try
         {
             var intermediate = expressionConverter.ConvertToIntermediateExpression(functionCallSyntax);

--- a/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
+++ b/src/Bicep.Core/Emit/ParameterAssignmentEvaluator.cs
@@ -506,14 +506,14 @@ public class ParameterAssignmentEvaluator
 
     public ImmutableArray<ExternalInputDefinition>? TryGetExternalInputDefinitions()
     {
-        var externalInputInfo = semanticModel.ExternalInputReferences.InfoBySerializedExpression;
-        if (externalInputInfo.Count == 0)
-        {
-            return null;
-        }
-
         try
         {
+            var externalInputInfo = semanticModel.ExternalInputReferences.InfoBySerializedExpression;
+            if (externalInputInfo.Count == 0)
+            {
+                return null;
+            }
+
             var context = GetExpressionEvaluationContext();
             var resultBuilder = ImmutableArray.CreateBuilder<ExternalInputDefinition>();
 


### PR DESCRIPTION
## Description

If any external input functions arguments are error symbols, bail from external input analysis.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19263)