### PR TITLE
Update waitUntil feature description in docs

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -93,7 +93,7 @@ param p string
 
 ### `waitUntil`
 
-The feature introduces waitUntil decorators on resource data type. waitUnitl() decorator waits for the resource until its usable based on the desired property's state. 
+The feature introduces waitUntil decorators on resource data type. waitUntil() decorator waits for the resource until its usable based on the desired property's state. 
 
 ## Other experimental functionality
 


### PR DESCRIPTION
Fixed the typo

## Description

This pull request makes a minor correction to the documentation by fixing a typo in the description of the `waitUntil` decorator. No functional or structural changes are introduced.

- Fixed a typo in the `docs/experimental-features.md` file, correcting "waitUnitl()" to "waitUntil()" in the description of the waitUntil decorator.

## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19560)