### PR TITLE
fix: `bicep console` multi-line user-defined type input handling

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/Commands/ConsoleCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/Commands/ConsoleCommandTests.cs
@@ -65,6 +65,32 @@ var target = {
     }
 
     [TestMethod]
+    public async Task Redirected_input_context_with_multi_line_type_union_should_succeed()
+    {
+        var input = """
+            type someRandomType = 'a'
+            | 'b'
+            | 'c'
+            | 'd'
+            var selected someRandomType = 'b'
+            selected
+            """;
+
+        var result = await Bicep(
+            (@out, err) => new IOContext(
+                new(new StringReader(input), IsRedirected: true),
+                new(@out, IsRedirected: false),
+                new(err, IsRedirected: false)),
+            "console");
+
+        result.Should().Succeed();
+        result.WithoutAnsi().Stdout.Should().BeEquivalentToIgnoringNewlines("""
+'b'
+
+""");
+    }
+
+    [TestMethod]
     public async Task Redirected_output_context_should_not_have_ansi_codes()
     {
         // "concat('Hello', ' ', 'World', '!')" | bicep console >

--- a/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
+++ b/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
@@ -310,7 +310,10 @@ public class ReplEnvironmentTests
     [TestMethod]
     public void ShouldSubmitBuffer_treats_whitespace_only_line_as_blank()
     {
-        ReplEnvironment.ShouldSubmitBuffer("var foo = {\n  \n", "  ").Should().BeTrue();
+        var bufferState = ReplEnvironment.GetBufferState("var foo = {\n  \n", "  ");
+
+        bufferState.ShouldSubmit.Should().BeTrue();
+        bufferState.IsTypeDeclaration.Should().BeFalse();
     }
 
     [TestMethod]

--- a/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
+++ b/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
@@ -308,6 +308,12 @@ public class ReplEnvironmentTests
     }
 
     [TestMethod]
+    public void ShouldSubmitBuffer_treats_whitespace_only_line_as_blank()
+    {
+        ReplEnvironment.ShouldSubmitBuffer("var foo = {\n  \n", "  ").Should().BeTrue();
+    }
+
+    [TestMethod]
     public void LoadFunctions_succeed()
     {
         var mockFileSystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -66,24 +66,49 @@ public class ConsoleCommand(
             // Handle input line by line (to support multi-line strings)
             var outputBuilder = new StringBuilder();
             var inputBuffer = new StringBuilder();
+            var pendingTypeContinuation = false;
 
             using var reader = new StringReader(input);
             while (await reader.ReadLineAsync() is { } line)
             {
+                var consumedWhitespaceSubmitLine = false;
+                while (pendingTypeContinuation && !IsTypeContinuationLine(line))
+                {
+                    outputBuilder.Append(EvaluateAndClearBuffer(inputBuffer));
+                    pendingTypeContinuation = false;
+
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        consumedWhitespaceSubmitLine = true;
+                    }
+                }
+
+                if (consumedWhitespaceSubmitLine)
+                {
+                    continue;
+                }
+
                 inputBuffer.Append(line);
                 inputBuffer.Append('\n');
 
                 var current = inputBuffer.ToString();
                 if (ReplEnvironment.ShouldSubmitBuffer(current, line))
                 {
-                    inputBuffer.Clear();
-                    outputBuilder.Append(replEnvironment.EvaluateAndGetOutput(current));
+                    if (EndsWithTypeDeclaration(current))
+                    {
+                        pendingTypeContinuation = true;
+                    }
+                    else
+                    {
+                        outputBuilder.Append(EvaluateAndClearBuffer(inputBuffer));
+                        pendingTypeContinuation = false;
+                    }
                 }
             }
 
             if (inputBuffer.Length > 0)
             {
-                outputBuilder.Append(replEnvironment.EvaluateAndGetOutput(inputBuffer.ToString()));
+                outputBuilder.Append(EvaluateAndClearBuffer(inputBuffer));
             }
 
             var output = outputBuilder.ToString();
@@ -101,12 +126,31 @@ public class ConsoleCommand(
         await io.Output.Writer.WriteLineAsync(string.Empty);
 
         var buffer = new StringBuilder();
+        var pendingTypeContinuationInteractive = false;
 
         while (true)
         {
-            if (await ReadLine(buffer) is not { } rawLine)
+            if (await ReadLine(buffer) is not { } inputLine)
             {
                 break;
+            }
+
+            var rawLine = inputLine.Text;
+            var consumedWhitespaceSubmitLine = false;
+            while (pendingTypeContinuationInteractive && !IsTypeContinuationLine(rawLine))
+            {
+                await io.Output.Writer.WriteAsync(EvaluateAndClearBuffer(buffer));
+                pendingTypeContinuationInteractive = false;
+
+                if (string.IsNullOrWhiteSpace(rawLine))
+                {
+                    consumedWhitespaceSubmitLine = true;
+                }
+            }
+
+            if (consumedWhitespaceSubmitLine)
+            {
+                continue;
             }
 
             if (buffer.Length == 0)
@@ -137,16 +181,47 @@ public class ConsoleCommand(
 
             if (ReplEnvironment.ShouldSubmitBuffer(current, rawLine))
             {
-                buffer.Clear();
-
-                // evaluate input
-                var output = replEnvironment.EvaluateAndGetOutput(current);
-                await io.Output.Writer.WriteAsync(output);
+                if (EndsWithTypeDeclaration(current) && ShouldDeferTypeDeclarationSubmit(rawLine, inputLine))
+                {
+                    pendingTypeContinuationInteractive = true;
+                }
+                else
+                {
+                    pendingTypeContinuationInteractive = false;
+                    await io.Output.Writer.WriteAsync(EvaluateAndClearBuffer(buffer));
+                }
             }
         }
 
         return 0;
     }
+
+    private string EvaluateAndClearBuffer(StringBuilder buffer)
+    {
+        var current = buffer.ToString();
+        buffer.Clear();
+
+        return replEnvironment.EvaluateAndGetOutput(current);
+    }
+
+    private static bool IsTypeContinuationLine(string line)
+        => line.TrimStart().StartsWith('|');
+
+    private static bool ShouldDeferTypeDeclarationSubmit(string line, InputLine inputLine)
+        => IsTypeContinuationLine(line)
+            ? !inputLine.StartedWithBufferedInput || inputLine.HasBufferedInputAfterEnter
+            : inputLine.HasBufferedInputAfterEnter;
+
+    private static bool EndsWithTypeDeclaration(string text)
+    {
+        var finalSyntax = new ReplParser(text).Program().Children
+            .Where(x => x is not Token { Type: TokenType.NewLine })
+            .LastOrDefault();
+
+        return finalSyntax is TypeDeclarationSyntax;
+    }
+
+    private readonly record struct InputLine(string Text, bool StartedWithBufferedInput, bool HasBufferedInputAfterEnter);
 
     private async Task<int> PrintHistory(StringBuilder buffer, List<Rune> lineBuffer, int cursorOffset, bool backwards)
     {
@@ -175,12 +250,14 @@ public class ConsoleCommand(
     private string GetPrefix(StringBuilder buffer)
         => buffer.Length == 0 ? FirstLinePrefix : "";
 
-    private async Task<string?> ReadLine(StringBuilder buffer)
+    private async Task<InputLine?> ReadLine(StringBuilder buffer)
     {
         await io.Output.Writer.WriteAsync(GetPrefix(buffer));
 
         var lineBuffer = new List<Rune>();
         var cursorOffset = 0;
+        var startedWithBufferedInput = Console.KeyAvailable;
+
         while (true)
         {
             var keyInfo = Console.ReadKey(intercept: true);
@@ -246,6 +323,6 @@ public class ConsoleCommand(
 
         await io.Output.Writer.WriteAsync("\n");
 
-        return string.Concat(lineBuffer);
+        return new(string.Concat(lineBuffer), startedWithBufferedInput, Console.KeyAvailable);
     }
 }

--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -71,21 +71,15 @@ public class ConsoleCommand(
             using var reader = new StringReader(input);
             while (await reader.ReadLineAsync() is { } line)
             {
-                var consumedWhitespaceSubmitLine = false;
-                while (pendingTypeContinuation && !IsTypeContinuationLine(line))
+                if (pendingTypeContinuation && !IsTypeContinuationLine(line))
                 {
                     outputBuilder.Append(EvaluateAndClearBuffer(inputBuffer));
                     pendingTypeContinuation = false;
 
                     if (string.IsNullOrWhiteSpace(line))
                     {
-                        consumedWhitespaceSubmitLine = true;
+                        continue;
                     }
-                }
-
-                if (consumedWhitespaceSubmitLine)
-                {
-                    continue;
                 }
 
                 inputBuffer.Append(line);
@@ -136,21 +130,15 @@ public class ConsoleCommand(
             }
 
             var rawLine = inputLine.Text;
-            var consumedWhitespaceSubmitLine = false;
-            while (pendingTypeContinuationInteractive && !IsTypeContinuationLine(rawLine))
+            if (pendingTypeContinuationInteractive && !IsTypeContinuationLine(rawLine))
             {
                 await io.Output.Writer.WriteAsync(EvaluateAndClearBuffer(buffer));
                 pendingTypeContinuationInteractive = false;
 
                 if (string.IsNullOrWhiteSpace(rawLine))
                 {
-                    consumedWhitespaceSubmitLine = true;
+                    continue;
                 }
-            }
-
-            if (consumedWhitespaceSubmitLine)
-            {
-                continue;
             }
 
             if (buffer.Length == 0)
@@ -208,9 +196,14 @@ public class ConsoleCommand(
         => line.TrimStart().StartsWith('|');
 
     private static bool ShouldDeferTypeDeclarationSubmit(string line, InputLine inputLine)
-        => IsTypeContinuationLine(line)
-            ? !inputLine.StartedWithBufferedInput || inputLine.HasBufferedInputAfterEnter
-            : inputLine.HasBufferedInputAfterEnter;
+    {
+        if (!IsTypeContinuationLine(line))
+        {
+            return inputLine.HasBufferedInputAfterEnter;
+        }
+
+        return !inputLine.StartedWithBufferedInput || inputLine.HasBufferedInputAfterEnter;
+    }
 
     private static bool EndsWithTypeDeclaration(string text)
     {

--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -86,9 +86,10 @@ public class ConsoleCommand(
                 inputBuffer.Append('\n');
 
                 var current = inputBuffer.ToString();
-                if (ReplEnvironment.ShouldSubmitBuffer(current, line))
+                var bufferState = ReplEnvironment.GetBufferState(current, line);
+                if (bufferState.ShouldSubmit)
                 {
-                    if (EndsWithTypeDeclaration(current))
+                    if (bufferState.IsTypeDeclaration)
                     {
                         pendingTypeContinuationRedirected = true;
                     }
@@ -167,9 +168,10 @@ public class ConsoleCommand(
 
             var current = buffer.ToString();
 
-            if (ReplEnvironment.ShouldSubmitBuffer(current, rawLine))
+            var bufferState = ReplEnvironment.GetBufferState(current, rawLine);
+            if (bufferState.ShouldSubmit)
             {
-                if (EndsWithTypeDeclaration(current) && ShouldWaitForTypeContinuation(inputLine))
+                if (bufferState.IsTypeDeclaration && ShouldWaitForTypeContinuation(inputLine))
                 {
                     pendingTypeContinuation = true;
                 }
@@ -198,15 +200,6 @@ public class ConsoleCommand(
     private static bool ShouldWaitForTypeContinuation(InputLine inputLine)
         => inputLine.HasBufferedInputAfterEnter ||
             (IsTypeContinuationLine(inputLine.Text) && !inputLine.StartedWithBufferedInput);
-
-    private static bool EndsWithTypeDeclaration(string text)
-    {
-        var finalSyntax = new ReplParser(text).Program().Children
-            .Where(x => x is not Token { Type: TokenType.NewLine })
-            .LastOrDefault();
-
-        return finalSyntax is TypeDeclarationSyntax;
-    }
 
     private readonly record struct InputLine(string Text, bool StartedWithBufferedInput, bool HasBufferedInputAfterEnter);
 

--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -66,15 +66,15 @@ public class ConsoleCommand(
             // Handle input line by line (to support multi-line strings)
             var outputBuilder = new StringBuilder();
             var inputBuffer = new StringBuilder();
-            var pendingTypeContinuation = false;
+            var pendingTypeContinuationRedirected = false;
 
             using var reader = new StringReader(input);
             while (await reader.ReadLineAsync() is { } line)
             {
-                if (pendingTypeContinuation && !IsTypeContinuationLine(line))
+                if (pendingTypeContinuationRedirected && !IsTypeContinuationLine(line))
                 {
                     outputBuilder.Append(EvaluateAndClearBuffer(inputBuffer));
-                    pendingTypeContinuation = false;
+                    pendingTypeContinuationRedirected = false;
 
                     if (string.IsNullOrWhiteSpace(line))
                     {
@@ -90,12 +90,12 @@ public class ConsoleCommand(
                 {
                     if (EndsWithTypeDeclaration(current))
                     {
-                        pendingTypeContinuation = true;
+                        pendingTypeContinuationRedirected = true;
                     }
                     else
                     {
                         outputBuilder.Append(EvaluateAndClearBuffer(inputBuffer));
-                        pendingTypeContinuation = false;
+                        pendingTypeContinuationRedirected = false;
                     }
                 }
             }

--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -120,7 +120,7 @@ public class ConsoleCommand(
         await io.Output.Writer.WriteLineAsync(string.Empty);
 
         var buffer = new StringBuilder();
-        var pendingTypeContinuationInteractive = false;
+        var pendingTypeContinuation = false;
 
         while (true)
         {
@@ -130,10 +130,10 @@ public class ConsoleCommand(
             }
 
             var rawLine = inputLine.Text;
-            if (pendingTypeContinuationInteractive && !IsTypeContinuationLine(rawLine))
+            if (pendingTypeContinuation && !IsTypeContinuationLine(rawLine))
             {
                 await io.Output.Writer.WriteAsync(EvaluateAndClearBuffer(buffer));
-                pendingTypeContinuationInteractive = false;
+                pendingTypeContinuation = false;
 
                 if (string.IsNullOrWhiteSpace(rawLine))
                 {
@@ -169,13 +169,13 @@ public class ConsoleCommand(
 
             if (ReplEnvironment.ShouldSubmitBuffer(current, rawLine))
             {
-                if (EndsWithTypeDeclaration(current) && ShouldDeferTypeDeclarationSubmit(rawLine, inputLine))
+                if (EndsWithTypeDeclaration(current) && ShouldWaitForTypeContinuation(inputLine))
                 {
-                    pendingTypeContinuationInteractive = true;
+                    pendingTypeContinuation = true;
                 }
                 else
                 {
-                    pendingTypeContinuationInteractive = false;
+                    pendingTypeContinuation = false;
                     await io.Output.Writer.WriteAsync(EvaluateAndClearBuffer(buffer));
                 }
             }
@@ -195,15 +195,9 @@ public class ConsoleCommand(
     private static bool IsTypeContinuationLine(string line)
         => line.TrimStart().StartsWith('|');
 
-    private static bool ShouldDeferTypeDeclarationSubmit(string line, InputLine inputLine)
-    {
-        if (!IsTypeContinuationLine(line))
-        {
-            return inputLine.HasBufferedInputAfterEnter;
-        }
-
-        return !inputLine.StartedWithBufferedInput || inputLine.HasBufferedInputAfterEnter;
-    }
+    private static bool ShouldWaitForTypeContinuation(InputLine inputLine)
+        => inputLine.HasBufferedInputAfterEnter ||
+            (IsTypeContinuationLine(inputLine.Text) && !inputLine.StartedWithBufferedInput);
 
     private static bool EndsWithTypeDeclaration(string text)
     {

--- a/src/Bicep.Cli/Services/ReplEnvironment.cs
+++ b/src/Bicep.Cli/Services/ReplEnvironment.cs
@@ -301,7 +301,7 @@ public class ReplEnvironment
     {
         // If line is blank, submit - even if structurally incomplete.
         // This avoids trapping the user in a state where they cannot recover.
-        if (currentLine.Length == 0)
+        if (string.IsNullOrWhiteSpace(currentLine))
         {
             return true;
         }

--- a/src/Bicep.Cli/Services/ReplEnvironment.cs
+++ b/src/Bicep.Cli/Services/ReplEnvironment.cs
@@ -297,21 +297,36 @@ public class ReplEnvironment
     /// and not inside (multi-line) string or interpolation expression.
     /// Not a full parse; parse errors still reported by real parser.
     /// </summary>
-    public static bool ShouldSubmitBuffer(string text, string currentLine)
+    public static ReplBufferState GetBufferState(string text, string currentLine)
     {
         // If line is blank, submit - even if structurally incomplete.
         // This avoids trapping the user in a state where they cannot recover.
         if (string.IsNullOrWhiteSpace(currentLine))
         {
-            return true;
+            return new ReplBufferState(
+                ShouldSubmit: true,
+                IsTypeDeclaration: false);
         }
 
         var program = new ReplParser(text).Program();
 
         // Use the existence of skipped trivia to determine whether we have a complete structure.
         var allNodes = SyntaxAggregator.Aggregate(program, x => x is not Token, useCst: true);
-        return allNodes.Last() is not SkippedTriviaSyntax;
+        var shouldSubmit = allNodes.Last() is not SkippedTriviaSyntax;
+
+        var finalExpression = program.Children
+            .Where(x => x is not Token { Type: TokenType.NewLine })
+            .LastOrDefault();
+
+        return new ReplBufferState(
+            ShouldSubmit: shouldSubmit,
+            IsTypeDeclaration: finalExpression is TypeDeclarationSyntax);
     }
+
+    public static bool ShouldSubmitBuffer(string text, string currentLine)
+        => GetBufferState(text, currentLine).ShouldSubmit;
 }
 
 public record AnnotatedReplResult(SyntaxBase? Value, IEnumerable<PrintHelper.AnnotatedDiagnostic> AnnotatedDiagnostics);
+
+public record ReplBufferState(bool ShouldSubmit, bool IsTypeDeclaration);


### PR DESCRIPTION
## Description

@levimatheri 

<!-- Provide a 1-2 sentence description of your change -->
`bicep console` did not handle multi-line user-defined types with `|` correctly. Example to reproduce:

1. Open `bicep console`
2. Paste the bicep:
```bicep
type someRandomType = 'a'
| 'b'
| 'c'
| 'd'
```
3. hit enter and you will get the error.

The REPL submit logic treated the first line (type someRandomType = 'a') as complete input, so the following | ... lines were processed separately and produced parser errors. See:

<img width="1764" height="348" alt="CleanShot 2026-05-21 at 21 40 35@2x" src="https://github.com/user-attachments/assets/c880e7a9-a301-4b99-8fd3-eb0912828b6b" />

This PR fixes the submit behaviour, and multi-line user-defined types with `|` are now handled correctly:

<img width="838" height="500" alt="CleanShot 2026-05-21 at 21 43 00@2x" src="https://github.com/user-attachments/assets/1d4a8683-d262-4d58-87bc-7fec2515657f" />


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19699)