### PR TITLE
make inherited parameters optional in bicep extends feature

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -186,18 +186,6 @@ namespace Bicep.Cli.IntegrationTests
                 """,
                 Path.GetDirectoryName(baseParamsFile));
 
-            FileHelper.SaveResultFile(
-                TestContext,
-                "bicepconfig.json",
-                """
-                {
-                    "experimentalFeaturesEnabled": {
-                        "extendableParamFiles": true
-                    }
-                }
-                """,
-                Path.GetDirectoryName(baseParamsFile));
-
             var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
 
             result.Should().Succeed();
@@ -256,18 +244,6 @@ namespace Bicep.Cli.IntegrationTests
                 """,
                 rootDir);
 
-            FileHelper.SaveResultFile(
-                TestContext,
-                "bicepconfig.json",
-                """
-                {
-                    "experimentalFeaturesEnabled": {
-                        "extendableParamFiles": true
-                    }
-                }
-                """,
-                rootDir);
-
             var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
 
             result.Should().Succeed();
@@ -314,18 +290,6 @@ namespace Bicep.Cli.IntegrationTests
                 """,
                 rootDir);
 
-            FileHelper.SaveResultFile(
-                TestContext,
-                "bicepconfig.json",
-                """
-                {
-                    "experimentalFeaturesEnabled": {
-                        "extendableParamFiles": true
-                    }
-                }
-                """,
-                rootDir);
-
             var environment = TestEnvironment.Default.WithVariables(("BICEP_PARAMETERS_OVERRIDES", new
             {
                 rgName = "override-rg"
@@ -364,18 +328,6 @@ namespace Bicep.Cli.IntegrationTests
                 extends './shared.bicepparam'
 
                 param localName = '${base.sharedName}-from-main'
-                """,
-                rootDir);
-
-            FileHelper.SaveResultFile(
-                TestContext,
-                "bicepconfig.json",
-                """
-                {
-                    "experimentalFeaturesEnabled": {
-                        "extendableParamFiles": true
-                    }
-                }
                 """,
                 rootDir);
 
@@ -421,18 +373,6 @@ namespace Bicep.Cli.IntegrationTests
                 """,
                 rootDir);
 
-            FileHelper.SaveResultFile(
-                TestContext,
-                "bicepconfig.json",
-                """
-                {
-                    "experimentalFeaturesEnabled": {
-                        "extendableParamFiles": true
-                    }
-                }
-                """,
-                rootDir);
-
             var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
 
             result.Should().Fail().And.HaveStderrMatch("*Error BCP259: The parameter \"rgNmae\" is assigned in the params file without being declared in the Bicep file.*");
@@ -468,18 +408,6 @@ namespace Bicep.Cli.IntegrationTests
                 "main.bicep",
                 """
                 param rgName string
-                """,
-                rootDir);
-
-            FileHelper.SaveResultFile(
-                TestContext,
-                "bicepconfig.json",
-                """
-                {
-                    "experimentalFeaturesEnabled": {
-                        "extendableParamFiles": true
-                    }
-                }
                 """,
                 rootDir);
 
@@ -522,18 +450,6 @@ namespace Bicep.Cli.IntegrationTests
                 "main.bicep",
                 """
                 param rgName string
-                """,
-                rootDir);
-
-            FileHelper.SaveResultFile(
-                TestContext,
-                "bicepconfig.json",
-                """
-                {
-                    "experimentalFeaturesEnabled": {
-                        "extendableParamFiles": true
-                    }
-                }
                 """,
                 rootDir);
 

--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -154,6 +154,395 @@ namespace Bicep.Cli.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Build_params_with_extends_ignores_inherited_params_not_declared_in_template()
+        {
+            var baseParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "shared.bicepparam",
+                """
+                using none
+
+                param location = 'switzerlandnorth'
+                param customerId = '12345'
+                param namePrefix = 'contoso'
+                """);
+
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+                extends './shared.bicepparam'
+
+                param rgName = '${base.namePrefix}-infra'
+                """,
+                Path.GetDirectoryName(baseParamsFile));
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                """
+                param rgName string
+                """,
+                Path.GetDirectoryName(baseParamsFile));
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "bicepconfig.json",
+                """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "extendableParamFiles": true
+                    }
+                }
+                """,
+                Path.GetDirectoryName(baseParamsFile));
+
+            var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Succeed();
+            var parametersStdout = result.Stdout.FromJson<BuildParamsStdout>();
+            var paramsObject = parametersStdout.parametersJson.FromJson<JToken>();
+
+            paramsObject.Should().HaveValueAtPath("parameters.rgName.value", "contoso-infra");
+            paramsObject.Should().NotHaveValueAtPath("parameters.location");
+            paramsObject.Should().NotHaveValueAtPath("parameters.customerId");
+            paramsObject.Should().NotHaveValueAtPath("parameters.namePrefix");
+        }
+
+        [TestMethod]
+        public async Task Build_params_with_extends_ignores_nested_inherited_params_not_declared_in_template()
+        {
+            var rootDir = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "shared.bicepparam",
+                """
+                using none
+
+                param customerId = '12345'
+                param namePrefix = 'contoso'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "common.bicepparam",
+                """
+                using none
+                extends './shared.bicepparam'
+
+                param environment = 'prod'
+                """,
+                rootDir);
+
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+                extends './common.bicepparam'
+
+                param rgName = '${base.namePrefix}-${base.environment}-rg'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                """
+                param rgName string
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "bicepconfig.json",
+                """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "extendableParamFiles": true
+                    }
+                }
+                """,
+                rootDir);
+
+            var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Succeed();
+            var paramsObject = result.Stdout.FromJson<BuildParamsStdout>().parametersJson.FromJson<JToken>();
+
+            paramsObject.Should().HaveValueAtPath("parameters.rgName.value", "contoso-prod-rg");
+            paramsObject.Should().NotHaveValueAtPath("parameters.customerId");
+            paramsObject.Should().NotHaveValueAtPath("parameters.namePrefix");
+            paramsObject.Should().NotHaveValueAtPath("parameters.environment");
+        }
+
+        [TestMethod]
+        public async Task Build_params_with_extends_and_override_keeps_filtering_inherited_params()
+        {
+            var rootDir = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "shared.bicepparam",
+                """
+                using none
+
+                param location = 'switzerlandnorth'
+                param namePrefix = 'contoso'
+                """,
+                rootDir);
+
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+                extends './shared.bicepparam'
+
+                param rgName = '${base.namePrefix}-infra'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                """
+                param rgName string
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "bicepconfig.json",
+                """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "extendableParamFiles": true
+                    }
+                }
+                """,
+                rootDir);
+
+            var environment = TestEnvironment.Default.WithVariables(("BICEP_PARAMETERS_OVERRIDES", new
+            {
+                rgName = "override-rg"
+            }.ToJson()));
+            var settings = CreateDefaultSettings() with { Environment = environment };
+
+            var result = await Bicep(settings, "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Succeed();
+            var paramsObject = result.Stdout.FromJson<BuildParamsStdout>().parametersJson.FromJson<JToken>();
+
+            paramsObject.Should().HaveValueAtPath("parameters.rgName.value", "override-rg");
+            paramsObject.Should().NotHaveValueAtPath("parameters.location");
+            paramsObject.Should().NotHaveValueAtPath("parameters.namePrefix");
+        }
+
+        [TestMethod]
+        public async Task Build_params_with_extends_and_using_none_emits_inherited_params()
+        {
+            var rootDir = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "shared.bicepparam",
+                """
+                using none
+
+                param sharedName = 'from-base'
+                """,
+                rootDir);
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using none
+                extends './shared.bicepparam'
+
+                param localName = '${base.sharedName}-from-main'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "bicepconfig.json",
+                """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "extendableParamFiles": true
+                    }
+                }
+                """,
+                rootDir);
+
+            var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Succeed();
+            var paramsObject = result.Stdout.FromJson<BuildParamsStdout>().parametersJson.FromJson<JToken>();
+
+            paramsObject.Should().HaveValueAtPath("parameters.sharedName.value", "from-base");
+            paramsObject.Should().HaveValueAtPath("parameters.localName.value", "from-base-from-main");
+        }
+
+        [TestMethod]
+        public async Task Build_params_with_extends_keeps_error_for_local_param_not_declared_in_template()
+        {
+            var rootDir = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "shared.bicepparam",
+                """
+                using none
+
+                param namePrefix = 'contoso'
+                """,
+                rootDir);
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+                extends './shared.bicepparam'
+
+                param rgNmae = '${base.namePrefix}-infra'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                """
+                param rgName string = 'default-rg'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "bicepconfig.json",
+                """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "extendableParamFiles": true
+                    }
+                }
+                """,
+                rootDir);
+
+            var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Fail().And.HaveStderrMatch("*Error BCP259: The parameter \"rgNmae\" is assigned in the params file without being declared in the Bicep file.*");
+        }
+
+        [TestMethod]
+        public async Task Build_params_with_extends_keeps_error_for_override_not_declared_in_template()
+        {
+            var rootDir = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "shared.bicepparam",
+                """
+                using none
+
+                param namePrefix = 'contoso'
+                """,
+                rootDir);
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+                extends './shared.bicepparam'
+
+                param rgName = '${base.namePrefix}-infra'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                """
+                param rgName string
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "bicepconfig.json",
+                """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "extendableParamFiles": true
+                    }
+                }
+                """,
+                rootDir);
+
+            var environment = TestEnvironment.Default.WithVariables(("BICEP_PARAMETERS_OVERRIDES", new
+            {
+                namePrefix = "wrong"
+            }.ToJson()));
+            var settings = CreateDefaultSettings() with { Environment = environment };
+
+            var result = await Bicep(settings, "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Fail().And.HaveStderrMatch("*Error BCP259: The parameter \"namePrefix\" is assigned in the params file without being declared in the Bicep file.*");
+        }
+
+        [TestMethod]
+        public async Task Build_params_with_extends_keeps_type_error_for_inherited_param_declared_in_template()
+        {
+            var rootDir = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "shared.bicepparam",
+                """
+                using none
+
+                param rgName = 42
+                """,
+                rootDir);
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+                extends './shared.bicepparam'
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                """
+                param rgName string
+                """,
+                rootDir);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "bicepconfig.json",
+                """
+                {
+                    "experimentalFeaturesEnabled": {
+                        "extendableParamFiles": true
+                    }
+                }
+                """,
+                rootDir);
+
+            var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Fail().And.HaveStderrMatch("*Error BCP033: Expected a value of type \"string\" but the provided value is of type \"42\".*");
+        }
+
+        [TestMethod]
         public async Task Build_params_extends_uses_complex_variables_from_base_file()
         {
             var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);

--- a/src/Bicep.Core/Emit/ParametersJsonWriter.cs
+++ b/src/Bicep.Core/Emit/ParametersJsonWriter.cs
@@ -35,13 +35,17 @@ public class ParametersJsonWriter
     private JToken GenerateParametersJToken(PositionTrackingJsonTextWriter jsonWriter)
     {
         var emitter = new ExpressionEmitter(jsonWriter, this.Context);
+        var filterToDeclaredParameters = this.Context.SemanticModel.Root.TryGetBicepFileSemanticModelViaUsing().IsSuccess(out var usingModel) &&
+            usingModel is not EmptySemanticModel;
+        var assignmentsToEmit = this.Context.SemanticModel.Root.ParameterAssignments
+            .Where(x => !filterToDeclaredParameters || this.Context.SemanticModel.TryGetParameterMetadata(x) is not null);
 
         jsonWriter.WriteStartObject();
         emitter.EmitProperty("$schema", "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#");
         emitter.EmitProperty("contentVersion", "1.0.0.0");
         emitter.EmitObjectProperty("parameters", () =>
         {
-            foreach (var assignment in this.Context.SemanticModel.Root.ParameterAssignments)
+            foreach (var assignment in assignmentsToEmit)
             {
                 emitter.EmitObjectProperty(assignment.Name, () =>
                 {

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -630,7 +630,8 @@ namespace Bicep.Core.Semantics
             }
 
             // parameters that are assigned but not declared
-            var missingAssignedParams = Root.ParameterAssignments.Where(s => TryGetParameterMetadata(s) is null);
+            var missingAssignedParams = Root.ParameterAssignments
+                .Where(s => s.Context.SourceFile == Root.Context.SourceFile && TryGetParameterMetadata(s) is null);
 
             // parameters that are declared but not assigned
             var missingRequiredParams = usingModel.Parameters


### PR DESCRIPTION
Fixes #16813
Fixes #5771
Fixes #11145

## Summary

This PR makes inherited `.bicepparam` parameters optional when using `extends`.

A shared base params file can now contain values that are only used by some deployment params files. If an inherited parameter is not declared by the target template, Bicep allows it and does not emit it to the final parameters JSON.

Local params in the final params file are still checked strictly, so typos still raise `BCP259`.

### Changes

- Allow unknown parameters when they come from an extended `.bicepparam` file.
- Keep `BCP259` for unknown parameters written in the final params file.
- Keep `BCP259` for unknown deployment-time overrides.
- Emit only parameters declared by the target template when the params file uses a real template.
- Keep `using none` behavior unchanged.

### Tests

Added coverage for:

- inherited extra params are allowed and not emitted
- nested inherited extra params are allowed and not emitted
- inherited params can still be used through `base.*`
- declared params can still be overridden
- `using none` still emits inherited params
- local unknown params still fail
- unknown overrides still fail
- inherited params declared by the template are still type checked

Run:

```bash
dotnet test
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19698)