### PR TITLE
Fix BCP120 on extension Required+DTC identifier properties

### DIFF
--- a/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
@@ -309,7 +309,7 @@ resource app 'Microsoft.Graph/applications@v1.0' = {
             // Builds a minimal MS Graph extension types package that contains a single
             // Microsoft.Graph/applications resource type with a uniqueName identifier
             // property (flags = Required | DeployTimeConstant | Identifier, value 25)
-            // and a plain read-only property for the negative test.
+            // and a plain read-only property (createdDateTime) for the negative test.
             return ExtensionTestHelper.CreateMockExtensionMockData(
                 "MicrosoftGraph",
                 "1.0.0",
@@ -330,10 +330,10 @@ resource app 'Microsoft.Graph/applications@v1.0' = {
                                         | Azure.Bicep.Types.Concrete.ObjectTypePropertyFlags.DeployTimeConstant
                                         | Azure.Bicep.Types.Concrete.ObjectTypePropertyFlags.Identifier,
                                     "The unique name of the application"),
-                                ["appId"] = new(
+                                ["createdDateTime"] = new(
                                     factory.GetReference(stringType),
                                     Azure.Bicep.Types.Concrete.ObjectTypePropertyFlags.ReadOnly,
-                                    "The application ID (read-only, not a deploy-time constant)"),
+                                    "The date and time the application was created (read-only, server-generated)"),
                             },
                             null));
 
@@ -385,7 +385,7 @@ resource app 'Microsoft.Graph/applications@v1.0' = {
                 new(),
                 artifactTarget: "example.azurecr.io/microsoftgraph/v1:1.0.0");
 
-            // ACT — use graphApp.appId (ReadOnly only, NOT Required+DTC) as storage account name
+            // ACT — use graphApp.createdDateTime (ReadOnly only, NOT Required+DTC) as storage account name
             var result = await CompilationHelper.RestoreAndCompile(services, """
                 extension 'br:example.azurecr.io/microsoftgraph/v1:1.0.0' as graph
 
@@ -394,14 +394,14 @@ resource app 'Microsoft.Graph/applications@v1.0' = {
                 }
 
                 resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
-                  name: graphApp.appId
+                  name: graphApp.createdDateTime
                   location: 'eastus'
                   sku: { name: 'Standard_LRS' }
                   kind: 'StorageV2'
                 }
                 """);
 
-            // ASSERT — must still produce BCP120 (appId is not a deploy-time constant)
+            // ASSERT — must still produce BCP120 (createdDateTime is server-generated, not a deploy-time constant)
             result.ExcludingLinterDiagnostics().Should().HaveDiagnostics([
                 ("BCP120", DiagnosticLevel.Error,
                     """This expression is being used in an assignment to the "name" property of the "Microsoft.Storage/storageAccounts" type, which requires a value that can be calculated at the start of the deployment. Properties of graphApp which can be calculated at the start include "uniqueName".""")

--- a/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
@@ -299,5 +299,112 @@ resource app 'Microsoft.Graph/applications@v1.0' = {
                 ("BCP037", DiagnosticLevel.Warning, "The property \"extraNestedProp\" is not allowed on objects of type \"MicrosoftGraphSpaApplication\". Permissible properties include \"redirectUris\". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues.")
             });
         }
+
+        // -----------------------------------------------------------------------
+        // ReadableAtDeployTime tests (Required + DeployTimeConstant fix)
+        // -----------------------------------------------------------------------
+
+        private static BinaryData GetMsGraphTypesTgzWithApplication()
+        {
+            // Builds a minimal MS Graph extension types package that contains a single
+            // Microsoft.Graph/applications resource type with a uniqueName identifier
+            // property (flags = Required | DeployTimeConstant | Identifier, value 25)
+            // and a plain read-only property for the negative test.
+            return ExtensionResourceTypeHelper.CreateTypesTgzBytesForCustomExtension(
+                "MicrosoftGraph",
+                "1.0.0",
+                new()
+                {
+                    CreateResourceTypes = (ctx, factory) =>
+                    {
+                        var stringType = factory.Create(() => new Azure.Bicep.Types.Concrete.StringType());
+
+                        var appBody = factory.Create(() => new Azure.Bicep.Types.Concrete.ObjectType(
+                            "Microsoft.Graph/applications",
+                            new Dictionary<string, Azure.Bicep.Types.Concrete.ObjectTypeProperty>
+                            {
+                                ["uniqueName"] = new(
+                                    factory.GetReference(stringType),
+                                    Azure.Bicep.Types.Concrete.ObjectTypePropertyFlags.Required
+                                        | Azure.Bicep.Types.Concrete.ObjectTypePropertyFlags.DeployTimeConstant
+                                        | Azure.Bicep.Types.Concrete.ObjectTypePropertyFlags.Identifier,
+                                    "The unique name of the application"),
+                                ["appId"] = new(
+                                    factory.GetReference(stringType),
+                                    Azure.Bicep.Types.Concrete.ObjectTypePropertyFlags.ReadOnly,
+                                    "The application ID (read-only, not a deploy-time constant)"),
+                            },
+                            null));
+
+                        return [factory.Create(() => new Azure.Bicep.Types.Concrete.ResourceType(
+                            "Microsoft.Graph/applications@v1.0",
+                            factory.GetReference(appBody),
+                            null,
+                            writableScopes_in: Azure.Bicep.Types.Concrete.ScopeType.All,
+                            readableScopes_in: Azure.Bicep.Types.Concrete.ScopeType.All))];
+                    }
+                });
+        }
+
+        [TestMethod]
+        public async Task MsGraph_uniqueName_is_readable_at_deploy_time()
+        {
+            // ARRANGE — publish a mock MS Graph extension with an applications resource
+            var services = await ExtensionTestHelper.GetServiceBuilderWithPublishedExtension(
+                GetMsGraphTypesTgzWithApplication(),
+                new(),
+                artifactTarget: "example.azurecr.io/microsoftgraph/v1:1.0.0");
+
+            // ACT — use graphApp.uniqueName (Required + DeployTimeConstant) as storage account name
+            var result = await CompilationHelper.RestoreAndCompile(services, """
+                extension 'br:example.azurecr.io/microsoftgraph/v1:1.0.0' as graph
+
+                resource graphApp 'Microsoft.Graph/applications@v1.0' = {
+                  uniqueName: 'myApp'
+                }
+
+                resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+                  name: graphApp.uniqueName
+                  location: 'eastus'
+                  sku: { name: 'Standard_LRS' }
+                  kind: 'StorageV2'
+                }
+                """);
+
+            // ASSERT — must compile clean, no BCP120
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        }
+
+        [TestMethod]
+        public async Task MsGraph_readOnly_property_is_not_readable_at_deploy_time()
+        {
+            // ARRANGE — same extension as above
+            var services = await ExtensionTestHelper.GetServiceBuilderWithPublishedExtension(
+                GetMsGraphTypesTgzWithApplication(),
+                new(),
+                artifactTarget: "example.azurecr.io/microsoftgraph/v1:1.0.0");
+
+            // ACT — use graphApp.appId (ReadOnly only, NOT Required+DTC) as storage account name
+            var result = await CompilationHelper.RestoreAndCompile(services, """
+                extension 'br:example.azurecr.io/microsoftgraph/v1:1.0.0' as graph
+
+                resource graphApp 'Microsoft.Graph/applications@v1.0' = {
+                  uniqueName: 'myApp'
+                }
+
+                resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+                  name: graphApp.appId
+                  location: 'eastus'
+                  sku: { name: 'Standard_LRS' }
+                  kind: 'StorageV2'
+                }
+                """);
+
+            // ASSERT — must still produce BCP120 (appId is not a deploy-time constant)
+            result.ExcludingLinterDiagnostics().Should().HaveDiagnostics([
+                ("BCP120", DiagnosticLevel.Error,
+                    """This expression is being used in an assignment to the "name" property of the "Microsoft.Storage/storageAccounts" type, which requires a value that can be calculated at the start of the deployment. Properties of graphApp which can be calculated at the start include "uniqueName".""")
+            ]);
+        }
     }
 }

--- a/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
+++ b/src/Bicep.Core.IntegrationTests/MsGraphTypesViaRegistryTests.cs
@@ -310,9 +310,10 @@ resource app 'Microsoft.Graph/applications@v1.0' = {
             // Microsoft.Graph/applications resource type with a uniqueName identifier
             // property (flags = Required | DeployTimeConstant | Identifier, value 25)
             // and a plain read-only property for the negative test.
-            return ExtensionResourceTypeHelper.CreateTypesTgzBytesForCustomExtension(
+            return ExtensionTestHelper.CreateMockExtensionMockData(
                 "MicrosoftGraph",
                 "1.0.0",
+                "v1",
                 new()
                 {
                     CreateResourceTypes = (ctx, factory) =>
@@ -343,7 +344,7 @@ resource app 'Microsoft.Graph/applications@v1.0' = {
                             writableScopes_in: Azure.Bicep.Types.Concrete.ScopeType.All,
                             readableScopes_in: Azure.Bicep.Types.Concrete.ScopeType.All))];
                     }
-                });
+                }).TypesTgzData;
         }
 
         [TestMethod]

--- a/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeProvider.cs
@@ -71,15 +71,8 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
             {
                 if (propertyType.Flags.HasFlag(TypePropertyFlags.Required | TypePropertyFlags.DeployTimeConstant))
                 {
-                    // Add ReadableAtDeployTime for any property that is both required and a deploy-time constant.
-                    // Rationale:
-                    //   Required           — the caller must supply the value; the service cannot generate or invent it.
-                    //   DeployTimeConstant — the value must be a constant committed before deployment starts.
-                    // Together these mean the value is fully under the caller's control and cannot be
-                    // server-generated or deferred, so it is always safe to read back at deploy time.
-                    // ResourceIdentifier is a strict subset of this condition (all identifiers are
-                    // Required + DeployTimeConstant), but the condition is broader and correctly covers
-                    // any required constant property, not only those flagged as identifiers.
+                    // Required + DeployTimeConstant means the caller owns the value fully and it cannot
+                    // be server-generated or deferred, so it is safe to read back at deploy time.
                     properties = properties.SetItem(propertyName, UpdateFlags(propertyType, propertyType.Flags | TypePropertyFlags.ReadableAtDeployTime));
                 }
             }

--- a/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeProvider.cs
@@ -67,6 +67,23 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
                 }
             }
 
+            foreach (var (propertyName, propertyType) in properties)
+            {
+                if (propertyType.Flags.HasFlag(TypePropertyFlags.Required | TypePropertyFlags.DeployTimeConstant))
+                {
+                    // Add ReadableAtDeployTime for any property that is both required and a deploy-time constant.
+                    // Rationale:
+                    //   Required           — the caller must supply the value; the service cannot generate or invent it.
+                    //   DeployTimeConstant — the value must be a constant committed before deployment starts.
+                    // Together these mean the value is fully under the caller's control and cannot be
+                    // server-generated or deferred, so it is always safe to read back at deploy time.
+                    // ResourceIdentifier is a strict subset of this condition (all identifiers are
+                    // Required + DeployTimeConstant), but the condition is broader and correctly covers
+                    // any required constant property, not only those flagged as identifiers.
+                    properties = properties.SetItem(propertyName, UpdateFlags(propertyType, propertyType.Flags | TypePropertyFlags.ReadableAtDeployTime));
+                }
+            }
+
             return new ObjectType(
                 objectType.Name,
                 objectType.ValidationFlags,


### PR DESCRIPTION
## Description

Extension resource types (e.g. the MS Graph `applications` resource) expose identifier properties such as `uniqueName` that are marked `Required` and `DeployTimeConstant` in the wire format. 

The `ExtensionResourceTypeProvider` doesn't set this Bicep-internal flag, causing BCP120 to be incorrectly raised when such properties were used in deploy-time-constant positions (e.g. as a storage account `name`). 

This fix adds a second post-processing pass in `ExtensionResourceTypeProvider.SetBicepResourceProperties` that stamps `ReadableAtDeployTime` on any property flagged as both `Required` and `DeployTimeConstant`. 

Two integration tests are added to `MsGraphTypesViaRegistryTests` to cover the positive case (no BCP120 on `uniqueName`) and the regression guard (BCP120 still raised for a read-only-only property).

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19637)