### PR TITLE
Remove isAction check for dependabot PRs

### DIFF
--- a/.github/policies/prMgmt.dependabot.yml
+++ b/.github/policies/prMgmt.dependabot.yml
@@ -11,8 +11,6 @@ configuration:
       - description: Approve PRs submitted by dependabot with the "dependencies" label
         if:
           - payloadType: Pull_Request
-          - isAction:
-              action: Opened
           - hasLabel:
               label: dependencies
           - isActivitySender:


### PR DESCRIPTION
Unfortunately this recent change means that PRs are no longer auto-approved if dependabot pushes a 2nd update (e.g. to resolve merge conflicts)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19599)