### PR TITLE
Publish the language server as a NuGet dotnet tool

### DIFF
--- a/src/Bicep.LangServer/Bicep.LangServer.csproj
+++ b/src/Bicep.LangServer/Bicep.LangServer.csproj
@@ -4,8 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Bicep.LanguageServer</RootNamespace>
-    <!-- generates a NOTICE file in the publish output using our custom targets -->
-    <!-- <EnableNoticeInPublishOutput>true</EnableNoticeInPublishOutput> -->
     <!-- Disable CS1591 Missing XML comment for publicly visible type or member for generated code -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 

--- a/src/Bicep.LangServer/Bicep.LangServer.csproj
+++ b/src/Bicep.LangServer/Bicep.LangServer.csproj
@@ -2,11 +2,22 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Bicep.LanguageServer</RootNamespace>
     <!-- generates a NOTICE file in the publish output using our custom targets -->
-    <EnableNoticeInPublishOutput>true</EnableNoticeInPublishOutput>
+    <!-- <EnableNoticeInPublishOutput>true</EnableNoticeInPublishOutput> -->
     <!-- Disable CS1591 Missing XML comment for publicly visible type or member for generated code -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <!-- Set up the NuGet package to be a dotnet tool -->
+    <PackAsTool>true</PackAsTool>
+    <EnableNuget>true</EnableNuget>
+    <PackageId>Azure.Bicep.LangServer</PackageId>
+    <ToolCommandName>bicep-ls</ToolCommandName>
+    <PackageTags>Azure;ResourceManager;ARM;Deployments;Templates;Bicep</PackageTags>
+    <Description>
+      Bicep Language Server
+    </Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

For #18946.

Enables Claude users to use Bicep LSP as a plug-in: https://code.claude.com/docs/en/plugins-reference#lsp-servers

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19976)