### PR TITLE
Theme vscode-elements widgets in visualizer ExportToolbar

### DIFF
--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportToolbar.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportToolbar.tsx
@@ -36,6 +36,37 @@ const $Toolbar = styled.div`
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   backdrop-filter: blur(8px);
   white-space: nowrap;
+
+  /*
+   * Override the VS Code design-token CSS variables consumed by
+   * <vscode-single-select> (and any other @vscode-elements widget
+   * we may add to this toolbar) so its shadow-DOM styles resolve
+   * to the visualizer's curated palette instead of the editor's
+   * native theme. The variables listed here are the ones declared
+   * by vscode-single-select via @cssprop; any not listed fall back
+   * to the library's defaults.
+   */
+  --vscode-foreground: ${({ theme }) => theme.text.primary};
+  --vscode-focusBorder: ${({ theme }) => theme.focusBorder};
+
+  --vscode-settings-dropdownBackground: ${({ theme }) => theme.controlBar.background};
+  --vscode-settings-dropdownForeground: ${({ theme }) => theme.text.primary};
+  --vscode-settings-dropdownBorder: ${({ theme }) => theme.controlBar.border};
+  --vscode-settings-dropdownListBorder: ${({ theme }) => theme.controlBar.border};
+  --vscode-settings-checkboxBackground: ${({ theme }) => theme.node.background};
+
+  --vscode-list-hoverBackground: ${({ theme }) => theme.controlBar.hoverBackground};
+  --vscode-list-hoverForeground: ${({ theme }) => theme.text.primary};
+  --vscode-list-activeSelectionBackground: ${({ theme }) => theme.controlBar.activeBackground};
+  --vscode-list-activeSelectionForeground: ${({ theme }) => theme.text.primary};
+  --vscode-list-focusOutline: ${({ theme }) => theme.focusBorder};
+  --vscode-list-focusHighlightForeground: ${({ theme }) => theme.focusBorder};
+  --vscode-list-highlightForeground: ${({ theme }) => theme.focusBorder};
+
+  --vscode-badge-background: ${({ theme }) => theme.text.secondary};
+  --vscode-badge-foreground: ${({ theme }) => theme.node.background};
+
+  --vscode-inputValidation-errorBorder: ${({ theme }) => theme.error};
 `;
 
 /** Logical group of related controls. */


### PR DESCRIPTION
## Summary

The visualizer's image-export toolbar uses `<vscode-single-select>` from `@vscode-elements/react-elements` for the **Background** and **Theme** dropdowns. Those web components style themselves from VS Code's native `--vscode-*` CSS custom properties, while the rest of the visualizer uses a curated `DefaultTheme` palette. The mismatch is most visible when a user runs a marketplace color theme (or applies `workbench.colorCustomizations`): the dropdown chrome reads as a foreign element next to the curated toolbar.

## Change

Scope a small block of `--vscode-*` overrides on the export toolbar root so `vscode-single-select`'s shadow-DOM styles resolve to the visualizer's `DefaultTheme` slots instead of the editor's tokens. The overrides cover every `@cssprop` declared by `vscode-single-select`; anything not listed falls back to the library's defaults.

| `vscode-elements` variable | Theme slot |
|---|---|
| `--vscode-foreground` | `text.primary` |
| `--vscode-focusBorder` | `focusBorder` |
| `--vscode-settings-dropdownBackground` | `controlBar.background` |
| `--vscode-settings-dropdownForeground` | `text.primary` |
| `--vscode-settings-dropdownBorder` | `controlBar.border` |
| `--vscode-settings-dropdownListBorder` | `controlBar.border` |
| `--vscode-settings-checkboxBackground` | `node.background` |
| `--vscode-list-hoverBackground` | `controlBar.hoverBackground` |
| `--vscode-list-hoverForeground` | `text.primary` |
| `--vscode-list-activeSelectionBackground` | `controlBar.activeBackground` |
| `--vscode-list-activeSelectionForeground` | `text.primary` |
| `--vscode-list-focusOutline` / `focusHighlightForeground` / `highlightForeground` | `focusBorder` |
| `--vscode-badge-background` | `text.secondary` |
| `--vscode-badge-foreground` | `node.background` |
| `--vscode-inputValidation-errorBorder` | `error` |

The overrides are scoped to `$Toolbar` only, so no other `--vscode-*` consumer in the webview is affected.

## Why not migrate the whole theme?

We considered (and drafted) a broader migration to make the visualizer pull all colors from `--vscode-*` tokens, but rejected it for now: it sacrifices the curated graph aesthetic, requires a dual-theme model to keep the PNG-export pipeline working, and multiplies the visual-test surface — all to fix one dropdown. This change keeps the curated palette as the source of truth and reverses cleanly if a full migration is ever pursued.

## Validation

- TypeScript compiles cleanly.
- Manual: open the export overlay, cycle the **Theme** dropdown through Current / Light / Dark / Light HC / Dark HC. Dropdown chrome matches the canvas preview in each state.
- Manual: in an Extension Development Host, switch from Default Dark+ to Monokai. Dropdown chrome stays aligned with the curated visualizer palette rather than picking up Monokai's colors.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19557)