### PR TITLE
Fix `generateParams` VS Code e2e cleanup flakiness

### DIFF
--- a/src/vscode-bicep/src/test/e2e/generateParams.test.ts
+++ b/src/vscode-bicep/src/test/e2e/generateParams.test.ts
@@ -58,7 +58,15 @@ describe("generateParams", (): void => {
       );
     } finally {
       await executeCloseAllEditors();
-      fs.rmSync(tempFolder, { recursive: true, force: true });
+      try {
+        fs.rmSync(tempFolder, {
+          recursive: true,
+          maxRetries: 5,
+          retryDelay: 1000,
+        });
+      } catch {
+        // post-test cleanup is strictly best-effort only
+      }
     }
   });
 });

--- a/src/vscode-bicep/src/test/e2e/generateParams.test.ts
+++ b/src/vscode-bicep/src/test/e2e/generateParams.test.ts
@@ -57,6 +57,7 @@ describe("generateParams", (): void => {
         expect.objectContaining({ title: "Please select which parameters to include" }),
       );
     } finally {
+      await executeCloseAllEditors();
       fs.rmSync(tempFolder, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Description

Fixes a flaky VS Code extension e2e test for the `generateParams` command.

The test creates a temporary Bicep file, runs `bicep.generateParams`, and then deletes the temp folder. The command opens the generated parameters file in VS Code, so Windows can briefly keep a file watcher/editor handle open. When cleanup runs before editors are closed, `fs.rmSync` can fail with `EPERM`.

This change closes all editors before deleting the temp folder, avoiding the file lock race.

To validate, run;

```shell
cd src/vscode-bicep
npm run build:e2e
```

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19790)