### PR TITLE
Avoid storing file reference on OciArtifactReference

### DIFF
--- a/src/Bicep.Core.Samples/MockRegistry.cs
+++ b/src/Bicep.Core.Samples/MockRegistry.cs
@@ -86,7 +86,7 @@ public static class MockRegistry
             referenceStr = referenceStr[3..];
         }
 
-        if (!TemplateSpecModuleReference.TryParse(BicepTestConstants.DummyBicepFile, null, referenceStr).IsSuccess(out var specReference, out var errorBuilder))
+        if (!TemplateSpecModuleReference.TryParse(BicepTestConstants.DummyBicepFile.Features, BicepTestConstants.DummyBicepFile.Configuration, null, referenceStr).IsSuccess(out var specReference, out var errorBuilder))
         {
             diagnostic = errorBuilder(DiagnosticBuilder.ForDocumentStart());
 

--- a/src/Bicep.Core.UnitTests/Modules/ArtifactAddressComponentsTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/ArtifactAddressComponentsTests.cs
@@ -113,13 +113,13 @@ namespace Bicep.Core.UnitTests.Modules
         private static bool IsValid(string package)
         {
             // NOTE: ArtifactAddressComponents doesn't currently have a parser separate from OciArtifactReference.
-            return OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile, ArtifactType.Module, null, package).IsSuccess(out var _, out var _);
+            return OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile.Features, BicepTestConstants.DummyBicepFile.Configuration, ArtifactType.Module, null, package).IsSuccess(out var _, out var _);
         }
 
         private static OciArtifactAddressComponents Parse(string package)
         {
             // NOTE: ArtifactAddressComponents doesn't currently have a parser separate from OciArtifactReference.
-            OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile, ArtifactType.Module, null, package).IsSuccess(out var parsed, out var failureBuilder).Should().BeTrue();
+            OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile.Features, BicepTestConstants.DummyBicepFile.Configuration, ArtifactType.Module, null, package).IsSuccess(out var parsed, out var failureBuilder).Should().BeTrue();
             failureBuilder!.Should().BeNull();
             parsed.Should().NotBeNull();
             return (OciArtifactAddressComponents)parsed!.AddressComponents;

--- a/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/OciArtifactModuleReferenceTests.cs
@@ -258,7 +258,7 @@ namespace Bicep.Core.UnitTests.Modules
         private static (OciArtifactReference, OciArtifactReference) ParsePair(string first, string second) => (Parse(first), Parse(second));
 
         private static ResultWithDiagnosticBuilder<OciArtifactReference> TryParseOciArtifactReference(string value, string? aliasName = null, RootConfiguration? configuration = null) =>
-            OciArtifactReference.TryParse(BicepTestConstants.CreateDummyBicepFile(configuration), ArtifactType.Module, aliasName, value);
+            OciArtifactReference.TryParse(BicepTestConstants.CreateDummyBicepFile(configuration).Features, BicepTestConstants.CreateDummyBicepFile(configuration).Configuration, ArtifactType.Module, aliasName, value);
 
         private static IEnumerable<object[]> GetValidCases()
         {

--- a/src/Bicep.Core.UnitTests/Modules/TemplateSpecModuleReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Modules/TemplateSpecModuleReferenceTests.cs
@@ -64,7 +64,7 @@ namespace Bicep.Core.UnitTests.Modules
         [DataTestMethod]
         public void TryParse_InvalidReference_ReturnsFalseAndSetsFailureBuilder(string rawValue)
         {
-            TemplateSpecModuleReference.TryParse(DummyReferencingFile, null, rawValue).IsSuccess(out var parsed, out var failureBuilder).Should().BeFalse();
+            TemplateSpecModuleReference.TryParse(DummyReferencingFile.Features, DummyReferencingFile.Configuration, null, rawValue).IsSuccess(out var parsed, out var failureBuilder).Should().BeFalse();
 
             parsed.Should().BeNull();
             failureBuilder!.Should().NotBeNull();
@@ -76,8 +76,9 @@ namespace Bicep.Core.UnitTests.Modules
         public void TryParse_AliasNotInConfiguration_ReturnsFalseAndSetsError(string aliasName, string referenceValue, string? configurationPath, string expectedCode, string expectedMessage)
         {
             var configuration = BicepTestConstants.CreateMockConfiguration(configFilePath: configurationPath);
+            var bicepFile = CreateBicepFile(configuration);
 
-            TemplateSpecModuleReference.TryParse(CreateBicepFile(configuration), aliasName, referenceValue).IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
+            TemplateSpecModuleReference.TryParse(bicepFile.Features, bicepFile.Configuration, aliasName, referenceValue).IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
 
             reference.Should().BeNull();
             errorBuilder!.Should().NotBeNull();
@@ -94,7 +95,7 @@ namespace Bicep.Core.UnitTests.Modules
         [DataRow("foo bar ÄÄÄ")]
         public void TryParse_InvalidAliasName_ReturnsFalseAndSetsErrorDiagnostic(string aliasName)
         {
-            TemplateSpecModuleReference.TryParse(DummyReferencingFile, aliasName, "").IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
+            TemplateSpecModuleReference.TryParse(DummyReferencingFile.Features, DummyReferencingFile.Configuration, aliasName, "").IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
 
             reference.Should().BeNull();
             errorBuilder!.Should().HaveCode("BCP211");
@@ -105,7 +106,8 @@ namespace Bicep.Core.UnitTests.Modules
         [DynamicData(nameof(GetInvalidData), DynamicDataSourceType.Method)]
         public void TryParse_InvalidAlias_ReturnsFalseAndSetsError(string aliasName, string referenceValue, RootConfiguration configuration, string expectedCode, string expectedMessage)
         {
-            TemplateSpecModuleReference.TryParse(CreateBicepFile(configuration), aliasName, referenceValue).IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
+            var bicepFile = CreateBicepFile(configuration);
+            TemplateSpecModuleReference.TryParse(bicepFile.Features, bicepFile.Configuration, aliasName, referenceValue).IsSuccess(out var reference, out var errorBuilder).Should().BeFalse();
 
             reference.Should().BeNull();
             errorBuilder!.Should().NotBeNull();
@@ -117,7 +119,8 @@ namespace Bicep.Core.UnitTests.Modules
         [DynamicData(nameof(GetValidData), DynamicDataSourceType.Method)]
         public void TryGetModuleReference_ValidAlias_ReplacesReferenceValue(string aliasName, string referenceValue, string fullyQualifiedReferenceValue, RootConfiguration configuration)
         {
-            TemplateSpecModuleReference.TryParse(CreateBicepFile(configuration), aliasName, referenceValue).IsSuccess(out var reference, out var errorBuilder).Should().BeTrue();
+            var bicepFile = CreateBicepFile(configuration);
+            TemplateSpecModuleReference.TryParse(bicepFile.Features, bicepFile.Configuration, aliasName, referenceValue).IsSuccess(out var reference, out var errorBuilder).Should().BeTrue();
 
             reference.Should().NotBeNull();
             reference!.FullyQualifiedReference.Should().Be(fullyQualifiedReferenceValue);
@@ -222,7 +225,7 @@ namespace Bicep.Core.UnitTests.Modules
 
         private static TemplateSpecModuleReference Parse(string rawValue)
         {
-            TemplateSpecModuleReference.TryParse(DummyReferencingFile, null, rawValue).IsSuccess(out var parsed, out var failureBuilder).Should().BeTrue();
+            TemplateSpecModuleReference.TryParse(DummyReferencingFile.Features, DummyReferencingFile.Configuration, null, rawValue).IsSuccess(out var parsed, out var failureBuilder).Should().BeTrue();
 
             parsed.Should().NotBeNull();
             failureBuilder!.Should().BeNull();

--- a/src/Bicep.Core.UnitTests/Registry/ArtifactDispatcherTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/ArtifactDispatcherTests.cs
@@ -136,14 +136,7 @@ namespace Bicep.Core.UnitTests.Registry
         [DynamicData(nameof(GetConfigurationData), DynamicDataSourceType.Method)]
         public async Task GetModuleRestoreStatus_ConfigurationChanges_ReturnsCachedStatusWhenChangeIsIrrelevant(RootConfiguration changedConfiguration, ArtifactRestoreStatus expectedStatus)
         {
-            // Arrange.
-            var configManagerMock = StrictMock.Of<IConfigurationManager>();
-            configManagerMock.SetupSequence(m => m.GetConfiguration(It.IsAny<IOUri>()))
-                .Returns(BicepTestConstants.CreateMockConfiguration())
-                .Returns(BicepTestConstants.CreateMockConfiguration())
-                .Returns(changedConfiguration);
-
-            var badFile = BicepTestConstants.CreateDummyBicepFile(configManagerMock.Object);
+            var badFile = BicepTestConstants.CreateDummyBicepFile(BicepTestConstants.CreateMockConfiguration());
             var badReference = new MockModuleReference(badFile, "bad");
 
             var registryMock = StrictMock.Of<IArtifactRegistry>();
@@ -159,11 +152,13 @@ namespace Bicep.Core.UnitTests.Registry
                 .Returns(Task.CompletedTask);
 
             var dispatcher = CreateDispatcher(registryMock.Object);
-            var configuration = BicepTestConstants.CreateMockConfiguration();
 
             await dispatcher.RestoreArtifacts(new[] { badReference }, false);
 
             // Act.
+            badFile = BicepTestConstants.CreateDummyBicepFile(changedConfiguration);
+            badReference = new MockModuleReference(badFile, "bad");
+
             var status = dispatcher.GetArtifactRestoreStatus(badReference, out _);
 
             // Assert.
@@ -229,7 +224,7 @@ namespace Bicep.Core.UnitTests.Registry
         private class MockModuleReference : ArtifactReference
         {
             public MockModuleReference(BicepSourceFile referencingFile, string reference)
-                : base(referencingFile, "mock")
+                : base(referencingFile.Features, referencingFile.Configuration, "mock")
             {
                 this.Reference = reference;
             }

--- a/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/OciModuleRegistryTests.cs
@@ -730,7 +730,7 @@ namespace Bicep.Core.UnitTests.Registry
 
         private OciArtifactReference CreateModuleReference(BicepSourceFile referencingFile, string registry, string repository, string? tag, string? digest)
         {
-            OciArtifactReference.TryParse(referencingFile, ArtifactType.Module, null, $"{registry}/{repository}:{tag}").IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParse(referencingFile.Features, referencingFile.Configuration, ArtifactType.Module, null, $"{registry}/{repository}:{tag}").IsSuccess(out var moduleReference).Should().BeTrue();
             return moduleReference!;
         }
 

--- a/src/Bicep.Core.UnitTests/Utils/ExtensionTestHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/ExtensionTestHelper.cs
@@ -37,7 +37,7 @@ public static class ExtensionTestHelper
 
     public static async Task<ServiceBuilder> GetServiceBuilderWithPublishedExtension(ExtensionPackage package, string target, FeatureProviderOverrides features, IFileSystem? fileSystem = null)
     {
-        var reference = OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile, ArtifactType.Module, null, target).Unwrap();
+        var reference = OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile.Features, BicepTestConstants.DummyBicepFile.Configuration, ArtifactType.Module, null, target).Unwrap();
 
         fileSystem ??= new MockFileSystem();
         var services = GetServiceBuilder(fileSystem, reference.Registry, reference.Repository, features);

--- a/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/OciRegistryHelper.cs
@@ -23,7 +23,7 @@ namespace Bicep.Core.UnitTests.Utils
     public static class OciRegistryHelper
     {
         public static OciArtifactReference CreateModuleReferenceMock(BicepSourceFile referencingFile, string registry, string repository, string? digest, string? tag)
-            => new(referencingFile, ArtifactType.Module, registry, repository, tag, digest);
+            => new(referencingFile.Features, referencingFile.Configuration, ArtifactType.Module, registry, repository, tag, digest);
 
         public static OciArtifactReference ParseModuleReference(string moduleId /* with or without br: */, Uri? parentModuleUri = null)
         {
@@ -31,7 +31,7 @@ namespace Bicep.Core.UnitTests.Utils
             {
                 moduleId = moduleId[OciArtifactReferenceFacts.SchemeWithColon.Length..];
             }
-            OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile, ArtifactType.Module, null, moduleId).IsSuccess(out var moduleReference).Should().BeTrue();
+            OciArtifactReference.TryParse(BicepTestConstants.DummyBicepFile.Features, BicepTestConstants.DummyBicepFile.Configuration, ArtifactType.Module, null, moduleId).IsSuccess(out var moduleReference).Should().BeTrue();
             return moduleReference!;
         }
 

--- a/src/Bicep.Core/Modules/LocalModuleReference.cs
+++ b/src/Bicep.Core/Modules/LocalModuleReference.cs
@@ -25,16 +25,21 @@ namespace Bicep.Core.Modules
         private readonly Lazy<ResultWithDiagnosticBuilder<IFileHandle>> lazyTargetFileResult;
         private readonly Lazy<ResultWithDiagnosticBuilder<BinaryData>> lazyExtensionBinaryDataResult;
         private readonly Lazy<LocalExtensionArtifact> lazyLocalExtensionArtifact;
+        private readonly BicepSourceFile referencingFile;
 
         private LocalModuleReference(BicepSourceFile referencingFile, ArtifactType artifactType, RelativePath path)
-            : base(referencingFile, ArtifactReferenceSchemes.Local)
+            : base(referencingFile.Features, referencingFile.Configuration, ArtifactReferenceSchemes.Local)
         {
             ArtifactType = artifactType;
             this.Path = path;
-            this.lazyTargetFileResult = new(() => this.ReferencingFile.FileHandle.TryGetRelativeFile(this.Path));
+            this.referencingFile = referencingFile;
+            this.lazyTargetFileResult = new(() => TryGetRelativeFile(this.Path));
             this.lazyExtensionBinaryDataResult = new(() => this.lazyTargetFileResult.Value.Transform(x => x.TryReadBinaryData()));
-            this.lazyLocalExtensionArtifact = new(() => new(this.lazyExtensionBinaryDataResult.Value.Unwrap(), referencingFile.Features.CacheRootDirectory));
+            this.lazyLocalExtensionArtifact = new(() => new(this.lazyExtensionBinaryDataResult.Value.Unwrap(), FeatureProvider.CacheRootDirectory));
         }
+
+        public ResultWithDiagnosticBuilder<IFileHandle> TryGetRelativeFile(RelativePath path)
+            => referencingFile.FileHandle.TryGetRelativeFile(path);
 
         public ArtifactType ArtifactType { get; }
 

--- a/src/Bicep.Core/Modules/TemplateSpecModuleReference.cs
+++ b/src/Bicep.Core/Modules/TemplateSpecModuleReference.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Azure.Deployments.Core.Uri;
 using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Features;
 using Bicep.Core.Registry;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.SourceGraph.Artifacts;
@@ -24,14 +25,14 @@ namespace Bicep.Core.Modules
 
         private static readonly Regex ResourceNameRegex = new(@"^[-\w\.\(\)]{0,89}[-\w\(\)]$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-        private TemplateSpecModuleReference(BicepSourceFile referencingFile, string subscriptionId, string resourceGroupName, string templateSpecName, string version)
-            : base(referencingFile, ArtifactReferenceSchemes.TemplateSpecs)
+        private TemplateSpecModuleReference(IFeatureProvider featureProvider, RootConfiguration configuration, string subscriptionId, string resourceGroupName, string templateSpecName, string version)
+            : base(featureProvider, configuration, ArtifactReferenceSchemes.TemplateSpecs)
         {
             this.SubscriptionId = subscriptionId;
             this.ResourceGroupName = resourceGroupName;
             this.TemplateSpecName = templateSpecName;
             this.Version = version;
-            this.templateSpecModuleArtifact = new(() => new(subscriptionId, resourceGroupName, templateSpecName, version, referencingFile.Features.CacheRootDirectory));
+            this.templateSpecModuleArtifact = new(() => new(subscriptionId, resourceGroupName, templateSpecName, version, featureProvider.CacheRootDirectory));
         }
 
         public override string UnqualifiedReference => $"{this.SubscriptionId}/{this.ResourceGroupName}/{this.TemplateSpecName}:{this.Version}";
@@ -69,11 +70,11 @@ namespace Bicep.Core.Modules
             return hash.ToHashCode();
         }
 
-        public static ResultWithDiagnosticBuilder<TemplateSpecModuleReference> TryParse(BicepSourceFile referencingFile, string? aliasName, string referenceValue)
+        public static ResultWithDiagnosticBuilder<TemplateSpecModuleReference> TryParse(IFeatureProvider featureProvider, RootConfiguration configuration, string? aliasName, string referenceValue)
         {
             if (aliasName is not null)
             {
-                if (!referencingFile.Configuration.ModuleAliases.TryGetTemplateSpecModuleAlias(aliasName).IsSuccess(out var alias, out var errorBuilder))
+                if (!configuration.ModuleAliases.TryGetTemplateSpecModuleAlias(aliasName).IsSuccess(out var alias, out var errorBuilder))
                 {
                     return new(errorBuilder);
                 }
@@ -132,7 +133,7 @@ namespace Bicep.Core.Modules
                 return new(x => x.InvalidTemplateSpecReferenceInvalidTemplateSpecVersion(aliasName, version, FullyQualify(referenceValue)));
             }
 
-            return new(new TemplateSpecModuleReference(referencingFile, subscriptionId, resourceGroupName, templateSpecName, version));
+            return new(new TemplateSpecModuleReference(featureProvider, configuration, subscriptionId, resourceGroupName, templateSpecName, version));
         }
 
         public override ResultWithDiagnosticBuilder<IFileHandle> TryGetEntryPointFileHandle() => new(this.MainTemplateSpecFile);

--- a/src/Bicep.Core/Registry/ArtifactReference.cs
+++ b/src/Bicep.Core/Registry/ArtifactReference.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Configuration;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Features;
 using Bicep.Core.SourceGraph;
 using Bicep.IO.Abstraction;
 
@@ -12,18 +14,18 @@ namespace Bicep.Core.Registry
     /// </summary>
     public abstract class ArtifactReference
     {
-        protected ArtifactReference(BicepSourceFile referencingFile, string scheme)
+        protected ArtifactReference(IFeatureProvider featureProvider, RootConfiguration configuration, string scheme)
         {
             Scheme = scheme;
-            ReferencingFile = referencingFile;
+            FeatureProvider = featureProvider;
+            Configuration = configuration;
         }
 
         public string Scheme { get; }
 
-        /// <summary>
-        /// The URI of the template in which this artifact reference appears.
-        /// </summary>
-        public BicepSourceFile ReferencingFile { get; }
+        public IFeatureProvider FeatureProvider { get; }
+
+        public RootConfiguration Configuration { get; }
 
         /// <summary>
         /// Gets the fully qualified artifact reference, which includes the scheme.

--- a/src/Bicep.Core/Registry/LocalModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/LocalModuleRegistry.cs
@@ -82,7 +82,7 @@ namespace Bicep.Core.Registry
         public override async Task PublishExtension(LocalModuleReference reference, ExtensionPackage package)
         {
             var archive = await ExtensionV1Archive.Build(package);
-            var fileHandle = reference.ReferencingFile.FileHandle.TryGetRelativeFile(reference.Path).Unwrap();
+            var fileHandle = reference.TryGetRelativeFile(reference.Path).Unwrap();
             fileHandle.Write(archive);
         }
 
@@ -140,7 +140,7 @@ namespace Bicep.Core.Registry
             // We must use '_' as a separator here because Windows does not allow ':' in file paths.
             var digest = OciDescriptor.ComputeDigest(OciDescriptor.AlgorithmIdentifierSha256, binaryData, separator: '_');
 
-            return reference.ReferencingFile.Features.CacheRootDirectory.GetDirectory($"local/{digest}");
+            return reference.FeatureProvider.CacheRootDirectory.GetDirectory($"local/{digest}");
         }
 
         protected override IDirectoryHandle GetArtifactDirectory(LocalModuleReference reference)
@@ -155,7 +155,7 @@ namespace Bicep.Core.Registry
 
         private static BinaryData? TryReadContent(LocalModuleReference reference)
         {
-            var moduleFileHandle = reference.ReferencingFile.FileHandle.TryGetRelativeFile(reference.Path).TryUnwrap();
+            var moduleFileHandle = reference.TryGetRelativeFile(reference.Path).TryUnwrap();
 
             return moduleFileHandle?.TryReadBinaryData().TryUnwrap();
         }

--- a/src/Bicep.Core/Registry/ModuleDispatcher.cs
+++ b/src/Bicep.Core/Registry/ModuleDispatcher.cs
@@ -161,7 +161,7 @@ namespace Bicep.Core.Registry
             out DiagnosticBuilder.DiagnosticBuilderDelegate? failureBuilder)
         {
             var registry = this.GetRegistry(artifactReference);
-            var configuration = artifactReference.ReferencingFile.Configuration;
+            var configuration = artifactReference.Configuration;
 
             // have we already failed to restore this artifact?
             if (this.HasRestoreFailed(artifactReference, configuration, out var restoreFailureBuilder))
@@ -183,7 +183,7 @@ namespace Bicep.Core.Registry
 
         public ResultWithDiagnosticBuilder<IFileHandle> TryGetLocalArtifactEntryPointFileHandle(ArtifactReference artifactReference)
         {
-            var configuration = artifactReference.ReferencingFile.Configuration;
+            var configuration = artifactReference.Configuration;
             // has restore already failed for this artifact?
             if (this.HasRestoreFailed(artifactReference, configuration, out var restoreFailureBuilder))
             {
@@ -237,7 +237,7 @@ namespace Bicep.Core.Registry
                     // update cache invalidation status for each failed module
                     foreach (var (failedReference, failureBuilder) in invalidateFailures)
                     {
-                        this.SetRestoreFailure(failedReference, failedReference.ReferencingFile.Configuration, failureBuilder);
+                        this.SetRestoreFailure(failedReference, failedReference.Configuration, failureBuilder);
                     }
                 }
 
@@ -246,7 +246,7 @@ namespace Bicep.Core.Registry
                 // update restore status for each failed module restore
                 foreach (var (failedReference, failureBuilder) in restoreFailures)
                 {
-                    this.SetRestoreFailure(failedReference, failedReference.ReferencingFile.Configuration, failureBuilder);
+                    this.SetRestoreFailure(failedReference, failedReference.Configuration, failureBuilder);
                 }
 
                 try

--- a/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
+++ b/src/Bicep.Core/Registry/Oci/OciArtifactReference.cs
@@ -22,17 +22,17 @@ namespace Bicep.Core.Registry.Oci
         private readonly Lazy<BicepRegistryModuleArtifact> lazyBicepRegistryModuleArtifact;
         private readonly Lazy<BicepRegistryExtensionArtifact> lazyBicepRegistryExtensionArtifact;
 
-        public OciArtifactReference(BicepSourceFile referencingFile, ArtifactType type, IOciArtifactAddressComponents artifactIdParts) :
-            base(referencingFile, OciArtifactReferenceFacts.Scheme)
+        public OciArtifactReference(IFeatureProvider featureProvider, RootConfiguration configuration, ArtifactType type, IOciArtifactAddressComponents artifactIdParts) :
+            base(featureProvider, configuration, OciArtifactReferenceFacts.Scheme)
         {
             Type = type;
             AddressComponents = artifactIdParts;
-            lazyBicepRegistryModuleArtifact = new(() => new(this.AddressComponents, this.ReferencingFile.Features.CacheRootDirectory));
-            lazyBicepRegistryExtensionArtifact = new(() => new(this.AddressComponents, this.ReferencingFile.Features.CacheRootDirectory));
+            lazyBicepRegistryModuleArtifact = new(() => new(this.AddressComponents, this.FeatureProvider.CacheRootDirectory));
+            lazyBicepRegistryExtensionArtifact = new(() => new(this.AddressComponents, this.FeatureProvider.CacheRootDirectory));
         }
 
-        public OciArtifactReference(BicepSourceFile referencingFile, ArtifactType type, string registry, string repository, string? tag, string? digest) :
-            base(referencingFile, OciArtifactReferenceFacts.Scheme)
+        public OciArtifactReference(IFeatureProvider featureProvider, RootConfiguration configuration, ArtifactType type, string registry, string repository, string? tag, string? digest) :
+            base(featureProvider, configuration, OciArtifactReferenceFacts.Scheme)
         {
             switch (tag, digest)
             {
@@ -44,8 +44,8 @@ namespace Bicep.Core.Registry.Oci
 
             Type = type;
             AddressComponents = new OciArtifactAddressComponents(registry, repository, tag, digest);
-            lazyBicepRegistryModuleArtifact = new(() => new(this.AddressComponents, this.ReferencingFile.Features.CacheRootDirectory));
-            lazyBicepRegistryExtensionArtifact = new(() => new(this.AddressComponents, this.ReferencingFile.Features.CacheRootDirectory));
+            lazyBicepRegistryModuleArtifact = new(() => new(this.AddressComponents, this.FeatureProvider.CacheRootDirectory));
+            lazyBicepRegistryExtensionArtifact = new(() => new(this.AddressComponents, this.FeatureProvider.CacheRootDirectory));
         }
 
         public IOciArtifactAddressComponents AddressComponents { get; }
@@ -99,11 +99,11 @@ namespace Bicep.Core.Registry.Oci
 
         // unqualifiedReference is the reference without a scheme or alias, e.g. "example.azurecr.invalid/foo/bar:v3"
         // The referencingFile is needed to resolve aliases and experimental features
-        public static ResultWithDiagnosticBuilder<OciArtifactReference> TryParse(BicepSourceFile referencingFile, ArtifactType type, string? aliasName, string unqualifiedReference)
+        public static ResultWithDiagnosticBuilder<OciArtifactReference> TryParse(IFeatureProvider features, RootConfiguration configuration, ArtifactType type, string? aliasName, string unqualifiedReference)
         {
-            if (TryParseComponents(referencingFile, type, aliasName, unqualifiedReference).IsSuccess(out var components, out var errorBuilder))
+            if (TryParseComponents(configuration, type, aliasName, unqualifiedReference).IsSuccess(out var components, out var errorBuilder))
             {
-                return new(new OciArtifactReference(referencingFile, type, components.Registry, components.Repository, components.Tag, components.Digest));
+                return new(new OciArtifactReference(features, configuration, type, components.Registry, components.Repository, components.Tag, components.Digest));
             }
             else
             {
@@ -116,14 +116,14 @@ namespace Bicep.Core.Registry.Oci
                 ? this.lazyBicepRegistryExtensionArtifact.Value
                 : throw new InvalidOperationException($"Cannot resolve extension artifact for type {this.Type}.");
 
-        private static ResultWithDiagnosticBuilder<OciArtifactAddressComponents> TryParseComponents(BicepSourceFile referencingFile, ArtifactType type, string? aliasName, string unqualifiedReference)
+        private static ResultWithDiagnosticBuilder<OciArtifactAddressComponents> TryParseComponents(RootConfiguration configuration, ArtifactType type, string? aliasName, string unqualifiedReference)
         {
             if (aliasName is { })
             {
                 switch (type)
                 {
                     case ArtifactType.Module:
-                        if (!referencingFile.Configuration.ModuleAliases.TryGetOciArtifactModuleAlias(aliasName).IsSuccess(out var moduleAlias, out var moduleFailureBuilder))
+                        if (!configuration.ModuleAliases.TryGetOciArtifactModuleAlias(aliasName).IsSuccess(out var moduleAlias, out var moduleFailureBuilder))
                         {
                             return new(moduleFailureBuilder);
                         }

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -48,7 +48,7 @@ namespace Bicep.Core.Registry
 
         public override ResultWithDiagnosticBuilder<ArtifactReference> TryParseArtifactReference(BicepSourceFile referencingFile, ArtifactType artifactType, string? aliasName, string reference)
         {
-            if (!OciArtifactReference.TryParse(referencingFile, artifactType, aliasName, reference).IsSuccess(out var @ref, out var failureBuilder))
+            if (!OciArtifactReference.TryParse(referencingFile.Features, referencingFile.Configuration, artifactType, aliasName, reference).IsSuccess(out var @ref, out var failureBuilder))
             {
                 return new(failureBuilder);
             }
@@ -87,7 +87,7 @@ namespace Bicep.Core.Registry
             try
             {
                 // Get module
-                await this.containerRegistryManager.PullArtifactAsync(reference.ReferencingFile.Configuration.Cloud, reference);
+                await this.containerRegistryManager.PullArtifactAsync(reference.Configuration.Cloud, reference);
             }
             catch (RequestFailedException exception) when (exception.Status == 404)
             {
@@ -208,7 +208,7 @@ namespace Bicep.Core.Registry
             foreach (var reference in referencesEvaluated)
             {
                 using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference).Uri.GetFilePath()}");
-                var (result, errorMessage) = await this.TryRestoreArtifactAsync(reference.ReferencingFile.Configuration, reference);
+                var (result, errorMessage) = await this.TryRestoreArtifactAsync(reference.Configuration, reference);
 
                 if (result is null)
                 {
@@ -261,7 +261,7 @@ namespace Bicep.Core.Registry
             try
             {
                 await this.containerRegistryManager.PushArtifactAsync(
-                    reference.ReferencingFile.Configuration.Cloud,
+                    reference.Configuration.Cloud,
                     reference,
                     // Technically null should be fine for mediaType, but ACR guys recommend OciImageManifest for safer compatibility
                     ManifestMediaType.OciImageManifest.ToString(),
@@ -316,7 +316,7 @@ namespace Bicep.Core.Registry
             try
             {
                 await this.containerRegistryManager.PushArtifactAsync(
-                    reference.ReferencingFile.Configuration.Cloud,
+                    reference.Configuration.Cloud,
                     reference,
                     // Technically null should be fine for mediaType, but ACR guys recommend OciImageManifest for safer compatibility
                     ManifestMediaType.OciImageManifest.ToString(),
@@ -459,7 +459,7 @@ namespace Bicep.Core.Registry
                 throw new InvalidOperationException("Module reference is missing both tag and digest.");
             }
 
-            return reference.ReferencingFile.Features.CacheRootDirectory.GetDirectory($"{ArtifactReferenceSchemes.Oci}/{registry}/{repository}/{tagOrDigest}");
+            return reference.FeatureProvider.CacheRootDirectory.GetDirectory($"{ArtifactReferenceSchemes.Oci}/{registry}/{repository}/{tagOrDigest}");
         }
 
         protected override IFileHandle GetArtifactLockFile(OciArtifactReference reference) => this.GetArtifactFile(reference, ArtifactFileType.Lock);

--- a/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
+++ b/src/Bicep.Core/Registry/TemplateSpecModuleRegistry.cs
@@ -32,7 +32,7 @@ namespace Bicep.Core.Registry
             {
                 return new(x => x.UnsupportedArtifactType(artifactType));
             }
-            if (!TemplateSpecModuleReference.TryParse(referencingFile, aliasName, reference).IsSuccess(out var @ref, out var failureBuilder))
+            if (!TemplateSpecModuleReference.TryParse(referencingFile.Features, referencingFile.Configuration, aliasName, reference).IsSuccess(out var @ref, out var failureBuilder))
             {
                 return new(failureBuilder);
             }
@@ -60,7 +60,7 @@ namespace Bicep.Core.Registry
                 using var timer = new ExecutionTimer($"Restore module {reference.FullyQualifiedReference} to {GetArtifactDirectory(reference).Uri.GetFilePath()}");
                 try
                 {
-                    var repository = this.repositoryFactory.CreateRepository(reference.ReferencingFile.Configuration, reference.SubscriptionId);
+                    var repository = this.repositoryFactory.CreateRepository(reference.Configuration, reference.SubscriptionId);
                     var templateSpecEntity = await repository.FindTemplateSpecByIdAsync(reference.TemplateSpecResourceId);
 
                     await this.WriteArtifactContentToCacheAsync(reference, templateSpecEntity);
@@ -90,7 +90,7 @@ namespace Bicep.Core.Registry
 
         protected override void WriteArtifactContentToCache(TemplateSpecModuleReference reference, TemplateSpecEntity entity) => reference.MainTemplateSpecFile.Write(entity.Content);
 
-        protected override IDirectoryHandle GetArtifactDirectory(TemplateSpecModuleReference reference) => reference.ReferencingFile.Features.CacheRootDirectory.GetDirectory(
+        protected override IDirectoryHandle GetArtifactDirectory(TemplateSpecModuleReference reference) => reference.FeatureProvider.CacheRootDirectory.GetDirectory(
             $"{this.Scheme}/{reference.SubscriptionId}/{reference.ResourceGroupName}/{reference.TemplateSpecName}/{reference.Version}".ToLowerInvariant());
 
         protected override IFileHandle GetArtifactLockFile(TemplateSpecModuleReference reference) => this.GetArtifactDirectory(reference).GetFile("lock");

--- a/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Registry/ModuleRestoreSchedulerTests.cs
@@ -200,7 +200,7 @@ namespace Bicep.LangServer.IntegrationTests.Registry
         private class MockArtifactRef : ArtifactReference
         {
             public MockArtifactRef(BicepSourceFile referencingFile, string value)
-                : base(referencingFile, "mock")
+                : base(referencingFile.Features, referencingFile.Configuration, "mock")
             {
                 this.Value = value;
             }

--- a/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepExternalSourceRequestHandlerTests.cs
@@ -395,7 +395,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             var referencingFile = BicepTestConstants.DummyBicepFile;
 
             TemplateSpecModuleReference
-                .TryParse(referencingFile, null, referenceValue)
+                .TryParse(referencingFile.Features, referencingFile.Configuration, null, referenceValue)
                 .IsSuccess(out var reference, out var errorBuilder)
                 .Should()
                 .BeTrue();
@@ -409,7 +409,8 @@ namespace Bicep.LangServer.UnitTests.Handlers
         {
             Uri? entrypointUri = testData.SourceEntrypoint is { } ? PathHelper.FilePathToFileUrl(testData.SourceEntrypoint) : null;
             OciArtifactReference reference = new(
-                BicepTestConstants.DummyBicepFile,
+                BicepTestConstants.DummyBicepFile.Features,
+                BicepTestConstants.DummyBicepFile.Configuration,
                 ArtifactType.Module,
                 testData.Registry,
                 testData.Repository,
@@ -553,7 +554,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
                 throw new ArgumentException("Module reference is not fully qualified.");
             }
 
-            return OciArtifactReference.TryParse(referencingFile, ArtifactType.Module, aliasName, fullyQualifiedReference[3..]).Unwrap();
+            return OciArtifactReference.TryParse(referencingFile.Features, referencingFile.Configuration, ArtifactType.Module, aliasName, fullyQualifiedReference[3..]).Unwrap();
         }
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepExternalSourceDocumentLinkHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepExternalSourceDocumentLinkHandler.cs
@@ -144,7 +144,7 @@ namespace Bicep.LanguageServer.Handlers
             var data = request.Data;
 
             var dummyFile = sourceFileFactory.CreateDummyArtifactReferencingFile();
-            if (!OciArtifactReference.TryParse(dummyFile, ArtifactType.Module, null, data.TargetArtifactId).IsSuccess(out var targetArtifactReference, out var error))
+            if (!OciArtifactReference.TryParse(dummyFile.Features, dummyFile.Configuration, ArtifactType.Module, null, data.TargetArtifactId).IsSuccess(out var targetArtifactReference, out var error))
             {
                 server.Window.ShowWarning($"Unable to parse the module source ID '{data.TargetArtifactId}': {error(DiagnosticBuilder.ForDocumentStart()).Message}");
                 telemetryProvider.PostEvent(ExternalSourceDocLinkClickFailure("TryParseModule"));

--- a/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
+++ b/src/Bicep.LangServer/Handlers/ExternalSourceReference.cs
@@ -150,7 +150,7 @@ namespace Bicep.LanguageServer.Handlers
         {
             if (OciArtifactAddressComponents.TryParse(Components.ArtifactId).IsSuccess(out var components, out var failureBuilder))
             { // No parent file template is available or needed because these are absolute references
-                return new(new OciArtifactReference(referencingFile, ArtifactType.Module, components));
+                return new(new OciArtifactReference(referencingFile.Features, referencingFile.Configuration, ArtifactType.Module, components));
             }
             else
             {


### PR DESCRIPTION
The goal for this PR is just to allow #19453 to use `IModuleDispatcher` directly, rather than having to duplicate some of the registry logic