### PR TITLE
Add diagnostics and tests for spread operator limitations with for-expressions

### DIFF
--- a/src/Bicep.Core.IntegrationTests/SpreadTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SpreadTests.cs
@@ -22,7 +22,7 @@ var other = {
 output test object = {
   foo: 'foo'
   ...other
-  baz: 'baz'  
+  baz: 'baz'
 }
 """);
 
@@ -125,7 +125,7 @@ var other = ['bar']
 var test = {
   foo: 'foo'
   ...other
-  baz: 'baz'  
+  baz: 'baz'
 }
 """);
 
@@ -144,7 +144,7 @@ var other = {
 var test = [
   'foo'
   ...other
-  'baz'  
+  'baz'
 ]
 """);
 
@@ -205,6 +205,35 @@ resource ex 'Microsoft.Network/expressRouteCircuits@2024-05-01' = {
     authorizations: [for item in array1: {
       name: item
     }]
+  }
+}
+""");
+
+        result.ExcludingLinterDiagnostics().Should().ContainDiagnostic(
+            "BCP417", Diagnostics.DiagnosticLevel.Error, """The spread operator "..." cannot be used inside objects with property for-expressions.""");
+    }
+
+    [TestMethod]
+    public void Spread_is_blocked_with_nested_for_loop()
+    {
+        // https://github.com/Azure/bicep/issues/19394
+        var result = CompilationHelper.Compile("""
+resource foo 'Microsoft.Storage/storageAccounts@2025-08-01' = {
+  name: uniqueString(resourceGroup().id, 'repro')
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    networkAcls: {
+      defaultAction: 'Deny'
+      ipRules: [for item in []: {
+        value: item
+        action: 'Allow'
+      }]
+    }
+    ...{}
   }
 }
 """);

--- a/src/Bicep.Core.IntegrationTests/SpreadTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SpreadTests.cs
@@ -210,7 +210,7 @@ resource ex 'Microsoft.Network/expressRouteCircuits@2024-05-01' = {
 """);
 
         result.ExcludingLinterDiagnostics().Should().ContainDiagnostic(
-            "BCP417", Diagnostics.DiagnosticLevel.Error, """The spread operator "..." cannot be used inside objects with property for-expressions.""");
+            "BCP417", Diagnostics.DiagnosticLevel.Error, """The spread operator "..." cannot be used inside objects containing property for-expressions.""");
     }
 
     [TestMethod]

--- a/src/Bicep.Core.IntegrationTests/SpreadTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SpreadTests.cs
@@ -241,6 +241,139 @@ resource foo 'Microsoft.Storage/storageAccounts@2025-08-01' = {
     }
 
     [TestMethod]
+    public void Nested_for_loop_with_spread_returns_diagnostic()
+    {
+        // https://github.com/Azure/bicep/issues/19394
+        var result = CompilationHelper.Compile("""
+resource foo 'Microsoft.Storage/storageAccounts@2025-08-01' = {
+  name: uniqueString(resourceGroup().id, 'repro')
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    networkAcls: {
+      defaultAction: 'Deny'
+      ipRules: [for item in []: {
+        value: item
+        action: 'Allow'
+      }]
+    }
+    ...{}
+  }
+}
+""");
+
+        result.ExcludingLinterDiagnostics().Should().ContainDiagnostic(
+            "BCP417", Diagnostics.DiagnosticLevel.Error, """The spread operator "..." cannot be used inside objects containing property for-expressions.""");
+    }
+
+    [TestMethod]
+    public void Spread_is_blocked_when_property_for_loop_is_nested()
+    {
+        var result = CompilationHelper.Compile("""
+var other = {
+  bypass: 'AzureServices'
+}
+
+resource foo 'Microsoft.Storage/storageAccounts@2025-08-01' = {
+  name: uniqueString(resourceGroup().id, 'repro')
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    networkAcls: {
+      ...other
+      defaultAction: 'Deny'
+      ipRules: [for item in ['10.0.0.1']: {
+        value: item
+        action: 'Allow'
+      }]
+    }
+  }
+}
+""");
+
+        result.ExcludingLinterDiagnostics().Should().ContainDiagnostic(
+            "BCP417", Diagnostics.DiagnosticLevel.Error, """The spread operator "..." cannot be used inside objects containing property for-expressions.""");
+    }
+
+    [TestMethod]
+    public void Spread_with_nested_lambda_map_is_allowed()
+    {
+        var result = CompilationHelper.Compile("""
+var other = {
+  enabled: true
+}
+
+var test = {
+  ...other
+  settings: {
+    values: map(['one', 'two'], item => {
+      name: item
+    })
+  }
+}
+
+output result object = test
+""");
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        var evaluated = TemplateEvaluator.Evaluate(result.Template).ToJToken();
+        evaluated.Should().HaveJsonAtPath("$.outputs['result'].value", """
+{
+  "enabled": true,
+  "settings": {
+    "values": [
+      {
+        "name": "one"
+      },
+      {
+        "name": "two"
+      }
+    ]
+  }
+}
+""");
+    }
+
+    [TestMethod]
+    public void Spread_source_with_for_loop_is_allowed()
+    {
+        var result = CompilationHelper.Compile("""
+var values = [for item in ['one', 'two']: item]
+
+var other = {
+  values: values
+}
+
+var test = {
+  ...other
+  enabled: true
+}
+
+output result object = test
+""");
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        var evaluated = TemplateEvaluator.Evaluate(result.Template).ToJToken();
+        evaluated.Should().HaveJsonAtPath("$.outputs['result'].value", """
+{
+  "values": [
+    "one",
+    "two"
+  ],
+  "enabled": true
+}
+""");
+    }
+
+    [TestMethod]
     public void Object_spread_edge_cases()
     {
         var result = CompilationHelper.Compile("""

--- a/src/Bicep.Core.IntegrationTests/SpreadTests.cs
+++ b/src/Bicep.Core.IntegrationTests/SpreadTests.cs
@@ -214,7 +214,7 @@ resource ex 'Microsoft.Network/expressRouteCircuits@2024-05-01' = {
     }
 
     [TestMethod]
-    public void Spread_is_blocked_with_nested_for_loop()
+    public void Nested_for_loop_without_spread_is_allowed()
     {
         // https://github.com/Azure/bicep/issues/19394
         var result = CompilationHelper.Compile("""
@@ -233,13 +233,11 @@ resource foo 'Microsoft.Storage/storageAccounts@2025-08-01' = {
         action: 'Allow'
       }]
     }
-    ...{}
   }
 }
 """);
 
-        result.ExcludingLinterDiagnostics().Should().ContainDiagnostic(
-            "BCP417", Diagnostics.DiagnosticLevel.Error, """The spread operator "..." cannot be used inside objects with property for-expressions.""");
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
 
     [TestMethod]

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1902,7 +1902,7 @@ namespace Bicep.Core.Diagnostics
 
             public Diagnostic SpreadOperatorCannotBeUsedWithForLoop(SpreadExpressionSyntax spread) => CoreError(
                 "BCP417",
-                $"The spread operator \"{spread.Ellipsis.Text}\" cannot be used inside objects with property for-expressions.");
+                $"The spread operator \"{spread.Ellipsis.Text}\" cannot be used inside objects containing property for-expressions.");
 
             public Diagnostic ExtensionCannotBeReferenced() => CoreError(
                 "BCP418",

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -915,7 +915,7 @@ namespace Bicep.Core.Emit
                     continue;
                 }
 
-                if (parentObject.Properties.Any(x => x.Value is ForSyntax))
+                if (SyntaxAggregator.AggregateByType<ForSyntax>(parentObject).Any(forSyntax => model.Binder.GetParent(forSyntax) is ObjectPropertySyntax property && ReferenceEquals(property.Value, forSyntax)))
                 {
                     diagnostics.Write(spread, x => x.SpreadOperatorCannotBeUsedWithForLoop(spread));
                 }


### PR DESCRIPTION
## Description

Updates spread operator emit validation to reject objects that combine spreads with nested property for-expressions, preventing template emission from crashing with an unexpected `ForLoopExpression`.

Fixes #19394

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19516)