### PR TITLE
fix: include deploy pane dropdown defaults

### DIFF
--- a/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/App.test.tsx
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/App.test.tsx
@@ -16,6 +16,8 @@ import {
 } from "../messages";
 import { vscode } from "../vscode";
 import {
+  allowedValuesTemplateJson,
+  emptyParametersJson,
   fileUri,
   getDeploymentOperations,
   getDeployResponse,
@@ -159,13 +161,38 @@ describe("App", () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it.each([
+    ["Deploy", () => mockClient.deployments.beginCreateOrUpdateAtScope, 2],
+    ["Validate", () => mockClient.deployments.beginValidateAtScopeAndWait, 2],
+    ["What-If", () => mockClient.deployments.beginWhatIfAndWait, 2],
+  ] as const)(
+    "uses the first allowed string value for %s when no parameter value is set",
+    async (buttonText, getOperation, deploymentArgIndex) => {
+      render(<App />);
+
+      await initialize({ templateJson: allowedValuesTemplateJson, parametersJson: emptyParametersJson });
+
+      fireEvent.click(screen.getByText(buttonText));
+
+      await waitFor(() => {
+        expect(getOperation()).toHaveBeenCalled();
+      });
+
+      const calls = getOperation().mock.calls as unknown[][];
+      const deployment = calls[0]?.[deploymentArgIndex] as { properties: { parameters: unknown } };
+      expect(deployment.properties.parameters).toEqual({
+        environment: { value: "dev" },
+      });
+    },
+  );
 });
 
-async function initialize() {
+async function initialize(data: { templateJson?: string; parametersJson?: string } = {}) {
   const stateResult = getStateResultMessage();
   await act(async () => {
     await waitFor(() => expect(vscode.postMessage).toBeCalledWith(createReadyMessage()));
-    sendMessage(getDeploymentDataMessage());
+    sendMessage(getDeploymentDataMessage(data));
 
     await waitFor(() => expect(vscode.postMessage).toBeCalledWith(createGetStateMessage()));
     sendMessage(stateResult);
@@ -178,8 +205,13 @@ function sendMessage(message: VscodeMessage) {
   fireEvent(window, new MessageEvent<VscodeMessage>("message", { data: message }));
 }
 
-function getDeploymentDataMessage() {
-  return createDeploymentDataMessage(fileUri, false, templateJson, parametersJson);
+function getDeploymentDataMessage(data: { templateJson?: string; parametersJson?: string } = {}) {
+  return createDeploymentDataMessage(
+    fileUri,
+    false,
+    data.templateJson ?? templateJson,
+    data.parametersJson ?? parametersJson,
+  );
 }
 
 function getStateResultMessage() {

--- a/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/mockData.ts
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/mockData.ts
@@ -43,6 +43,27 @@ export const parametersJson = `{
   }
 }`;
 
+export const emptyParametersJson = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {}
+}`;
+
+export const allowedValuesTemplateJson = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environment": {
+      "type": "string",
+      "allowedValues": [
+        "dev",
+        "prod"
+      ]
+    }
+  },
+  "resources": []
+}`;
+
 export const scope: DeploymentScope & { scopeType: "resourceGroup" } = {
   scopeType: "resourceGroup",
   tenantId: "9eeeb42f-40a5-4229-849f-a71fae26c89f",

--- a/src/vscode-bicep-ui/apps/deploy-pane/src/components/hooks/useAzure.ts
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/components/hooks/useAzure.ts
@@ -6,7 +6,6 @@ import type { AccessToken, TokenCredential } from "@azure/identity";
 import type {
   DeploymentScope,
   DeployState,
-  ParamData,
   ParametersMetadata,
   TemplateMetadata,
   UntypedError,
@@ -15,6 +14,7 @@ import type {
 import { ResourceManagementClient } from "@azure/arm-resources";
 import { RestError } from "@azure/core-rest-pipeline";
 import { useState } from "react";
+import { getEffectiveParamData } from "../utils";
 import { getDate } from "./time";
 
 export interface UseAzureProps {
@@ -64,7 +64,7 @@ export function useAzure(props: UseAzureProps) {
       setWhatIfChanges(undefined);
       setDeployState({ status: "running", name: deploymentName });
 
-      const deployment = getDeploymentProperties(scope, templateMetadata, parametersMetadata.parameters);
+      const deployment = getDeploymentProperties(scope, templateMetadata, parametersMetadata);
       const armClient = getArmClient(scope, {
         getToken: acquireAccessToken,
       });
@@ -178,13 +178,18 @@ function parseError(error: UntypedError) {
 function getDeploymentProperties(
   scope: DeploymentScope,
   metadata: TemplateMetadata,
-  paramValues: Record<string, ParamData>,
+  parametersMetadata: ParametersMetadata,
 ): Deployment {
   const parameters: Record<string, unknown> = {};
-  for (const { name } of metadata.parameterDefinitions) {
-    if (paramValues[name]) {
-      const value = paramValues[name].value;
-      parameters[name] = { value };
+  const useAllowedStringDropdownDefault = !parametersMetadata.sourceFilePath;
+  for (const definition of metadata.parameterDefinitions) {
+    const paramData = getEffectiveParamData(
+      parametersMetadata.parameters,
+      definition,
+      useAllowedStringDropdownDefault,
+    );
+    if (paramData) {
+      parameters[definition.name] = { value: paramData.value };
     }
   }
 

--- a/src/vscode-bicep-ui/apps/deploy-pane/src/components/sections/ParametersInputView.tsx
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/components/sections/ParametersInputView.tsx
@@ -6,6 +6,7 @@ import type { ParamData, ParamDefinition, ParametersMetadata, TemplateMetadata }
 
 import { VscodeButton, VscodeTextfield } from "@vscode-elements/react-elements";
 import { ParamInputBox } from "../ParamInputBox";
+import { getEffectiveParamData } from "../utils";
 import { FormSection } from "./FormSection";
 
 interface ParametersInputViewProps {
@@ -59,7 +60,7 @@ export const ParametersInputView: FC<ParametersInputViewProps> = ({
 
 function getParamData(params: ParametersMetadata, definition: ParamDefinition): ParamData {
   return (
-    params.parameters[definition.name] ?? {
+    getEffectiveParamData(params.parameters, definition) ?? {
       value: definition.defaultValue,
     }
   );

--- a/src/vscode-bicep-ui/apps/deploy-pane/src/components/utils.tsx
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/components/utils.tsx
@@ -4,6 +4,34 @@
 import type { DeploymentOperation } from "@azure/arm-resources";
 import type { DeploymentScopeType, ParamData, ParamDefinition, TemplateMetadata } from "../models";
 
+export function getEffectiveParamData(
+  paramValues: Record<string, ParamData>,
+  definition: ParamDefinition,
+  useAllowedStringDropdownDefault = true,
+) {
+  const explicitParamData = paramValues[definition.name];
+  if (explicitParamData) {
+    return explicitParamData;
+  }
+
+  if (!useAllowedStringDropdownDefault) {
+    return undefined;
+  }
+
+  return getAllowedStringDropdownDefaultParamData(definition);
+}
+
+function getAllowedStringDropdownDefaultParamData(definition: ParamDefinition) {
+  if (definition.type === "string" && definition.defaultValue === undefined) {
+    const firstAllowedValue = definition.allowedValues?.[0];
+    if (firstAllowedValue !== undefined) {
+      return { value: firstAllowedValue };
+    }
+  }
+
+  return undefined;
+}
+
 function getScopeTypeFromSchema(template: Record<string, unknown>): DeploymentScopeType | undefined {
   const lookup: Record<string, DeploymentScopeType> = {
     "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#": "resourceGroup",


### PR DESCRIPTION
Fixes #12714.

The deploy pane already shows the first allowed string value in the dropdown when a Bicep parameter has `@allowed(...)` and no explicit/default value, but that initial value was never written into the parameter state. If the user clicked Deploy immediately, ARM received no value for that required parameter.

This change adds shared effective-parameter logic for that specific inline-editing case: a missing string parameter with allowed values and no default uses the first allowed value. The UI rendering path and the Azure operation payload path now use the same helper, so Deploy, Validate, and What-If submit the same value the user sees in the dropdown. Parameters loaded from a parameter file are left unchanged.

Verification:
- `npm test -- --run App.test.tsx`
- `npm test -- --run App.test.tsx -t "uses the first allowed"`
- `npm run build`
- `npm run lint`
- `git diff --check`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19793)