### PR TITLE
Remove Experimental Features ThisNamespace and NullIfNotFound

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -17,20 +17,6 @@ Should be enabled in tandem with `testFramework` experimental feature flag for e
 
 Enables `deploy`, `what-if` and `teardown` command groups, as well as the `with` syntax in a `.bicepparam` file. For more information, see [Using the Deploy Commands](./experimental/deploy-commands.md).
 
-### `existingNullIfNotFound`
-
-Enables the use of the `@nullIfNotFound()` decorator for existing resources. When applied to an existing resource, the resource will return `null` if it doesn't exist at deployment time instead of failing. This allows you to gracefully handle cases where the resource may not exist. (Note: This feature will not work until the backend service support has been deployed)
-
-```bicep
-@nullIfNotFound()
-resource exampleResource 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
-  name: 'test'
-}
-
-// Access with safe navigation since the resource may be null
-output accessTier string = exampleResource.?properties.accessTier ?? ''
-```
-
 ### `extendableParamFiles`
 
 Enables the ability to extend bicepparam files from other bicepparam files. For more information, see [Extendable Bicep Params Files](./experimental/extendable-param-files.md).

--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -53,21 +53,6 @@ Allows the ARM template layer to use a new schema to represent resources as an o
 ### `testFramework`
 
 Should be enabled in tandem with `assertions` experimental feature flag for expected functionality. Allows you to author client-side, offline unit-test test blocks that reference Bicep files and mock deployment parameters in a separate `test.bicep` file using the new `test` keyword. Test blocks can be run with the command *bicep test <filepath_to_file_with_test_blocks>* which runs all `assert` statements in the Bicep files referenced by the test blocks. For more information, see [Bicep Experimental Test Framework](https://github.com/Azure/bicep/issues/11967).
-### `thisNamespace`
-
-Enables the `this` namespace for accessing the current resource instance. The `this` namespace is only discoverable in resource bodies. Currently, `this.exists()` and `this.existingResource()` are available for usage. `this.exists()` returns a bool indicating the existence of the current resource. `this.existingResource()` returns null if the resource does not exist and returns the full resource if the resource exists. (Note: This feature will not work until the backend service support has been deployed)
-```
-resource usingThis 'Microsoft...' = {
-  name: 'example'
-  location: 'eastus'
-  properties: {
-    property1: this.exists() ? 'resource exists' : 'resource does not exist'
-    property2: this.existingResource().?properties.?property2
-    property3: this.existingResource().?tags
-  }
-}
-```
-
 ### `userDefinedConstraints`
 
 Enables the `@validate()` decorator on types, type properties, parameters, and outputs. The decorator takes two arguments: 1) a lambda function that accepts the decorator target's value and returns a boolean indicating if the value is valid (`true`) or not (`false`), and 2) an optional error message to use if the lambda returns `false`.

--- a/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
@@ -403,5 +403,37 @@ output accountLocation string? = storageAccount.?location
                 template.Should().HaveValueAtPath("$.outputs['accountLocation'].value", "[tryGet(reference('storageAccount', '2021-04-01', 'full'), 'location')]");
             }
         }
+            [TestMethod]
+            public void NullableExisting_NestedChildResource_ShouldEmitExperimentalLanguageVersion()
+            {
+                // @nullIfNotFound on a nested existing child resource should still trigger the experimental language version
+                var (template, diagnostics, _) = CompilationHelper.Compile(@"
+    resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+      name: 'testStorage'
+      location: 'westus'
+      sku: {
+        name: 'Standard_LRS'
+      }
+      kind: 'StorageV2'
+
+      @nullIfNotFound()
+      resource blobService 'blobServices' existing = {
+        name: 'default'
+      }
     }
-}
+
+    output blobServiceId string? = storageAccount::blobService.?id
+    ");
+                using (new AssertionScope())
+                {
+                    diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
+                    template.Should().NotBeNull();
+                    // Verify the experimental language version is used (required for @nullIfNotFound)
+                    template.Should().HaveValueAtPath("$.languageVersion", "2.1-experimental");
+                    // Verify the nested existing resource has the correct options
+                    template.Should().HaveValueAtPath("$.resources['storageAccount::blobService'].existing", true);
+                    template.Should().HaveValueAtPath("$.resources['storageAccount::blobService']['@options'].nullIfNotFound", new JArray());
+                }
+            }
+        }
+    }

--- a/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.Diagnostics;
-using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
 using FluentAssertions;
@@ -16,34 +14,11 @@ namespace Bicep.Core.IntegrationTests
     [TestClass]
     public class NullableExistingResourceTests
     {
-        [NotNull]
-        public TestContext? TestContext { get; set; }
-
-        [TestMethod]
-        public void NullableExisting_DecoratorShouldNotBeRecognizedWhenFeatureDisabled()
-        {
-            // Test that @nullIfNotFound() decorator is not recognized when feature is disabled
-            var (template, diagnostics, _) = CompilationHelper.Compile(@"
-#disable-next-line no-unused-existing-resources
-@nullIfNotFound()
-resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
-  name: 'testStorage'
-}
-");
-            using (new AssertionScope())
-            {
-                template.Should().NotHaveValue();
-                // When feature is disabled, the decorator function doesn't exist in the sys namespace
-                diagnostics.ExcludingLinterDiagnostics().Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"nullIfNotFound\" does not exist in the current context.");
-            }
-        }
-
         [TestMethod]
         public void NullableExisting_FullyQualifiedDecoratorShouldWork()
         {
             // Test that @sys.nullIfNotFound() (fully qualified) works the same as @nullIfNotFound()
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @sys.nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
@@ -68,8 +43,7 @@ output location string? = storageAccount.?location
             // Nullable existing resources should behave like conditional resources:
             // - Direct access to runtime properties should produce a warning
             // - Access to compile-time properties (id, name, type, apiVersion) should not produce warnings
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
@@ -102,8 +76,7 @@ output resourceApiVersion string = storageAccount.apiVersion
         public void NullableExisting_RuntimePropertyAccess_ShouldProduceWarning()
         {
             // Access to runtime properties should produce a warning (same as conditional resources)
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
@@ -132,8 +105,7 @@ output skuName string = storageAccount.sku.name
         public void NullableExisting_RegularExistingShouldStillWork()
         {
             // Regular existing (without @nullIfNotFound()) should still work the same way
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
 }
@@ -145,9 +117,7 @@ output accountId string = storageAccount.id
                 // Regular existing should still be non-nullable
                 diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
                 template.Should().NotBeNull();
-                template.Should().HaveValueAtPath("$.resources['storageAccount'].existing", true);
                 // Regular existing should NOT have nullIfNotFound in @options
-                template.Should().NotHaveValueAtPath("$.resources['storageAccount']['@options'].nullIfNotFound");
                 // Verify the output expression for regular existing resource
                 template.Should().HaveValueAtPath("$.outputs['accountId'].value", "[resourceId('Microsoft.Storage/storageAccounts', 'testStorage')]");
             }
@@ -157,8 +127,7 @@ output accountId string = storageAccount.id
         public void NullableExisting_NullComparisonShouldWork()
         {
             // Null comparison should work with nullable existing resources
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
@@ -182,8 +151,7 @@ output exists bool = storageAccount != null
         public void NullableExisting_DecoratorCannotBeUsedWithNewResource()
         {
             // The @nullIfNotFound() decorator should produce an error on non-existing resources
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
@@ -204,8 +172,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void NullableExisting_PropertyAccess_WithSafeAccess_ShouldWork()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
@@ -229,8 +196,7 @@ output location string? = storageAccount.?location
         public void NullableExisting_SafeAccessAndNullCoalescing_OnRuntimeProperties()
         {
             // Test safe access (.?) and null coalescing (??) on runtime properties that would produce warnings without them
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
@@ -274,8 +240,7 @@ output accessTierWithDefault string = storageAccount.?properties.accessTier ?? '
         public void NullableExisting_DependsOn_ShouldBePopulated()
         {
             // Test that dependsOn is correctly populated when a new resource references a nullable existing resource
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource existingStorage 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'existingStorageAccount'
@@ -315,8 +280,7 @@ resource newStorage 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         public void NullableExisting_ConditionalListKeys_WithNullCheck()
         {
             // Test using null check with ternary to conditionally call listKeys on a nullable existing resource
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: 'testStorage'
@@ -342,8 +306,7 @@ output firstKey string = storageAccount != null ? storageAccount!.listKeys().key
         public void NullableExisting_WithForLoop_ShouldCompile()
         {
             // Test that nullable existing resources work with for loops
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 param storageNames array = ['storage1', 'storage2', 'storage3']
 
 @nullIfNotFound()
@@ -373,8 +336,7 @@ output secondAccountLocation string? = storageAccounts[1].?location
             // Test using a nullable existing resource (key vault) as parent for a child resource (secret)
             // Note: The parent property accepts the nullable resource and compiles successfully.
             // The deployment may fail at runtime if the key vault doesn't exist.
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 @nullIfNotFound()
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: 'myKeyVault'
@@ -407,8 +369,7 @@ output secretId string = secret.id
         public void NullableExisting_WithScope_ShouldCompile()
         {
             // Test that nullable existing resources work with scope property
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ExistingNullIfNotFoundEnabled: true));
-            var (template, diagnostics, _) = CompilationHelper.Compile(services, @"
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
 param subscriptionId string
 param resourceGroupName string
 

--- a/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
@@ -403,37 +403,38 @@ output accountLocation string? = storageAccount.?location
                 template.Should().HaveValueAtPath("$.outputs['accountLocation'].value", "[tryGet(reference('storageAccount', '2021-04-01', 'full'), 'location')]");
             }
         }
-            [TestMethod]
-            public void NullableExisting_NestedChildResource_ShouldEmitExperimentalLanguageVersion()
+
+        [TestMethod]
+        public void NullableExisting_NestedChildResource_ShouldEmitExperimentalLanguageVersion()
+        {
+            // @nullIfNotFound on a nested existing child resource should still trigger the experimental language version
+            var (template, diagnostics, _) = CompilationHelper.Compile(@"
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'testStorage'
+  location: 'westus'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+
+  @nullIfNotFound()
+  resource blobService 'blobServices' existing = {
+    name: 'default'
+  }
+}
+
+output blobServiceId string? = storageAccount::blobService.?id
+");
+            using (new AssertionScope())
             {
-                // @nullIfNotFound on a nested existing child resource should still trigger the experimental language version
-                var (template, diagnostics, _) = CompilationHelper.Compile(@"
-    resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
-      name: 'testStorage'
-      location: 'westus'
-      sku: {
-        name: 'Standard_LRS'
-      }
-      kind: 'StorageV2'
-
-      @nullIfNotFound()
-      resource blobService 'blobServices' existing = {
-        name: 'default'
-      }
-    }
-
-    output blobServiceId string? = storageAccount::blobService.?id
-    ");
-                using (new AssertionScope())
-                {
-                    diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
-                    template.Should().NotBeNull();
-                    // Verify the experimental language version is used (required for @nullIfNotFound)
-                    template.Should().HaveValueAtPath("$.languageVersion", "2.1-experimental");
-                    // Verify the nested existing resource has the correct options
-                    template.Should().HaveValueAtPath("$.resources['storageAccount::blobService'].existing", true);
-                    template.Should().HaveValueAtPath("$.resources['storageAccount::blobService']['@options'].nullIfNotFound", new JArray());
-                }
+                diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
+                template.Should().NotBeNull();
+                // Verify the experimental language version is used (required for @nullIfNotFound)
+                template.Should().HaveValueAtPath("$.languageVersion", "2.1-experimental");
+                // Verify the nested existing resource has the correct options
+                template.Should().HaveValueAtPath("$.resources['storageAccount::blobService'].existing", true);
+                template.Should().HaveValueAtPath("$.resources['storageAccount::blobService']['@options'].nullIfNotFound", new JArray());
             }
         }
     }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/AKS_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/AKS_LF/main.symbols.bicep
@@ -35,6 +35,7 @@ param agentVMSize string = 'Standard_DS2_v2'
 // osType was a defaultValue with only one allowedValue, which seems strange?, could be a good TTK test
 
 resource aks 'Microsoft.ContainerService/managedClusters@2020-03-01' = {
+//@[0:08) Local this. Type: object. Declaration start char: 71, length: 755
 //@[9:12) Resource aks. Type: Microsoft.ContainerService/managedClusters@2020-03-01. Declaration start char: 0, length: 826
     name: clusterName
     location: location

--- a/src/Bicep.Core.Samples/Files/baselines/Dependencies_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Dependencies_LF/main.symbols.bicep
@@ -24,6 +24,7 @@ var resourceDependency = {
 output resourceAType string = resA.type
 //@[7:20) Output resourceAType. Type: string. Declaration start char: 0, length: 39
 resource resA 'My.Rp/myResourceType@2020-01-01' = {
+//@[0:08) Local this. Type: object. Declaration start char: 50, length: 84
 //@[9:13) Resource resA. Type: My.Rp/myResourceType@2020-01-01. Declaration start char: 0, length: 134
   name: 'resA'
   properties: {
@@ -35,6 +36,7 @@ resource resA 'My.Rp/myResourceType@2020-01-01' = {
 output resourceBId string = resB.id
 //@[7:18) Output resourceBId. Type: string. Declaration start char: 0, length: 35
 resource resB 'My.Rp/myResourceType@2020-01-01' = {
+//@[0:08) Local this. Type: object. Declaration start char: 50, length: 75
 //@[9:13) Resource resB. Type: My.Rp/myResourceType@2020-01-01. Declaration start char: 0, length: 125
   name: 'resB'
   properties: {
@@ -49,6 +51,7 @@ var resourceIds = {
 }
 
 resource resC 'My.Rp/myResourceType@2020-01-01' = {
+//@[0:08) Local this. Type: object. Declaration start char: 50, length: 67
 //@[9:13) Resource resC. Type: My.Rp/myResourceType@2020-01-01. Declaration start char: 0, length: 117
   name: 'resC'
   properties: {
@@ -57,6 +60,7 @@ resource resC 'My.Rp/myResourceType@2020-01-01' = {
 }
 
 resource resD 'My.Rp/myResourceType/childType@2020-01-01' = {
+//@[0:08) Local this. Type: object. Declaration start char: 60, length: 51
 //@[9:13) Resource resD. Type: My.Rp/myResourceType/childType@2020-01-01. Declaration start char: 0, length: 111
   name: '${resC.name}/resD'
   properties: {
@@ -64,6 +68,7 @@ resource resD 'My.Rp/myResourceType/childType@2020-01-01' = {
 }
 
 resource resE 'My.Rp/myResourceType/childType@2020-01-01' = {
+//@[0:08) Local this. Type: object. Declaration start char: 60, length: 66
 //@[9:13) Resource resE. Type: My.Rp/myResourceType/childType@2020-01-01. Declaration start char: 0, length: 126
   name: 'resC/resD_2'
   properties: {

--- a/src/Bicep.Core.Samples/Files/baselines/DisableNextLineDiagnosticsDirective_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/DisableNextLineDiagnosticsDirective_CRLF/main.symbols.bicep
@@ -10,6 +10,7 @@ var vmProperties = {
   evictionPolicy: 'Deallocate'
 }
 resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
+//@[0:08) Local this. Type: object. Declaration start char: 61, length: 103
 //@[9:11) Resource vm. Type: Microsoft.Compute/virtualMachines@2020-12-01. Declaration start char: 0, length: 164
   name: 'vm'
   location: 'West US'

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbols.bicep
@@ -68,12 +68,14 @@ resource scopedKv1 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
 // BEGIN: Test resources
 
 resource testResource1 'az:My.Rp/TestType@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 56, length: 47
 //@[009:022) Resource testResource1. Type: My.Rp/TestType@2020-01-01. Declaration start char: 0, length: 103
   name: 'testResource1'
   properties: {}
 }
 
 resource aks 'Microsoft.ContainerService/managedClusters@2024-02-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 71, length: 67
 //@[009:012) Resource aks. Type: Microsoft.ContainerService/managedClusters@2024-02-01. Declaration start char: 0, length: 138
   name: 'aksCluster'
   location: az.resourceGroup().location

--- a/src/Bicep.Core.Samples/Files/baselines/IntermediaryVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/IntermediaryVariables_LF/main.symbols.bicep
@@ -14,6 +14,7 @@ var vmProperties = {
 }
 
 resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 61, length: 65
 //@[09:11) Resource vm. Type: Microsoft.Compute/virtualMachines@2020-12-01. Declaration start char: 0, length: 126
   name: 'vm'
   location: 'West US'
@@ -32,6 +33,7 @@ var ipConfigurations = [for i in range(0, 2): {
 }]
 
 resource nic 'Microsoft.Network/networkInterfaces@2020-11-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 64, length: 76
 //@[09:12) Resource nic. Type: Microsoft.Network/networkInterfaces@2020-11-01. Declaration start char: 0, length: 140
   name: 'abc'
   properties: {
@@ -41,6 +43,7 @@ resource nic 'Microsoft.Network/networkInterfaces@2020-11-01' = {
 
 resource nicLoop 'Microsoft.Network/networkInterfaces@2020-11-01' = [for i in range(0, 2): {
 //@[73:74) Local i. Type: int. Declaration start char: 73, length: 1
+//@[00:08) Local this. Type: object[]. Declaration start char: 68, length: 145
 //@[09:16) Resource nicLoop. Type: Microsoft.Network/networkInterfaces@2020-11-01[]. Declaration start char: 0, length: 213
   name: 'abc${i}'
   properties: {
@@ -53,6 +56,7 @@ resource nicLoop 'Microsoft.Network/networkInterfaces@2020-11-01' = [for i in ra
 
 resource nicLoop2 'Microsoft.Network/networkInterfaces@2020-11-01' = [for ipConfig in ipConfigurations: {
 //@[74:82) Local ipConfig. Type: object. Declaration start char: 74, length: 8
+//@[00:08) Local this. Type: object[]. Declaration start char: 69, length: 158
 //@[09:17) Resource nicLoop2. Type: Microsoft.Network/networkInterfaces@2020-11-01[]. Declaration start char: 0, length: 227
   name: 'abc${ipConfig.name}'
   properties: {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidCycles_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidCycles_CRLF/main.symbols.bicep
@@ -51,6 +51,7 @@ var twotwo = one.
 
 // resource completion cycles
 resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[0:08) Local this. Type: error. Declaration start char: 63, length: 187
 //@[9:13) Resource res1. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 250
   // #completionTest(14) -> empty
   name: res2.n
@@ -63,6 +64,7 @@ resource res1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   kind: 'StorageV2'
 }
 resource res2 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[0:08) Local this. Type: error. Declaration start char: 63, length: 183
 //@[9:13) Resource res2. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 246
   name: res1.name
   location: 'l'

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExtensions_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExtensions_CRLF/main.symbols.bicep
@@ -64,6 +64,7 @@ var configProp = 'config'
 // Extension symbols are blocked in resources because each config property returns an object { value, keyVaultReference } and "value" is not available when a reference is provided.
 // Users should use deployment parameters for this scenario.
 resource testResource1 'az:My.Rp/TestType@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 56, length: 175
 //@[09:022) Resource testResource1. Type: My.Rp/TestType@2020-01-01. Declaration start char: 0, length: 231
   name: k8s.config.namespace
   properties: {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidLambdas_LF/main.symbols.bicep
@@ -126,6 +126,7 @@ var inArray = [
 
 resource stg 'Microsoft.Storage/storageAccounts@2021-09-01' = [for i in range(0, 2): {
 //@[67:68) Local i. Type: int. Declaration start char: 67, length: 1
+//@[00:08) Local this. Type: object[]. Declaration start char: 62, length: 132
 //@[09:12) Resource stg. Type: Microsoft.Storage/storageAccounts@2021-09-01[]. Declaration start char: 0, length: 194
   name: 'antteststg${i}'
   location: 'West US'

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/main.symbols.bicep
@@ -265,6 +265,7 @@ module moduleWithBadScope './empty.bicep' = {
 }
 
 resource runtimeValidRes1 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 75, length: 115
 //@[09:25) Resource runtimeValidRes1. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 190
   name: 'runtimeValidRes1Name'
   location: 'westeurope'

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decorators.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decorators.json
@@ -206,6 +206,23 @@
     }
   },
   {
+    "label": "nullIfNotFound",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnullIfNotFound(): any\n\n```  \n  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nullIfNotFound",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nullIfNotFound()$0"
+    }
+  },
+  {
     "label": "onlyIfNotExists",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decoratorsPlusNamespace.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/decoratorsPlusNamespace.json
@@ -206,6 +206,23 @@
     }
   },
   {
+    "label": "nullIfNotFound",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nnullIfNotFound(): any\n\n```  \n  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_nullIfNotFound",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "nullIfNotFound()$0"
+    }
+  },
+  {
     "label": "onlyIfNotExists",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/main.symbols.bicep
@@ -218,6 +218,7 @@ param paramModifierSelfCycle string
 var sampleVar = 'sample'
 //@[04:013) Variable sampleVar. Type: 'sample'. Declaration start char: 0, length: 24
 resource sampleResource 'Microsoft.Foo/foos@2020-02-02' = {
+//@[00:008) Local this. Type: object. Declaration start char: 58, length: 17
 //@[09:023) Resource sampleResource. Type: Microsoft.Foo/foos@2020-02-02. Declaration start char: 0, length: 75
   name: 'foo'
 }

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -6221,6 +6221,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -6185,6 +6185,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -6213,6 +6213,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -6199,6 +6199,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -6213,6 +6213,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -6213,6 +6213,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -6199,6 +6199,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -6171,6 +6171,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -6201,6 +6201,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -6297,6 +6297,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -6185,6 +6185,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -6185,6 +6185,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -6230,6 +6230,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -6252,6 +6252,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -6216,6 +6216,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -6216,6 +6216,24 @@
     }
   },
   {
+    "label": "this",
+    "kind": "variable",
+    "detail": "this",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_this",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "this."
+    },
+    "command": {
+      "title": "symbol completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "toLogicalZone",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.symbols.bicep
@@ -4,67 +4,84 @@ bad
 
 // incomplete #completionTest(9) -> empty
 resource 
+//@[000:008) Local this. Type: error. Declaration start char: 9, length: 0
 //@[009:009) Resource <missing>. Type: error. Declaration start char: 0, length: 9
 resource foo
+//@[000:008) Local this. Type: error. Declaration start char: 12, length: 0
 //@[009:012) Resource foo. Type: error. Declaration start char: 0, length: 12
 resource fo/o
+//@[000:008) Local this. Type: error. Declaration start char: 13, length: 0
 //@[009:011) Resource fo. Type: error. Declaration start char: 0, length: 13
 resource foo 'ddd'
+//@[000:008) Local this. Type: error. Declaration start char: 18, length: 0
 //@[009:012) Resource foo. Type: error. Declaration start char: 0, length: 18
 
 // #completionTest(23) -> resourceTypes
 resource trailingSpace  
+//@[000:008) Local this. Type: error. Declaration start char: 24, length: 0
 //@[009:022) Resource trailingSpace. Type: error. Declaration start char: 0, length: 24
 
 // #completionTest(19,20) -> resourceObject
 resource foo 'ddd'= 
+//@[000:008) Local this. Type: error. Declaration start char: 20, length: 0
 //@[009:012) Resource foo. Type: error. Declaration start char: 0, length: 20
 
 // wrong resource type
 resource foo 'ddd'={
+//@[000:008) Local this. Type: object. Declaration start char: 19, length: 4
 //@[009:012) Resource foo. Type: error. Declaration start char: 0, length: 23
 }
 
 resource foo 'ddd'=if (1 + 1 == 2) {
+//@[000:008) Local this. Type: object. Declaration start char: 35, length: 4
 //@[009:012) Resource foo. Type: error. Declaration start char: 0, length: 39
 }
 
 // using string interpolation for the resource type
 resource foo 'Microsoft.${provider}/foos@2020-02-02-alpha'= {
+//@[000:008) Local this. Type: object. Declaration start char: 60, length: 4
 //@[009:012) Resource foo. Type: error. Declaration start char: 0, length: 64
 }
 
 resource foo 'Microsoft.${provider}/foos@2020-02-02-alpha'= if (true) {
+//@[000:008) Local this. Type: object. Declaration start char: 70, length: 4
 //@[009:012) Resource foo. Type: error. Declaration start char: 0, length: 74
 }
 
 // missing required property
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'={
+//@[000:008) Local this. Type: object. Declaration start char: 51, length: 4
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 55
 }
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (name == 'value') {
+//@[000:008) Local this. Type: object. Declaration start char: 73, length: 4
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 77
 }
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if ({ 'a': b }.a == 'foo') {
+//@[000:008) Local this. Type: object. Declaration start char: 79, length: 4
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 83
 }
 
 // simulate typing if condition
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if
+//@[000:008) Local this. Type: error. Declaration start char: 54, length: 0
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 54
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (
+//@[000:008) Local this. Type: error. Declaration start char: 60, length: 0
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 120
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (true
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (true)
+//@[000:008) Local this. Type: error. Declaration start char: 61, length: 0
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 61
 
 // missing condition
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if {
+//@[000:008) Local this. Type: object. Declaration start char: 55, length: 19
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 74
   name: 'foo'
 }
@@ -72,35 +89,41 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if {
 // empty condition
 // #completionTest(56) -> symbols
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if () {
+//@[000:008) Local this. Type: object. Declaration start char: 58, length: 19
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 77
   name: 'foo'
 }
 
 // #completionTest(57, 59) -> symbols
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (     ) {
+//@[000:008) Local this. Type: object. Declaration start char: 63, length: 19
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 82
   name: 'foo'
 }
 
 // invalid condition type
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= if (123) {
+//@[000:008) Local this. Type: object. Declaration start char: 61, length: 19
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 80
   name: 'foo'
 }
 
 // runtime functions are no allowed in resource conditions
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (reference('Micorosft.Management/managementGroups/MG', '2020-05-01').name == 'something') {
+//@[000:008) Local this. Type: object. Declaration start char: 146, length: 19
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 165
   name: 'foo'
 }
 
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha' = if (listKeys('foo', '2020-05-01').bar == true) {
+//@[000:008) Local this. Type: object. Declaration start char: 100, length: 19
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 119
   name: 'foo'
 }
 
 // duplicate property at the top level
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+//@[000:008) Local this. Type: error. Declaration start char: 52, length: 33
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 85
   name: 'foo'
   name: true
@@ -108,6 +131,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 
 // duplicate property at the top level with string literal syntax
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+//@[000:008) Local this. Type: error. Declaration start char: 52, length: 35
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 87
   name: 'foo'
   'name': true
@@ -115,6 +139,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 
 // duplicate property inside
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+//@[000:008) Local this. Type: error. Declaration start char: 52, length: 69
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 121
   name: 'foo'
   properties: {
@@ -125,6 +150,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 
 // duplicate property inside with string literal syntax
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+//@[000:008) Local this. Type: error. Declaration start char: 52, length: 71
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 123
   name: 'foo'
   properties: {
@@ -135,6 +161,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 
 // wrong property types
 resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+//@[000:008) Local this. Type: object. Declaration start char: 52, length: 72
 //@[009:012) Resource foo. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 124
   name: 'foo'
   location: [
@@ -143,6 +170,7 @@ resource foo 'Microsoft.Foo/foos@2020-02-02-alpha'= {
 }
 
 resource bar 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: error. Declaration start char: 53, length: 178
 //@[009:012) Resource bar. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 231
   name: true ? 's' : 'a' + 1
   properties: {
@@ -158,12 +186,14 @@ resource bar 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 
 // there should be no completions without the colon
 resource noCompletionsWithoutColon 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 88, length: 50
 //@[009:034) Resource noCompletionsWithoutColon. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 138
   // #completionTest(7,8) -> empty
   kind  
 }
 
 resource noCompletionsBeforeColon 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 87, length: 51
 //@[009:033) Resource noCompletionsBeforeColon. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 138
   // #completionTest(7,8) -> empty
   kind  :
@@ -181,6 +211,7 @@ output resrefout bool = bar.id
 
 // attempting to set read-only properties
 resource baz 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: object. Declaration start char: 53, length: 66
 //@[009:012) Resource baz. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 119
   name: 'test'
   id: 2
@@ -189,6 +220,7 @@ resource baz 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource readOnlyPropertyAssignment 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 85, length: 267
 //@[009:035) Resource readOnlyPropertyAssignment. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 352
   name: 'vnet-bicep'
   location: 'westeurope'
@@ -205,6 +237,7 @@ resource readOnlyPropertyAssignment 'Microsoft.Network/virtualNetworks@2020-06-0
 }
 
 resource badDepends 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: object. Declaration start char: 60, length: 53
 //@[009:019) Resource badDepends. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 113
   name: 'test'
   dependsOn: [
@@ -213,6 +246,7 @@ resource badDepends 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource badDepends2 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: object. Declaration start char: 61, length: 64
 //@[009:020) Resource badDepends2. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 125
   name: 'test'
   dependsOn: [
@@ -222,11 +256,13 @@ resource badDepends2 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource badDepends3 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: object. Declaration start char: 61, length: 20
 //@[009:020) Resource badDepends3. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 81
   name: 'test'
 }
 
 resource badDepends4 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: object. Declaration start char: 61, length: 58
 //@[009:020) Resource badDepends4. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 119
   name: 'test'
   dependsOn: [
@@ -235,6 +271,7 @@ resource badDepends4 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 }
 
 resource badDepends5 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: error. Declaration start char: 61, length: 56
 //@[009:020) Resource badDepends5. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 117
   name: 'test'
   dependsOn: badDepends3.dependsOn
@@ -243,6 +280,7 @@ resource badDepends5 'Microsoft.Foo/foos@2020-02-02-alpha' = {
 var interpVal = 'abc'
 //@[004:013) Variable interpVal. Type: 'abc'. Declaration start char: 0, length: 21
 resource badInterp 'Microsoft.Foo/foos@2020-02-02-alpha' = {
+//@[000:008) Local this. Type: error. Declaration start char: 59, length: 146
 //@[009:018) Resource badInterp. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 205
   name: 'test'
   '${interpVal}': 'unsupported' // resource definition does not allow for additionalProperties
@@ -258,6 +296,7 @@ module validModule './module.bicep' = {
 }
 
 resource runtimeValidRes1 'Microsoft.Compute/virtualMachines@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 75, length: 99
 //@[009:025) Resource runtimeValidRes1. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 174
   name: 'name1'
   location: 'eastus'
@@ -267,6 +306,7 @@ resource runtimeValidRes1 'Microsoft.Compute/virtualMachines@2020-06-01' = {
 }
 
 resource runtimeValidRes2 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 79, length: 250
 //@[009:025) Resource runtimeValidRes2. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 329
   name: concat(concat(runtimeValidRes1.id, runtimeValidRes1.name), runtimeValidRes1.type)
   kind:'AzureCLI'
@@ -278,31 +318,37 @@ resource runtimeValidRes2 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 }
 
 resource runtimeValidRes3 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 43
 //@[009:025) Resource runtimeValidRes3. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 131
   name: '${runtimeValidRes1.name}_v1'
 }
 
 resource runtimeValidRes4 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 47
 //@[009:025) Resource runtimeValidRes4. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 135
   name: concat(validModule['name'], 'v1')
 }
 
 resource runtimeValidRes5 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 38
 //@[009:025) Resource runtimeValidRes5. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 126
   name: '${validModule.name}_v1'
 }
 
 resource runtimeInvalidRes1 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 39
 //@[009:027) Resource runtimeInvalidRes1. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 129
   name: runtimeValidRes1.location
 }
 
 resource runtimeInvalidRes2 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 42
 //@[009:027) Resource runtimeInvalidRes2. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 132
   name: runtimeValidRes1['location']
 }
 
 resource runtimeInvalidRes3 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 81, length: 211
 //@[009:027) Resource runtimeInvalidRes3. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 292
   name: runtimeValidRes1.properties.evictionPolicy
   kind:'AzureCLI'
@@ -314,21 +360,25 @@ resource runtimeInvalidRes3 'Microsoft.Resources/deploymentScripts@2020-10-01' =
 }
 
 resource runtimeInvalidRes4 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 59
 //@[009:027) Resource runtimeInvalidRes4. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 149
   name: runtimeValidRes1['properties'].evictionPolicy
 }
 
 resource runtimeInvalidRes5 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 62
 //@[009:027) Resource runtimeInvalidRes5. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 152
   name: runtimeValidRes1['properties']['evictionPolicy']
 }
 
 resource runtimeInvalidRes6 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 59
 //@[009:027) Resource runtimeInvalidRes6. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 149
   name: runtimeValidRes1.properties['evictionPolicy']
 }
 
 resource runtimeInvalidRes7 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 54
 //@[009:027) Resource runtimeInvalidRes7. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 144
   name: runtimeValidRes2.properties.azCliVersion
 }
@@ -336,26 +386,31 @@ resource runtimeInvalidRes7 'Microsoft.Advisor/recommendations/suppressions@2020
 var magicString1 = 'location'
 //@[004:016) Variable magicString1. Type: 'location'. Declaration start char: 0, length: 29
 resource runtimeInvalidRes8 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 49
 //@[009:027) Resource runtimeInvalidRes8. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 139
   name: runtimeValidRes2['${magicString1}']
 }
 
 resource runtimeInvalidRes10 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 91, length: 44
 //@[009:028) Resource runtimeInvalidRes10. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 135
   name: '${runtimeValidRes3.location}'
 }
 
 resource runtimeInvalidRes11 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 91, length: 40
 //@[009:028) Resource runtimeInvalidRes11. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 131
   name: validModule.params['name']
 }
 
 resource runtimeInvalidRes12 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 91, length: 149
 //@[009:028) Resource runtimeInvalidRes12. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 240
   name: concat(runtimeValidRes1.location, runtimeValidRes2['location'], runtimeInvalidRes3['properties'].azCliVersion, validModule.params.name)
 }
 
 resource runtimeInvalidRes13 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 91, length: 152
 //@[009:028) Resource runtimeInvalidRes13. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 243
   name: '${runtimeValidRes1.location}${runtimeValidRes2['location']}${runtimeInvalidRes3.properties['azCliVersion']}${validModule['params'].name}'
 }
@@ -389,47 +444,56 @@ var runtimeValid = {
 }
 
 resource runtimeInvalidRes14 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 91, length: 33
 //@[009:028) Resource runtimeInvalidRes14. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 124
   name: runtimeInvalid.foo1
 }
 
 resource runtimeInvalidRes15 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 91, length: 33
 //@[009:028) Resource runtimeInvalidRes15. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 124
   name: runtimeInvalid.foo2
 }
 
 resource runtimeInvalidRes16 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 91, length: 57
 //@[009:028) Resource runtimeInvalidRes16. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 148
   name: runtimeInvalid.foo3.properties.azCliVersion
 }
 
 // Note: This is actually a runtime valid value. However, other properties of the variable cannot be resolved, so we block this.
 resource runtimeInvalidRes17 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 91, length: 33
 //@[009:028) Resource runtimeInvalidRes17. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 124
   name: runtimeInvalid.foo4
 }
 
 resource runtimeInvalidRes18 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 91, length: 135
 //@[009:028) Resource runtimeInvalidRes18. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 226
   name: concat(runtimeInvalid.foo1, runtimeValidRes2['properties'].azCliVersion, '${runtimeValidRes1.location}', runtimefoo4.hop)
 }
 
 resource runtimeValidRes6 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 31
 //@[009:025) Resource runtimeValidRes6. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 119
   name: runtimeValid.foo1
 }
 
 resource runtimeValidRes7 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 31
 //@[009:025) Resource runtimeValidRes7. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 119
   name: runtimeValid.foo2
 }
 
 resource runtimeValidRes8 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 31
 //@[009:025) Resource runtimeValidRes8. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 119
   name: runtimeValid.foo3
 }
 
 resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 31
 //@[009:025) Resource runtimeValidRes9. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 119
   name: runtimeValid.foo4
 }
@@ -437,12 +501,14 @@ resource runtimeValidRes9 'Microsoft.Advisor/recommendations/suppressions@2020-0
 var magicString2 = 'name'
 //@[004:016) Variable magicString2. Type: 'name'. Declaration start char: 0, length: 25
 resource runtimeValidRes10 'Microsoft.Advisor/recommendations/suppressions@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 89, length: 49
 //@[009:026) Resource runtimeValidRes10. Type: Microsoft.Advisor/recommendations/suppressions@2020-01-01. Declaration start char: 0, length: 138
   name: runtimeValidRes2['${magicString2}']
 }
 
 resource loopForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
 //@[076:081) Local thing. Type: never. Declaration start char: 76, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 71, length: 59
 //@[009:028) Resource loopForRuntimeCheck. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 130
   name: 'test'
   location: 'test'
@@ -454,6 +520,7 @@ var runtimeCheckVar2 = runtimeCheckVar
 //@[004:020) Variable runtimeCheckVar2. Type: 'Private' | 'Public'. Declaration start char: 0, length: 38
 
 resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 81, length: 50
 //@[009:038) Resource singleResourceForRuntimeCheck. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 131
   name: runtimeCheckVar2
   location: 'test'
@@ -461,6 +528,7 @@ resource singleResourceForRuntimeCheck 'Microsoft.Network/dnsZones@2018-05-01' =
 
 resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: {
 //@[077:082) Local thing. Type: never. Declaration start char: 77, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 72, length: 69
 //@[009:029) Resource loopForRuntimeCheck2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 141
   name: runtimeCheckVar2
   location: 'test'
@@ -468,6 +536,7 @@ resource loopForRuntimeCheck2 'Microsoft.Network/dnsZones@2018-05-01' = [for thi
 
 resource loopForRuntimeCheck3 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
 //@[077:087) Local otherThing. Type: never. Declaration start char: 77, length: 10
+//@[000:008) Local this. Type: object[]. Declaration start char: 72, length: 100
 //@[009:029) Resource loopForRuntimeCheck3. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 172
   name: loopForRuntimeCheck[0].properties.zoneType
   location: 'test'
@@ -479,18 +548,21 @@ var varForRuntimeCheck4b = varForRuntimeCheck4a
 //@[004:024) Variable varForRuntimeCheck4b. Type: 'Private' | 'Public'. Declaration start char: 0, length: 47
 resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for otherThing in []: {
 //@[077:087) Local otherThing. Type: never. Declaration start char: 77, length: 10
+//@[000:008) Local this. Type: object[]. Declaration start char: 72, length: 78
 //@[009:029) Resource loopForRuntimeCheck4. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 150
   name: varForRuntimeCheck4b
   location: 'test'
 }]
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
+//@[000:008) Local this. Type: object. Declaration start char: 92, length: 61
 //@[009:034) Resource missingTopLevelProperties. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 153
   // #completionTest(0, 1, 2) -> topLevelProperties
   
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
+//@[000:008) Local this. Type: object. Declaration start char: 102, length: 203
 //@[009:044) Resource missingTopLevelPropertiesExceptName. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 305
   // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
@@ -501,6 +573,7 @@ resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@
 
 // #completionTest(24,25,26,49,65,69,70) -> virtualNetworksResourceTypes
 resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 73, length: 458
 //@[009:023) Resource unfinishedVnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 531
   name: 'v'
   location: 'eastus'
@@ -527,6 +600,7 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 Discriminator key missing
 */
 resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 86, length: 62
 //@[009:032) Resource discriminatorKeyMissing. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 148
   // #completionTest(0,1,2) -> discriminatorProperty
   
@@ -536,6 +610,7 @@ resource discriminatorKeyMissing 'Microsoft.Resources/deploymentScripts@2020-10-
 Discriminator key missing (conditional)
 */
 resource discriminatorKeyMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(true) {
+//@[000:008) Local this. Type: object. Declaration start char: 98, length: 62
 //@[009:035) Resource discriminatorKeyMissing_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 160
   // #completionTest(0,1,2) -> discriminatorProperty
   
@@ -546,6 +621,7 @@ Discriminator key missing (loop)
 */
 resource discriminatorKeyMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
 //@[095:100) Local thing. Type: never. Declaration start char: 95, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 90, length: 81
 //@[009:036) Resource discriminatorKeyMissing_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 171
   // #completionTest(0,1,2) -> discriminatorProperty
   
@@ -556,6 +632,7 @@ Discriminator key missing (filtered loop)
 */
 resource discriminatorKeyMissing_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
 //@[098:103) Local thing. Type: never. Declaration start char: 98, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 93, length: 90
 //@[009:039) Resource discriminatorKeyMissing_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 183
   // #completionTest(0,1,2) -> discriminatorProperty
   
@@ -565,6 +642,7 @@ resource discriminatorKeyMissing_for_if 'Microsoft.Resources/deploymentScripts@2
 Discriminator key value missing with property access
 */
 resource discriminatorKeyValueMissing 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 91, length: 84
 //@[009:037) Resource discriminatorKeyValueMissing. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 175
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols
   kind:   
@@ -584,6 +662,7 @@ var discriminatorKeyValueMissingCompletions3 = discriminatorKeyValueMissing[]
 Discriminator key value missing with property access (conditional)
 */
 resource discriminatorKeyValueMissing_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(false) {
+//@[000:008) Local this. Type: error. Declaration start char: 104, length: 87
 //@[009:040) Resource discriminatorKeyValueMissing_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 191
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_if
   kind:   
@@ -604,6 +683,7 @@ Discriminator key value missing with property access (loops)
 */
 resource discriminatorKeyValueMissing_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
 //@[100:105) Local thing. Type: never. Declaration start char: 100, length: 5
+//@[000:008) Local this. Type: error. Declaration start char: 95, length: 107
 //@[009:041) Resource discriminatorKeyValueMissing_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 202
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for
   kind:   
@@ -629,6 +709,7 @@ Discriminator key value missing with property access (filtered loops)
 */
 resource discriminatorKeyValueMissing_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
 //@[103:108) Local thing. Type: never. Declaration start char: 103, length: 5
+//@[000:008) Local this. Type: error. Declaration start char: 98, length: 119
 //@[009:044) Resource discriminatorKeyValueMissing_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 217
   // #completionTest(7,8,9,10) -> deploymentScriptKindsPlusSymbols_for_if
   kind:   
@@ -653,6 +734,7 @@ var discriminatorKeyValueMissingCompletions3_for_if = discriminatorKeyValueMissi
 Discriminator value set 1
 */
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 85, length: 181
 //@[009:031) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 266
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -677,6 +759,7 @@ var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 Discriminator value set 1 (conditional)
 */
 resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
+//@[000:008) Local this. Type: object. Declaration start char: 97, length: 181
 //@[009:034) Resource discriminatorKeySetOne_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 278
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -702,6 +785,7 @@ Discriminator value set 1 (loop)
 */
 resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
 //@[095:100) Local thing. Type: never. Declaration start char: 95, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 89, length: 201
 //@[009:035) Resource discriminatorKeySetOne_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 290
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -727,6 +811,7 @@ Discriminator value set 1 (filtered loop)
 */
 resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: if(true) {
 //@[098:103) Local thing. Type: never. Declaration start char: 98, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 92, length: 210
 //@[009:038) Resource discriminatorKeySetOne_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 302
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -752,6 +837,7 @@ var discriminatorKeySetOneCompletions3_for_if = discriminatorKeySetOne_for_if[1]
 Discriminator value set 2
 */
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 85, length: 187
 //@[009:031) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 272
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -779,6 +865,7 @@ var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['pro
 Discriminator value set 2 (conditional)
 */
 resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 88, length: 187
 //@[009:034) Resource discriminatorKeySetTwo_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 275
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -808,6 +895,7 @@ Discriminator value set 2 (loops)
 */
 resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
 //@[094:099) Local thing. Type: never. Declaration start char: 94, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 89, length: 206
 //@[009:035) Resource discriminatorKeySetTwo_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 295
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -837,6 +925,7 @@ Discriminator value set 2 (filtered loops)
 */
 resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
 //@[097:102) Local thing. Type: never. Declaration start char: 97, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 92, length: 215
 //@[009:038) Resource discriminatorKeySetTwo_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 307
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
@@ -863,6 +952,7 @@ var discriminatorKeySetTwoCompletionsArrayIndexer2_for_if = discriminatorKeySetT
 
 
 resource incorrectPropertiesKey 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 85, length: 48
 //@[009:031) Resource incorrectPropertiesKey. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 133
   kind: 'AzureCLI'
 
@@ -874,6 +964,7 @@ var mock = incorrectPropertiesKey.p
 //@[004:008) Variable mock. Type: error. Declaration start char: 0, length: 35
 
 resource incorrectPropertiesKey2 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 86, length: 710
 //@[009:032) Resource incorrectPropertiesKey2. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 796
   kind: 'AzureCLI'
   name: 'test'
@@ -906,17 +997,21 @@ resource incorrectPropertiesKey2 'Microsoft.Resources/deploymentScripts@2020-10-
 
 // #completionTest(21) -> resourceTypes
 resource missingType 
+//@[000:008) Local this. Type: error. Declaration start char: 21, length: 0
 //@[009:020) Resource missingType. Type: error. Declaration start char: 0, length: 21
 
 // #completionTest(37,38,39,40,41,42,43,44) -> resourceTypes
 resource startedTypingTypeWithQuotes 'virma'
+//@[000:008) Local this. Type: error. Declaration start char: 44, length: 0
 //@[009:036) Resource startedTypingTypeWithQuotes. Type: error. Declaration start char: 0, length: 44
 
 // #completionTest(40,41,42,43,44,45) -> resourceTypes
 resource startedTypingTypeWithoutQuotes virma
+//@[000:008) Local this. Type: error. Declaration start char: 45, length: 0
 //@[009:039) Resource startedTypingTypeWithoutQuotes. Type: error. Declaration start char: 0, length: 45
 
 resource dashesInPropertyNames 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 89, length: 4
 //@[009:030) Resource dashesInPropertyNames. Type: Microsoft.ContainerService/managedClusters@2020-09-01. Declaration start char: 0, length: 93
 }
 // #completionTest(78) -> autoScalerPropertiesRequireEscaping
@@ -930,6 +1025,7 @@ var letsAccessTheDashes2 = dashesInPropertyNames.properties.autoScalerProfile.
 Nested discriminator missing key
 */
 resource nestedDiscriminatorMissingKey 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[000:008) Local this. Type: object. Declaration start char: 100, length: 90
 //@[009:038) Resource nestedDiscriminatorMissingKey. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 190
   name: 'test'
   location: 'l'
@@ -953,6 +1049,7 @@ var nestedDiscriminatorMissingKeyIndexCompletions = nestedDiscriminatorMissingKe
 Nested discriminator missing key (conditional)
 */
 resource nestedDiscriminatorMissingKey_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(bool(1)) {
+//@[000:008) Local this. Type: object. Declaration start char: 115, length: 90
 //@[009:041) Resource nestedDiscriminatorMissingKey_if. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 205
   name: 'test'
   location: 'l'
@@ -977,6 +1074,7 @@ Nested discriminator missing key (loop)
 */
 resource nestedDiscriminatorMissingKey_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
 //@[109:114) Local thing. Type: never. Declaration start char: 109, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 104, length: 109
 //@[009:042) Resource nestedDiscriminatorMissingKey_for. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview[]. Declaration start char: 0, length: 213
   name: 'test'
   location: 'l'
@@ -1002,6 +1100,7 @@ Nested discriminator missing key (filtered loop)
 */
 resource nestedDiscriminatorMissingKey_for_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: if(true) {
 //@[112:117) Local thing. Type: never. Declaration start char: 112, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 107, length: 118
 //@[009:045) Resource nestedDiscriminatorMissingKey_for_if. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview[]. Declaration start char: 0, length: 225
   name: 'test'
   location: 'l'
@@ -1026,6 +1125,7 @@ var nestedDiscriminatorMissingKeyIndexCompletions_for_if = nestedDiscriminatorMi
 Nested discriminator
 */
 resource nestedDiscriminator 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = {
+//@[000:008) Local this. Type: object. Declaration start char: 90, length: 88
 //@[009:028) Resource nestedDiscriminator. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 178
   name: 'test'
   location: 'l'
@@ -1055,6 +1155,7 @@ var nestedDiscriminatorArrayIndexCompletions = nestedDiscriminator.properties[a]
 Nested discriminator (conditional)
 */
 resource nestedDiscriminator_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = if(true) {
+//@[000:008) Local this. Type: object. Declaration start char: 102, length: 88
 //@[009:031) Resource nestedDiscriminator_if. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview. Declaration start char: 0, length: 190
   name: 'test'
   location: 'l'
@@ -1086,6 +1187,7 @@ Nested discriminator (loop)
 */
 resource nestedDiscriminator_for 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: {
 //@[099:104) Local thing. Type: never. Declaration start char: 99, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 94, length: 107
 //@[009:032) Resource nestedDiscriminator_for. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview[]. Declaration start char: 0, length: 201
   name: 'test'
   location: 'l'
@@ -1117,6 +1219,7 @@ Nested discriminator (filtered loop)
 */
 resource nestedDiscriminator_for_if 'Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview' = [for thing in []: if(true) {
 //@[102:107) Local thing. Type: never. Declaration start char: 102, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 97, length: 116
 //@[009:035) Resource nestedDiscriminator_for_if. Type: Microsoft.DocumentDB/databaseAccounts@2020-06-01-preview[]. Declaration start char: 0, length: 213
   name: 'test'
   location: 'l'
@@ -1146,6 +1249,7 @@ var nestedDiscriminatorArrayIndexCompletions_for_if = nestedDiscriminator_for_if
 
 // sample resource to validate completions on the next declarations
 resource nestedPropertyAccessOnConditional 'Microsoft.Compute/virtualMachines@2020-06-01' = if(true) {
+//@[000:008) Local this. Type: object. Declaration start char: 101, length: 108
 //@[009:042) Resource nestedPropertyAccessOnConditional. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 209
   location: 'test'
   name: 'test'
@@ -1164,6 +1268,7 @@ var sigh = nestedPropertyAccessOnConditional.properties.
   boolean property value completions
 */ 
 resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 97, length: 125
 //@[009:036) Resource booleanPropertyPartialValue. Type: Microsoft.Compute/virtualMachines/extensions@2020-06-01. Declaration start char: 0, length: 222
   properties: {
     // #completionTest(28,29,30) -> boolPropertyValuesPlusSymbols
@@ -1172,6 +1277,7 @@ resource booleanPropertyPartialValue 'Microsoft.Compute/virtualMachines/extensio
 }
 
 resource selfScope 'My.Rp/mockResource@2020-12-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 53, length: 45
 //@[009:018) Resource selfScope. Type: My.Rp/mockResource@2020-12-01. Declaration start char: 0, length: 98
   name: 'selfScope'
   scope: selfScope
@@ -1183,48 +1289,57 @@ var notAResource = {
   a: 'resource!'
 }
 resource invalidScope 'My.Rp/mockResource@2020-12-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 56, length: 51
 //@[009:021) Resource invalidScope. Type: My.Rp/mockResource@2020-12-01. Declaration start char: 0, length: 107
   name: 'invalidScope'
   scope: notAResource
 }
 
 resource invalidScope2 'My.Rp/mockResource@2020-12-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 57, length: 55
 //@[009:022) Resource invalidScope2. Type: My.Rp/mockResource@2020-12-01. Declaration start char: 0, length: 112
   name: 'invalidScope2'
   scope: resourceGroup()
 }
 
 resource invalidScope3 'My.Rp/mockResource@2020-12-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 57, length: 54
 //@[009:022) Resource invalidScope3. Type: My.Rp/mockResource@2020-12-01. Declaration start char: 0, length: 111
   name: 'invalidScope3'
   scope: subscription()
 }
 
 resource invalidDuplicateName1 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 67, length: 36
 //@[009:030) Resource invalidDuplicateName1. Type: Mock.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 103
   name: 'invalidDuplicateName'
 }
 resource invalidDuplicateName2 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 67, length: 36
 //@[009:030) Resource invalidDuplicateName2. Type: Mock.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 103
   name: 'invalidDuplicateName'
 }
 resource invalidDuplicateName3 'Mock.Rp/mockResource@2019-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 67, length: 36
 //@[009:030) Resource invalidDuplicateName3. Type: Mock.Rp/mockResource@2019-01-01. Declaration start char: 0, length: 103
   name: 'invalidDuplicateName'
 }
 
 resource validResourceForInvalidExtensionResourceDuplicateName 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 99, length: 69
 //@[009:062) Resource validResourceForInvalidExtensionResourceDuplicateName. Type: Mock.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 168
   name: 'validResourceForInvalidExtensionResourceDuplicateName'
 }
 
 resource invalidExtensionResourceDuplicateName1 'Mock.Rp/mockExtResource@2020-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 87, length: 117
 //@[009:047) Resource invalidExtensionResourceDuplicateName1. Type: Mock.Rp/mockExtResource@2020-01-01. Declaration start char: 0, length: 204
   name: 'invalidExtensionResourceDuplicateName'
   scope: validResourceForInvalidExtensionResourceDuplicateName
 }
 
 resource invalidExtensionResourceDuplicateName2 'Mock.Rp/mockExtResource@2019-01-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 87, length: 117
 //@[009:047) Resource invalidExtensionResourceDuplicateName2. Type: Mock.Rp/mockExtResource@2019-01-01. Declaration start char: 0, length: 204
   name: 'invalidExtensionResourceDuplicateName'
   scope: validResourceForInvalidExtensionResourceDuplicateName
@@ -1233,11 +1348,13 @@ resource invalidExtensionResourceDuplicateName2 'Mock.Rp/mockExtResource@2019-01
 @concat('foo', 'bar')
 @secure()
 resource invalidDecorator 'Microsoft.Foo/foos@2020-02-02-alpha'= {
+//@[000:008) Local this. Type: object. Declaration start char: 65, length: 32
 //@[009:025) Resource invalidDecorator. Type: Microsoft.Foo/foos@2020-02-02-alpha. Declaration start char: 0, length: 131
   name: 'invalidDecorator'
 }
 
 resource cyclicRes 'Mock.Rp/mockExistingResource@2020-01-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 63, length: 45
 //@[009:018) Resource cyclicRes. Type: Mock.Rp/mockExistingResource@2020-01-01. Declaration start char: 0, length: 108
   name: 'cyclicRes'
   scope: cyclicRes
@@ -1251,87 +1368,108 @@ resource cyclicExistingRes 'Mock.Rp/mockExistingResource@2020-01-01' existing = 
 
 // loop parsing cases
 resource expectedForKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = []
+//@[000:008) Local this. Type: error. Declaration start char: 77, length: 2
 //@[009:027) Resource expectedForKeyword. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 79
 
 resource expectedForKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [f]
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 3
 //@[009:028) Resource expectedForKeyword2. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 81
 
 resource expectedLoopVar 'Microsoft.Storage/storageAccounts@2019-06-01' = [for]
+//@[000:008) Local this. Type: error. Declaration start char: 74, length: 5
 //@[009:024) Resource expectedLoopVar. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 79
 
 resource expectedInKeyword 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x]
 //@[081:082) Local x. Type: any. Declaration start char: 81, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 76, length: 7
 //@[009:026) Resource expectedInKeyword. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 83
 
 resource expectedInKeyword2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x b]
 //@[082:083) Local x. Type: any. Declaration start char: 82, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 77, length: 9
 //@[009:027) Resource expectedInKeyword2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 86
 
 resource expectedArrayExpression 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in]
 //@[087:088) Local x. Type: any. Declaration start char: 87, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 82, length: 10
 //@[009:032) Resource expectedArrayExpression. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 92
 
 resource expectedColon 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y]
 //@[077:078) Local x. Type: any. Declaration start char: 77, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 72, length: 12
 //@[009:022) Resource expectedColon. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 84
 
 resource expectedLoopBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y:]
 //@[080:081) Local x. Type: any. Declaration start char: 80, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 75, length: 13
 //@[009:025) Resource expectedLoopBody. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 88
 
 // loop index parsing cases
 resource expectedLoopItemName 'Microsoft.Network/dnsZones@2018-05-01' = [for ()]
+//@[000:008) Local this. Type: error. Declaration start char: 72, length: 8
 //@[009:029) Resource expectedLoopItemName. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 80
 
 resource expectedLoopItemName2 'Microsoft.Network/dnsZones@2018-05-01' = [for (
+//@[000:008) Local this. Type: error. Declaration start char: 73, length: 6
 //@[009:030) Resource expectedLoopItemName2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 79
 
 resource expectedComma 'Microsoft.Network/dnsZones@2018-05-01' = [for (x)]
+//@[000:008) Local this. Type: error. Declaration start char: 65, length: 9
 //@[009:022) Resource expectedComma. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 74
 
 resource expectedLoopIndexName 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, )]
+//@[000:008) Local this. Type: error. Declaration start char: 73, length: 11
 //@[009:030) Resource expectedLoopIndexName. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 84
 
 resource expectedInKeyword3 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, y)]
 //@[076:077) Local x. Type: any. Declaration start char: 76, length: 1
 //@[079:080) Local y. Type: int. Declaration start char: 79, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 70, length: 12
 //@[009:027) Resource expectedInKeyword3. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 82
 
 resource expectedInKeyword4 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, y) z]
 //@[076:077) Local x. Type: any. Declaration start char: 76, length: 1
 //@[079:080) Local y. Type: int. Declaration start char: 79, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 70, length: 14
 //@[009:027) Resource expectedInKeyword4. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 84
 
 resource expectedArrayExpression2 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, y) in ]
 //@[082:083) Local x. Type: any. Declaration start char: 82, length: 1
 //@[085:086) Local y. Type: int. Declaration start char: 85, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 76, length: 16
 //@[009:033) Resource expectedArrayExpression2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 92
 
 resource expectedColon2 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, y) in z]
 //@[072:073) Local x. Type: any. Declaration start char: 72, length: 1
 //@[075:076) Local y. Type: int. Declaration start char: 75, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 66, length: 17
 //@[009:023) Resource expectedColon2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 83
 
 resource expectedLoopBody2 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, y) in z:]
 //@[075:076) Local x. Type: any. Declaration start char: 75, length: 1
 //@[078:079) Local y. Type: int. Declaration start char: 78, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 69, length: 18
 //@[009:026) Resource expectedLoopBody2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 87
 
 // loop filter parsing cases
 resource expectedLoopFilterOpenParen 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y: if]
 //@[091:092) Local x. Type: any. Declaration start char: 91, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 86, length: 16
 //@[009:036) Resource expectedLoopFilterOpenParen. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 102
 resource expectedLoopFilterOpenParen2 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, y) in z: if]
 //@[086:087) Local x. Type: any. Declaration start char: 86, length: 1
 //@[089:090) Local y. Type: int. Declaration start char: 89, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 80, length: 21
 //@[009:037) Resource expectedLoopFilterOpenParen2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 101
 
 resource expectedLoopFilterPredicateAndBody 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in y: if()]
 //@[098:099) Local x. Type: any. Declaration start char: 98, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 93, length: 18
 //@[009:043) Resource expectedLoopFilterPredicateAndBody. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 111
 resource expectedLoopFilterPredicateAndBody2 'Microsoft.Network/dnsZones@2018-05-01' = [for (x, y) in z: if()]
 //@[093:094) Local x. Type: any. Declaration start char: 93, length: 1
 //@[096:097) Local y. Type: int. Declaration start char: 96, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 87, length: 23
 //@[009:044) Resource expectedLoopFilterPredicateAndBody2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 110
 
 // wrong body type
@@ -1339,27 +1477,32 @@ var emptyArray = []
 //@[004:014) Variable emptyArray. Type: <empty array>. Declaration start char: 0, length: 19
 resource wrongLoopBodyType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for x in emptyArray:4]
 //@[081:082) Local x. Type: never. Declaration start char: 81, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 76, length: 23
 //@[009:026) Resource wrongLoopBodyType. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 99
 resource wrongLoopBodyType2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (x ,i) in emptyArray:4]
 //@[083:084) Local x. Type: never. Declaration start char: 83, length: 1
 //@[086:087) Local i. Type: int. Declaration start char: 86, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 77, length: 28
 //@[009:027) Resource wrongLoopBodyType2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 105
 
 // duplicate variable in the same scope
 resource itemAndIndexSameName 'Microsoft.AAD/domainServices@2020-01-01' = [for (same, same) in emptyArray: {
 //@[080:084) Local same. Type: never. Declaration start char: 80, length: 4
 //@[086:090) Local same. Type: int. Declaration start char: 86, length: 4
+//@[000:008) Local this. Type: object[]. Declaration start char: 74, length: 38
 //@[009:029) Resource itemAndIndexSameName. Type: Microsoft.AAD/domainServices@2020-01-01[]. Declaration start char: 0, length: 112
 }]
 
 // errors in the array expression
 resource arrayExpressionErrors 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in union([], 2): {
 //@[085:092) Local account. Type: any. Declaration start char: 85, length: 7
+//@[000:008) Local this. Type: error. Declaration start char: 80, length: 35
 //@[009:030) Resource arrayExpressionErrors. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 115
 }]
 resource arrayExpressionErrors2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account,k) in union([], 2): {
 //@[087:094) Local account. Type: any. Declaration start char: 87, length: 7
 //@[095:096) Local k. Type: int. Declaration start char: 95, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 81, length: 39
 //@[009:031) Resource arrayExpressionErrors2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 120
 }]
 
@@ -1368,39 +1511,46 @@ var notAnArray = true
 //@[004:014) Variable notAnArray. Type: true. Declaration start char: 0, length: 21
 resource wrongArrayType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in notAnArray: {
 //@[078:085) Local account. Type: any. Declaration start char: 78, length: 7
+//@[000:008) Local this. Type: error. Declaration start char: 73, length: 33
 //@[009:023) Resource wrongArrayType. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 106
 }]
 resource wrongArrayType2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account,i) in notAnArray: {
 //@[080:087) Local account. Type: any. Declaration start char: 80, length: 7
 //@[088:089) Local i. Type: int. Declaration start char: 88, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 74, length: 37
 //@[009:024) Resource wrongArrayType2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 111
 }]
 
 // wrong filter expression type
 resource wrongFilterExpressionType 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in emptyArray: if(4) {
 //@[089:096) Local account. Type: never. Declaration start char: 89, length: 7
+//@[000:008) Local this. Type: object[]. Declaration start char: 84, length: 39
 //@[009:034) Resource wrongFilterExpressionType. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 123
 }]
 resource wrongFilterExpressionType2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account,i) in emptyArray: if(concat('s')){
 //@[091:098) Local account. Type: never. Declaration start char: 91, length: 7
 //@[099:100) Local i. Type: int. Declaration start char: 99, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 85, length: 52
 //@[009:035) Resource wrongFilterExpressionType2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 137
 }]
 
 // missing required properties
 resource missingRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
 //@[089:096) Local account. Type: never. Declaration start char: 89, length: 7
+//@[000:008) Local this. Type: object[]. Declaration start char: 84, length: 25
 //@[009:034) Resource missingRequiredProperties. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 109
 }]
 resource missingRequiredProperties2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account,j) in []: {
 //@[091:098) Local account. Type: never. Declaration start char: 91, length: 7
 //@[099:100) Local j. Type: int. Declaration start char: 99, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 85, length: 29
 //@[009:035) Resource missingRequiredProperties2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 114
 }]
 
 // fewer missing required properties and a wrong property
 resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in []: {
 //@[094:101) Local account. Type: never. Declaration start char: 94, length: 7
+//@[000:008) Local this. Type: object[]. Declaration start char: 89, length: 107
 //@[009:039) Resource missingFewerRequiredProperties. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 196
   name: account
   location: 'eastus42'
@@ -1412,6 +1562,7 @@ resource missingFewerRequiredProperties 'Microsoft.Storage/storageAccounts@2019-
 // wrong property inside the nested property loop
 resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[089:090) Local i. Type: int. Declaration start char: 89, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 84, length: 178
 //@[009:034) Resource wrongPropertyInNestedLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 262
   name: 'vnet-${i}'
   properties: {
@@ -1425,6 +1576,7 @@ resource wrongPropertyInNestedLoop 'Microsoft.Network/virtualNetworks@2020-06-01
 resource wrongPropertyInNestedLoop2 'Microsoft.Network/virtualNetworks@2020-06-01' = [for (i,k) in range(0, 3): {
 //@[091:092) Local i. Type: int. Declaration start char: 91, length: 1
 //@[093:094) Local k. Type: int. Declaration start char: 93, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 85, length: 187
 //@[009:035) Resource wrongPropertyInNestedLoop2. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 272
   name: 'vnet-${i}'
   properties: {
@@ -1439,6 +1591,7 @@ resource wrongPropertyInNestedLoop2 'Microsoft.Network/virtualNetworks@2020-06-0
 // nonexistent arrays and loop variables
 resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in notAThing: {
 //@[081:082) Local i. Type: any. Declaration start char: 81, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 76, length: 204
 //@[009:026) Resource nonexistentArrays. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 280
   name: 'vnet-${justPlainWrong}'
   properties: {
@@ -1453,6 +1606,7 @@ resource nonexistentArrays 'Microsoft.Network/virtualNetworks@2020-06-01' = [for
 // property loops cannot be nested
 resource propertyLoopsCannotNest 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[087:094) Local account. Type: any. Declaration start char: 87, length: 7
+//@[000:008) Local this. Type: error. Declaration start char: 82, length: 346
 //@[009:032) Resource propertyLoopsCannotNest. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 428
   name: account.name
   location: account.location
@@ -1475,6 +1629,7 @@ resource propertyLoopsCannotNest 'Microsoft.Storage/storageAccounts@2019-06-01' 
 resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account,i) in storageAccounts: {
 //@[089:096) Local account. Type: any. Declaration start char: 89, length: 7
 //@[097:098) Local i. Type: int. Declaration start char: 97, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 83, length: 358
 //@[009:033) Resource propertyLoopsCannotNest2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 441
   name: account.name
   location: account.location
@@ -1500,6 +1655,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 // property loops cannot be nested (even more nesting)
 resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[088:095) Local account. Type: any. Declaration start char: 88, length: 7
+//@[000:008) Local this. Type: error. Declaration start char: 83, length: 551
 //@[009:033) Resource propertyLoopsCannotNest2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 634
   name: account.name
   location: account.location
@@ -1527,6 +1683,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 // loops cannot be used inside of expressions
 resource stuffs 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[070:077) Local account. Type: any. Declaration start char: 70, length: 7
+//@[000:008) Local this. Type: error. Declaration start char: 65, length: 316
 //@[009:015) Resource stuffs. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 381
   name: account.name
   location: account.location
@@ -1547,6 +1704,7 @@ resource stuffs 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in
 // using the same loop variable in a new language scope should be allowed
 resource premiumStorages 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[079:086) Local account. Type: any. Declaration start char: 79, length: 7
+//@[000:008) Local this. Type: error. Declaration start char: 74, length: 294
 //@[009:024) Resource premiumStorages. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 368
   // #completionTest(7) -> symbolsPlusAccount1
   name: account.name
@@ -1565,6 +1723,7 @@ output directRefViaOutput array = union(premiumStorages, stuffs)
 //@[007:025) Output directRefViaOutput. Type: array. Declaration start char: 0, length: 64
 
 resource directRefViaSingleResourceBody 'Microsoft.Network/dnszones@2018-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 82, length: 117
 //@[009:039) Resource directRefViaSingleResourceBody. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 199
   name: 'myZone2'
   location: 'global'
@@ -1574,6 +1733,7 @@ resource directRefViaSingleResourceBody 'Microsoft.Network/dnszones@2018-05-01' 
 }
 
 resource directRefViaSingleConditionalResourceBody 'Microsoft.Network/dnszones@2018-05-01' = if(true) {
+//@[000:008) Local this. Type: object. Declaration start char: 102, length: 133
 //@[009:050) Resource directRefViaSingleConditionalResourceBody. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 235
   name: 'myZone3'
   location: 'global'
@@ -1585,6 +1745,7 @@ resource directRefViaSingleConditionalResourceBody 'Microsoft.Network/dnszones@2
 @batchSize()
 resource directRefViaSingleLoopResourceBody 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[098:099) Local i. Type: int. Declaration start char: 98, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 93, length: 101
 //@[009:043) Resource directRefViaSingleLoopResourceBody. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 208
   name: 'vnet-${i}'
   properties: {
@@ -1595,6 +1756,7 @@ resource directRefViaSingleLoopResourceBody 'Microsoft.Network/virtualNetworks@2
 @batchSize(0)
 resource directRefViaSingleLoopResourceBodyWithExtraDependsOn 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[116:117) Local i. Type: int. Declaration start char: 116, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 111, length: 176
 //@[009:061) Resource directRefViaSingleLoopResourceBodyWithExtraDependsOn. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 302
   name: 'vnet-${i}'
   properties: {
@@ -1611,6 +1773,7 @@ resource directRefViaSingleLoopResourceBodyWithExtraDependsOn 'Microsoft.Network
 var expressionInPropertyLoopVar = true
 //@[004:031) Variable expressionInPropertyLoopVar. Type: true. Declaration start char: 0, length: 38
 resource expressionsInPropertyLoopName 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 81, length: 151
 //@[009:038) Resource expressionsInPropertyLoopName. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 232
   name: 'hello'
   location: 'eastus'
@@ -1624,33 +1787,41 @@ resource expressionsInPropertyLoopName 'Microsoft.Network/dnsZones@2018-05-01' =
 @batchSize(-1)
 resource nonObjectResourceLoopBody 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: 'test']
 //@[082:087) Local thing. Type: never. Declaration start char: 82, length: 5
+//@[000:008) Local this. Type: error. Declaration start char: 77, length: 25
 //@[009:034) Resource nonObjectResourceLoopBody. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 118
 resource nonObjectResourceLoopBody2 'Microsoft.Network/dnsZones@2018-05-01' = [for thing in []: environment()]
 //@[083:088) Local thing. Type: never. Declaration start char: 83, length: 5
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 32
 //@[009:035) Resource nonObjectResourceLoopBody2. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 110
 resource nonObjectResourceLoopBody3 'Microsoft.Network/dnsZones@2018-05-01' = [for (thing,i) in []: 'test']
 //@[084:089) Local thing. Type: never. Declaration start char: 84, length: 5
 //@[090:091) Local i. Type: int. Declaration start char: 90, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 29
 //@[009:035) Resource nonObjectResourceLoopBody3. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 107
 resource nonObjectResourceLoopBody4 'Microsoft.Network/dnsZones@2018-05-01' = [for (thing,i) in []: environment()]
 //@[084:089) Local thing. Type: never. Declaration start char: 84, length: 5
 //@[090:091) Local i. Type: int. Declaration start char: 90, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 36
 //@[009:035) Resource nonObjectResourceLoopBody4. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 114
 resource nonObjectResourceLoopBody3 'Microsoft.Network/dnsZones@2018-05-01' = [for (thing,i) in []: if(true) 'test']
 //@[084:089) Local thing. Type: never. Declaration start char: 84, length: 5
 //@[090:091) Local i. Type: int. Declaration start char: 90, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 38
 //@[009:035) Resource nonObjectResourceLoopBody3. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 116
 resource nonObjectResourceLoopBody4 'Microsoft.Network/dnsZones@2018-05-01' = [for (thing,i) in []: if(true) environment()]
 //@[084:089) Local thing. Type: never. Declaration start char: 84, length: 5
 //@[090:091) Local i. Type: int. Declaration start char: 90, length: 1
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 45
 //@[009:035) Resource nonObjectResourceLoopBody4. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 123
 
 // #completionTest(54,55) -> objectPlusFor
 resource foo 'Microsoft.Network/dnsZones@2018-05-01' = 
+//@[000:008) Local this. Type: error. Declaration start char: 55, length: 0
 //@[009:012) Resource foo. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 55
 
 resource foo 'Microsoft.Network/dnsZones@2018-05-01' = [for item in []: {
 //@[060:064) Local item. Type: never. Declaration start char: 60, length: 4
+//@[000:008) Local this. Type: error. Declaration start char: 55, length: 202
 //@[009:012) Resource foo. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 257
   properties: {
     // #completionTest(32,33) -> symbolsPlusArrayAndFor
@@ -1663,6 +1834,7 @@ resource foo 'Microsoft.Network/dnsZones@2018-05-01' = [for item in []: {
 }]
 
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 63, length: 262
 //@[009:013) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 325
   properties: {
     virtualNetworkPeerings: [for item in []: {
@@ -1685,6 +1857,7 @@ resource p1_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
 }
 
 resource p1_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 65, length: 41
 //@[009:018) Resource p1_child1. Type: Microsoft.Rp1/resource1/child1@2020-06-01. Declaration start char: 0, length: 106
   parent: p1_res1
   name: 'child1'
@@ -1692,16 +1865,19 @@ resource p1_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
 
 // parent property with scope on child resource
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 56, length: 20
 //@[009:016) Resource p2_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 76
   name: 'res1'
 }
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 56, length: 20
 //@[009:016) Resource p2_res2. Type: Microsoft.Rp2/resource2@2020-06-01. Declaration start char: 0, length: 76
   name: 'res2'
 }
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 68, length: 59
 //@[009:021) Resource p2_res2child. Type: Microsoft.Rp2/resource2/child2@2020-06-01. Declaration start char: 0, length: 127
   scope: p2_res1
   parent: p2_res2
@@ -1710,6 +1886,7 @@ resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
 
 // parent property self-cycle
 resource p3_vmExt 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 46
 //@[009:017) Resource p3_vmExt. Type: Microsoft.Compute/virtualMachines/extensions@2020-06-01. Declaration start char: 0, length: 124
   parent: p3_vmExt
   location: 'eastus'
@@ -1717,12 +1894,14 @@ resource p3_vmExt 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
 
 // parent property 2-cycle
 resource p4_vm 'Microsoft.Compute/virtualMachines@2020-06-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 64, length: 46
 //@[009:014) Resource p4_vm. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 110
   parent: p4_vmExt
   location: 'eastus'
 }
 
 resource p4_vmExt 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 78, length: 43
 //@[009:017) Resource p4_vmExt. Type: Microsoft.Compute/virtualMachines/extensions@2020-06-01. Declaration start char: 0, length: 121
   parent: p4_vm
   location: 'eastus'
@@ -1730,11 +1909,13 @@ resource p4_vmExt 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
 
 // parent property with invalid child
 resource p5_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 56, length: 20
 //@[009:016) Resource p5_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 76
   name: 'res1'
 }
 
 resource p5_res2 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 63, length: 39
 //@[009:016) Resource p5_res2. Type: Microsoft.Rp2/resource2/child2@2020-06-01. Declaration start char: 0, length: 102
   parent: p5_res1
   name: 'res2'
@@ -1742,11 +1923,13 @@ resource p5_res2 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
 
 // parent property with invalid parent
 resource p6_res1 '${true}' = {
+//@[000:008) Local this. Type: object. Declaration start char: 29, length: 20
 //@[009:016) Resource p6_res1. Type: error. Declaration start char: 0, length: 49
   name: 'res1'
 }
 
 resource p6_res2 'Microsoft.Rp1/resource1/child2@2020-06-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 63, length: 39
 //@[009:016) Resource p6_res2. Type: Microsoft.Rp1/resource1/child2@2020-06-01. Declaration start char: 0, length: 102
   parent: p6_res1
   name: 'res2'
@@ -1754,17 +1937,20 @@ resource p6_res2 'Microsoft.Rp1/resource1/child2@2020-06-01' = {
 
 // parent property with incorrectly-formatted name
 resource p7_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 56, length: 20
 //@[009:016) Resource p7_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 76
   name: 'res1'
 }
 
 resource p7_res2 'Microsoft.Rp1/resource1/child2@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 63, length: 44
 //@[009:016) Resource p7_res2. Type: Microsoft.Rp1/resource1/child2@2020-06-01. Declaration start char: 0, length: 107
   parent: p7_res1
   name: 'res1/res2'
 }
 
 resource p7_res3 'Microsoft.Rp1/resource1/child2@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 63, length: 55
 //@[009:016) Resource p7_res3. Type: Microsoft.Rp1/resource1/child2@2020-06-01. Declaration start char: 0, length: 118
   parent: p7_res1
   name: '${p7_res1.name}/res2'
@@ -1772,6 +1958,7 @@ resource p7_res3 'Microsoft.Rp1/resource1/child2@2020-06-01' = {
 
 // top-level resource with too many '/' characters
 resource p8_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 56, length: 25
 //@[009:016) Resource p8_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 81
   name: 'res1/res2'
 }
@@ -1784,6 +1971,7 @@ resource existingResProperty 'Microsoft.Compute/virtualMachines@2020-06-01' exis
 }
 
 resource invalidExistingLocationRef 'Microsoft.Compute/virtualMachines/extensions@2020-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 96, length: 100
 //@[009:035) Resource invalidExistingLocationRef. Type: Microsoft.Compute/virtualMachines/extensions@2020-06-01. Declaration start char: 0, length: 196
     parent: existingResProperty
     name: 'myExt'
@@ -1791,6 +1979,7 @@ resource invalidExistingLocationRef 'Microsoft.Compute/virtualMachines/extension
 }
 
 resource anyTypeInDependsOn 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 70, length: 189
 //@[009:027) Resource anyTypeInDependsOn. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 259
   name: 'anyTypeInDependsOn'
   location: resourceGroup().location
@@ -1802,22 +1991,26 @@ resource anyTypeInDependsOn 'Microsoft.Network/dnsZones@2018-05-01' = {
 }
 
 resource anyTypeInParent 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 73, length: 25
 //@[009:024) Resource anyTypeInParent. Type: Microsoft.Network/dnsZones/CNAME@2018-05-01. Declaration start char: 0, length: 98
   parent: any(true)
 }
 
 resource anyTypeInParentLoop 'Microsoft.Network/dnsZones/CNAME@2018-05-01' = [for thing in []: {
 //@[082:087) Local thing. Type: never. Declaration start char: 82, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 77, length: 44
 //@[009:028) Resource anyTypeInParentLoop. Type: Microsoft.Network/dnsZones/CNAME@2018-05-01[]. Declaration start char: 0, length: 121
   parent: any(true)
 }]
 
 resource anyTypeInScope 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 69, length: 46
 //@[009:023) Resource anyTypeInScope. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 115
   scope: any(invalidExistingLocationRef)
 }
 
 resource anyTypeInScopeConditional 'Microsoft.Authorization/locks@2016-09-01' = if(true) {
+//@[000:008) Local this. Type: object. Declaration start char: 89, length: 46
 //@[009:034) Resource anyTypeInScopeConditional. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 135
   scope: any(invalidExistingLocationRef)
 }
@@ -1836,45 +2029,55 @@ resource anyTypeInExistingScopeLoop 'Microsoft.Network/dnsZones/AAAA@2018-05-01'
 }]
 
 resource tenantLevelResourceBlocked 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 89, length: 42
 //@[009:035) Resource tenantLevelResourceBlocked. Type: Microsoft.Management/managementGroups@2020-05-01. Declaration start char: 0, length: 131
   name: 'tenantLevelResourceBlocked'
 }
 
 // #completionTest(15,36,37) -> resourceTypes
 resource comp1 'Microsoft.Resources/'
+//@[000:008) Local this. Type: error. Declaration start char: 37, length: 0
 //@[009:014) Resource comp1. Type: error. Declaration start char: 0, length: 37
 
 // #completionTest(15,16,17) -> resourceTypes
 resource comp2 ''
+//@[000:008) Local this. Type: error. Declaration start char: 17, length: 0
 //@[009:014) Resource comp2. Type: error. Declaration start char: 0, length: 17
 
 // #completionTest(38) -> resourceTypes
 resource comp3 'Microsoft.Resources/t'
+//@[000:008) Local this. Type: error. Declaration start char: 38, length: 0
 //@[009:014) Resource comp3. Type: error. Declaration start char: 0, length: 38
 
 // #completionTest(40) -> resourceTypes
 resource comp4 'Microsoft.Resources/t/v'
+//@[000:008) Local this. Type: error. Declaration start char: 40, length: 0
 //@[009:014) Resource comp4. Type: error. Declaration start char: 0, length: 40
 
 // #completionTest(49) -> resourceTypes
 resource comp5 'Microsoft.Storage/storageAccounts'
+//@[000:008) Local this. Type: error. Declaration start char: 50, length: 0
 //@[009:014) Resource comp5. Type: error. Declaration start char: 0, length: 50
 
 // #completionTest(50) -> storageAccountsResourceTypes
 resource comp6 'Microsoft.Storage/storageAccounts@'
+//@[000:008) Local this. Type: error. Declaration start char: 51, length: 0
 //@[009:014) Resource comp6. Type: error. Declaration start char: 0, length: 51
 
 // #completionTest(52) -> templateSpecsResourceTypes
 resource comp7 'Microsoft.Resources/templateSpecs@20'
+//@[000:008) Local this. Type: error. Declaration start char: 53, length: 0
 //@[009:014) Resource comp7. Type: error. Declaration start char: 0, length: 53
 
 // #completionTest(60,61) -> virtualNetworksResourceTypes
 resource comp8 'Microsoft.Network/virtualNetworks@2020-06-01'
+//@[000:008) Local this. Type: error. Declaration start char: 61, length: 0
 //@[009:014) Resource comp8. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 61
 
 
 // issue #3000
 resource issue3000LogicApp1 'Microsoft.Logic/workflows@2019-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 69, length: 384
 //@[009:027) Resource issue3000LogicApp1. Type: Microsoft.Logic/workflows@2019-05-01. Declaration start char: 0, length: 453
   name: 'issue3000LogicApp1'
   location: resourceGroup().location
@@ -1903,6 +2106,7 @@ resource issue3000LogicApp1 'Microsoft.Logic/workflows@2019-05-01' = {
 }
 
 resource issue3000LogicApp2 'Microsoft.Logic/workflows@2019-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 69, length: 383
 //@[009:027) Resource issue3000LogicApp2. Type: Microsoft.Logic/workflows@2019-05-01. Declaration start char: 0, length: 452
   name: 'issue3000LogicApp2'
   location: resourceGroup().location
@@ -1933,6 +2137,7 @@ resource issue3000LogicApp2 'Microsoft.Logic/workflows@2019-05-01' = {
 }
 
 resource issue3000stg 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 71, length: 163
 //@[009:021) Resource issue3000stg. Type: Microsoft.Storage/storageAccounts@2021-04-01. Declaration start char: 0, length: 234
   name: 'issue3000stg'
   kind: 'StorageV2'
@@ -1969,6 +2174,7 @@ resource logAnalyticsWorkspaces 'Microsoft.OperationalInsights/workspaces@2020-1
 }]
 
 resource dataCollectionRuleRes 'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 85, length: 752
 //@[009:030) Resource dataCollectionRuleRes. Type: Microsoft.Insights/dataCollectionRules@2021-04-01. Declaration start char: 0, length: 837
   name: dataCollectionRule.name
   location: dataCollectionRule.location
@@ -1994,6 +2200,7 @@ resource dataCollectionRuleRes 'Microsoft.Insights/dataCollectionRules@2021-04-0
 }
 
 resource dataCollectionRuleRes2 'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 86, length: 359
 //@[009:031) Resource dataCollectionRuleRes2. Type: Microsoft.Insights/dataCollectionRules@2021-04-01. Declaration start char: 0, length: 445
   name: dataCollectionRule.name
   location: dataCollectionRule.location
@@ -2023,6 +2230,7 @@ param issue4668_identity object
 param issue4668_properties object
 //@[006:026) Parameter issue4668_properties. Type: object. Declaration start char: 0, length: 91
 resource issue4668_mainResource 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 85, length: 144
 //@[009:031) Resource issue4668_mainResource. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 229
   name: 'testscript'
   location: 'westeurope'
@@ -2042,6 +2250,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' existing = {
 
 // parent & nested child with decorators https://github.com/Azure/bicep/issues/10970
 resource sqlServer1 'Microsoft.Sql/servers@2021-11-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 57, length: 62
 //@[009:019) Resource sqlServer1. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 119
   name: 'sqlServer1'
   location: 'polandcentral'
@@ -2049,6 +2258,7 @@ resource sqlServer1 'Microsoft.Sql/servers@2021-11-01' = {
   @
 }
 resource sqlServer2 'Microsoft.Sql/servers@2021-11-01' = {
+//@[000:008) Local this. Type: error. Declaration start char: 57, length: 174
 //@[009:019) Resource sqlServer2. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 231
   name: 'sqlServer2'
   location: 'polandcentral'
@@ -2062,6 +2272,7 @@ resource sqlServer2 'Microsoft.Sql/servers@2021-11-01' = {
   }
 }
 resource sqlServer3 'Microsoft.Sql/servers@2021-11-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 57, length: 103
 //@[009:019) Resource sqlServer3. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 160
   name: 'sqlServer3'
   location: 'polandcentral'
@@ -2070,6 +2281,7 @@ resource sqlServer3 'Microsoft.Sql/servers@2021-11-01' = {
 
 }
 resource sqlServer4 'Microsoft.Sql/servers@2021-11-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 57, length: 76
 //@[009:019) Resource sqlServer4. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 133
   name: 'sqlServer4'
   location: 'polandcentral'
@@ -2078,12 +2290,14 @@ resource sqlServer4 'Microsoft.Sql/servers@2021-11-01' = {
 
 }
 resource sqlServer5 'Microsoft.Sql/servers@2021-11-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 57, length: 166
 //@[009:019) Resource sqlServer5. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 223
   name: 'sqlServer5'
   location: 'polandcentral'
 
   @batchSize(1)
   resource sqlDatabase 'databases' = {
+//@[002:010) Local this. Type: object. Declaration start char: 37, length: 53
 //@[011:022) Resource sqlDatabase. Type: Microsoft.Sql/servers/databases@2021-11-01. Declaration start char: 2, length: 105
     name: 'db'
     location: 'polandcentral'

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidRuntimeValueUsages_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidRuntimeValueUsages_LF/main.symbols.bicep
@@ -1,4 +1,5 @@
 resource foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 62, length: 160
 //@[09:12) Resource foo. Type: Microsoft.Storage/storageAccounts@2022-09-01. Declaration start char: 0, length: 222
   name: 'foo'
   location: 'westus'
@@ -8,12 +9,14 @@ resource foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   kind: 'StorageV2'
 
   resource fooChild 'fileServices' = {
+//@[02:10) Local this. Type: object. Declaration start char: 37, length: 25
 //@[11:19) Resource fooChild. Type: Microsoft.Storage/storageAccounts/fileServices@2022-09-01. Declaration start char: 2, length: 60
     name: 'default'
   }
 }
 resource foos 'Microsoft.Storage/storageAccounts@2022-09-01' = [for i in range(0, 2): {
 //@[68:69) Local i. Type: int. Declaration start char: 68, length: 1
+//@[00:08) Local this. Type: object[]. Declaration start char: 63, length: 125
 //@[09:13) Resource foos. Type: Microsoft.Storage/storageAccounts@2022-09-01[]. Declaration start char: 0, length: 188
   name: 'foo-${i}'
   location: 'westus'

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/main.symbols.bicep
@@ -280,6 +280,7 @@ var zoneInput = []
 resource zones 'Microsoft.Network/dnsZones@2018-05-01' = [for (zone, i) in zoneInput: {
 //@[63:67) Local zone. Type: never. Declaration start char: 63, length: 4
 //@[69:70) Local i. Type: int. Declaration start char: 69, length: 1
+//@[00:08) Local this. Type: error. Declaration start char: 57, length: 86
 //@[09:14) Resource zones. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 143
   name: zone
   location: az.resourceGroup().location

--- a/src/Bicep.Core.Samples/Files/baselines/LoopsIndexed_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/LoopsIndexed_LF/main.symbols.bicep
@@ -7,6 +7,7 @@ param index int
 
 // single resource
 resource singleResource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 73, length: 136
 //@[009:023) Resource singleResource. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 209
   name: '${name}single-resource-name'
   location: resourceGroup().location
@@ -18,6 +19,7 @@ resource singleResource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 
 // extension of single resource
 resource singleResourceExtension 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 78, length: 104
 //@[009:032) Resource singleResourceExtension. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 182
   scope: singleResource
   name: 'single-resource-lock'
@@ -28,6 +30,7 @@ resource singleResourceExtension 'Microsoft.Authorization/locks@2016-09-01' = {
 
 // single resource cascade extension
 resource singleResourceCascadeExtension 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 85, length: 126
 //@[009:039) Resource singleResourceCascadeExtension. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 211
   scope: singleResourceExtension
   name: 'single-resource-cascade-extension'
@@ -41,6 +44,7 @@ resource singleResourceCascadeExtension 'Microsoft.Authorization/locks@2016-09-0
 resource storageAccounts 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, index) in accounts: {
 //@[080:087) Local account. Type: any. Declaration start char: 80, length: 7
 //@[089:094) Local index. Type: int. Declaration start char: 89, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 74, length: 218
 //@[009:024) Resource storageAccounts. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 307
   name: '${name}-collection-${account.name}-${index}'
   location: account.location
@@ -55,6 +59,7 @@ resource storageAccounts 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (
 
 // extension of a single resource in a collection
 resource extendSingleResourceInCollection 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 87, length: 125
 //@[009:041) Resource extendSingleResourceInCollection. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 212
   name: 'one-resource-collection-item-lock'
   properties: {
@@ -67,6 +72,7 @@ resource extendSingleResourceInCollection 'Microsoft.Authorization/locks@2016-09
 resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for (i, i2) in range(0,1): {
 //@[080:081) Local i. Type: 0. Declaration start char: 80, length: 1
 //@[083:085) Local i2. Type: 0. Declaration start char: 83, length: 2
+//@[000:008) Local this. Type: object[]. Declaration start char: 74, length: 161
 //@[009:028) Resource extensionCollection. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 235
   name: 'lock-${i}-${i2}'
   properties: {
@@ -80,6 +86,7 @@ resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for (
 resource lockTheLocks 'Microsoft.Authorization/locks@2016-09-01' = [for (i, i2) in range(0,1): {
 //@[073:074) Local i. Type: 0. Declaration start char: 73, length: 1
 //@[076:078) Local i2. Type: 0. Declaration start char: 76, length: 2
+//@[000:008) Local this. Type: object[]. Declaration start char: 67, length: 179
 //@[009:021) Resource lockTheLocks. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 260
   name: 'lock-the-lock-${i}-${i2}'
   properties: {
@@ -119,6 +126,7 @@ output indexViaReference string = storageAccounts[int(storageAccounts[index].pro
 resource storageAccounts2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, idx) in accounts: {
 //@[081:088) Local account. Type: any. Declaration start char: 81, length: 7
 //@[090:093) Local idx. Type: int. Declaration start char: 90, length: 3
+//@[000:008) Local this. Type: object[]. Declaration start char: 75, length: 215
 //@[009:025) Resource storageAccounts2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 290
   name: '${name}-collection-${account.name}-${idx}'
   location: account.location
@@ -135,6 +143,7 @@ resource storageAccounts2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for 
 resource firstSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (i,ii) in range(0, length(accounts)): {
 //@[073:074) Local i. Type: int. Declaration start char: 73, length: 1
 //@[075:077) Local ii. Type: int. Declaration start char: 75, length: 2
+//@[000:008) Local this. Type: object[]. Declaration start char: 67, length: 176
 //@[009:017) Resource firstSet. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 243
   name: '${name}-set1-${i}-${ii}'
   location: resourceGroup().location
@@ -147,6 +156,7 @@ resource firstSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (i,ii) i
 resource secondSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (i,iii) in range(0, length(accounts)): {
 //@[074:075) Local i. Type: int. Declaration start char: 74, length: 1
 //@[076:079) Local iii. Type: int. Declaration start char: 76, length: 3
+//@[000:008) Local this. Type: object[]. Declaration start char: 68, length: 215
 //@[009:018) Resource secondSet. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 283
   name: '${name}-set2-${i}-${iii}'
   location: resourceGroup().location
@@ -161,6 +171,7 @@ resource secondSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (i,iii)
 
 // depending on collection and one resource in the collection optimizes the latter part away
 resource anotherSingleResource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 80, length: 186
 //@[009:030) Resource anotherSingleResource. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 266
   name: '${name}single-resource-name'
   location: resourceGroup().location
@@ -190,6 +201,7 @@ var vnetConfigurations = [
 resource vnets 'Microsoft.Network/virtualNetworks@2020-06-01' = [for (vnetConfig, index) in vnetConfigurations: {
 //@[070:080) Local vnetConfig. Type: object | object. Declaration start char: 70, length: 10
 //@[082:087) Local index. Type: int. Declaration start char: 82, length: 5
+//@[000:008) Local this. Type: object[]. Declaration start char: 64, length: 122
 //@[009:014) Resource vnets. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 186
   name: '${vnetConfig.name}-${index}'
   location: vnetConfig.location
@@ -197,6 +209,7 @@ resource vnets 'Microsoft.Network/virtualNetworks@2020-06-01' = [for (vnetConfig
 
 // implicit dependency on single resource from a resource collection
 resource implicitDependencyOnSingleResourceByIndex 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 93, length: 144
 //@[009:050) Resource implicitDependencyOnSingleResourceByIndex. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 237
   name: 'test'
   location: 'global'
@@ -211,6 +224,7 @@ resource implicitDependencyOnSingleResourceByIndex 'Microsoft.Network/dnsZones@2
 
 // implicit and explicit dependency combined
 resource combinedDependencies 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 72, length: 222
 //@[009:029) Resource combinedDependencies. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 294
   name: 'test2'
   location: 'global'
@@ -329,6 +343,7 @@ output existingIndexedResourceAccessTier string = existingStorageAccounts[index%
 resource duplicatedNames 'Microsoft.Network/dnsZones@2018-05-01' = [for (zone,i) in []: {
 //@[073:077) Local zone. Type: never. Declaration start char: 73, length: 4
 //@[078:079) Local i. Type: int. Declaration start char: 78, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 67, length: 73
 //@[009:024) Resource duplicatedNames. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 140
   name: 'no loop variable'
   location: 'eastus'
@@ -338,6 +353,7 @@ resource duplicatedNames 'Microsoft.Network/dnsZones@2018-05-01' = [for (zone,i)
 resource referenceToDuplicateNames 'Microsoft.Network/dnsZones@2018-05-01' = [for (zone,i) in []: {
 //@[083:087) Local zone. Type: never. Declaration start char: 83, length: 4
 //@[088:089) Local i. Type: int. Declaration start char: 88, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 77, length: 121
 //@[009:034) Resource referenceToDuplicateNames. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 198
   name: 'no loop variable 2'
   location: 'eastus'
@@ -363,6 +379,7 @@ module apim 'passthrough.bicep' = [for (region, i) in regions: {
 }]
 
 resource propertyLoopDependencyOnModuleCollection 'Microsoft.Network/frontDoors@2020-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 94, length: 698
 //@[009:049) Resource propertyLoopDependencyOnModuleCollection. Type: Microsoft.Network/frontDoors@2020-05-01. Declaration start char: 0, length: 792
   name: name
   location: 'Global'
@@ -393,6 +410,7 @@ resource propertyLoopDependencyOnModuleCollection 'Microsoft.Network/frontDoors@
 resource indexedModuleCollectionDependency 'Microsoft.Network/frontDoors@2020-05-01' = [for (index, i) in range(0, length(regions)): {
 //@[093:098) Local index. Type: int. Declaration start char: 93, length: 5
 //@[100:101) Local i. Type: int. Declaration start char: 100, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 87, length: 684
 //@[009:042) Resource indexedModuleCollectionDependency. Type: Microsoft.Network/frontDoors@2020-05-01[]. Declaration start char: 0, length: 771
   name: '${name}-${index}-${i}'
   location: 'Global'
@@ -420,6 +438,7 @@ resource indexedModuleCollectionDependency 'Microsoft.Network/frontDoors@2020-05
 }]
 
 resource propertyLoopDependencyOnResourceCollection 'Microsoft.Network/frontDoors@2020-05-01' = {
+//@[000:008) Local this. Type: object. Declaration start char: 96, length: 775
 //@[009:051) Resource propertyLoopDependencyOnResourceCollection. Type: Microsoft.Network/frontDoors@2020-05-01. Declaration start char: 0, length: 871
   name: name
   location: 'Global'
@@ -449,6 +468,7 @@ resource propertyLoopDependencyOnResourceCollection 'Microsoft.Network/frontDoor
 resource indexedResourceCollectionDependency 'Microsoft.Network/frontDoors@2020-05-01' = [for (index,i) in range(0, length(accounts)): {
 //@[095:100) Local index. Type: int. Declaration start char: 95, length: 5
 //@[101:102) Local i. Type: int. Declaration start char: 101, length: 1
+//@[000:008) Local this. Type: object[]. Declaration start char: 89, length: 772
 //@[009:044) Resource indexedResourceCollectionDependency. Type: Microsoft.Network/frontDoors@2020-05-01[]. Declaration start char: 0, length: 861
   name: '${name}-${index}-${i}'
   location: 'Global'

--- a/src/Bicep.Core.Samples/Files/baselines/Loops_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Loops_LF/main.symbols.bicep
@@ -7,6 +7,7 @@ param index int
 
 // single resource
 resource singleResource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 73, length: 136
 //@[09:023) Resource singleResource. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 209
   name: '${name}single-resource-name'
   location: resourceGroup().location
@@ -18,6 +19,7 @@ resource singleResource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 
 // extension of single resource
 resource singleResourceExtension 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 78, length: 104
 //@[09:032) Resource singleResourceExtension. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 182
   scope: singleResource
   name: 'single-resource-lock'
@@ -28,6 +30,7 @@ resource singleResourceExtension 'Microsoft.Authorization/locks@2016-09-01' = {
 
 // single resource cascade extension
 resource singleResourceCascadeExtension 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 85, length: 126
 //@[09:039) Resource singleResourceCascadeExtension. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 211
   scope: singleResourceExtension
   name: 'single-resource-cascade-extension'
@@ -40,6 +43,7 @@ resource singleResourceCascadeExtension 'Microsoft.Authorization/locks@2016-09-0
 @batchSize(42)
 resource storageAccounts 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in accounts: {
 //@[79:086) Local account. Type: any. Declaration start char: 79, length: 7
+//@[00:008) Local this. Type: object[]. Declaration start char: 74, length: 200
 //@[09:024) Resource storageAccounts. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 289
   name: '${name}-collection-${account.name}'
   location: account.location
@@ -54,6 +58,7 @@ resource storageAccounts 'Microsoft.Storage/storageAccounts@2019-06-01' = [for a
 
 // extension of a single resource in a collection
 resource extendSingleResourceInCollection 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 87, length: 125
 //@[09:041) Resource extendSingleResourceInCollection. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 212
   name: 'one-resource-collection-item-lock'
   properties: {
@@ -65,6 +70,7 @@ resource extendSingleResourceInCollection 'Microsoft.Authorization/locks@2016-09
 // collection of extensions
 resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for i in range(0,1): {
 //@[79:080) Local i. Type: 0. Declaration start char: 79, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 74, length: 138
 //@[09:028) Resource extensionCollection. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 212
   name: 'lock-${i}'
   properties: {
@@ -77,6 +83,7 @@ resource extensionCollection 'Microsoft.Authorization/locks@2016-09-01' = [for i
 @batchSize(1)
 resource lockTheLocks 'Microsoft.Authorization/locks@2016-09-01' = [for i in range(0,1): {
 //@[72:073) Local i. Type: 0. Declaration start char: 72, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 67, length: 155
 //@[09:021) Resource lockTheLocks. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 236
   name: 'lock-the-lock-${i}'
   properties: {
@@ -115,6 +122,7 @@ output indexViaReference string = storageAccounts[int(storageAccounts[index].pro
 // dependency on a resource collection
 resource storageAccounts2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in accounts: {
 //@[80:087) Local account. Type: any. Declaration start char: 80, length: 7
+//@[00:008) Local this. Type: object[]. Declaration start char: 75, length: 201
 //@[09:025) Resource storageAccounts2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 276
   name: '${name}-collection-${account.name}'
   location: account.location
@@ -130,6 +138,7 @@ resource storageAccounts2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for 
 // one-to-one paired dependencies
 resource firstSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for i in range(0, length(accounts)): {
 //@[72:073) Local i. Type: int. Declaration start char: 72, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 67, length: 165
 //@[09:017) Resource firstSet. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 232
   name: '${name}-set1-${i}'
   location: resourceGroup().location
@@ -141,6 +150,7 @@ resource firstSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for i in ran
 
 resource secondSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for i in range(0, length(accounts)): {
 //@[73:074) Local i. Type: int. Declaration start char: 73, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 68, length: 200
 //@[09:018) Resource secondSet. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 268
   name: '${name}-set2-${i}'
   location: resourceGroup().location
@@ -155,6 +165,7 @@ resource secondSet 'Microsoft.Storage/storageAccounts@2019-06-01' = [for i in ra
 
 // depending on collection and one resource in the collection optimizes the latter part away
 resource anotherSingleResource 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 80, length: 186
 //@[09:030) Resource anotherSingleResource. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 266
   name: '${name}single-resource-name'
   location: resourceGroup().location
@@ -183,6 +194,7 @@ var vnetConfigurations = [
 
 resource vnets 'Microsoft.Network/virtualNetworks@2020-06-01' = [for vnetConfig in vnetConfigurations: {
 //@[69:079) Local vnetConfig. Type: object | object. Declaration start char: 69, length: 10
+//@[00:008) Local this. Type: object[]. Declaration start char: 64, length: 99
 //@[09:014) Resource vnets. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 163
   name: vnetConfig.name
   location: vnetConfig.location
@@ -190,6 +202,7 @@ resource vnets 'Microsoft.Network/virtualNetworks@2020-06-01' = [for vnetConfig 
 
 // implicit dependency on single resource from a resource collection
 resource implicitDependencyOnSingleResourceByIndex 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 93, length: 144
 //@[09:050) Resource implicitDependencyOnSingleResourceByIndex. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 237
   name: 'test'
   location: 'global'
@@ -204,6 +217,7 @@ resource implicitDependencyOnSingleResourceByIndex 'Microsoft.Network/dnsZones@2
 
 // implicit and explicit dependency combined
 resource combinedDependencies 'Microsoft.Network/dnsZones@2018-05-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 72, length: 222
 //@[09:029) Resource combinedDependencies. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 294
   name: 'test2'
   location: 'global'
@@ -317,6 +331,7 @@ output existingIndexedResourceAccessTier string = existingStorageAccounts[index%
 
 resource duplicatedNames 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in []: {
 //@[72:076) Local zone. Type: never. Declaration start char: 72, length: 4
+//@[00:008) Local this. Type: object[]. Declaration start char: 67, length: 69
 //@[09:024) Resource duplicatedNames. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 136
   name: 'no loop variable'
   location: 'eastus'
@@ -325,6 +340,7 @@ resource duplicatedNames 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in 
 // reference to a resource collection whose name expression does not reference any loop variables
 resource referenceToDuplicateNames 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in []: {
 //@[82:086) Local zone. Type: never. Declaration start char: 82, length: 4
+//@[00:008) Local this. Type: object[]. Declaration start char: 77, length: 117
 //@[09:034) Resource referenceToDuplicateNames. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 194
   name: 'no loop variable 2'
   location: 'eastus'
@@ -349,6 +365,7 @@ module apim 'passthrough.bicep' = [for region in regions: {
 }]
 
 resource propertyLoopDependencyOnModuleCollection 'Microsoft.Network/frontDoors@2020-05-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 94, length: 686
 //@[09:049) Resource propertyLoopDependencyOnModuleCollection. Type: Microsoft.Network/frontDoors@2020-05-01. Declaration start char: 0, length: 780
   name: name
   location: 'Global'
@@ -377,6 +394,7 @@ resource propertyLoopDependencyOnModuleCollection 'Microsoft.Network/frontDoors@
 
 resource indexedModuleCollectionDependency 'Microsoft.Network/frontDoors@2020-05-01' = [for index in range(0, length(regions)): {
 //@[92:097) Local index. Type: int. Declaration start char: 92, length: 5
+//@[00:008) Local this. Type: object[]. Declaration start char: 87, length: 670
 //@[09:042) Resource indexedModuleCollectionDependency. Type: Microsoft.Network/frontDoors@2020-05-01[]. Declaration start char: 0, length: 757
   name: '${name}-${index}'
   location: 'Global'
@@ -404,6 +422,7 @@ resource indexedModuleCollectionDependency 'Microsoft.Network/frontDoors@2020-05
 }]
 
 resource propertyLoopDependencyOnResourceCollection 'Microsoft.Network/frontDoors@2020-05-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 96, length: 775
 //@[09:051) Resource propertyLoopDependencyOnResourceCollection. Type: Microsoft.Network/frontDoors@2020-05-01. Declaration start char: 0, length: 871
   name: name
   location: 'Global'
@@ -432,6 +451,7 @@ resource propertyLoopDependencyOnResourceCollection 'Microsoft.Network/frontDoor
 
 resource indexedResourceCollectionDependency 'Microsoft.Network/frontDoors@2020-05-01' = [for index in range(0, length(accounts)): {
 //@[94:099) Local index. Type: int. Declaration start char: 94, length: 5
+//@[00:008) Local this. Type: object[]. Declaration start char: 89, length: 759
 //@[09:044) Resource indexedResourceCollectionDependency. Type: Microsoft.Network/frontDoors@2020-05-01[]. Declaration start char: 0, length: 848
   name: '${name}-${index}'
   location: 'Global'
@@ -460,6 +480,7 @@ resource indexedResourceCollectionDependency 'Microsoft.Network/frontDoors@2020-
 
 resource filteredZones 'Microsoft.Network/dnsZones@2018-05-01' = [for i in range(0,10): if(i % 3 == 0) {
 //@[70:071) Local i. Type: int. Declaration start char: 70, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 65, length: 98
 //@[09:022) Resource filteredZones. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 163
   name: 'zone${i}'
   location: resourceGroup().location
@@ -477,6 +498,7 @@ module filteredModules 'passthrough.bicep' = [for i in range(0,6): if(i % 2 == 0
 resource filteredIndexedZones 'Microsoft.Network/dnsZones@2018-05-01' = [for (account, i) in accounts: if(account.enabled) {
 //@[78:085) Local account. Type: any. Declaration start char: 78, length: 7
 //@[87:088) Local i. Type: int. Declaration start char: 87, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 72, length: 127
 //@[09:029) Resource filteredIndexedZones. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 199
   name: 'indexedZone-${account.name}-${i}'
   location: account.location

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesSubscription_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesSubscription_LF/main.symbols.bicep
@@ -15,6 +15,7 @@ var scripts = take(groups, 2)
 
 resource resourceGroups 'Microsoft.Resources/resourceGroups@2020-06-01' = [for name in groups: {
 //@[79:83) Local name. Type: 'bicep1' | 'bicep2' | 'bicep3' | 'bicep4'. Declaration start char: 79, length: 4
+//@[00:08) Local this. Type: object[]. Declaration start char: 74, length: 74
 //@[09:23) Resource resourceGroups. Type: Microsoft.Resources/resourceGroups@2020-06-01[]. Declaration start char: 0, length: 148
   name: '${prefix}-${name}'
   location: 'westus'

--- a/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Modules_CRLF/main.symbols.bicep
@@ -90,6 +90,7 @@ module optionalWithAllParams './child/optionalParams.bicep'= {
 }
 
 resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 65, length: 168
 //@[09:28) Resource resWithDependencies. Type: Mock.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 233
   name: 'harry'
   properties: {
@@ -137,6 +138,7 @@ module moduleWithCalculatedName './child/optionalParams.bicep'= {
 }
 
 resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 79, length: 162
 //@[09:42) Resource resWithCalculatedNameDependencies. Type: Mock.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 241
   name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
   properties: {

--- a/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/NestedResources_LF/main.symbols.bicep
@@ -1,4 +1,5 @@
 resource basicParent 'My.Rp/parentType@2020-12-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 53, length: 606
 //@[09:20) Resource basicParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 659
   name: 'basicParent'
   properties: {
@@ -6,6 +7,7 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
   }
 
   resource basicChild 'childType' = {
+//@[02:10) Local this. Type: object. Declaration start char: 36, length: 313
 //@[11:21) Resource basicChild. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 347
     name: 'basicChild'
     properties: {
@@ -14,6 +16,7 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
     }
 
     resource basicGrandchild 'grandchildType' = {
+//@[04:12) Local this. Type: object. Declaration start char: 48, length: 150
 //@[13:28) Resource basicGrandchild. Type: My.Rp/parentType/childType/grandchildType@2020-12-01. Declaration start char: 4, length: 194
       name: 'basicGrandchild'
       properties: {
@@ -24,6 +27,7 @@ resource basicParent 'My.Rp/parentType@2020-12-01' = {
   }
 
   resource basicSibling 'childType' = {
+//@[02:10) Local this. Type: object. Declaration start char: 38, length: 152
 //@[11:23) Resource basicSibling. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 188
     name: 'basicSibling'
     properties: {
@@ -48,6 +52,7 @@ resource existingParent 'My.Rp/parentType@2020-12-01' existing = {
     name: 'existingChild'
 
     resource existingGrandchild 'grandchildType' = {
+//@[04:12) Local this. Type: object. Declaration start char: 51, length: 159
 //@[13:31) Resource existingGrandchild. Type: My.Rp/parentType/childType/grandchildType@2020-12-01. Declaration start char: 4, length: 206
       name: 'existingGrandchild'
       properties: {
@@ -65,14 +70,17 @@ param createChild bool
 param createGrandchild bool
 //@[06:22) Parameter createGrandchild. Type: bool. Declaration start char: 0, length: 27
 resource conditionParent 'My.Rp/parentType@2020-12-01' = if (createParent) {
+//@[00:08) Local this. Type: object. Declaration start char: 75, length: 358
 //@[09:24) Resource conditionParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 433
   name: 'conditionParent'
 
   resource conditionChild 'childType' = if (createChild) {
+//@[02:10) Local this. Type: object. Declaration start char: 57, length: 270
 //@[11:25) Resource conditionChild. Type: My.Rp/parentType/childType@2020-12-01. Declaration start char: 2, length: 325
     name: 'conditionChild'
 
     resource conditionGrandchild 'grandchildType' = if (createGrandchild) {
+//@[04:12) Local this. Type: object. Declaration start char: 74, length: 162
 //@[13:32) Resource conditionGrandchild. Type: My.Rp/parentType/childType/grandchildType@2020-12-01. Declaration start char: 4, length: 232
       name: 'conditionGrandchild'
       properties: {
@@ -89,11 +97,13 @@ var items = [
   'b'
 ]
 resource loopParent 'My.Rp/parentType@2020-12-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 52, length: 109
 //@[09:19) Resource loopParent. Type: My.Rp/parentType@2020-12-01. Declaration start char: 0, length: 161
   name: 'loopParent'
 
   resource loopChild 'childType' = [for item in items: {
 //@[40:44) Local item. Type: 'a' | 'b'. Declaration start char: 40, length: 4
+//@[02:10) Local this. Type: object[]. Declaration start char: 35, length: 48
 //@[11:20) Resource loopChild. Type: My.Rp/parentType/childType@2020-12-01[]. Declaration start char: 2, length: 81
     name: 'loopChild'
   }]

--- a/src/Bicep.Core.Samples/Files/baselines/Registry_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Registry_LF/main.symbols.bicep
@@ -1,6 +1,7 @@
 targetScope = 'subscription'
 
 resource rg 'Microsoft.Resources/resourceGroups@2020-06-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 62, length: 60
 //@[09:11) Resource rg. Type: Microsoft.Resources/resourceGroups@2020-06-01. Declaration start char: 0, length: 122
   name: 'adotfrank-rg'
   location: deployment().location

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesManagementGroup_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesManagementGroup_CRLF/main.symbols.bicep
@@ -9,6 +9,7 @@ param readerPrincipals array
 //@[06:022) Parameter readerPrincipals. Type: array. Declaration start char: 0, length: 28
 
 resource owner 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+//@[00:008) Local this. Type: object. Declaration start char: 78, length: 164
 //@[09:014) Resource owner. Type: Microsoft.Authorization/roleAssignments@2020-04-01-preview. Declaration start char: 0, length: 242
   name: guid('owner', ownerPrincipalId)
   properties: {
@@ -19,6 +20,7 @@ resource owner 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
 
 resource contributors 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for contributor in contributorPrincipals: {
 //@[90:101) Local contributor. Type: any. Declaration start char: 90, length: 11
+//@[00:008) Local this. Type: object[]. Declaration start char: 85, length: 236
 //@[09:021) Resource contributors. Type: Microsoft.Authorization/roleAssignments@2020-04-01-preview[]. Declaration start char: 0, length: 321
   name: guid('contributor', contributor)
   properties: {
@@ -32,6 +34,7 @@ resource contributors 'Microsoft.Authorization/roleAssignments@2020-04-01-previe
 
 resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for reader in readerPrincipals: {
 //@[85:091) Local reader. Type: any. Declaration start char: 85, length: 6
+//@[00:008) Local this. Type: object[]. Declaration start char: 80, length: 232
 //@[09:016) Resource readers. Type: Microsoft.Authorization/roleAssignments@2020-04-01-preview[]. Declaration start char: 0, length: 312
   name: guid('reader', reader)
   properties: {
@@ -45,6 +48,7 @@ resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = 
 }]
 
 resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 72, length: 41
 //@[09:018) Resource single_mg. Type: Microsoft.Management/managementGroups@2020-05-01. Declaration start char: 0, length: 113
   scope: tenant()
   name: 'one-mg'
@@ -52,6 +56,7 @@ resource single_mg 'Microsoft.Management/managementGroups@2020-05-01' = {
 
 // Blueprints are read-only at tenant Scope, but it's a convenient example to use to validate this.
 resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[00:008) Local this. Type: object. Declaration start char: 80, length: 69
 //@[09:025) Resource tenant_blueprint. Type: Microsoft.Blueprint/blueprints@2018-11-01-preview. Declaration start char: 0, length: 149
   name: 'tenant-blueprint'
   properties: {}
@@ -59,6 +64,7 @@ resource tenant_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = 
 }
 
 resource mg_blueprint 'Microsoft.Blueprint/blueprints@2018-11-01-preview' = {
+//@[00:008) Local this. Type: object. Declaration start char: 76, length: 46
 //@[09:021) Resource mg_blueprint. Type: Microsoft.Blueprint/blueprints@2018-11-01-preview. Declaration start char: 0, length: 122
   name: 'mg-blueprint'
   properties: {}

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesSubscription_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesSubscription_CRLF/main.symbols.bicep
@@ -9,6 +9,7 @@ param readerPrincipals array
 //@[06:022) Parameter readerPrincipals. Type: array. Declaration start char: 0, length: 28
 
 resource owner 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+//@[00:008) Local this. Type: object. Declaration start char: 78, length: 164
 //@[09:014) Resource owner. Type: Microsoft.Authorization/roleAssignments@2020-04-01-preview. Declaration start char: 0, length: 242
   name: guid('owner', ownerPrincipalId)
   properties: {
@@ -19,6 +20,7 @@ resource owner 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
 
 resource contributors 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for contributor in contributorPrincipals: {
 //@[90:101) Local contributor. Type: any. Declaration start char: 90, length: 11
+//@[00:008) Local this. Type: object[]. Declaration start char: 85, length: 236
 //@[09:021) Resource contributors. Type: Microsoft.Authorization/roleAssignments@2020-04-01-preview[]. Declaration start char: 0, length: 321
   name: guid('contributor', contributor)
   properties: {
@@ -32,6 +34,7 @@ resource contributors 'Microsoft.Authorization/roleAssignments@2020-04-01-previe
 
 resource readers 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for reader in readerPrincipals: {
 //@[85:091) Local reader. Type: any. Declaration start char: 85, length: 6
+//@[00:008) Local this. Type: object[]. Declaration start char: 80, length: 232
 //@[09:016) Resource readers. Type: Microsoft.Authorization/roleAssignments@2020-04-01-preview[]. Declaration start char: 0, length: 312
   name: guid('reader', reader)
   properties: {

--- a/src/Bicep.Core.Samples/Files/baselines/ResourcesTenant_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ResourcesTenant_CRLF/main.symbols.bicep
@@ -13,6 +13,7 @@ var managementGroups = [
 ]
 
 resource singleGroup 'Microsoft.Management/managementGroups@2020-05-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 74, length: 80
 //@[09:20) Resource singleGroup. Type: Microsoft.Management/managementGroups@2020-05-01. Declaration start char: 0, length: 154
   name: 'myMG'
   properties: {
@@ -22,6 +23,7 @@ resource singleGroup 'Microsoft.Management/managementGroups@2020-05-01' = {
 
 resource manyGroups 'Microsoft.Management/managementGroups@2020-05-01' = [for mg in managementGroups: {
 //@[78:80) Local mg. Type: object | object. Declaration start char: 78, length: 2
+//@[00:08) Local this. Type: object[]. Declaration start char: 73, length: 151
 //@[09:19) Resource manyGroups. Type: Microsoft.Management/managementGroups@2020-05-01[]. Declaration start char: 0, length: 224
   name: mg.name
   properties: {
@@ -32,6 +34,7 @@ resource manyGroups 'Microsoft.Management/managementGroups@2020-05-01' = [for mg
 resource anotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for (mg, index) in managementGroups: {
 //@[79:81) Local mg. Type: object | object. Declaration start char: 79, length: 2
 //@[83:88) Local index. Type: int. Declaration start char: 83, length: 5
+//@[00:08) Local this. Type: object[]. Declaration start char: 73, length: 246
 //@[09:19) Resource anotherSet. Type: Microsoft.Management/managementGroups@2020-05-01[]. Declaration start char: 0, length: 319
   name: concat(mg.name, '-one-', index)
   properties: {
@@ -44,6 +47,7 @@ resource anotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for (m
 
 resource yetAnotherSet 'Microsoft.Management/managementGroups@2020-05-01' = [for mg in managementGroups: {
 //@[81:83) Local mg. Type: object | object. Declaration start char: 81, length: 2
+//@[00:08) Local this. Type: object[]. Declaration start char: 76, length: 215
 //@[09:22) Resource yetAnotherSet. Type: Microsoft.Management/managementGroups@2020-05-01[]. Declaration start char: 0, length: 291
   name: concat(mg.name, '-two')
   properties: {

--- a/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Resources_CRLF/main.symbols.bicep
@@ -1,6 +1,7 @@
 
 @sys.description('this is basicStorage')
 resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 71, length: 112
 //@[09:021) Resource basicStorage. Type: Microsoft.Storage/storageAccounts@2019-06-01. Declaration start char: 0, length: 225
   name: 'basicblobs'
   location: 'westus'
@@ -12,12 +13,14 @@ resource basicStorage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
 
 @sys.description('this is dnsZone')
 resource dnsZone 'Microsoft.Network/dnszones@2018-05-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 59, length: 44
 //@[09:016) Resource dnsZone. Type: Microsoft.Network/dnsZones@2018-05-01. Declaration start char: 0, length: 140
   name: 'myZone'
   location: 'global'
 }
 
 resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 75, length: 394
 //@[09:025) Resource myStorageAccount. Type: Microsoft.Storage/storageAccounts@2017-10-01. Declaration start char: 0, length: 469
   name: 'myencryptedone'
   location: 'eastus2'
@@ -43,6 +46,7 @@ resource myStorageAccount 'Microsoft.Storage/storageAccounts@2017-10-01' = {
 }
 
 resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 74, length: 465
 //@[09:024) Resource withExpressions. Type: Microsoft.Storage/storageAccounts@2017-10-01. Declaration start char: 0, length: 539
   name: 'myencryptedone2'
   location: 'eastus2'
@@ -84,6 +88,7 @@ var location = resourceGroup().location
 //@[04:012) Variable location. Type: string. Declaration start char: 0, length: 39
 
 resource farm 'Microsoft.Web/serverFarms@2019-08-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 55, length: 316
 //@[09:013) Resource farm. Type: Microsoft.Web/serverfarms@2019-08-01. Declaration start char: 0, length: 371
   // dependsOn: resourceId('Microsoft.DocumentDB/databaseAccounts', cosmosAccountName)
   name: hostingPlanName
@@ -114,6 +119,7 @@ param webSiteName string
 param cosmosDb object
 //@[06:014) Parameter cosmosDb. Type: object. Declaration start char: 0, length: 21
 resource site 'Microsoft.Web/sites@2019-08-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 49, length: 640
 //@[09:013) Resource site. Type: Microsoft.Web/sites@2019-08-01. Declaration start char: 0, length: 689
   name: webSiteName
   location: location
@@ -153,6 +159,7 @@ output siteType string = site.type
 //@[07:015) Output siteType. Type: string. Declaration start char: 0, length: 34
 
 resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 63, length: 291
 //@[09:015) Resource nested. Type: Microsoft.Resources/deployments@2019-10-01. Declaration start char: 0, length: 354
   name: 'nestedTemplate1'
   properties: {
@@ -169,6 +176,7 @@ resource nested 'Microsoft.Resources/deployments@2019-10-01' = {
 
 // should be able to access the read only properties
 resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 71, length: 213
 //@[09:036) Resource accessingReadOnlyProperties. Type: Microsoft.Foo/foos@2019-10-01. Declaration start char: 0, length: 284
   name: 'nestedTemplate1'
   properties: {
@@ -182,16 +190,19 @@ resource accessingReadOnlyProperties 'Microsoft.Foo/foos@2019-10-01' = {
 }
 
 resource resourceA 'My.Rp/typeA@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 46, length: 25
 //@[09:018) Resource resourceA. Type: My.Rp/typeA@2020-01-01. Declaration start char: 0, length: 71
   name: 'resourceA'
 }
 
 resource resourceB 'My.Rp/typeA/typeB@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 52, length: 43
 //@[09:018) Resource resourceB. Type: My.Rp/typeA/typeB@2020-01-01. Declaration start char: 0, length: 95
   name: '${resourceA.name}/resourceB'
 }
 
 resource resourceC 'My.Rp/typeA/typeB@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 52, length: 220
 //@[09:018) Resource resourceC. Type: My.Rp/typeA/typeB@2020-01-01. Declaration start char: 0, length: 272
   name: '${resourceA.name}/resourceC'
   properties: {
@@ -225,6 +236,7 @@ var setResourceCRef = true
 //@[04:019) Variable setResourceCRef. Type: true. Declaration start char: 0, length: 26
 
 resource resourceD 'My.Rp/typeD@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 46, length: 185
 //@[09:018) Resource resourceD. Type: My.Rp/typeD@2020-01-01. Declaration start char: 0, length: 231
   name: 'constant'
   properties: {
@@ -237,6 +249,7 @@ resource resourceD 'My.Rp/typeD@2020-01-01' = {
 var myInterpKey = 'abc'
 //@[04:015) Variable myInterpKey. Type: 'abc'. Declaration start char: 0, length: 23
 resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 56, length: 146
 //@[09:027) Resource resourceWithInterp. Type: My.Rp/interp@2020-01-01. Declaration start char: 0, length: 202
   name: 'interpTest'
   properties: {
@@ -247,6 +260,7 @@ resource resourceWithInterp 'My.Rp/interp@2020-01-01' = {
 }
 
 resource resourceWithEscaping 'My.Rp/mockResource@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 64, length: 170
 //@[09:029) Resource resourceWithEscaping. Type: My.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 234
   name: 'test'
   properties: {
@@ -260,6 +274,7 @@ param shouldDeployVm bool = true
 
 @sys.description('this is vmWithCondition')
 resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (shouldDeployVm) {
+//@[00:008) Local this. Type: object. Declaration start char: 94, length: 169
 //@[09:024) Resource vmWithCondition. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 308
   name: 'vmName'
   location: 'westus'
@@ -274,6 +289,7 @@ resource vmWithCondition 'Microsoft.Compute/virtualMachines@2020-06-01' = if (sh
 
 @sys.description('this is another vmWithCondition')
 resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
+//@[00:008) Local this. Type: object. Declaration start char: 40, length: 170
 //@[09:025) Resource vmWithCondition2. Type: Microsoft.Compute/virtualMachines@2020-06-01. Declaration start char: 0, length: 339
                     if (shouldDeployVm) {
   name: 'vmName2'
@@ -288,18 +304,21 @@ resource vmWithCondition2 'Microsoft.Compute/virtualMachines@2020-06-01' =
 }
 
 resource extension1 'My.Rp/extensionResource@2020-12-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 59, length: 51
 //@[09:019) Resource extension1. Type: My.Rp/extensionResource@2020-12-01. Declaration start char: 0, length: 110
   name: 'extension'
   scope: vmWithCondition
 }
 
 resource extension2 'My.Rp/extensionResource@2020-12-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 59, length: 46
 //@[09:019) Resource extension2. Type: My.Rp/extensionResource@2020-12-01. Declaration start char: 0, length: 105
   name: 'extension'
   scope: extension1
 }
 
 resource extensionDependencies 'My.Rp/mockResource@2020-01-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 65, length: 294
 //@[09:030) Resource extensionDependencies. Type: My.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 359
   name: 'extensionDependencies'
   properties: {
@@ -326,6 +345,7 @@ resource existing2 'Mock.Rp/existingExtensionResource@2020-01-01' existing = {
 }
 
 resource extension3 'My.Rp/extensionResource@2020-12-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 59, length: 46
 //@[09:019) Resource extension3. Type: My.Rp/extensionResource@2020-12-01. Declaration start char: 0, length: 105
   name: 'extension3'
   scope: existing1
@@ -350,6 +370,7 @@ var storageAccounts = [
 @sys.description('this is just a storage account loop')
 resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[80:087) Local account. Type: object | object. Declaration start char: 80, length: 7
+//@[00:008) Local this. Type: object[]. Declaration start char: 75, length: 152
 //@[09:025) Resource storageResources. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 284
   name: account.name
   location: account.location
@@ -364,6 +385,7 @@ resource storageResources 'Microsoft.Storage/storageAccounts@2019-06-01' = [for 
 resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01' = [for (account, i) in storageAccounts: {
 //@[90:097) Local account. Type: object | object. Declaration start char: 90, length: 7
 //@[99:100) Local i. Type: int. Declaration start char: 99, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 84, length: 166
 //@[09:034) Resource storageResourcesWithIndex. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 318
   name: '${account.name}${i}'
   location: account.location
@@ -377,6 +399,7 @@ resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01
 @sys.description('this is just a basic nested loop')
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[68:069) Local i. Type: int. Declaration start char: 68, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 63, length: 277
 //@[09:013) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 394
   name: 'vnet-${i}'
   properties: {
@@ -393,6 +416,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 // duplicate identifiers within the loop are allowed
 resource duplicateIdentifiersWithinLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[94:095) Local i. Type: int. Declaration start char: 94, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 89, length: 150
 //@[09:039) Resource duplicateIdentifiersWithinLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 239
   name: 'vnet-${i}'
   properties: {
@@ -408,6 +432,7 @@ var canHaveDuplicatesAcrossScopes = 'hello'
 //@[04:033) Variable canHaveDuplicatesAcrossScopes. Type: 'hello'. Declaration start char: 0, length: 43
 resource duplicateInGlobalAndOneLoop 'Microsoft.Network/virtualNetworks@2020-06-01' = [for canHaveDuplicatesAcrossScopes in range(0, 3): {
 //@[91:120) Local canHaveDuplicatesAcrossScopes. Type: int. Declaration start char: 91, length: 29
+//@[00:008) Local this. Type: object[]. Declaration start char: 86, length: 206
 //@[09:036) Resource duplicateInGlobalAndOneLoop. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 292
   name: 'vnet-${canHaveDuplicatesAcrossScopes}'
   properties: {
@@ -423,6 +448,7 @@ var duplicatesEverywhere = 'hello'
 //@[04:024) Variable duplicatesEverywhere. Type: 'hello'. Declaration start char: 0, length: 34
 resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06-01' = [for duplicatesEverywhere in range(0, 3): {
 //@[92:112) Local duplicatesEverywhere. Type: int. Declaration start char: 92, length: 20
+//@[00:008) Local this. Type: object[]. Declaration start char: 87, length: 221
 //@[09:037) Resource duplicateInGlobalAndTwoLoops. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 308
   name: 'vnet-${duplicatesEverywhere}'
   properties: {
@@ -438,6 +464,7 @@ resource duplicateInGlobalAndTwoLoops 'Microsoft.Network/virtualNetworks@2020-06
 */
 resource dnsZones 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in range(0,4): {
 //@[65:069) Local zone. Type: int. Declaration start char: 65, length: 4
+//@[00:008) Local this. Type: object[]. Declaration start char: 60, length: 75
 //@[09:017) Resource dnsZones. Type: Microsoft.Network/dnsZones@2018-05-01[]. Declaration start char: 0, length: 135
   name: 'zone${zone}'
   location: 'global'
@@ -445,6 +472,7 @@ resource dnsZones 'Microsoft.Network/dnsZones@2018-05-01' = [for zone in range(0
 
 resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in range(0,2): {
 //@[72:076) Local lock. Type: int. Declaration start char: 72, length: 4
+//@[00:008) Local this. Type: object[]. Declaration start char: 67, length: 127
 //@[09:021) Resource locksOnZones. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 194
   name: 'lock${lock}'
   properties: {
@@ -456,6 +484,7 @@ resource locksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for lock in 
 resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (lock, i) in range(0,3): {
 //@[77:081) Local lock. Type: int. Declaration start char: 77, length: 4
 //@[83:084) Local i. Type: int. Declaration start char: 83, length: 1
+//@[00:008) Local this. Type: object[]. Declaration start char: 71, length: 125
 //@[09:025) Resource moreLocksOnZones. Type: Microsoft.Authorization/locks@2016-09-01[]. Declaration start char: 0, length: 196
   name: 'another${i}'
   properties: {
@@ -465,6 +494,7 @@ resource moreLocksOnZones 'Microsoft.Authorization/locks@2016-09-01' = [for (loc
 }]
 
 resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 76, length: 94
 //@[09:030) Resource singleLockOnFirstZone. Type: Microsoft.Authorization/locks@2016-09-01. Declaration start char: 0, length: 170
   name: 'single-lock'
   properties: {
@@ -475,6 +505,7 @@ resource singleLockOnFirstZone 'Microsoft.Authorization/locks@2016-09-01' = {
 
 
 resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 66, length: 168
 //@[09:016) Resource p1_vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 234
   location: resourceGroup().location
   name: 'myVnet'
@@ -488,6 +519,7 @@ resource p1_vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 }
 
 resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 77, length: 98
 //@[09:019) Resource p1_subnet1. Type: Microsoft.Network/virtualNetworks/subnets@2020-06-01. Declaration start char: 0, length: 175
   parent: p1_vnet
   name: 'subnet1'
@@ -497,6 +529,7 @@ resource p1_subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
 }
 
 resource p1_subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 77, length: 98
 //@[09:019) Resource p1_subnet2. Type: Microsoft.Network/virtualNetworks/subnets@2020-06-01. Declaration start char: 0, length: 175
   parent: p1_vnet
   name: 'subnet2'
@@ -516,23 +549,27 @@ output p1_subnet1id string = p1_subnet1.id
 
 // parent property with extension resource
 resource p2_res1 'Microsoft.Rp1/resource1@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 56, length: 22
 //@[09:016) Resource p2_res1. Type: Microsoft.Rp1/resource1@2020-06-01. Declaration start char: 0, length: 78
   name: 'p2res1'
 }
 
 resource p2_res1child 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 68, length: 41
 //@[09:021) Resource p2_res1child. Type: Microsoft.Rp1/resource1/child1@2020-06-01. Declaration start char: 0, length: 109
   parent: p2_res1
   name: 'child1'
 }
 
 resource p2_res2 'Microsoft.Rp2/resource2@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 56, length: 43
 //@[09:016) Resource p2_res2. Type: Microsoft.Rp2/resource2@2020-06-01. Declaration start char: 0, length: 99
   scope: p2_res1child
   name: 'res2'
 }
 
 resource p2_res2child 'Microsoft.Rp2/resource2/child2@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 68, length: 41
 //@[09:021) Resource p2_res2child. Type: Microsoft.Rp2/resource2/child2@2020-06-01. Declaration start char: 0, length: 109
   parent: p2_res2
   name: 'child2'
@@ -554,6 +591,7 @@ resource p3_res1 'Microsoft.Rp1/resource1@2020-06-01' existing = {
 }
 
 resource p3_child1 'Microsoft.Rp1/resource1/child1@2020-06-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 65, length: 41
 //@[09:018) Resource p3_child1. Type: Microsoft.Rp1/resource1/child1@2020-06-01. Declaration start char: 0, length: 106
   parent: p3_res1
   name: 'child1'
@@ -594,6 +632,7 @@ output p4_res1childid string = p4_child1.id
 var dbs = ['db1', 'db2','db3']
 //@[04:007) Variable dbs. Type: ['db1', 'db2', 'db3']. Declaration start char: 0, length: 30
 resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 56, length: 471
 //@[09:018) Resource sqlServer. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 527
   name: 'sql-server-name'
   location: 'polandcentral'
@@ -602,6 +641,7 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
   @description('Sql Databases')
   resource sqlDatabases 'databases' = [for db in dbs: {
 //@[43:045) Local db. Type: 'db1' | 'db2' | 'db3'. Declaration start char: 43, length: 2
+//@[02:010) Local this. Type: object[]. Declaration start char: 38, length: 68
 //@[11:023) Resource sqlDatabases. Type: Microsoft.Sql/servers/databases@2021-11-01[]. Declaration start char: 2, length: 154
     name: db
     location: 'polandcentral'
@@ -609,6 +649,7 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
 
   @description('Primary Sql Database')
   resource primaryDb 'databases' = {
+//@[02:010) Local this. Type: object. Declaration start char: 35, length: 172
 //@[11:020) Resource primaryDb. Type: Microsoft.Sql/servers/databases@2021-11-01. Declaration start char: 2, length: 245
     name: 'primary-db'
     location: 'polandcentral'
@@ -639,6 +680,7 @@ var sqlConfig = {
 }
 
 resource sqlServerWithNameof 'Microsoft.Sql/servers@2021-11-01' = {
+//@[00:008) Local this. Type: object. Declaration start char: 66, length: 107
 //@[09:028) Resource sqlServerWithNameof. Type: Microsoft.Sql/servers@2021-11-01. Declaration start char: 0, length: 173
   name: 'sql-server-nameof-${nameof(sqlConfig['server-name'])}'
   location: nameof(sqlConfig.westus)

--- a/src/Bicep.Core.Samples/Files/baselines/ValidDeployTimeUsages_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ValidDeployTimeUsages_LF/main.symbols.bicep
@@ -1,4 +1,5 @@
 resource foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 62, length: 160
 //@[09:12) Resource foo. Type: Microsoft.Storage/storageAccounts@2022-09-01. Declaration start char: 0, length: 222
   name: 'foo'
   location: 'westus'
@@ -8,12 +9,14 @@ resource foo 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   kind: 'StorageV2'
 
   resource fooChild 'fileServices' = {
+//@[02:10) Local this. Type: object. Declaration start char: 37, length: 25
 //@[11:19) Resource fooChild. Type: Microsoft.Storage/storageAccounts/fileServices@2022-09-01. Declaration start char: 2, length: 60
     name: 'default'
   }
 }
 resource foos 'Microsoft.Storage/storageAccounts@2022-09-01' = [for i in range(0, 2): {
 //@[68:69) Local i. Type: int. Declaration start char: 68, length: 1
+//@[00:08) Local this. Type: object[]. Declaration start char: 63, length: 125
 //@[09:13) Resource foos. Type: Microsoft.Storage/storageAccounts@2022-09-01[]. Declaration start char: 0, length: 188
   name: 'foo-${i}'
   location: 'westus'

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -112,8 +112,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "resourceInfoCodegen": false,
           "userDefinedConstraints": false,
           "deployCommands": false,
-          "thisNamespace": false,
-          "existingNullIfNotFound": false
+          "thisNamespace": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -196,8 +195,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "moduleExtensionConfigs": false,
           "userDefinedConstraints": false,
           "deployCommands": false,
-          "thisNamespace": false,
-          "existingNullIfNotFound": false
+          "thisNamespace": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -302,8 +300,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "moduleExtensionConfigs": false,
           "userDefinedConstraints": false,
           "deployCommands": false,
-          "thisNamespace": false,
-          "existingNullIfNotFound": false
+          "thisNamespace": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -389,8 +386,7 @@ namespace Bicep.Core.UnitTests.Configuration
                 ModuleExtensionConfigs: false,
                 UserDefinedConstraints: false,
                 DeployCommands: false,
-                ThisNamespace: false,
-                ExistingNullIfNotFound: false);
+                ThisNamespace: false);
 
             configuration.WithExperimentalFeaturesEnabled(experimentalFeaturesEnabled).Should().HaveContents(/*lang=json,strict*/ """
             {
@@ -474,8 +470,7 @@ namespace Bicep.Core.UnitTests.Configuration
                 "moduleExtensionConfigs": false,
                 "userDefinedConstraints": false,
                 "deployCommands": false,
-                "thisNamespace": false,
-                "existingNullIfNotFound": false
+                "thisNamespace": false
             },
             "formatting": {
                 "indentKind": "Space",
@@ -826,8 +821,7 @@ namespace Bicep.Core.UnitTests.Configuration
                     "moduleExtensionConfigs": false,
                     "userDefinedConstraints": false,
                     "deployCommands": false,
-                    "thisNamespace": false,
-                    "existingNullIfNotFound": false
+                    "thisNamespace": false
                   },
                   "formatting": {
                     "indentKind": "Space",

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -111,8 +111,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "localDeploy": false,
           "resourceInfoCodegen": false,
           "userDefinedConstraints": false,
-          "deployCommands": false,
-          "thisNamespace": false
+          "deployCommands": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -194,8 +193,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "resourceInfoCodegen": false,
           "moduleExtensionConfigs": false,
           "userDefinedConstraints": false,
-          "deployCommands": false,
-          "thisNamespace": false
+          "deployCommands": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -299,8 +297,7 @@ namespace Bicep.Core.UnitTests.Configuration
           "resourceInfoCodegen": false,
           "moduleExtensionConfigs": false,
           "userDefinedConstraints": false,
-          "deployCommands": false,
-          "thisNamespace": false
+          "deployCommands": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -385,8 +382,7 @@ namespace Bicep.Core.UnitTests.Configuration
                 ResourceInfoCodegen: false,
                 ModuleExtensionConfigs: false,
                 UserDefinedConstraints: false,
-                DeployCommands: false,
-                ThisNamespace: false);
+                DeployCommands: false);
 
             configuration.WithExperimentalFeaturesEnabled(experimentalFeaturesEnabled).Should().HaveContents(/*lang=json,strict*/ """
             {
@@ -469,8 +465,7 @@ namespace Bicep.Core.UnitTests.Configuration
                 "resourceInfoCodegen": false,
                 "moduleExtensionConfigs": false,
                 "userDefinedConstraints": false,
-                "deployCommands": false,
-                "thisNamespace": false
+                "deployCommands": false
             },
             "formatting": {
                 "indentKind": "Space",
@@ -820,8 +815,7 @@ namespace Bicep.Core.UnitTests.Configuration
                     "resourceInfoCodegen": false,
                     "moduleExtensionConfigs": false,
                     "userDefinedConstraints": false,
-                    "deployCommands": false,
-                    "thisNamespace": false
+                    "deployCommands": false
                   },
                   "formatting": {
                     "indentKind": "Space",

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -24,8 +24,7 @@ public record FeatureProviderOverrides(
     string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
     bool? ModuleExtensionConfigsEnabled = default,
     bool? UserDefinedConstraintsEnabled = default,
-    bool? DeployCommandsEnabled = default,
-    bool? ThisNamespaceEnabled = default)
+    bool? DeployCommandsEnabled = default)
 {
     public FeatureProviderOverrides(
         TestContext testContext,
@@ -44,8 +43,7 @@ public record FeatureProviderOverrides(
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
         bool? ModuleExtensionConfigsEnabled = default,
         bool? UserDefinedConstraintsEnabled = default,
-        bool? DeployCommandsEnabled = default,
-        bool? ThisNamespaceEnabled = default) : this(
+        bool? DeployCommandsEnabled = default) : this(
             FileHelper.GetCacheRootDirectory(testContext),
             RegistryEnabled,
             SymbolicNameCodegenEnabled,
@@ -62,7 +60,6 @@ public record FeatureProviderOverrides(
             AssemblyVersion,
             ModuleExtensionConfigsEnabled,
             UserDefinedConstraintsEnabled,
-            DeployCommandsEnabled,
-            ThisNamespaceEnabled)
+            DeployCommandsEnabled)
     { }
 }

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -25,8 +25,7 @@ public record FeatureProviderOverrides(
     bool? ModuleExtensionConfigsEnabled = default,
     bool? UserDefinedConstraintsEnabled = default,
     bool? DeployCommandsEnabled = default,
-    bool? ThisNamespaceEnabled = default,
-    bool? ExistingNullIfNotFoundEnabled = default)
+    bool? ThisNamespaceEnabled = default)
 {
     public FeatureProviderOverrides(
         TestContext testContext,
@@ -46,8 +45,7 @@ public record FeatureProviderOverrides(
         bool? ModuleExtensionConfigsEnabled = default,
         bool? UserDefinedConstraintsEnabled = default,
         bool? DeployCommandsEnabled = default,
-        bool? ThisNamespaceEnabled = default,
-        bool? ExistingNullIfNotFoundEnabled = default) : this(
+        bool? ThisNamespaceEnabled = default) : this(
             FileHelper.GetCacheRootDirectory(testContext),
             RegistryEnabled,
             SymbolicNameCodegenEnabled,
@@ -65,7 +63,6 @@ public record FeatureProviderOverrides(
             ModuleExtensionConfigsEnabled,
             UserDefinedConstraintsEnabled,
             DeployCommandsEnabled,
-            ThisNamespaceEnabled,
-            ExistingNullIfNotFoundEnabled)
+            ThisNamespaceEnabled)
     { }
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -46,6 +46,4 @@ public class OverriddenFeatureProvider : IFeatureProvider
     public bool UserDefinedConstraintsEnabled => overrides.UserDefinedConstraintsEnabled ?? features.UserDefinedConstraintsEnabled;
 
     public bool DeployCommandsEnabled => overrides.DeployCommandsEnabled ?? features.DeployCommandsEnabled;
-
-    public bool ThisNamespaceEnabled => overrides.ThisNamespaceEnabled ?? features.ThisNamespaceEnabled;
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -48,6 +48,4 @@ public class OverriddenFeatureProvider : IFeatureProvider
     public bool DeployCommandsEnabled => overrides.DeployCommandsEnabled ?? features.DeployCommandsEnabled;
 
     public bool ThisNamespaceEnabled => overrides.ThisNamespaceEnabled ?? features.ThisNamespaceEnabled;
-
-    public bool ExistingNullIfNotFoundEnabled => overrides.ExistingNullIfNotFoundEnabled ?? features.ExistingNullIfNotFoundEnabled;
 }

--- a/src/Bicep.Core.UnitTests/Semantics/Namespaces/ThisNamespaceTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/Namespaces/ThisNamespaceTests.cs
@@ -19,9 +19,9 @@ namespace Bicep.Core.UnitTests.Semantics.Namespaces
         public TestContext? TestContext { get; set; }
 
         [TestMethod]
-        public void ThisNamespace_ShouldNotBeRecognizedWhenFeatureDisabled()
+        public void ThisNamespace_ExistsFunction_ShouldBeRecognized()
         {
-            // Test that this.exists() function is not recognized when feature is disabled
+            // Test that this.exists() function is recognized
             var result = CompilationHelper.Compile(@"
                 resource test 'Microsoft.Storage/storageAccounts@2021-04-01' = {
                   name: 'test'
@@ -31,18 +31,15 @@ namespace Bicep.Core.UnitTests.Semantics.Namespaces
                   }
                   kind: 'StorageV2'
                   properties: {
-                    customProperty: this.exists()
+                    allowBlobPublicAccess: this.exists()
                   }
                 }
                 ");
-            result.Should().HaveDiagnostics(new[]
-            {
-                ("BCP057", DiagnosticLevel.Error, "The name \"this\" does not exist in the current context.")
-            });
+            result.Should().NotHaveAnyDiagnostics();
         }
 
         [TestMethod]
-        public void ThisNamespace_ShouldNotBreakExistingVariablesFeatureDisabled()
+        public void ThisNamespace_VariableNamedThis_ShouldFailWithReservedName()
         {
             var result = CompilationHelper.Compile(@"
                 var this = false
@@ -58,22 +55,18 @@ namespace Bicep.Core.UnitTests.Semantics.Namespaces
                   }
                 }
                 ");
-            result.Should().NotHaveAnyDiagnostics();
-
-            using (new AssertionScope())
+            result.Should().HaveDiagnostics(new[]
             {
-                var template = result.Template;
-
-                // Check that this.exists() is compiled to not(empty(target('full')))
-                template.Should().HaveValueAtPath("$.resources[0].properties.allowBlobPublicAccess", "[variables('this')]");
-            }
+                ("BCP084", DiagnosticLevel.Error, "The symbolic name \"this\" is reserved. Please use a different symbolic name. Reserved namespaces are \"az\", \"sys\", \"this\"."),
+                ("no-unused-vars", DiagnosticLevel.Warning, "Variable \"this\" is declared but never used."),
+                ("BCP036", DiagnosticLevel.Warning, "The property \"allowBlobPublicAccess\" expected a value of type \"bool | null\" but the provided value is of type \"this\". If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues."),
+            });
         }
 
         [TestMethod]
         public void ThisNamespace_CompilationGeneratesCorrectArmFunctions()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
   location: 'westus'
@@ -101,8 +94,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void ThisNamespace_CompilationGeneratesCorrectArmFunctionsInForLoops()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = [for i in range(0, 3): {
   name: 'testStorage-${i}'
   location: 'westus'
@@ -130,8 +122,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = [for i in
         [TestMethod]
         public void ThisNamespace_CompilationGeneratesCorrectArmFunctionsNested()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
   location: 'westus'
@@ -174,8 +165,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void ThisNamespace_InTopLevelResourceProperties_ShouldFail()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: this.exists() ? 'testStorage' : 'defaultStorage'
   location: 'westus'
@@ -198,8 +188,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void ThisNamespace_InModuleParameters_ShouldFail()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, ("main.bicep", @"
+            var result = CompilationHelper.Compile(("main.bicep", @"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
   location: 'westus'
@@ -232,8 +221,7 @@ output sto bool = storageExists
         [TestMethod]
         public void ThisNamespace_InNestedAndResourceProperty_ShouldSucceed()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
   location: 'westus'
@@ -263,8 +251,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void ThisNamespace_MultiplePropertiesInSameResource_ShouldSucceed()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
   location: 'westus'
@@ -296,8 +283,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void ThisNamespace_ExistingResource_CompilationGeneratesCorrectArmFunctionsWithTryGet()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
   location: 'westus'
@@ -327,8 +313,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void ThisNamespace_AllSupportedFunctions_ShouldWork()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
   location: 'westus'
@@ -371,9 +356,7 @@ resource secret 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
             var typesTgz = ExtensionResourceTypeHelper.GetTestTypesTgz();
             var extensionTgz = await ExtensionV1Archive.Build(new(typesTgz, false, []));
 
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-
-            var result = await CompilationHelper.RestoreAndCompile(services,
+            var result = await CompilationHelper.RestoreAndCompile(new ServiceBuilder().WithFeatureOverrides(new(TestContext)),
               ("main.bicep", new("""
                   extension '../extension.tgz'
 
@@ -404,9 +387,7 @@ resource secret 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
             var typesTgz = ExtensionResourceTypeHelper.GetTestTypesTgz();
             var extensionTgz = await ExtensionV1Archive.Build(new(typesTgz, false, []));
 
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-
-            var result = await CompilationHelper.RestoreAndCompile(services,
+            var result = await CompilationHelper.RestoreAndCompile(new ServiceBuilder().WithFeatureOverrides(new(TestContext)),
               ("main.bicep", new("""
                   extension '../extension.tgz'
 
@@ -431,8 +412,7 @@ resource secret 'Microsoft.KeyVault/vaults/secrets@2024-12-01-preview' = {
         [TestMethod]
         public void ThisNamespace_VariableThisShouldRaiseDiagnosticWhenFeatureEnabled_ShouldFail()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 var this = 'test'
 
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
@@ -459,8 +439,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
         [TestMethod]
         public void ThisNamespace_ThisInExisting_ShouldFail()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
   name: this.exists() ? 'testStorage' : 'defaultStorage'
 }
@@ -471,10 +450,68 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' existing = 
         }
 
         [TestMethod]
+        public void ThisNamespace_ParamNamedThis_ShouldFail()
+        {
+            var result = CompilationHelper.Compile(@"
+param this string
+");
+
+            result.Should().ContainDiagnostic("BCP084", DiagnosticLevel.Error, "The symbolic name \"this\" is reserved. Please use a different symbolic name. Reserved namespaces are \"az\", \"sys\", \"this\".");
+        }
+
+        [TestMethod]
+        public void ThisNamespace_ResourceNamedThis_ShouldFail()
+        {
+            var result = CompilationHelper.Compile(@"
+resource this 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'test'
+  location: 'westus'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+");
+
+            result.Should().ContainDiagnostic("BCP084", DiagnosticLevel.Error, "The symbolic name \"this\" is reserved. Please use a different symbolic name. Reserved namespaces are \"az\", \"sys\", \"this\".");
+        }
+
+        [TestMethod]
+        public void ThisNamespace_TypeNamedThis_ShouldFail()
+        {
+            var result = CompilationHelper.Compile(@"
+type this = string
+");
+
+            result.Should().ContainDiagnostic("BCP084", DiagnosticLevel.Error, "The symbolic name \"this\" is reserved. Please use a different symbolic name. Reserved namespaces are \"az\", \"sys\", \"this\".");
+        }
+
+        [TestMethod]
+        public void ThisNamespace_InOutputValue_ShouldFail()
+        {
+            // this.exists() should not be accessible outside of a resource body
+            var result = CompilationHelper.Compile(@"
+output test bool = this.exists()
+");
+
+            result.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"this\" does not exist in the current context.");
+        }
+
+        [TestMethod]
+        public void ThisNamespace_InVariableValue_ShouldFail()
+        {
+            // this.exists() should not be accessible outside of a resource body
+            var result = CompilationHelper.Compile(@"
+var test = this.exists()
+");
+
+            result.Should().ContainDiagnostic("BCP057", DiagnosticLevel.Error, "The name \"this\" does not exist in the current context.");
+        }
+
+        [TestMethod]
         public void ThisNamespace_ForLoopNamedThis_ShouldSucceed()
         {
-            var services = new ServiceBuilder().WithFeatureOverrides(new(TestContext, ThisNamespaceEnabled: true));
-            var result = CompilationHelper.Compile(services, @"
+            var result = CompilationHelper.Compile(@"
 resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = [for this in range(0,2): {
   name: 'testStorage${this}'
   location: 'westus'
@@ -494,7 +531,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = [for this
             {
                 var template = result.Template;
 
-                template.Should().HaveValueAtPath("$.resources.testResource.name", "[format('testStorage{0}', range(0, 2)[copyIndex()])]");
+                template.Should().HaveValueAtPath("$.resources[0].name", "[format('testStorage{0}', range(0, 2)[copyIndex()])]");
             }
         }
     }

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -23,8 +23,7 @@ public record ExperimentalFeaturesEnabled(
     bool ModuleExtensionConfigs,
     bool UserDefinedConstraints,
     bool DeployCommands,
-    bool ThisNamespace,
-    bool ExistingNullIfNotFound)
+    bool ThisNamespace)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
         => element.ToNonNullObject<ExperimentalFeaturesEnabled>();
@@ -45,6 +44,5 @@ public record ExperimentalFeaturesEnabled(
         ModuleExtensionConfigs: false,
         UserDefinedConstraints: false,
         DeployCommands: false,
-        ThisNamespace: false,
-        ExistingNullIfNotFound: false);
+        ThisNamespace: false);
 }

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -22,8 +22,7 @@ public record ExperimentalFeaturesEnabled(
     bool ResourceInfoCodegen,
     bool ModuleExtensionConfigs,
     bool UserDefinedConstraints,
-    bool DeployCommands,
-    bool ThisNamespace)
+    bool DeployCommands)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
         => element.ToNonNullObject<ExperimentalFeaturesEnabled>();
@@ -43,6 +42,5 @@ public record ExperimentalFeaturesEnabled(
         ResourceInfoCodegen: false,
         ModuleExtensionConfigs: false,
         UserDefinedConstraints: false,
-        DeployCommands: false,
-        ThisNamespace: false);
+        DeployCommands: false);
 }

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -14,10 +14,10 @@ namespace Bicep.Core.Emit
         {
             FileKind = model.SourceFileKind;
             UseExperimentalTemplateLanguageVersion = model.Features.EnabledFeatureMetadata.Any(feature => feature.usesExperimentalArmEngineFeature) ||
-                // @nullIfNotFound and this namespace are GA'd Bicep features but still require the experimental ARM engine language version
-                model.Root.ResourceDeclarations.Any(r => SemanticModelHelper.TryGetDecoratorInNamespace(
+                // @nullIfNotFound and this namespace are GA'd Bicep features but still require the experimental ARM engine language version.
+                model.DeclaredResources.Any(r => SemanticModelHelper.TryGetDecoratorInNamespace(
                     model,
-                    r.DeclaringResource,
+                    r.Symbol.DeclaringResource,
                     SystemNamespaceType.BuiltInName,
                     LanguageConstants.NullIfNotFoundDecoratorName) is not null) ||
                 SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -14,11 +14,19 @@ namespace Bicep.Core.Emit
         {
             FileKind = model.SourceFileKind;
             UseExperimentalTemplateLanguageVersion = model.Features.EnabledFeatureMetadata.Any(feature => feature.usesExperimentalArmEngineFeature) ||
+                // @nullIfNotFound and this namespace are GA'd Bicep features but still require the experimental ARM engine language version
                 model.Root.ResourceDeclarations.Any(r => SemanticModelHelper.TryGetDecoratorInNamespace(
                     model,
                     r.DeclaringResource,
                     SystemNamespaceType.BuiltInName,
-                    LanguageConstants.NullIfNotFoundDecoratorName) is not null);
+                    LanguageConstants.NullIfNotFoundDecoratorName) is not null) ||
+                SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,
+                    seed: false,
+                    function: (found, syntax) => found ||
+                        (syntax is InstanceFunctionCallSyntax ifcs &&
+                         model.Binder.GetSymbolInfo(ifcs.BaseExpression) is LocalThisNamespaceSymbol),
+                    resultSelector: result => result,
+                    continuationFunction: (result, syntax) => !result);
 
             // Symbolic names are used if (evaluated in increasing order of computational cost):
             EnableSymbolicNames =

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -13,7 +13,12 @@ namespace Bicep.Core.Emit
         public EmitterSettings(SemanticModel model)
         {
             FileKind = model.SourceFileKind;
-            UseExperimentalTemplateLanguageVersion = model.Features.EnabledFeatureMetadata.Any(feature => feature.usesExperimentalArmEngineFeature);
+            UseExperimentalTemplateLanguageVersion = model.Features.EnabledFeatureMetadata.Any(feature => feature.usesExperimentalArmEngineFeature) ||
+                model.Root.ResourceDeclarations.Any(r => SemanticModelHelper.TryGetDecoratorInNamespace(
+                    model,
+                    r.DeclaringResource,
+                    SystemNamespaceType.BuiltInName,
+                    LanguageConstants.NullIfNotFoundDecoratorName) is not null);
 
             // Symbolic names are used if (evaluated in increasing order of computational cost):
             EnableSymbolicNames =

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -56,8 +56,6 @@ namespace Bicep.Core.Features
 
         public bool ThisNamespaceEnabled => configuration.ExperimentalFeaturesEnabled.ThisNamespace;
 
-        public bool ExistingNullIfNotFoundEnabled => configuration.ExperimentalFeaturesEnabled.ExistingNullIfNotFound;
-
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)
             => bool.TryParse(Environment.GetEnvironmentVariable(envVar), out var value) ? value : defaultValue;
 

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -54,8 +54,6 @@ namespace Bicep.Core.Features
 
         public bool DeployCommandsEnabled => configuration.ExperimentalFeaturesEnabled.DeployCommands;
 
-        public bool ThisNamespaceEnabled => configuration.ExperimentalFeaturesEnabled.ThisNamespace;
-
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)
             => bool.TryParse(Environment.GetEnvironmentVariable(envVar), out var value) ? value : defaultValue;
 

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -37,8 +37,6 @@ public interface IFeatureProvider
 
     bool DeployCommandsEnabled { get; }
 
-    bool ThisNamespaceEnabled { get; }
-
     IEnumerable<(string name, bool impactsCompilation, bool usesExperimentalArmEngineFeature)> EnabledFeatureMetadata
     {
         get
@@ -59,7 +57,6 @@ public interface IFeatureProvider
                 (ModuleExtensionConfigsEnabled, "Enable defining extension configs for modules", true, true),
                 (UserDefinedConstraintsEnabled, "Enable @validate() decorator", true, true),
                 (DeployCommandsEnabled, "Enable deploy commands", true, true),
-                (ThisNamespaceEnabled, "Enable 'this' namespace", true, true),
             })
             {
                 if (enabled)

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -39,8 +39,6 @@ public interface IFeatureProvider
 
     bool ThisNamespaceEnabled { get; }
 
-    bool ExistingNullIfNotFoundEnabled { get; }
-
     IEnumerable<(string name, bool impactsCompilation, bool usesExperimentalArmEngineFeature)> EnabledFeatureMetadata
     {
         get
@@ -62,7 +60,6 @@ public interface IFeatureProvider
                 (UserDefinedConstraintsEnabled, "Enable @validate() decorator", true, true),
                 (DeployCommandsEnabled, "Enable deploy commands", true, true),
                 (ThisNamespaceEnabled, "Enable 'this' namespace", true, true),
-                (ExistingNullIfNotFoundEnabled, "Enable @nullIfNotFound() decorator for existing resources", true, true),
             })
             {
                 if (enabled)

--- a/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
+++ b/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
@@ -26,6 +26,5 @@ namespace Bicep.Core.Features
         public bool UserDefinedConstraintsEnabled => features.UserDefinedConstraints;
         public bool DeployCommandsEnabled => features.DeployCommands;
         public bool ThisNamespaceEnabled => features.ThisNamespace;
-        public bool ExistingNullIfNotFoundEnabled => features.ExistingNullIfNotFound;
     }
 }

--- a/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
+++ b/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
@@ -25,6 +25,5 @@ namespace Bicep.Core.Features
         public bool ModuleExtensionConfigsEnabled => features.ModuleExtensionConfigs;
         public bool UserDefinedConstraintsEnabled => features.UserDefinedConstraints;
         public bool DeployCommandsEnabled => features.DeployCommands;
-        public bool ThisNamespaceEnabled => features.ThisNamespace;
     }
 }

--- a/src/Bicep.Core/Semantics/DeclarationVisitor.cs
+++ b/src/Bicep.Core/Semantics/DeclarationVisitor.cs
@@ -118,8 +118,8 @@ namespace Bicep.Core.Semantics
             var scope = new LocalScope(string.Empty, syntax, bindingSyntax, ImmutableArray<DeclaredSymbol>.Empty, ImmutableArray<LocalScope>.Empty, ScopeResolution.InheritAll);
             this.PushScope(scope);
 
-            // Add a local 'this' namespace symbol to the resource scope when the feature is enabled
-            if (this.context.SourceFile.Features.ThisNamespaceEnabled && !syntax.IsExistingResource())
+            // Add a local 'this' namespace symbol to the resource scope
+            if (!syntax.IsExistingResource())
             {
                 // Use the bindingSyntax (the resource body) as the declaring syntax to avoid conflicts
                 // with the ResourceSymbol which uses the ResourceDeclarationSyntax

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -335,7 +335,7 @@ namespace Bicep.Core.Semantics
                     .Where(decl => decl.NameSource.IsValid && this.builtInNamespaces.ContainsKey(decl.Name))
                     .Select(reservedSymbol => DiagnosticBuilder.ForPosition(reservedSymbol.NameSource).SymbolicNameCannotUseReservedNamespaceName(reservedSymbol.Name, this.builtInNamespaces.Keys)));
 
-                if (this.features.ThisNamespaceEnabled && scope is FileSymbol)
+                if (scope is FileSymbol)
                 {
                     this.Diagnostics.AddRange(referenceableDeclarations
                         .Where(decl => decl.NameSource.IsValid && decl.Name == ThisNamespaceType.BuiltInName)

--- a/src/Bicep.Core/Semantics/FileSymbol.cs
+++ b/src/Bicep.Core/Semantics/FileSymbol.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
-using Bicep.Core.Features;
 using Bicep.Core.Navigation;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.SourceGraph;
@@ -271,19 +270,16 @@ namespace Bicep.Core.Semantics
         private sealed class DuplicateIdentifierValidatorVisitor : SymbolVisitor
         {
             private readonly ImmutableDictionary<string, BuiltInNamespaceSymbol> builtInNamespaces;
-            private readonly IFeatureProvider features;
 
-            private DuplicateIdentifierValidatorVisitor(ImmutableDictionary<string, BuiltInNamespaceSymbol> builtInNamespaces, IFeatureProvider features)
+            private DuplicateIdentifierValidatorVisitor(ImmutableDictionary<string, BuiltInNamespaceSymbol> builtInNamespaces)
             {
                 this.builtInNamespaces = builtInNamespaces;
-                this.features = features;
             }
 
             public static IEnumerable<Diagnostic> GetDiagnostics(FileSymbol file)
             {
                 var visitor = new DuplicateIdentifierValidatorVisitor(
-                    file.NamespaceResolver.ImplicitNamespaces,
-                    file.Context.SourceFile.Features);
+                    file.NamespaceResolver.ImplicitNamespaces);
                 visitor.Visit(file);
 
                 return visitor.Diagnostics;

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -2064,22 +2064,19 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithEvaluator(AddDecoratorConfigToResource)
                     .Build();
 
-                if (featureProvider.ExistingNullIfNotFoundEnabled)
-                {
-                    yield return new DecoratorBuilder(LanguageConstants.NullIfNotFoundDecoratorName)
-                        .WithDescription("Marks an existing resource as nullable, returning null if the resource doesn't exist at deployment time instead of failing.")
-                        .WithFlags(FunctionFlags.ResourceDecorator)
-                        .WithValidator((decoratorName, decoratorSyntax, targetType, typeManager, binder, parsingErrorLookup, diagnosticWriter) =>
+                yield return new DecoratorBuilder(LanguageConstants.NullIfNotFoundDecoratorName)
+                    .WithDescription("Marks an existing resource as nullable, returning null if the resource doesn't exist at deployment time instead of failing.")
+                    .WithFlags(FunctionFlags.ResourceDecorator)
+                    .WithValidator((decoratorName, decoratorSyntax, targetType, typeManager, binder, parsingErrorLookup, diagnosticWriter) =>
+                    {
+                        var decoratorTarget = binder.GetParent(decoratorSyntax);
+                        if (decoratorTarget is ResourceDeclarationSyntax resourceDeclaration && !resourceDeclaration.IsExistingResource())
                         {
-                            var decoratorTarget = binder.GetParent(decoratorSyntax);
-                            if (decoratorTarget is ResourceDeclarationSyntax resourceDeclaration && !resourceDeclaration.IsExistingResource())
-                            {
-                                diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).NullIfNotFoundOnlyValidOnExistingResources());
-                            }
-                        })
-                        .WithEvaluator(AddDecoratorConfigToResource)
-                        .Build();
-                }
+                            diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).NullIfNotFoundOnlyValidOnExistingResources());
+                        }
+                    })
+                    .WithEvaluator(AddDecoratorConfigToResource)
+                    .Build();
 
                 yield return new DecoratorBuilder(LanguageConstants.ParameterSealedPropertyName)
                     .WithDescription("Marks an object parameter as only permitting properties specifically included in the type definition")

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -382,6 +382,11 @@ resource service 'Microsoft.Storage/storageAccounts/fileServices@2021-02-01' = {
             symbolCompletions.Should().SatisfyRespectively(
               x =>
               {
+                  x.Label.Should().Be("this");
+                  x.Kind.Should().Be(CompletionItemKind.Variable);
+              },
+              x =>
+              {
                   x.Label.Should().Be("myInt");
                   x.Kind.Should().Be(CompletionItemKind.Field);
                   x.Documentation!.MarkupContent!.Value.Should().Be("Type: `0 | 1`  \nthis is an int value  \n");
@@ -6155,7 +6160,7 @@ output people Person[] = [{
                 TestContext,
                 text,
                 bicepFile.Uri,
-                services => services.WithFeatureOverrides(new(ThisNamespaceEnabled: true)).WithAzResources(customTypes));
+                services => services.WithAzResources(customTypes));
 
             var file = new FileRequestHelper(helper.Client, bicepFile);
             var completions = await file.RequestAndResolveCompletions(cursor);

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -6381,8 +6381,7 @@ param foo string = 'bar'
         {
             using var server = await MultiFileLanguageServerHelper.StartLanguageServer(
                 TestContext,
-                s => s.WithFeatureOverrides(new(ExistingNullIfNotFoundEnabled: true))
-                    .WithNamespaceProvider(BuiltInTestTypes.Create()));
+                s => s.WithNamespaceProvider(BuiltInTestTypes.Create()));
             var helper = new ServerRequestHelper(TestContext, server);
 
             // Test that @nullIfNotFound is offered for existing resources

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -925,10 +925,6 @@
         "deployCommands": {
           "type": "boolean",
           "description": "Allows you to access the 'deploy', 'what-if' and 'teardown' commands. See https://aka.ms/bicep/experimental-features#deploycommands"
-        },
-        "thisNamespace": {
-          "type": "boolean",
-          "description": "Allows you to use this namespace to modify resource properties based on whether the resource already exists. Ex. this.exists() and this.existingResource(). See https://aka.ms/bicep/experimental-features#thisnamespace"
         }
       },
       "additionalProperties": false

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -929,10 +929,6 @@
         "thisNamespace": {
           "type": "boolean",
           "description": "Allows you to use this namespace to modify resource properties based on whether the resource already exists. Ex. this.exists() and this.existingResource(). See https://aka.ms/bicep/experimental-features#thisnamespace"
-        },
-        "existingNullIfNotFound": {
-          "type": "boolean",
-          "description": "Enables the @nullIfNotFound() decorator for existing resources, allowing them to return null if not found at deployment time. See https://aka.ms/bicep/experimental-features#existingnullifnotfound"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Description

GA ThisNamespace and @NullIfNotFound by removing the experimental feature flag.

Note: We will continue to emit an experimental language when these features are used until the backend deploys support in language version 2.0

## Example Usage

```bicep
resource usingThis 'Microsoft...' = {
  name: 'example'
  location: 'eastus'
  properties: {
    property1: this.exists() ? 'resource exists' : 'resource does not exist'
    property2: this.existingResource().?properties.?property2
    property3: this.existingResource().?tags
  }
}
```
```bicep
@nullIfNotFound()
resource exampleResource 'Microsoft.Storage/storageAccounts@2021-04-01' existing = {
  name: 'test'
}
// Access with safe navigation since the resource may be null
output accessTier string = exampleResource.?properties.accessTier ?? ''
```
## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19639)