### PR TITLE
Pin System.Security.Cryptography.Xml to 8.0.3 to fix CVE-2026-33116

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -105,6 +105,8 @@
     <PackageVersion Include="System.Memory.Data" Version="10.0.5" />
     <!-- force an upgrade of this dependency as it seems to cause build flakiness for unknown reasons -->
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <!-- pin to patched version to resolve CVE-2026-33116 (https://github.com/advisories/GHSA-37gx-xxp4-5rgx) -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />
     <PackageVersion Include="Tools.InnoSetup" Version="6.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
The advisory CVE-2026-33116 (GHSA-37gx-xxp4-5rgx) was published on 2026-04-14, flagging System.Security.Cryptography.Xml 8.0.2 as vulnerable to a DoS attack via EncryptedXml infinite loop. This package is a transitive dependency brought in by Microsoft.PowerPlatform.ResourceStack -> Microsoft.Windows.Compatibility. Pin the transitive dependency to the patched version 8.0.3 using CentralPackageTransitivePinningEnabled.

The dependency chain is [Microsoft.PowerPlatform.ResourceStack 7.0.0.2080] → [Microsoft.Windows.Compatibility 8.0.10] → [System.Security.Cryptography.Xml 8.0.2]. Therefore, bumps version to 8.0.3

## Description

<!-- Provide a 1-2 sentence description of your change -->

## Example Usage

<!-- Provide example usage if you are making syntax or CLI changes. 
     Provide screenshots if you are making changes to editor user experience.
     Delete this section if it doesn't apply to your change. -->

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19449)