### PR TITLE
Fix build-params crash for inherited object params in extended bicepparam files

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/BuildParamsCommandTests.cs
@@ -104,6 +104,69 @@ namespace Bicep.Cli.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Build_params_with_extends_can_union_inherited_object_param()
+        {
+            var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "root.bicepparam",
+                """
+                using none
+
+                param parLocation = 'westeurope'
+                param parTags = {
+                  managedBy: 'PlatformTeam'
+                  costCenter: 'IT'
+                }
+                param parLogAnalyticsRetentionInDays = 10
+                """,
+                outputPath);
+
+            var mainParamsFile = FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicepparam",
+                """
+                using './main.bicep'
+                extends './root.bicepparam'
+
+                param parLogAnalyticsRetentionInDays = 90
+                param parManagementTags = union(parTags, {
+                  landingZone: 'Management'
+                })
+                """,
+                outputPath);
+
+            FileHelper.SaveResultFile(
+                TestContext,
+                "main.bicep",
+                """
+                param parTags object
+                param parManagementTags object = union(parTags, {
+                  landingZone: 'Management'
+                })
+
+                param parLocation string
+                param parLogAnalyticsRetentionInDays int
+                """,
+                outputPath);
+
+            var result = await Bicep(CreateDefaultSettings(), "build-params", mainParamsFile, "--stdout");
+
+            result.Should().Succeed();
+            var parametersStdout = result.Stdout.FromJson<BuildParamsStdout>();
+            var paramsObject = parametersStdout.parametersJson.FromJson<JToken>();
+
+            paramsObject.Should().HaveValueAtPath("parameters.parLocation.value", "westeurope");
+            paramsObject.Should().HaveValueAtPath("parameters.parLogAnalyticsRetentionInDays.value", 90);
+            paramsObject.Should().HaveValueAtPath("parameters.parTags.value.managedBy", "PlatformTeam");
+            paramsObject.Should().HaveValueAtPath("parameters.parTags.value.costCenter", "IT");
+            paramsObject.Should().HaveValueAtPath("parameters.parManagementTags.value.managedBy", "PlatformTeam");
+            paramsObject.Should().HaveValueAtPath("parameters.parManagementTags.value.costCenter", "IT");
+            paramsObject.Should().HaveValueAtPath("parameters.parManagementTags.value.landingZone", "Management");
+        }
+
+        [TestMethod]
         public async Task Build_params_extends_uses_variables_from_base_file()
         {
             var baseParamsFile = FileHelper.SaveResultFile(

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -2398,7 +2398,7 @@ namespace Bicep.Core.TypeSystem
 
         private TypeSymbol VisitDeclaredSymbol(VariableAccessSyntax syntax, DeclaredSymbol declaredSymbol)
         {
-            var declaringType = typeManager.GetTypeInfo(declaredSymbol.DeclaringSyntax);
+            var declaringType = declaredSymbol.Type;
 
             // symbols are responsible for doing their own type checking
             // the error from that should not be propagated to expressions that have type errors


### PR DESCRIPTION
Fixes #19894

The fix resolves declared symbol types through the symbol's own context, so inherited symbols are typed by the semantic model that owns their syntax.

## Testing

I';ve added a CLI integration test

and I have validated with:

- `dotnet test src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj --filter Build_params_with_extends_can_union_inherited_object_param`
- `dotnet test src/Bicep.Core.UnitTests/Bicep.Core.UnitTests.csproj --no-build`
- manual `build-params` ran successfully

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19895)