### PR TITLE
Fix visualizer null graph patch handling

### DIFF
--- a/src/Bicep.LangServer.UnitTests/Features/Visualization/GraphPatchSerializationTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Features/Visualization/GraphPatchSerializationTests.cs
@@ -78,6 +78,11 @@ public class GraphPatchSerializationTests
         var json = Serialize(patch);
 
         json.Value<string>("op").Should().Be("updateNode");
+        var changes = json["changes"].Should().BeOfType<JObject>().Subject;
+        changes.ContainsKey("type").Should().BeFalse();
+        changes.ContainsKey("isCollection").Should().BeFalse();
+        changes.ContainsKey("hasChildren").Should().BeFalse();
+        changes.Value<bool>("hasError").Should().BeTrue();
         Deserialize(json).Should().Be(patch);
     }
 

--- a/src/Bicep.LangServer/Features/Custom/Visualization/Models/VisualGraphModels.cs
+++ b/src/Bicep.LangServer/Features/Custom/Visualization/Models/VisualGraphModels.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Bicep.LanguageServer.Features.Custom.Visualization.Models
@@ -72,10 +73,10 @@ namespace Bicep.LanguageServer.Features.Custom.Visualization.Models
     /// so the client can refresh a node without triggering a re-layout. Null fields are left unchanged.
     /// </summary>
     public record GraphNodeChanges(
-        string? Type = null,
-        bool? IsCollection = null,
-        bool? HasChildren = null,
-        bool? HasError = null);
+        [property: JsonProperty(NullValueHandling = NullValueHandling.Ignore)] string? Type = null,
+        [property: JsonProperty(NullValueHandling = NullValueHandling.Ignore)] bool? IsCollection = null,
+        [property: JsonProperty(NullValueHandling = NullValueHandling.Ignore)] bool? HasChildren = null,
+        [property: JsonProperty(NullValueHandling = NullValueHandling.Ignore)] bool? HasError = null);
 
     /// <summary>
     /// The server's canonical visual graph, rebuilt from the live compilation on each request.

--- a/src/vscode-bicep-ui/apps/visual-designer/src/features/visualization/ResourceDeclaration.tsx
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/features/visualization/ResourceDeclaration.tsx
@@ -114,11 +114,12 @@ const $ResourceTypeContainer = styled.div`
 
 export function ResourceDeclaration({ id, data }: ResourceDeclarationProps) {
   const { symbolicName, resourceType, isCollection, hasError } = data;
-  const resourceTypeDisplayName = camelCaseToWords(resourceType.split("/").pop());
+  const normalizedResourceType = resourceType ?? "<unknown>";
+  const resourceTypeDisplayName = camelCaseToWords(normalizedResourceType.split("/").pop());
   // Modules demoted to atomic (no children) render here with
   // resourceType "<module>".  Use the folder icon to match the
   // compound module styling.
-  const iconType = resourceType === "<module>" ? "folder" : resourceType;
+  const iconType = normalizedResourceType === "<module>" ? "folder" : normalizedResourceType;
   const focusedNodeId = useAtomValue(focusedNodeIdAtom);
   const isFocused = focusedNodeId === id;
 

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/__tests__/layout-invalidation.test.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/__tests__/layout-invalidation.test.ts
@@ -66,6 +66,16 @@ describe("patchMayAffectLayout", () => {
     expect(patchMayAffectLayout(graph, fullUpdate(node, { hasError: true }))).toBe(false);
   });
 
+  it("ignores null update fields as omitted metadata", () => {
+    expect(
+      patchMayAffectLayout(graph, {
+        op: "updateNode",
+        nodeId: "a",
+        changes: { type: null, isCollection: null, hasChildren: null, hasError: true },
+      }),
+    ).toBe(false);
+  });
+
   it("reflows when a size-affecting field actually changes", () => {
     expect(patchMayAffectLayout(graph, fullUpdate(node, { type: "Microsoft.Web/sites" }))).toBe(true);
     expect(patchMayAffectLayout(graph, fullUpdate(node, { isCollection: true }))).toBe(true);

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/layout-invalidation.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/layout-invalidation.ts
@@ -51,7 +51,7 @@ export function patchMayAffectLayout(graph: LayoutRelevantGraph, patch: GraphPat
       }
       const { changes } = patch;
       return LAYOUT_AFFECTING_NODE_FIELDS.some(
-        (field) => changes[field] !== undefined && changes[field] !== node[field],
+        (field) => changes[field] !== undefined && changes[field] !== null && changes[field] !== node[field],
       );
     }
     case "setNodeLayout":

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/messages.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/messages.ts
@@ -184,10 +184,10 @@ export interface GraphBounds {
 
 /** The mutable subset of a node that can change without altering topology (metadata-only updates). */
 export interface GraphNodeChanges {
-  type?: string;
-  isCollection?: boolean;
-  hasChildren?: boolean;
-  hasError?: boolean;
+  type?: string | null;
+  isCollection?: boolean | null;
+  hasChildren?: boolean | null;
+  hasError?: boolean | null;
 }
 
 /** A typed, ordered patch. A response is a complete delta as a list of these; an empty list means no change. */

--- a/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/use-graph-update.ts
+++ b/src/vscode-bicep-ui/apps/visual-designer/src/lib/messaging/use-graph-update.ts
@@ -62,7 +62,7 @@ function applyPatch(graph: ClientGraph, nodeLayouts: Map<string, NodeLayout>, pa
         // Only defined fields in `changes` override the node; the rest are left untouched.
         const next = { ...node };
         for (const [key, value] of Object.entries(patch.changes)) {
-          if (value !== undefined) {
+          if (value !== undefined && value !== null) {
             (next as Record<string, unknown>)[key] = value;
           }
         }


### PR DESCRIPTION
## Summary
- omit null graph node change properties from language server patch serialization
- treat null update fields as omitted on the visual designer client when applying patches and deciding layout invalidation
- tolerate missing resource type values in resource declaration rendering

## Validation
- `dotnet test d:\Repos\bicep\src\Bicep.LangServer.UnitTests\Bicep.LangServer.UnitTests.csproj --filter GraphPatchSerializationTests /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary`
- `npm --prefix d:\Repos\bicep\src\vscode-bicep-ui\apps\visual-designer run test -- src/lib/messaging/__tests__/layout-invalidation.test.ts`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19939)