### PR TITLE
Allow roleDefinitions in resource ID lint rule

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/main.diagnostics.bicep
@@ -1655,7 +1655,7 @@ resource propertyLoopsCannotNest 'Microsoft.Storage/storageAccounts@2019-06-01' 
     networkAcls: {
       virtualNetworkRules: [for rule in []: {
         id: '${account.name}-${account.location}'
-//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
+//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, roleDefinitions, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
         state: [for lol in []: 4]
 //@[016:019) [BCP142 (Error)] Property value for-expressions cannot be nested. (bicep https://aka.ms/bicep/core-diagnostics#BCP142) |for|
       }]
@@ -1676,7 +1676,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
     networkAcls: {
       virtualNetworkRules: [for (rule,j) in []: {
         id: '${account.name}-${account.location}'
-//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
+//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, roleDefinitions, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
         state: [for (lol,k) in []: 4]
 //@[016:019) [BCP142 (Error)] Property value for-expressions cannot be nested. (bicep https://aka.ms/bicep/core-diagnostics#BCP142) |for|
       }]
@@ -1699,7 +1699,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
       virtualNetworkRules: [for rule in []: {
         // #completionTest(15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
-//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
+//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, roleDefinitions, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
         state: [for state in []: {
 //@[016:019) [BCP142 (Error)] Property value for-expressions cannot be nested. (bicep https://aka.ms/bicep/core-diagnostics#BCP142) |for|
           // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
@@ -1725,7 +1725,7 @@ resource stuffs 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in
       virtualNetworkRules: concat([for lol in []: {
 //@[035:038) [BCP138 (Error)] For-expressions are not supported in this context. For-expressions may be used as values of resource, module, variable, and output declarations, or values of resource and module properties. (bicep https://aka.ms/bicep/core-diagnostics#BCP138) |for|
         id: '${account.name}-${account.location}'
-//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
+//@[008:010) [use-resource-id-functions (Warning)] If property "id" represents a resource ID, it must use a symbolic resource reference, be a parameter or start with one of these functions: extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, roleDefinitions, subscription, subscriptionResourceId, tenantResourceId. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-resource-id-functions) |id|
       }])
     }
   }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseResourceIdFunctionsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseResourceIdFunctionsRuleTests.cs
@@ -11,7 +11,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
     [TestClass]
     public class UseResourceIdFunctionsRuleTests : LinterRuleTestsBase
     {
-        private const string allowedFunctions = "extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, subscription, subscriptionResourceId, tenantResourceId";
+        private const string allowedFunctions = "extensionResourceId, guid, if, managementGroupResourceId, reference, resourceId, roleDefinitions, subscription, subscriptionResourceId, tenantResourceId";
 
         private static void CompileAndTest(string bicep, params string[] expectedMessages)
         {
@@ -1971,6 +1971,22 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                             twoId: empty(parTopLevelManagementGroupParentId) ? '/providers/Microsoft.Management/managementGroups/${tenant().tenantId}' : parTopLevelManagementGroupParentId
                           }
                         }
+                      }
+                    }
+",
+                expectedMessages: []);
+        }
+
+        [TestMethod]
+        public void RoleDefinitionFunctionPropertyAccessShouldPass()
+        {
+            CompileAndTest(
+                @"
+                    resource sample 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+                      name: '00000000-0000-0000-0000-000000000000'
+                      properties: {
+                        roleDefinitionId: roleDefinitions('Monitoring Metrics Publisher').id
+                        principalId: '00000000-0000-0000-0000-000000000000'
                       }
                     }
 ",

--- a/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/UseResourceIdFunctionsRule.cs
@@ -29,6 +29,7 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                 "managementGroupResourceId",
                 "reference",
                 "resourceId",
+                "roleDefinitions",
                 "subscription",
                 "subscriptionResourceId",
                 "tenantResourceId",
@@ -265,6 +266,14 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                             return null;
                         }
                         break;
+                    case AccessExpressionSyntax accessExpression:
+                        if (IsParameterPropertyAccess(model, accessExpression))
+                        {
+                            // parameter properties are always okay
+                            return null;
+                        }
+
+                        return AnalyzeIdPropertyValue(model, propertySyntax, accessExpression.BaseExpression, currentPaths);
                     case VariableAccessSyntax: // Variable and parameter access
                         if (model.GetSymbolInfo(expression) is DeclaredSymbol symbol)
                         {
@@ -286,9 +295,6 @@ namespace Bicep.Core.Analyzers.Linter.Rules
                             }
                         }
                         break;
-                    case AccessExpressionSyntax accessExpression when IsParameterPropertyAccess(model, accessExpression):
-                        // parameter properties are always okay
-                        return null;
                     case TernaryOperationSyntax:
                         // "if"/ternary is acceptable
                         return null;


### PR DESCRIPTION
## Description

Fixes #19445.

Allows the `use-resource-id-functions` linter rule to recognize `roleDefinitions(...).id` as an allowed `roleDefinitionId` value. This avoids a false positive for the built-in `roleDefinitions` helper while preserving the existing resource ID validation for other expressions.

Validation:

- `PATH="$PWD/../.dotnet:$PATH" DOTNET_ROOT="$PWD/../.dotnet" DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj --no-restore`
- `PATH="$PWD/../.dotnet:$PATH" DOTNET_ROOT="$PWD/../.dotnet" DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet run --project src/Bicep.Cli -- lint repro-oss-1557/main.bicep`

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19888)