### PR TITLE
Add linter rule to warn for unrecognized resource types in reference/list* functions

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Outputs_CRLF/main.diagnostics.bicep
@@ -62,9 +62,11 @@ output expressionBasedIndexer string = {
 }[resourceGroup().location].foo
 
 var secondaryKeyIntermediateVar = listKeys(resourceId('Mock.RP/type', 'steve'), '2020-01-01').secondaryKey
+//@[34:93) [use-recognized-resource-type (Warning)] Resource type "Mock.RP/type" is not recognized in function "listKeys". If this resource type does exist, the API version must be specified as a function argument. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-recognized-resource-type) |listKeys(resourceId('Mock.RP/type', 'steve'), '2020-01-01')|
 
 output primaryKey string = listKeys(resourceId('Mock.RP/type', 'nigel'), '2020-01-01').primaryKey
 //@[27:86) [outputs-should-not-contain-secrets (Warning)] Outputs should not contain secrets. Found possible secret: function 'listKeys' (bicep core linter https://aka.ms/bicep/linter-diagnostics#outputs-should-not-contain-secrets) |listKeys(resourceId('Mock.RP/type', 'nigel'), '2020-01-01')|
+//@[27:86) [use-recognized-resource-type (Warning)] Resource type "Mock.RP/type" is not recognized in function "listKeys". If this resource type does exist, the API version must be specified as a function argument. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-recognized-resource-type) |listKeys(resourceId('Mock.RP/type', 'nigel'), '2020-01-01')|
 output secondaryKey string = secondaryKeyIntermediateVar
 
 var varWithOverlappingOutput = 'hello'

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/main.diagnostics.bicep
@@ -148,6 +148,7 @@ var myPropertyName = '${singleQuote}foo${singleQuote}'
 //@[04:18) [no-unused-vars (Warning)] Variable "myPropertyName" is declared but never used. (bicep core linter https://aka.ms/bicep/linter-diagnostics#no-unused-vars) |myPropertyName|
 
 var unusedIntermediate = listKeys(resourceId('Mock.RP/type', 'steve'), '2020-01-01')
+//@[25:84) [use-recognized-resource-type (Warning)] Resource type "Mock.RP/type" is not recognized in function "listKeys". If this resource type does exist, the API version must be specified as a function argument. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-recognized-resource-type) |listKeys(resourceId('Mock.RP/type', 'steve'), '2020-01-01')|
 var unusedIntermediateRef = unusedIntermediate.secondaryKey
 //@[04:25) [no-unused-vars (Warning)] Variable "unusedIntermediateRef" is declared but never used. (bicep core linter https://aka.ms/bicep/linter-diagnostics#no-unused-vars) |unusedIntermediateRef|
 

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecognizedResourceTypeRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecognizedResourceTypeRuleTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Analyzers.Linter.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests;
+
+[TestClass]
+public class UseRecognizedResourceTypeRuleTests : LinterRuleTestsBase
+{
+    private void CompileAndTest(string text, int expectedDiagnosticCount, Options? options = null)
+        => AssertLinterRuleDiagnostics(UseRecognizedResourceTypeRule.Code, text, expectedDiagnosticCount, options ?? new Options(OnCompileErrors.Ignore, IncludePosition.None));
+
+    private void CompileAndTest(string text, string[] expectedMessages, Options? options = null)
+        => AssertLinterRuleDiagnostics(UseRecognizedResourceTypeRule.Code, text, expectedMessages, options ?? new Options(OnCompileErrors.Ignore, IncludePosition.None));
+
+    [TestMethod]
+    public void Rule_should_warn_for_unrecognized_resource_type_in_reference()
+    {
+        CompileAndTest(
+            """
+            output foo object = reference('Microsoft.Foo/bar', '2020-01-01')
+            """,
+            1);
+    }
+
+    [TestMethod]
+    public void Rule_should_warn_for_unrecognized_resource_type_in_list_function()
+    {
+        CompileAndTest(
+            """
+            output foo object = listKeys('Microsoft.Foo/bar', '2020-01-01')
+            """,
+            1);
+    }
+
+    [TestMethod]
+    public void Rule_should_not_warn_for_recognized_resource_type_in_reference()
+    {
+        CompileAndTest(
+            """
+            output foo object = reference('Microsoft.Storage/storageAccounts', '2022-09-01')
+            """,
+            0);
+    }
+
+    [TestMethod]
+    public void Rule_should_not_warn_when_reference_has_no_arguments()
+    {
+        // This will produce a compile error, not a linter warning
+        CompileAndTest(
+            """
+            output foo object = reference()
+            """,
+            0);
+    }
+
+    [TestMethod]
+    public void Rule_should_not_warn_when_first_arg_is_not_a_resource_type_string()
+    {
+        // When the first arg is a non-resource-type string (e.g. a resource name), don't warn
+        CompileAndTest(
+            """
+            output foo object = reference('myResourceName', '2020-01-01')
+            """,
+            0);
+    }
+
+    [TestMethod]
+    public void Rule_should_warn_for_unrecognized_type_in_resourceId_call()
+    {
+        CompileAndTest(
+            """
+            output foo object = reference(resourceId('Microsoft.Foo/bar', 'name1'), '2020-01-01')
+            """,
+            1);
+    }
+
+    [TestMethod]
+    public void Rule_should_not_warn_for_recognized_type_in_resourceId_call()
+    {
+        CompileAndTest(
+            """
+            output foo object = reference(resourceId('Microsoft.Storage/storageAccounts', 'name1'), '2022-09-01')
+            """,
+            0);
+    }
+
+    [TestMethod]
+    public void Rule_should_warn_for_unrecognized_type_with_variable_reference()
+    {
+        CompileAndTest(
+            """
+            var resType = 'Microsoft.Foo/bar'
+            output foo object = reference(resType, '2020-01-01')
+            """,
+            1);
+    }
+
+    [TestMethod]
+    public void Rule_should_not_warn_for_parameter_with_no_default()
+    {
+        // When a parameter is used and has no default value, we can't determine the resource type
+        CompileAndTest(
+            """
+            param resType string
+            output foo object = reference(resType, '2020-01-01')
+            """,
+            0);
+    }
+
+    [TestMethod]
+    public void Rule_should_warn_for_unrecognized_type_in_listKeys()
+    {
+        CompileAndTest(
+            """
+            output foo object = listKeys('Microsoft.Fake/nonExistent', '2020-01-01')
+            """,
+            1);
+    }
+
+    [TestMethod]
+    public void Rule_message_includes_resource_type_and_function_name()
+    {
+        CompileAndTest(
+            """
+            output foo object = reference('Microsoft.Foo/bar', '2020-01-01')
+            """,
+            [
+                """Resource type "Microsoft.Foo/bar" is not recognized in function "reference". If this resource type does exist, the API version must be specified as a function argument.""",
+            ]);
+    }
+}

--- a/src/Bicep.Core/Analyzers/Linter/Common/LinterResourceTypePatterns.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Common/LinterResourceTypePatterns.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace Bicep.Core.Analyzers.Linter.Common;
+
+public static class LinterResourceTypePatterns
+{
+    public static readonly Regex ResourceTypeRegex = new(
+        "^ [a-z]+\\.[a-z]+ (\\/ [a-z]+)+ $",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+}

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecentApiVersionRule.cs
@@ -4,7 +4,6 @@
 using System.Data;
 using System.Diagnostics;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Bicep.Core.Analyzers.Linter.ApiVersions;
 using Bicep.Core.Analyzers.Linter.Common;
 using Bicep.Core.CodeAction;
@@ -32,10 +31,6 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         private const string GracePeriodInDaysKey = "gracePeriodInDays";
         public const int DefaultGracePeriodInDays = 90;
         private const int MinimumValidGracePeriodInDays = 0;
-
-        private static readonly Regex resourceTypeRegex = new(
-            "^ [a-z]+\\.[a-z]+ (\\/ [a-z]+)+ $",
-            RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
         public record Failure(
             TextSpan Span,
@@ -233,7 +228,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 {
                     argLiteral = argLiteral.TrimEnd('/');
 
-                    if (resourceTypeRegex.IsMatch(argLiteral))
+                    if (LinterResourceTypePatterns.ResourceTypeRegex.IsMatch(argLiteral))
                     {
                         // Now folder any following arguments that are also literals into this string separated by "/", e.g.:
                         //   (..., 'Microsoft.Compute/virtualMachineScaleSets', 'virtualMachines/runCommands', 'name', <non-string-literal-arg>, ...)
@@ -265,7 +260,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
             if (LinterExpressionHelper.TryGetEvaluatedStringLiteral(model, expression)
                 is (string resourceIdResTypeString, _, _))
             {
-                if (resourceTypeRegex.IsMatch(resourceIdResTypeString))
+                if (LinterResourceTypePatterns.ResourceTypeRegex.IsMatch(resourceIdResTypeString))
                 {
                     return resourceIdResTypeString;
                 }
@@ -308,7 +303,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
         {
             var resourceType = resourceId;
             var mostRecentValid = resourceId;
-            while (resourceTypeRegex.IsMatch(resourceType))
+            while (LinterResourceTypePatterns.ResourceTypeRegex.IsMatch(resourceType))
             {
                 if (model.ApiVersionProvider.GetApiVersions(model.TargetScope, resourceType).Any())
                 {

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecognizedResourceTypeRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecognizedResourceTypeRule.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Text.RegularExpressions;
 using Bicep.Core.Analyzers.Linter.Common;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
@@ -14,10 +13,6 @@ namespace Bicep.Core.Analyzers.Linter.Rules;
 public sealed class UseRecognizedResourceTypeRule : LinterRuleBase
 {
     public new const string Code = "use-recognized-resource-type";
-
-    private static readonly Regex ResourceTypeRegex = new(
-        "^ [a-z]+\\.[a-z]+ (\\/ [a-z]+)+ $",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
 
     public UseRecognizedResourceTypeRule() : base(
         code: Code,
@@ -93,7 +88,7 @@ public sealed class UseRecognizedResourceTypeRule : LinterRuleBase
 
         // Handle string literal resource type like 'Microsoft.Storage/storageAccounts'
         if (LinterExpressionHelper.TryGetEvaluatedStringLiteral(model, expression)
-            is (string literalValue, _, _) && ResourceTypeRegex.IsMatch(literalValue))
+            is (string literalValue, _, _) && LinterResourceTypePatterns.ResourceTypeRegex.IsMatch(literalValue))
         {
             return literalValue;
         }
@@ -115,7 +110,7 @@ public sealed class UseRecognizedResourceTypeRule : LinterRuleBase
             if (LinterExpressionHelper.TryGetEvaluatedStringLiteral(model, arg.Expression) is (string argLiteral, _, _))
             {
                 argLiteral = argLiteral.TrimEnd('/');
-                if (ResourceTypeRegex.IsMatch(argLiteral))
+                if (LinterResourceTypePatterns.ResourceTypeRegex.IsMatch(argLiteral))
                 {
                     return argLiteral;
                 }

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseRecognizedResourceTypeRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseRecognizedResourceTypeRule.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+using Bicep.Core.Analyzers.Linter.Common;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.Syntax;
+using Bicep.Core.Text;
+
+namespace Bicep.Core.Analyzers.Linter.Rules;
+
+public sealed class UseRecognizedResourceTypeRule : LinterRuleBase
+{
+    public new const string Code = "use-recognized-resource-type";
+
+    private static readonly Regex ResourceTypeRegex = new(
+        "^ [a-z]+\\.[a-z]+ (\\/ [a-z]+)+ $",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+
+    public UseRecognizedResourceTypeRule() : base(
+        code: Code,
+        description: CoreResources.UseRecognizedResourceTypeRule_Description,
+        LinterRuleCategory.PotentialCodeIssues)
+    { }
+
+    public override string FormatMessage(params object[] values)
+        => (string)values[0];
+
+    public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
+    {
+        var functionCalls = LinterExpressionHelper.FindFunctionCallsByName(
+            model,
+            model.SourceFile.ProgramSyntax,
+            AzNamespaceType.BuiltInName,
+            "reference|(list.*)");
+
+        foreach (var functionCall in functionCalls)
+        {
+            if (TryGetUnrecognizedResourceType(model, functionCall) is string unrecognizedType)
+            {
+                var suggestion = SpellChecker.GetSpellingSuggestion(
+                    unrecognizedType,
+                    model.ApiVersionProvider.GetResourceTypeNames(model.TargetScope));
+
+                string message;
+                if (suggestion is not null)
+                {
+                    message = string.Format(CoreResources.UseRecognizedResourceTypeRule_MessageFormatWithSuggestion, unrecognizedType, functionCall.Name.IdentifierName, suggestion);
+                }
+                else
+                {
+                    message = string.Format(CoreResources.UseRecognizedResourceTypeRule_MessageFormat, unrecognizedType, functionCall.Name.IdentifierName);
+                }
+
+                yield return CreateDiagnosticForSpan(diagnosticLevel, functionCall.Span, message);
+            }
+        }
+    }
+
+    private static string? TryGetUnrecognizedResourceType(SemanticModel model, FunctionCallSyntaxBase functionCall)
+    {
+        if (functionCall.Arguments.Length < 1)
+        {
+            return null;
+        }
+
+        var firstArg = functionCall.Arguments[0].Expression;
+        var resourceType = TryExtractResourceType(model, firstArg);
+
+        if (resourceType is null)
+        {
+            return null;
+        }
+
+        // Check if the resource type is recognized
+        if (model.ApiVersionProvider.GetApiVersions(model.TargetScope, resourceType).Any())
+        {
+            return null;
+        }
+
+        return resourceType;
+    }
+
+    private static string? TryExtractResourceType(SemanticModel model, SyntaxBase expression)
+    {
+        // Handle resourceId(<resourcetype>, ...)
+        if (expression is FunctionCallSyntaxBase functionCall)
+        {
+            return TryGetResourceTypeFromResourceIdCall(model, functionCall);
+        }
+
+        // Handle string literal resource type like 'Microsoft.Storage/storageAccounts'
+        if (LinterExpressionHelper.TryGetEvaluatedStringLiteral(model, expression)
+            is (string literalValue, _, _) && ResourceTypeRegex.IsMatch(literalValue))
+        {
+            return literalValue;
+        }
+
+        return null;
+    }
+
+    private static string? TryGetResourceTypeFromResourceIdCall(SemanticModel model, FunctionCallSyntaxBase functionCall)
+    {
+        if (!functionCall.Name.IdentifierName.Equals("resourceId", LanguageConstants.IdentifierComparison))
+        {
+            return null;
+        }
+
+        // resourceId() can have optional subscription/resource group args at the beginning,
+        // so look for the first argument that looks like a resource type
+        foreach (var arg in functionCall.Arguments)
+        {
+            if (LinterExpressionHelper.TryGetEvaluatedStringLiteral(model, arg.Expression) is (string argLiteral, _, _))
+            {
+                argLiteral = argLiteral.TrimEnd('/');
+                if (ResourceTypeRegex.IsMatch(argLiteral))
+                {
+                    return argLiteral;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -1229,5 +1229,32 @@ namespace Bicep.Core {
                 return ResourceManager.GetString("WhatIfShortCircuitingRuleMessageFormat", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warn if a &apos;reference&apos; or &apos;list*&apos; function call uses an unrecognized resource type..
+        /// </summary>
+        internal static string UseRecognizedResourceTypeRule_Description {
+            get {
+                return ResourceManager.GetString("UseRecognizedResourceTypeRule_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resource type &quot;{0}&quot; is not recognized in function &quot;{1}&quot;. If this resource type does exist, the API version must be specified as a function argument..
+        /// </summary>
+        internal static string UseRecognizedResourceTypeRule_MessageFormat {
+            get {
+                return ResourceManager.GetString("UseRecognizedResourceTypeRule_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resource type &quot;{0}&quot; is not recognized in function &quot;{1}&quot;. Did you mean &quot;{2}&quot;? If this resource type does exist, the API version must be specified as a function argument..
+        /// </summary>
+        internal static string UseRecognizedResourceTypeRule_MessageFormatWithSuggestion {
+            get {
+                return ResourceManager.GetString("UseRecognizedResourceTypeRule_MessageFormatWithSuggestion", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -553,4 +553,15 @@
   <data name="NoExplicitAnyRule_Description" xml:space="preserve">
     <value>Avoid using an explicit 'any' type whenever possible.</value>
   </data>
+  <data name="UseRecognizedResourceTypeRule_Description" xml:space="preserve">
+    <value>Warn if a 'reference' or 'list*' function call uses an unrecognized resource type.</value>
+  </data>
+  <data name="UseRecognizedResourceTypeRule_MessageFormat" xml:space="preserve">
+    <value>Resource type "{0}" is not recognized in function "{1}". If this resource type does exist, the API version must be specified as a function argument.</value>
+    <comment>{0} = resource type, {1} = function name</comment>
+  </data>
+  <data name="UseRecognizedResourceTypeRule_MessageFormatWithSuggestion" xml:space="preserve">
+    <value>Resource type "{0}" is not recognized in function "{1}". Did you mean "{2}"? If this resource type does exist, the API version must be specified as a function argument.</value>
+    <comment>{0} = resource type, {1} = function name, {2} = suggested resource type</comment>
+  </data>
 </root>

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -767,6 +767,16 @@
                     }
                   ]
                 },
+                "use-recognized-resource-type": {
+                  "allOf": [
+                    {
+                      "description": "Warn if a 'reference' or 'list*' function call uses an unrecognized resource type. Defaults to 'Warning'. See https://aka.ms/bicep/linter-diagnostics#use-recognized-resource-type"
+                    },
+                    {
+                      "$ref": "#/definitions/rule-def-level-warning"
+                    }
+                  ]
+                },
                 "use-secure-value-for-secure-inputs": {
                   "allOf": [
                     {


### PR DESCRIPTION
## Description

Fixes #19172

Adds a new linter rule `use-recognized-resource-type` that emits a warning when a `reference` or `list*` function call uses a resource type that is not recognized by Bicep's type system.

### What the rule does

- Inspects the first argument of `reference()` and `list*()` function calls
- Extracts resource types from string literals, variable references, and `resourceId()` wrapper calls
- Checks the extracted type against known Azure resource types via `ApiVersionProvider`
- Suggests similar type names via spell-checking when the type is unrecognized
- Defaults to **Warning** level (`PotentialCodeIssues` category)

### Example

```bicep
// This will emit a warning because 'Microsoft.Foo/bar' is not a recognized resource type
output foo object = reference('Microsoft.Foo/bar', '2020-01-01')
```

### Files changed

| File | Purpose |
|------|---------|
| `src/Bicep.Core/Analyzers/Linter/Rules/UseRecognizedResourceTypeRule.cs` | New linter rule implementation |
| `src/Bicep.Core/CoreResources.resx` | Resource strings for description and messages |
| `src/Bicep.Core/CoreResources.Designer.cs` | Auto-generated resource accessors |
| `src/vscode-bicep/schemas/bicepconfig.schema.json` | Schema entry for configuring the rule |
| `src/Bicep.Core.UnitTests/.../UseRecognizedResourceTypeRuleTests.cs` | Unit tests |

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19303)