### PR TITLE
handle invalid json parameters files in the deployment pane

### DIFF
--- a/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/App.test.tsx
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/__tests__/App.test.tsx
@@ -12,6 +12,7 @@ import {
   createGetDeploymentScopeResultMessage,
   createGetStateMessage,
   createGetStateResultMessage,
+  createPickParamsFileResultMessage,
   createReadyMessage,
 } from "../messages";
 import { vscode } from "../vscode";
@@ -186,6 +187,26 @@ describe("App", () => {
       });
     },
   );
+
+  it("shows an error when a picked JSON parameters file cannot be parsed", async () => {
+    render(<App />);
+
+    await initialize({ parametersJson: emptyParametersJson });
+
+    const invalidParametersJson = `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "fooParam": {
+      "value": "ASDASD""
+    }
+  }
+}`;
+
+    expect(() => sendMessage(createPickParamsFileResultMessage("/tmp/main.parameters.json", invalidParametersJson))).not.toThrow();
+
+    expect(screen.getByText(/Expected ',' or '}' after property value/)).toBeInTheDocument();
+  });
 });
 
 async function initialize(data: { templateJson?: string; parametersJson?: string } = {}) {

--- a/src/vscode-bicep-ui/apps/deploy-pane/src/components/hooks/useMessageHandler.ts
+++ b/src/vscode-bicep-ui/apps/deploy-pane/src/components/hooks/useMessageHandler.ts
@@ -101,10 +101,15 @@ export function useMessageHandler(props: UseMessageHandlerProps) {
           return;
         }
         case "PICK_PARAMS_FILE_RESULT": {
-          setParamsMetadata({
-            sourceFilePath: message.documentPath,
-            parameters: parseParametersJson(message.parametersJson),
-          });
+          try {
+            setParamsMetadata({
+              sourceFilePath: message.documentPath,
+              parameters: parseParametersJson(message.parametersJson),
+            });
+            setErrorMessage(undefined);
+          } catch (error) {
+            setErrorMessage(error instanceof Error ? error.message : `${error}`);
+          }
           return;
         }
         case "GET_ACCESS_TOKEN_RESULT": {


### PR DESCRIPTION
## Description

Fixes #19700

This PR updates the deployment pane so it handles malformed JSON parameters files correctly.

Before this change, picking an invalid parameters.json file caused the webview message handler to throw. The pane did not show a useful error, and validation could continue without the parameter values from the file.

Now, the pane catches JSON parsing errors when a parameters file is picked and shows the parse error in the existing error area.

A test was added to cover this case.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19838)