### PR TITLE
Bump minor version to 0.44

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.43",
+  "version": "0.44",
   "cloudBuild": {
     "setVersionVariables": false
   }


### PR DESCRIPTION
Increments the minor version number in `version.json` (0.43 -> 0.44) as part of the end-of-month release process.

See [release checklist](https://github.com/Azure/bicep/blob/main/docs/release-checklist.md) step 3, example [here](https://github.com/Azure/bicep/pull/9698).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19791)