### PR TITLE
add getSecret parameter reference regression coverage

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests;
@@ -338,6 +339,97 @@ param bar = getSecret(subId, rgName, kvName, secretName)
         {
             ["kind"] = "secretVersion",
         });
+    }
+
+    [TestMethod]
+    public void All_getSecret_forms_emit_keyVault_references()
+    {
+        var parametersResult = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+using none
+
+param fromGetSecret = getSecret('subId', 'rgName', 'kvName', 'secretName', 'secretVersion')
+param fromAzGetSecret = az.getSecret('subId', 'rgName', 'kvName', 'secretName', 'secretVersion')
+param fromGetSecretWithoutVersion = getSecret('subId', 'rgName', 'kvName', 'secretName')
+param fromAzGetSecretWithoutVersion = az.getSecret('subId', 'rgName', 'kvName', 'secretName')
+"""));
+
+        var templateResult = CompilationHelper.Compile(
+            ("main.bicep", """
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'kvName'
+}
+
+module secret 'secret.bicep' = {
+  name: 'secret'
+  params: {
+    fromResourceGetSecret: kv.getSecret('secretName', 'secretVersion')
+    fromResourceGetSecretWithoutVersion: kv.getSecret('secretName')
+  }
+}
+"""),
+            ("secret.bicep", """
+@secure()
+param fromResourceGetSecret string
+
+@secure()
+param fromResourceGetSecretWithoutVersion string
+"""));
+
+        using (new AssertionScope())
+        {
+            parametersResult.Should().NotHaveAnyDiagnostics();
+            templateResult.Should().NotHaveAnyDiagnostics();
+        }
+
+        var parameters = TemplateHelper.ConvertAndAssertParameters(parametersResult.Parameters);
+
+        AssertGetSecretForms(parameters, templateResult.Template, "fromGetSecret", "fromAzGetSecret", "fromResourceGetSecret", "secretVersion");
+        AssertGetSecretForms(parameters, templateResult.Template, "fromGetSecretWithoutVersion", "fromAzGetSecretWithoutVersion", "fromResourceGetSecretWithoutVersion", null);
+    }
+
+    private static void AssertGetSecretForms(
+        ImmutableDictionary<string, TemplateHelper.ParameterProperties> parameters,
+        JToken? template,
+        string getSecretParameterName,
+        string azGetSecretParameterName,
+        string resourceGetSecretParameterName,
+        string? expectedSecretVersion)
+    {
+        var getSecretReference = parameters[getSecretParameterName].Reference;
+        var azGetSecretReference = parameters[azGetSecretParameterName].Reference;
+        var resourceGetSecretParameter = template!.SelectToken($"$.resources[?(@.name == 'secret')].properties.parameters.{resourceGetSecretParameterName}")!;
+        var resourceGetSecretReference = resourceGetSecretParameter.SelectToken("$.reference");
+
+        using (new AssertionScope())
+        {
+            parameters[getSecretParameterName].Value.Should().BeNull();
+            parameters[azGetSecretParameterName].Value.Should().BeNull();
+            resourceGetSecretParameter.SelectToken("$.value").Should().BeNull();
+
+            getSecretReference.Should().NotBeNull();
+            azGetSecretReference.Should().NotBeNull();
+            getSecretReference!.Should().DeepEqual(azGetSecretReference!);
+
+            AssertKeyVaultReference(getSecretReference, "secretName", expectedSecretVersion);
+            AssertKeyVaultReference(azGetSecretReference, "secretName", expectedSecretVersion);
+            AssertKeyVaultReference(resourceGetSecretReference, "secretName", expectedSecretVersion);
+        }
+    }
+
+    private static void AssertKeyVaultReference(JToken? reference, string expectedSecretName, string? expectedSecretVersion)
+    {
+        reference.Should().NotBeNull();
+        reference!.SelectToken("$.keyVault.id").Should().NotBeNull();
+        reference.SelectToken("$.secretName")!.Should().DeepEqual(expectedSecretName);
+        if (expectedSecretVersion is null)
+        {
+            reference.SelectToken("$.secretVersion").Should().BeNull();
+        }
+        else
+        {
+            reference.SelectToken("$.secretVersion")!.Should().DeepEqual(expectedSecretVersion);
+        }
     }
 
     [TestMethod]


### PR DESCRIPTION
The reported behavior in #18455 appears to already be resolved by previous Bicep work, or the remaining symptom is on the Azure CLI deployment/error-reporting side rather than in Bicep emission.

Bicep emits valid ARM JSON for Key Vault parameter references. The test I've added here confirms that `getSecret()`, `az.getSecret()`, and `kv.getSecret()` all compile correctly and produce the expected ARM template/parameters JSON representation.

Adds regression coverage for Key Vault secret reference emission across the supported `getSecret` forms:

- `.bicepparam` `getSecret(...)`
- `.bicepparam` `az.getSecret(...)`
- `.bicep` resource method `kv.getSecret(...)`

The new test verifies these forms compile successfully and emit the expected ARM JSON Key Vault parameter reference shape, both with and without `secretVersion`.

Closes #18455

## Validation

```bash
dotnet test Bicep.Core.IntegrationTests.csproj --filter "Name=All_getSecret_forms_emit_keyVault_references"
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19714)