### PR TITLE
fix vs code generate params json output path

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/GenerateParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/GenerateParamsCommandTests.cs
@@ -70,6 +70,40 @@ namespace Bicep.Cli.IntegrationTests
         }
 
         [TestMethod]
+        public async Task GenerateParams_ImplicitOutputFormatJson_ExistingCompiledTemplate_Should_CreateParametersJson()
+        {
+            var bicep = @"param name string = 'sampleparameter'
+output used string = name";
+            var templateJson = @"{ ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"" }";
+
+            var tempDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
+            Directory.CreateDirectory(tempDirectory);
+
+            var bicepFilePath = Path.Combine(tempDirectory, "main.bicep");
+            var templateJsonPath = Path.Combine(tempDirectory, "main.json");
+            var parametersJsonPath = Path.Combine(tempDirectory, "main.parameters.json");
+
+            File.WriteAllText(bicepFilePath, bicep);
+            File.WriteAllText(templateJsonPath, templateJson);
+
+            var (output, error, result) = await Bicep("generate-params", bicepFilePath);
+
+            var content = File.ReadAllText(parametersJsonPath).ReplaceLineEndings();
+
+            using (new AssertionScope())
+            {
+                result.Should().Be(0);
+                output.Should().BeEmpty();
+                error.Should().BeEmpty();
+                File.ReadAllText(templateJsonPath).Should().Be(templateJson);
+                content.Should().Be(@"{
+  ""$schema"": ""https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#"",
+  ""contentVersion"": ""1.0.0.0""
+}".ReplaceLineEndings());
+            }
+        }
+
+        [TestMethod]
         public async Task GenerateParams_ImplicitOutputFormatJson_ExplicitIncludeParamsAll_OneParameterWithDefaultValue_Should_Succeed()
         {
             var bicep = $@"param name string = 'sampleparameter'";

--- a/src/Bicep.LangServer.IntegrationTests/GenerateParamsCommandTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/GenerateParamsCommandTests.cs
@@ -58,5 +58,41 @@ namespace Bicep.LangServer.IntegrationTests
             var commandOutput = File.ReadAllText(Path.ChangeExtension(bicepFilePath, ".parameters.json"));
             commandOutput.Should().BeEquivalentToIgnoringNewlines(expectedJson);
         }
+
+        [TestMethod]
+        public async Task GenerateParams_command_should_generate_paramsfile_when_compiled_template_exists()
+        {
+            var diagnosticsListener = new MultipleMessageListener<PublishDiagnosticsParams>();
+
+            using var helper = await LanguageServerHelper.StartServer(
+                this.TestContext,
+                options => options.OnPublishDiagnostics(diagnosticsListener.AddMessage),
+                services => services.WithNamespaceProvider(BuiltInTestTypes.Create()).WithFeatureOverrides(new(TestContext)));
+            var client = helper.Client;
+
+            var outputDirectory = FileHelper.GetUniqueTestOutputPath(TestContext);
+            Directory.CreateDirectory(outputDirectory);
+
+            var bicepFilePath = Path.Combine(outputDirectory, "main.bicep");
+            var templateJsonPath = Path.ChangeExtension(bicepFilePath, ".json");
+            var parametersJsonPath = Path.ChangeExtension(bicepFilePath, ".parameters.json");
+
+            File.WriteAllText(bicepFilePath, "param name string\n");
+            File.WriteAllText(templateJsonPath, "{ \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#\" }");
+
+            client.TextDocument.DidOpenTextDocument(TextDocumentParamHelper.CreateDidOpenDocumentParamsFromFile(bicepFilePath, 1));
+            await diagnosticsListener.WaitNext();
+
+            var commandParams = new BicepGenerateParamsCommandParams(bicepFilePath, OutputFormatOption.Json, IncludeParamsOption.RequiredOnly);
+
+            await client.Workspace.ExecuteCommand(new Command
+            {
+                Name = "generateParams",
+                Arguments = new JArray(new[] { commandParams.ToJToken() })
+            });
+
+            File.Exists(parametersJsonPath).Should().BeTrue();
+            File.Exists(templateJsonPath).Should().BeTrue();
+        }
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepGenerateParamsCommandHandler.cs
@@ -55,19 +55,24 @@ namespace Bicep.LanguageServer.Handlers
         private async Task<string> GenerateCompiledParametersFileAndReturnOutputMessage(OutputFormatOption outputFormat, IncludeParamsOption includeParams, DocumentUri documentUri)
         {
             var bicepFileUri = documentUri.ToIOUri();
-            var extension = outputFormat == OutputFormatOption.BicepParam ? LanguageConstants.ParamsFileExtension : LanguageConstants.JsonFileExtension;
+            var extension = outputFormat switch
+            {
+                OutputFormatOption.Json => $".parameters{LanguageConstants.JsonFileExtension}",
+                OutputFormatOption.BicepParam => LanguageConstants.ParamsFileExtension,
+                _ => throw new ArgumentOutOfRangeException(nameof(outputFormat), $"Unsupported output format: {outputFormat}")
+            };
             var compiledFileUri = bicepFileUri.WithExtension(extension);
             var compiledFile = this.fileExplorer.GetFile(compiledFileUri);
 
-            // If the template exists and has a .json extension and contains the Bicep metadata, fail the generate params.
+            // If the JSON output file exists and is not a parameters file, fail the generate params.
             // If not, continue to update the file.
-            if (extension == LanguageConstants.JsonFileExtension && compiledFile.Exists())
+            if (outputFormat == OutputFormatOption.Json && compiledFile.Exists())
             {
                 var template = await compiledFile.ReadAllTextAsync();
 
                 if (!TemplateIsParametersFile(template))
                 {
-                    return "Generating parameters file failed. The file \"" + compiledFile + "\" already exists. If overwriting the file is intended, delete it manually and retry the Generate Parameters command.";
+                    return $"Generating parameters file failed. The file \"{compiledFile.Uri}\" already exists. If overwriting the file is intended, delete it manually and retry the Generate Parameters command.";
                 }
             }
 
@@ -84,7 +89,7 @@ namespace Bicep.LanguageServer.Handlers
 
             var model = compilation.GetEntrypointSemanticModel();
             var emitter = new TemplateEmitter(model);
-            using var fileStream = new FileStream(compiledFileUri, FileMode.Create, FileAccess.Write);
+            using var fileStream = compiledFile.OpenWrite();
             var result = emitter.EmitTemplateGeneratedParameterFile(fileStream, existingContent, outputFormat, includeParams);
 
             return $"Generating parameters file succeeded. Processed file '{compiledFile.Uri}'";

--- a/src/vscode-bicep/src/test/e2e/commands.ts
+++ b/src/vscode-bicep/src/test/e2e/commands.ts
@@ -72,8 +72,8 @@ export async function executeBuildParamsCommand(documentUri: vscode.Uri): Promis
   return await vscode.commands.executeCommand("bicep.buildParams", documentUri);
 }
 
-export async function executeGenerateParamsCommand(documentUri: vscode.Uri, outputFormat?: "json" | "bicepparam", includeParams?: "requiredonly" | "all"): Promise<void> {
-  return await vscode.commands.executeCommand("bicep.generateParams", documentUri, outputFormat, includeParams);
+export async function executeGenerateParamsCommand(documentUri: vscode.Uri): Promise<void> {
+  return await vscode.commands.executeCommand("bicep.generateParams", documentUri);
 }
 
 export async function executeDecompileCommand(documentUri: vscode.Uri): Promise<void> {

--- a/src/vscode-bicep/src/test/e2e/commands.ts
+++ b/src/vscode-bicep/src/test/e2e/commands.ts
@@ -72,6 +72,10 @@ export async function executeBuildParamsCommand(documentUri: vscode.Uri): Promis
   return await vscode.commands.executeCommand("bicep.buildParams", documentUri);
 }
 
+export async function executeGenerateParamsCommand(documentUri: vscode.Uri, outputFormat?: "json" | "bicepparam", includeParams?: "requiredonly" | "all"): Promise<void> {
+  return await vscode.commands.executeCommand("bicep.generateParams", documentUri, outputFormat, includeParams);
+}
+
 export async function executeDecompileCommand(documentUri: vscode.Uri): Promise<void> {
   return await vscode.commands.executeCommand("bicep.decompile", documentUri);
 }

--- a/src/vscode-bicep/src/test/e2e/generateParams.test.ts
+++ b/src/vscode-bicep/src/test/e2e/generateParams.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { afterEach, describe, expect, it } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import vscode from "vscode";
+import { sleep } from "../../utils/time";
+import { createUniqueTempFolder } from "../utils/createUniqueTempFolder";
+import { executeCloseAllEditors, executeGenerateParamsCommand } from "./commands";
+
+describe("generateParams", (): void => {
+  afterEach(async () => {
+    await executeCloseAllEditors();
+  });
+
+  it("should generate parameters file if the compiled template already exists", async () => {
+    const tempFolder = createUniqueTempFolder("bicep-generate-params-");
+
+    try {
+      const bicepFilePath = path.join(tempFolder, "main.bicep");
+      const templateJsonPath = path.join(tempFolder, "main.json");
+      const parametersJsonPath = path.join(tempFolder, "main.parameters.json");
+
+      fs.writeFileSync(bicepFilePath, "param name string\noutput used string = name\n");
+      fs.writeFileSync(
+        templateJsonPath,
+        '{ "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#" }',
+      );
+
+      const textDocument = await vscode.workspace.openTextDocument(bicepFilePath);
+
+      // Give the language server some time to finish compilation.
+      await sleep(2000);
+
+      await executeGenerateParamsCommand(textDocument.uri, "json", "requiredonly");
+
+      expect(fs.existsSync(parametersJsonPath)).toBe(true);
+      expect(fs.existsSync(templateJsonPath)).toBe(true);
+    } finally {
+      fs.rmSync(tempFolder, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/vscode-bicep/src/test/e2e/generateParams.test.ts
+++ b/src/vscode-bicep/src/test/e2e/generateParams.test.ts
@@ -8,8 +8,15 @@ import { sleep } from "../../utils/time";
 import { createUniqueTempFolder } from "../utils/createUniqueTempFolder";
 import { executeCloseAllEditors, executeGenerateParamsCommand } from "./commands";
 
+type ShowStringQuickPick = (
+  items: readonly string[],
+  options?: vscode.QuickPickOptions,
+  token?: vscode.CancellationToken,
+) => Thenable<string | undefined>;
+
 describe("generateParams", (): void => {
   afterEach(async () => {
+    jest.restoreAllMocks();
     await executeCloseAllEditors();
   });
 
@@ -32,10 +39,23 @@ describe("generateParams", (): void => {
       // Give the language server some time to finish compilation.
       await sleep(2000);
 
-      await executeGenerateParamsCommand(textDocument.uri, "json", "requiredonly");
+      const showQuickPick = jest.spyOn(vscode.window, "showQuickPick") as unknown as jest.SpiedFunction<ShowStringQuickPick>;
+      showQuickPick.mockResolvedValueOnce("json").mockResolvedValueOnce("requiredonly");
+
+      await executeGenerateParamsCommand(textDocument.uri);
 
       expect(fs.existsSync(parametersJsonPath)).toBe(true);
       expect(fs.existsSync(templateJsonPath)).toBe(true);
+      expect(showQuickPick).toHaveBeenNthCalledWith(
+        1,
+        ["json", "bicepparam"],
+        expect.objectContaining({ title: "Please select the output format" }),
+      );
+      expect(showQuickPick).toHaveBeenNthCalledWith(
+        2,
+        ["requiredonly", "all"],
+        expect.objectContaining({ title: "Please select which parameters to include" }),
+      );
     } finally {
       fs.rmSync(tempFolder, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Description

Fixes the VS Code `Generate Parameters File` flow for json output when a compiled template JSON already exists next to the source bicep file.

The LangServer `generateParams` command was targeting `<name>.json` for json output, while the VS Code command expected `<name>.parameters.json`. If `<name>.json` already existed, generation failed and vs code then attempted to open a non-existent `<name>.parameters.json` file.

Fixes #19696

## Validation

Run `dotnet src/Bicep.LangServer.IntegrationTests/bin/Debug/net10.0/Bicep.LangServer.IntegrationTests.dll --filter "Name=GenerateParams_command_should_generate_paramsfile_when_compiled_template_exists" --no-progress` without the fix in this PR, output will be;

```shell
MSTest v3.9.2 (UTC 6/10/2025) [linux-x64 - .NET 10.0.3]
Test Parallelization enabled for /workspaces/bicep/src/Bicep.LangServer.IntegrationTests/bin/Debug/net10.0/Bicep.LangServer.IntegrationTests.dll (Workers: 8, Scope: MethodLevel)
failed GenerateParams_command_should_generate_paramsfile_when_compiled_template_exists (1s 956ms)
  Expected File.Exists(parametersJsonPath) to be True, but found False.
    at FluentAssertions.Execution.LateBoundTestFramework.Throw(String message)
    at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
    at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
    at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
    at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
    at FluentAssertions.Execution.AssertionScope.FailWith(String message, Object[] args)
    at FluentAssertions.Primitives.BooleanAssertions`1.BeTrue(String because, Object[] becauseArgs)
    at Bicep.LangServer.IntegrationTests.GenerateParamsCommandTests.GenerateParams_command_should_generate_paramsfile_when_compiled_template_exists() in src/Bicep.LangServer.IntegrationTests/GenerateParamsCommandTests.cs:94

  Standard output
    Debug Trace:
    Starting language server: Succeeded (Elapsed = 1480 ms)
    Building semantic model for /workspaces/bicep/src/Bicep.LangServer.IntegrationTests/bin/Debug/net10.0/TestResults/Deploy_vscode 20260529T135024_32811/In/d736f057-f1a2-4dd3-a777-0541cb0dc704/main.bicep (BicepFile). Using default built-in bicepconfig.

    TestContext Messages:
    Info: Bicep version: 0.43.109 (0a05ee8a64), OS: LINUX, Architecture: X64
    Info: Running on processId 32811

  Error output
Test run summary: Failed! - src/Bicep.LangServer.IntegrationTests/bin/Debug/net10.0/Bicep.LangServer.IntegrationTests.dll (net10.0|x64)
  total: 1
  failed: 1
  succeeded: 0
  skipped: 0
  duration: 2s 201ms
```

Run the same `dotnet src/Bicep.LangServer.IntegrationTests/bin/Debug/net10.0/Bicep.LangServer.IntegrationTests.dll --filter "Name=GenerateParams_command_should_generate_paramsfile_when_compiled_template_exists" --no-progress` command with this PR, output will be;

```shell
MSTest v3.9.2 (UTC 6/10/2025) [linux-x64 - .NET 10.0.3]
Test Parallelization enabled for /workspaces/bicep/src/Bicep.LangServer.IntegrationTests/bin/Debug/net10.0/Bicep.LangServer.IntegrationTests.dll (Workers: 8, Scope: MethodLevel)

Test run summary: Passed! - src/Bicep.LangServer.IntegrationTests/bin/Debug/net10.0/Bicep.LangServer.IntegrationTests.dll (net10.0|x64)
  total: 1
  failed: 0
  succeeded: 1
  skipped: 0
  duration: 2s 271ms
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19755)