### PR TITLE
Add Playwright E2E tests for Visual Designer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,6 +200,27 @@ jobs:
         run: npm run test
         working-directory: ./src/vscode-bicep-ui
 
+      - name: Install Playwright browsers (visual-designer)
+        if: runner.os == 'Linux'
+        run: npm run e2e:install
+        working-directory: ./src/vscode-bicep-ui/apps/visual-designer
+
+      - name: Run Playwright E2E tests (visual-designer)
+        if: runner.os == 'Linux'
+        run: npm run e2e
+        working-directory: ./src/vscode-bicep-ui/apps/visual-designer
+        env:
+          CI: "true"
+
+      - name: Upload Playwright report (visual-designer)
+        if: always() && runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: visual-designer-playwright-report
+          path: ./src/vscode-bicep-ui/apps/visual-designer/e2e/.report
+          if-no-files-found: ignore
+          retention-days: 7
+
   test-vscode-ext:
     name: "Test: VSCode Extension"
     runs-on: ${{ matrix.os }}

--- a/src/vscode-bicep-ui/.gitignore
+++ b/src/vscode-bicep-ui/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 .turbo
 *.log
+*.tsbuildinfo
 dist
 dist-ssr
 storybook-static
@@ -11,5 +12,12 @@ storybook-static
 server/dist
 public/dist
 coverage
+
+# Playwright
+**/e2e/.report/
+**/e2e/.results/
+playwright-report
+test-results
+.playwright
 
 !packages/*

--- a/src/vscode-bicep-ui/apps/visual-designer/e2e/app-loads.spec.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/e2e/app-loads.spec.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect, test } from "@playwright/test";
+import { openVisualDesigner } from "./fixtures";
+
+test.describe("Application bootstrap", () => {
+  test("loads the visual designer shell", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page).toHaveTitle(/Visual Designer/i);
+    await expect(page.getByTestId("app-root")).toBeVisible();
+    await expect(page.getByTestId("graph-canvas")).toBeVisible();
+    await expect(page.getByTestId("control-bar")).toBeVisible();
+    await expect(page.getByTestId("status-bar")).toBeVisible();
+  });
+
+  test("renders without console errors", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        errors.push(msg.text());
+      }
+    });
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    await openVisualDesigner(page);
+
+    // Filter out errors that are not actionable for E2E (e.g. dev-only
+    // resource fetch warnings from external CDNs).  Surface anything else.
+    const significant = errors.filter(
+      (text) => !/failed to load resource/i.test(text) && !/codicon/i.test(text),
+    );
+    expect(significant, `Unexpected console errors:\n${significant.join("\n")}`).toEqual([]);
+  });
+
+  test("auto-receives the default deployment graph from the fake channel", async ({ page }) => {
+    await openVisualDesigner(page);
+
+    const count = await page.getByTestId("graph-node").count();
+    expect(count).toBeGreaterThan(0);
+  });
+});

--- a/src/vscode-bicep-ui/apps/visual-designer/e2e/controls.spec.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/e2e/controls.spec.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect, test } from "@playwright/test";
+import { getGraphTransform, loadSampleGraph, openVisualDesigner } from "./fixtures";
+
+test.describe("Status bar", () => {
+  test.beforeEach(async ({ page }) => {
+    await openVisualDesigner(page);
+  });
+
+  test("reports a ready state for a healthy graph", async ({ page }) => {
+    await loadSampleGraph(page, "flat");
+
+    await expect(page.getByTestId("status-bar")).toHaveAttribute("data-status", "ready");
+    await expect(page.getByTestId("status-error-link")).toHaveCount(0);
+    await expect(page.getByTestId("status-empty-message")).toHaveCount(0);
+  });
+
+  test("surfaces the error count for a graph that has diagnostics", async ({ page }) => {
+    await loadSampleGraph(page, "error");
+
+    const statusBar = page.getByTestId("status-bar");
+    await expect(statusBar).toHaveAttribute("data-status", "errors");
+    await expect(statusBar).toHaveAttribute("data-error-count", "3");
+    await expect(page.getByTestId("status-error-link")).toHaveText(/3\s+errors/);
+  });
+
+  test("shows the empty-state message when the graph is null", async ({ page }) => {
+    await loadSampleGraph(page, "empty");
+
+    await expect(page.getByTestId("status-bar")).toHaveAttribute("data-status", "empty");
+    await expect(page.getByTestId("status-empty-message")).toBeVisible();
+  });
+});
+
+test.describe("Control bar", () => {
+  test.beforeEach(async ({ page }) => {
+    await openVisualDesigner(page);
+  });
+
+  test("exposes all controls and disables graph-dependent ones when empty", async ({ page }) => {
+    await expect(page.getByTestId("control-zoom-in")).toBeEnabled();
+    await expect(page.getByTestId("control-zoom-out")).toBeEnabled();
+
+    await loadSampleGraph(page, "empty");
+
+    await expect(page.getByTestId("control-fit-view")).toBeDisabled();
+    await expect(page.getByTestId("control-reset-layout")).toBeDisabled();
+    await expect(page.getByTestId("control-export")).toBeDisabled();
+  });
+
+  test("re-enables graph-dependent controls when a graph is loaded", async ({ page }) => {
+    await loadSampleGraph(page, "empty");
+    await expect(page.getByTestId("control-fit-view")).toBeDisabled();
+
+    await loadSampleGraph(page, "flat");
+    await expect(page.getByTestId("control-fit-view")).toBeEnabled();
+    await expect(page.getByTestId("control-reset-layout")).toBeEnabled();
+    await expect(page.getByTestId("control-export")).toBeEnabled();
+  });
+
+  test("zoom in changes the pan-zoom transform", async ({ page }) => {
+    await loadSampleGraph(page, "flat");
+
+    const before = await getGraphTransform(page);
+    await page.getByTestId("control-zoom-in").click();
+    // The pan-zoom transform updates synchronously after the click,
+    // but allow a frame for the styled-component to flush.
+    await expect
+      .poll(async () => await getGraphTransform(page), { timeout: 5_000 })
+      .not.toBe(before);
+  });
+
+  test("zoom out also changes the pan-zoom transform", async ({ page }) => {
+    await loadSampleGraph(page, "flat");
+
+    const before = await getGraphTransform(page);
+    await page.getByTestId("control-zoom-out").click();
+    await expect
+      .poll(async () => await getGraphTransform(page), { timeout: 5_000 })
+      .not.toBe(before);
+  });
+
+  test("fit-view recenters the graph after zoom changes", async ({ page }) => {
+    await loadSampleGraph(page, "flat");
+
+    await page.getByTestId("control-zoom-in").click();
+    await page.getByTestId("control-zoom-in").click();
+    const zoomed = await getGraphTransform(page);
+
+    await page.getByTestId("control-fit-view").click();
+    await expect
+      .poll(async () => await getGraphTransform(page), { timeout: 5_000 })
+      .not.toBe(zoomed);
+  });
+});
+
+test.describe("Export overlay", () => {
+  test.beforeEach(async ({ page }) => {
+    await openVisualDesigner(page);
+    await loadSampleGraph(page, "flat");
+  });
+
+  test("opens via the export control and closes with Escape", async ({ page }) => {
+    await expect(page.getByTestId("export-overlay")).toHaveCount(0);
+
+    await page.getByTestId("control-export").click();
+    await expect(page.getByTestId("export-overlay")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("export-overlay")).toHaveCount(0);
+  });
+});

--- a/src/vscode-bicep-ui/apps/visual-designer/e2e/fixtures.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/e2e/fixtures.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { Page } from "@playwright/test";
+
+import { expect } from "@playwright/test";
+
+/**
+ * Sample graphs exposed by the dev toolbar.  The slugs match the
+ * `data-testid` values generated in {@link DevToolbar.tsx}.
+ */
+export const SAMPLE_GRAPHS = {
+  module: { slug: "dev-graph-module-graph", label: "Module graph" },
+  flat: { slug: "dev-graph-flat-graph", label: "Flat graph" },
+  error: { slug: "dev-graph-error-graph", label: "Error graph" },
+  complex: { slug: "dev-graph-complex-graph", label: "Complex graph" },
+  empty: { slug: "dev-graph-empty-null", label: "Empty (null)" },
+} as const;
+
+export type SampleGraphKey = keyof typeof SAMPLE_GRAPHS;
+
+/**
+ * Navigate to the visual designer and wait for the React app to mount
+ * and the initial sample graph (the dev fake channel pushes the
+ * "Module graph" 50 ms after the READY notification) to render.
+ */
+export async function openVisualDesigner(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.getByTestId("app-root")).toBeVisible();
+  await expect(page.getByTestId("graph-canvas")).toBeVisible();
+  await expect(page.getByTestId("dev-toolbar")).toBeVisible();
+  await waitForAnyNode(page);
+}
+
+/**
+ * Click a sample-graph button in the dev toolbar and wait for the
+ * graph to settle: nodes must be present (or absent, for the empty
+ * sample) and the status bar must reflect the new state.
+ */
+export async function loadSampleGraph(page: Page, key: SampleGraphKey): Promise<void> {
+  const { slug } = SAMPLE_GRAPHS[key];
+  await page.getByTestId(slug).click();
+
+  if (key === "empty") {
+    await expect(page.getByTestId("graph-node")).toHaveCount(0);
+    await expect(page.getByTestId("status-bar")).toHaveAttribute("data-status", "empty");
+    return;
+  }
+
+  await waitForAnyNode(page);
+}
+
+/** Wait until at least one graph node has been laid out and is visible. */
+export async function waitForAnyNode(page: Page): Promise<void> {
+  await expect(page.getByTestId("graph-node").first()).toBeVisible();
+}
+
+/** Return the count of graph nodes currently rendered. */
+export function nodeCount(page: Page): Promise<number> {
+  return page.getByTestId("graph-node").count();
+}
+
+/** Return the current pan-zoom transform on the inner graph layer. */
+export async function getGraphTransform(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const layer = document.querySelector<HTMLElement>(
+      '[data-testid="graph-canvas"] [style*="transform"]',
+    );
+    if (!layer) return "";
+    return layer.style.transform || getComputedStyle(layer).transform;
+  });
+}

--- a/src/vscode-bicep-ui/apps/visual-designer/e2e/graph-rendering.spec.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/e2e/graph-rendering.spec.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect, test } from "@playwright/test";
+import { loadSampleGraph, nodeCount, openVisualDesigner } from "./fixtures";
+
+test.describe("Graph rendering", () => {
+  test.beforeEach(async ({ page }) => {
+    await openVisualDesigner(page);
+  });
+
+  test("renders the flat graph with the expected resource nodes", async ({ page }) => {
+    await loadSampleGraph(page, "flat");
+
+    // The flat sample has four atomic resources: vnet, subnet, nsg, pip.
+    const atomicNodes = page.locator('[data-testid="graph-node"][data-node-kind="atomic"]');
+    await expect(atomicNodes).toHaveCount(4);
+
+    for (const id of ["vnet", "subnet", "nsg", "pip"]) {
+      await expect(page.locator(`[data-node-id="${id}"]`)).toBeVisible();
+    }
+  });
+
+  test("renders compound (module) nodes for the module graph", async ({ page }) => {
+    await loadSampleGraph(page, "module");
+
+    const compoundNodes = page.locator('[data-testid="graph-node"][data-node-kind="compound"]');
+    await expect(compoundNodes).toHaveCount(1);
+    await expect(page.locator('[data-node-id="myModule"]')).toBeVisible();
+
+    // The module contains two children, plus there are two top-level
+    // atomic nodes.
+    const atomicNodes = page.locator('[data-testid="graph-node"][data-node-kind="atomic"]');
+    await expect(atomicNodes).toHaveCount(4);
+  });
+
+  test("renders a richer topology for the complex graph", async ({ page }) => {
+    await loadSampleGraph(page, "complex");
+
+    // The complex sample contains 13 modules + 2 top-level resource groups.
+    const compoundNodes = page.locator('[data-testid="graph-node"][data-node-kind="compound"]');
+    await expect(compoundNodes).toHaveCount(13);
+
+    const total = await nodeCount(page);
+    expect(total).toBeGreaterThan(20);
+  });
+
+  test("renders an empty canvas for a null graph", async ({ page }) => {
+    await loadSampleGraph(page, "empty");
+
+    await expect(page.getByTestId("graph-node")).toHaveCount(0);
+    await expect(page.getByTestId("status-bar")).toHaveAttribute("data-status", "empty");
+    await expect(page.getByTestId("status-empty-message")).toBeVisible();
+  });
+
+  test("swaps the graph in-place when a new sample is loaded", async ({ page }) => {
+    await loadSampleGraph(page, "flat");
+    const flatCount = await nodeCount(page);
+
+    await loadSampleGraph(page, "complex");
+    const complexCount = await nodeCount(page);
+
+    expect(complexCount).toBeGreaterThan(flatCount);
+
+    await loadSampleGraph(page, "empty");
+    await expect(page.getByTestId("graph-node")).toHaveCount(0);
+  });
+});

--- a/src/vscode-bicep-ui/apps/visual-designer/e2e/node-interactions.spec.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/e2e/node-interactions.spec.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { expect, test } from "@playwright/test";
+import { loadSampleGraph, nodeCount, openVisualDesigner } from "./fixtures";
+
+test.describe("Node interactions", () => {
+  test.beforeEach(async ({ page }) => {
+    await openVisualDesigner(page);
+    await loadSampleGraph(page, "flat");
+  });
+
+  test("clicking a node focuses it", async ({ page }) => {
+    const target = page.locator('[data-node-id="vnet"]');
+    await expect(target).toBeVisible();
+
+    await target.click();
+
+    // The focused node sits at the highest z-index in the layer.
+    // The atom drives a re-render that boosts that node's stacking
+    // order — we assert via the underlying state by re-querying that
+    // the focused node id was set on the canvas.
+    const focusedId = await page.evaluate(() => {
+      const all = Array.from(document.querySelectorAll<HTMLElement>("[data-node-id]"));
+      const sorted = all
+        .map((el) => ({ id: el.dataset.nodeId ?? "", z: Number(getComputedStyle(el).zIndex) || 0 }))
+        .sort((a, b) => b.z - a.z);
+      return sorted[0]?.id ?? null;
+    });
+    expect(focusedId).toBe("vnet");
+  });
+
+  test("clicking blank canvas clears node focus", async ({ page }) => {
+    const target = page.locator('[data-node-id="subnet"]');
+    await target.click();
+
+    const canvas = page.getByTestId("graph-canvas");
+    const box = await canvas.boundingBox();
+    expect(box).not.toBeNull();
+    // Click far away from any node — top-left corner is usually empty.
+    await canvas.click({ position: { x: 10, y: 10 } });
+
+    // After clearing focus, all nodes should share the same baseline
+    // z-index (no single node elevated above the rest).
+    const elevated = await page.evaluate(() => {
+      const all = Array.from(document.querySelectorAll<HTMLElement>("[data-node-id]"));
+      const zs = all.map((el) => Number(getComputedStyle(el).zIndex) || 0);
+      const max = Math.max(...zs);
+      return zs.filter((z) => z === max).length;
+    });
+    expect(elevated).toBeGreaterThan(1);
+  });
+
+  test("double-clicking a node sends a reveal-file-range notification", async ({ page }) => {
+    // The FakeMessageChannel logs reveal notifications to the console;
+    // sniff that channel as a proxy for the outgoing message.
+    const reveals: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "log" && msg.text().includes("revealFileRange")) {
+        reveals.push(msg.text());
+      }
+    });
+
+    await page.locator('[data-node-id="nsg"]').dblclick();
+
+    await expect.poll(() => reveals.length, { timeout: 5_000 }).toBeGreaterThan(0);
+  });
+
+  test("a graph swap survives multiple updates without losing nodes", async ({ page }) => {
+    await loadSampleGraph(page, "module");
+    const moduleCount = await nodeCount(page);
+    expect(moduleCount).toBeGreaterThan(0);
+
+    await loadSampleGraph(page, "flat");
+    await expect(page.getByTestId("graph-node")).toHaveCount(4);
+  });
+});

--- a/src/vscode-bicep-ui/apps/visual-designer/package.json
+++ b/src/vscode-bicep-ui/apps/visual-designer/package.json
@@ -5,12 +5,18 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc -b && vite build",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --fix",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report ./e2e/.report",
+    "e2e:install": "playwright install --with-deps chromium"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@types/node": "^22.10.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",

--- a/src/vscode-bicep-ui/apps/visual-designer/playwright.config.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/playwright.config.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the Visual Designer React app.
+ *
+ * Tests run against `vite dev`, which boots the React app together
+ * with the {@link DevAppShell} that wires a {@link FakeMessageChannel}
+ * and renders the {@link DevToolbar}.  The toolbar lets tests swap
+ * between named sample deployment graphs without spinning up the
+ * VS Code extension host.
+ */
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 5173);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: /.*\.spec\.ts/,
+  outputDir: "./e2e/.results",
+
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+
+  reporter: process.env.CI
+    ? [
+        ["github"],
+        ["html", { open: "never", outputFolder: "./e2e/.report" }],
+        ["list"],
+      ]
+    : [["list"], ["html", { open: "never", outputFolder: "./e2e/.report" }]],
+
+  use: {
+    baseURL: BASE_URL,
+    headless: true,
+    viewport: { width: 1440, height: 900 },
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    actionTimeout: 10_000,
+    navigationTimeout: 20_000,
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 120_000,
+  },
+});

--- a/src/vscode-bicep-ui/apps/visual-designer/src/App.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/App.tsx
@@ -174,7 +174,7 @@ function AppCore() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
-      <$AppContainer>
+      <$AppContainer data-testid="app-root">
         <PanZoomProvider>
           <GraphContainer />
         </PanZoomProvider>

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/controls/ControlBar.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/controls/ControlBar.tsx
@@ -80,14 +80,30 @@ export function ControlBar() {
   const openExportOverlay = useSetAtom(openExportOverlayAtom);
 
   return (
-    <$ControlBar>
-      <$ControlButton onClick={() => zoomIn(1.5)} title="Zoom In" aria-label="Zoom In">
+    <$ControlBar data-testid="control-bar">
+      <$ControlButton
+        onClick={() => zoomIn(1.5)}
+        title="Zoom In"
+        aria-label="Zoom In"
+        data-testid="control-zoom-in"
+      >
         <Codicon name="zoom-in" size={16} />
       </$ControlButton>
-      <$ControlButton onClick={() => zoomOut(1.5)} title="Zoom Out" aria-label="Zoom Out">
+      <$ControlButton
+        onClick={() => zoomOut(1.5)}
+        title="Zoom Out"
+        aria-label="Zoom Out"
+        data-testid="control-zoom-out"
+      >
         <Codicon name="zoom-out" size={16} />
       </$ControlButton>
-      <$ControlButton onClick={fitView} title="Fit View" aria-label="Fit View" disabled={!controls.canFitView}>
+      <$ControlButton
+        onClick={fitView}
+        title="Fit View"
+        aria-label="Fit View"
+        disabled={!controls.canFitView}
+        data-testid="control-fit-view"
+      >
         <Codicon name="screen-full" size={16} />
       </$ControlButton>
       <$ControlButton
@@ -95,6 +111,7 @@ export function ControlBar() {
         title="Reset Layout"
         aria-label="Reset Layout"
         disabled={!controls.canResetLayout}
+        data-testid="control-reset-layout"
       >
         <Codicon name="type-hierarchy-sub" size={16} />
       </$ControlButton>
@@ -104,6 +121,7 @@ export function ControlBar() {
         title="Export Graph"
         aria-label="Export Graph"
         disabled={!controls.canExportGraph}
+        data-testid="control-export"
       >
         <Codicon name="desktop-download" size={16} />
       </$ControlButton>

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/devtools/DevToolbar.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/devtools/DevToolbar.tsx
@@ -80,21 +80,38 @@ export function DevToolbar({ channel }: DevToolbarProps) {
   };
 
   return (
-    <$Toolbar>
+    <$Toolbar data-testid="dev-toolbar">
       <$Label>DEV</$Label>
       <$SectionLabel>Graphs</$SectionLabel>
       {Object.entries(SAMPLE_GRAPHS).map(([name, graph]) => (
-        <$Button key={name} onClick={() => channel.pushGraph(graph)}>
+        <$Button
+          key={name}
+          onClick={() => channel.pushGraph(graph)}
+          data-testid={`dev-graph-${slugify(name)}`}
+        >
           {name}
         </$Button>
       ))}
       <$Separator />
       <$SectionLabel>Mutations</$SectionLabel>
       {GRAPH_MUTATIONS.map((mutation) => (
-        <$Button key={mutation.label} title={mutation.description} onClick={() => applyMutation(mutation.apply)}>
+        <$Button
+          key={mutation.label}
+          title={mutation.description}
+          onClick={() => applyMutation(mutation.apply)}
+          data-testid={`dev-mutation-${slugify(mutation.label)}`}
+        >
           {mutation.label}
         </$Button>
       ))}
     </$Toolbar>
   );
+}
+
+function slugify(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
 }

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportOverlay.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/export/ExportOverlay.tsx
@@ -37,7 +37,7 @@ export function ExportOverlay() {
   }, [handleClose]);
 
   return (
-    <$OverlayContainer>
+    <$OverlayContainer data-testid="export-overlay">
       <ExportToolbar />
     </$OverlayContainer>
   );

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/status/StatusBar.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/status/StatusBar.tsx
@@ -58,19 +58,29 @@ export function StatusBar() {
     });
   }, [messageChannel]);
 
+  const errorCount = graphStatus.kind === "errors" ? graphStatus.errorCount : 0;
+
   return (
-    <$StatusBarContainer>
-      <$StatusCircle $hasErrors={graphStatus.kind === "errors"} />
+    <$StatusBarContainer
+      data-testid="status-bar"
+      data-status={graphStatus.kind}
+      data-error-count={errorCount}
+    >
+      <$StatusCircle $hasErrors={graphStatus.kind === "errors"} data-testid="status-indicator" />
       {graphStatus.kind === "errors" && (
         <span>
           There {graphStatus.errorCount === 1 ? "is" : "are"}{" "}
-          <$ErrorLink onClick={handleShowProblems}>
+          <$ErrorLink onClick={handleShowProblems} data-testid="status-error-link">
             {graphStatus.errorCount} {graphStatus.errorCount === 1 ? "error" : "errors"}
           </$ErrorLink>{" "}
           in the file. The rendered graph may not be accurate.
         </span>
       )}
-      {graphStatus.kind === "empty" && <span>There are no resources or modules in the file. Nothing to display.</span>}
+      {graphStatus.kind === "empty" && (
+        <span data-testid="status-empty-message">
+          There are no resources or modules in the file. Nothing to display.
+        </span>
+      )}
     </$StatusBarContainer>
   );
 }

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/AtomicNode.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/AtomicNode.tsx
@@ -97,7 +97,7 @@ export function AtomicNode({ id, boxAtom, dataAtom }: AtomicNodeState) {
   });
 
   return (
-    <BaseNode ref={ref} id={id} zIndex={zIndex}>
+    <BaseNode ref={ref} id={id} kind="atomic" zIndex={zIndex}>
       <NodeContent id={id} kind="atomic" dataAtom={dataAtom} />
     </BaseNode>
   );

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/BaseNode.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/BaseNode.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 
 import type { PropsWithChildren } from "react";
+import type { NodeKind } from "@/lib/graph/atoms";
 
 import { forwardRef } from "react";
 import { styled } from "styled-components";
 
-export type BaseNodeProps = PropsWithChildren<{ id: string; zIndex: number }>;
+export type BaseNodeProps = PropsWithChildren<{ id: string; kind: NodeKind; zIndex: number }>;
 
 const $BaseNode = styled.div<{ $zIndex: number }>`
   display: flex;
@@ -17,9 +18,9 @@ const $BaseNode = styled.div<{ $zIndex: number }>`
   z-index: ${({ $zIndex }) => $zIndex};
 `;
 
-export const BaseNode = forwardRef<HTMLDivElement, BaseNodeProps>(({ id, zIndex, children }, ref) => {
+export const BaseNode = forwardRef<HTMLDivElement, BaseNodeProps>(({ id, kind, zIndex, children }, ref) => {
   return (
-    <$BaseNode ref={ref} $zIndex={zIndex} data-node-id={id}>
+    <$BaseNode ref={ref} $zIndex={zIndex} data-testid="graph-node" data-node-id={id} data-node-kind={kind}>
       {children}
     </$BaseNode>
   );

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/Canvas.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/Canvas.tsx
@@ -128,7 +128,7 @@ export function Canvas({ children, showBackground = true }: CanvasProps) {
   }, [store]);
 
   return (
-    <$Container ref={containerRef}>
+    <$Container ref={containerRef} data-testid="graph-canvas">
       <$PanZoom>
         {showBackground && <CanvasBackground />}
         {children}

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/CompoundNode.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/graph/components/CompoundNode.tsx
@@ -78,7 +78,7 @@ export function CompoundNode({ id, childIdsAtom, boxAtom, dataAtom }: CompoundNo
   });
 
   return (
-    <BaseNode ref={ref} id={id} zIndex={zIndex}>
+    <BaseNode ref={ref} id={id} kind="compound" zIndex={zIndex}>
       <NodeContent id={id} kind="compound" dataAtom={dataAtom} />
     </BaseNode>
   );

--- a/src/vscode-bicep-ui/apps/visual-designer/tsconfig.app.json
+++ b/src/vscode-bicep-ui/apps/visual-designer/tsconfig.app.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "include": ["src"],
+  "compilerOptions": {
+    "composite": true,
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/src/vscode-bicep-ui/apps/visual-designer/tsconfig.e2e.json
+++ b/src/vscode-bicep-ui/apps/visual-designer/tsconfig.e2e.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["../../tsconfig.base.json"],
+  "include": ["playwright.config.ts", "e2e/**/*.ts"],
+  "compilerOptions": {
+    "composite": true,
+    "noUncheckedIndexedAccess": true,
+    "types": ["node"]
+  }
+}

--- a/src/vscode-bicep-ui/apps/visual-designer/tsconfig.json
+++ b/src/vscode-bicep-ui/apps/visual-designer/tsconfig.json
@@ -1,11 +1,4 @@
 {
-  "extends": ["../../tsconfig.base.json"],
-  "include": ["src"],
-  "compilerOptions": {
-    "noUncheckedIndexedAccess": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  }
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.e2e.json" }]
 }

--- a/src/vscode-bicep-ui/eslint.config.mjs
+++ b/src/vscode-bicep-ui/eslint.config.mjs
@@ -9,7 +9,7 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    ignores: ["**/*.{js,cjs,mjs}", "**/.turbo/", "**/dist/"],
+    ignores: ["**/*.{js,cjs,mjs}", "**/.turbo/", "**/dist/", "**/e2e/.results/", "**/e2e/.report/"],
   },
   {
     files: ["**/*.ts", "**/*.tsx"],

--- a/src/vscode-bicep-ui/package-lock.json
+++ b/src/vscode-bicep-ui/package-lock.json
@@ -95,11 +95,23 @@
         "styled-components": "^6.3.11"
       },
       "devDependencies": {
+        "@playwright/test": "^1.49.1",
+        "@types/node": "^22.10.5",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
         "@vscode-elements/webview-playground": "^1.1.3",
         "vite": "^7.3.2"
+      }
+    },
+    "apps/visual-designer/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "apps/visual-designer/node_modules/@vscode-elements/react-elements": {
@@ -120,6 +132,13 @@
       "dependencies": {
         "lit": "^3.2.1"
       }
+    },
+    "apps/visual-designer/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -629,6 +648,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -868,6 +888,7 @@
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -925,6 +946,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
@@ -2132,6 +2154,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@react-hook/latest": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
@@ -2620,6 +2658,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3216,6 +3255,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3291,6 +3331,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3631,6 +3672,7 @@
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3640,6 +3682,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3736,6 +3779,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -4202,7 +4246,8 @@
       "version": "0.0.45",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
       "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/@vscode/extension-telemetry": {
       "version": "1.5.1",
@@ -4332,6 +4377,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4746,6 +4792,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5049,7 +5096,6 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5059,7 +5105,6 @@
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
       "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5083,7 +5128,6 @@
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5093,7 +5137,6 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3"
       },
@@ -5116,7 +5159,6 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5126,7 +5168,6 @@
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
       "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-dispatch": "1 - 3",
@@ -5761,6 +5802,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5825,6 +5867,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7460,6 +7503,7 @@
       "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.19.1.tgz",
       "integrity": "sha512-sqm9lVZiqBHZH8aSRk32DSiZDHY3yUIlulXYn9GQj7/LvoUdYXSMti7ZPJGo+6zjzKFt5a25k/I6iBCi43PJcw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -8497,6 +8541,53 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8558,6 +8649,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8634,6 +8726,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8709,6 +8802,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8871,6 +8965,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9277,6 +9372,7 @@
       "integrity": "sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -9574,6 +9670,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.0.tgz",
       "integrity": "sha512-BL1EDFpt+q10eAeZB0q9ps6pSlPejaBQWBkiuM16pyoVTG4NhZrPrZK0cqNbrozxSsYwUsJ9SQYN6NyeKJYX9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -9866,7 +9963,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/turbo": {
       "version": "2.9.5",
@@ -9983,6 +10081,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10140,6 +10239,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10308,6 +10408,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",


### PR DESCRIPTION
## Summary

Adds end-to-end test coverage for the Bicep Visual Designer React app using Playwright (Chromium), and wires it into CI.

## Changes

### Playwright infrastructure
- New `playwright.config.ts`: Chromium-only project, auto-boots the Vite dev server at `127.0.0.1:5173`, CI-aware (`retries=2`, `workers=1`, `forbidOnly=true`), HTML report to `e2e/.report`, artifacts to `e2e/.results`.
- New `e2e/fixtures.ts`: shared helpers — `SAMPLE_GRAPHS`, `openVisualDesigner`, `loadSampleGraph`, `waitForAnyNode`, `nodeCount`, `getGraphTransform`.
- 4 spec files, **21 tests total**:
  - `app-loads.spec.ts` — shell loads, no unexpected console errors, default graph auto-received.
  - `graph-rendering.spec.ts` — flat/module/complex/empty sample graphs, graph swap.
  - `controls.spec.ts` — status bar states, control enable/disable, zoom/fit-view transforms, export overlay open/close.
  - `node-interactions.spec.ts` — focus on click, blur on empty click, `revealFileRange` on dblclick, focus survival across graph swaps.

### Test instrumentation
Added stable `data-testid` (and related data attributes) to:
- `App.tsx` (`app-root`)
- `lib/graph/components/Canvas.tsx` (`graph-canvas`)
- `lib/graph/components/BaseNode.tsx` / `AtomicNode.tsx` / `CompoundNode.tsx` (`graph-node` + `data-node-id` + `data-node-kind`)
- `features/controls/ControlBar.tsx` (`control-bar`, `control-zoom-in`, `control-zoom-out`, `control-fit-view`, `control-reset-layout`, `control-export`)
- `features/status/StatusBar.tsx` (`status-bar` + `data-status` + `data-error-count`, `status-indicator`, `status-error-link`, `status-empty-message`)
- `features/devtools/DevToolbar.tsx` (`dev-toolbar`, `dev-graph-*`, `dev-mutation-*`)
- `features/export/ExportOverlay.tsx` (`export-overlay`)

### TypeScript project references
- Root `tsconfig.json` is now solution-style and references `tsconfig.app.json` (src) and `tsconfig.e2e.json` (`playwright.config.ts` + `e2e/**`, `types: ["node"]`).
- `build` script: `tsc -b && vite build`.
- Removes deprecated `baseUrl` from the app tsconfig (TS 4.1+ resolves `paths` relative to the tsconfig).

### Scripts
- `e2e`, `e2e:ui`, `e2e:report`, `e2e:install` in `apps/visual-designer/package.json`.
- The `e2e:*` namespace (instead of `test:e2e:*`) keeps Playwright out of the unit-test `turbo test` pipeline used elsewhere in the monorepo.

### CI (`.github/workflows/build.yml`)
In the `test-vscode-bicep-ui` job, after `Run tests`, gated on Linux:
1. `npm run e2e:install` (installs Chromium + deps)
2. `npm run e2e` (`CI=true`)
3. Upload `e2e/.report` as `visual-designer-playwright-report` artifact (`if: always()`, 7-day retention).

### Hygiene
- `.gitignore`: ignore `*.tsbuildinfo`, `**/e2e/.report/`, `**/e2e/.results/`, plus Playwright defaults.
- `eslint.config.mjs`: ignore `**/e2e/.results/` and `**/e2e/.report/`.

## Validation
- `tsc -b` → exit 0
- `npm run lint` → clean
- `npm run e2e` locally → **21 passed** in ~34s.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19689)