### PR TITLE
Fix export toolbar overlapping control bar on narrow windows

### DIFF
--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportOverlay.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportOverlay.tsx
@@ -10,9 +10,17 @@ import { ExportToolbar } from "./ExportToolbar";
 const $OverlayContainer = styled.div`
   position: absolute;
   top: 16px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 16px;
+  right: 60px;
+  display: flex;
+  justify-content: flex-end;
+  overflow: hidden;
   z-index: 200;
+  pointer-events: none;
+
+  > * {
+    pointer-events: auto;
+  }
 `;
 
 /**

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportToolbar.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportToolbar.tsx
@@ -30,12 +30,13 @@ const $Toolbar = styled.div`
   align-items: center;
   gap: 6px;
   padding: 6px 8px;
+  flex-shrink: 0;
+  margin: 0 auto;
   background-color: ${({ theme }) => theme.controlBar.background};
   border: 1px solid ${({ theme }) => theme.controlBar.border};
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   backdrop-filter: blur(8px);
-  white-space: nowrap;
 `;
 
 /** Logical group of related controls. */

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -362,6 +362,12 @@
           "group": "navigation"
         },
         {
+          "command": "bicep.showVisualDesignerToSide",
+          "when": "editorLangId == bicep",
+          "alt": "bicep.showVisualDesigner",
+          "group": "navigation"
+        },
+        {
           "command": "bicep.showSourceFromVisualizer",
           "when": "bicepVisualizerFocus",
           "group": "navigation"


### PR DESCRIPTION
## Problem

The image export toolbar and the graph control bar overlap when the window width is too narrow. Both are absolutely positioned at `top: 16px` — the export overlay is centered (`left: 50%; transform: translateX(-50%)`) while the control bar is pinned top-right (`right: 16px`). On narrow viewports the wide export toolbar extends into the control bar area.

## Fix

- **ExportOverlay**: Replace center-transform positioning with `left: 16px; right: 60px` to create a safe zone that reserves space for the control bar. Use `display: flex; justify-content: flex-end; overflow: hidden` so the toolbar clips from the left when space is tight.
- **ExportToolbar**: Add `flex-shrink: 0; margin: 0 auto` so the toolbar centers when there's enough space, but right-aligns (keeping Save As / Close visible) when the container overflows. Remove `white-space: nowrap`.
- **package.json**: Register `bicep.showVisualDesignerToSide` command in the editor title navigation menu.

## Behavior

- **Wide window**: Export toolbar is centered, control bar is visible at top-right — no overlap.
- **Narrow window**: Export toolbar right-aligns, left-side controls clip off, Save As and Close buttons remain visible, control bar remains accessible.