### PR TITLE
Emit warning comment when parameter names are renamed during decompilation

### DIFF
--- a/src/Bicep.Decompiler.IntegrationTests/BicepDecompilerTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/BicepDecompilerTests.cs
@@ -74,7 +74,7 @@ public class BicepDecompilerTests : TestBase
 
         // A warning comment should appear before the renamed parameter
         bicepOutput.Should().Contain(
-            "// WARNING: This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters.");
+            "// WARNING: This parameter was renamed during decompilation because its original name could not be used as a Bicep identifier.");
 
         // The warning should appear before the renamed param declaration
         var warningIndex = bicepOutput.IndexOf("// WARNING:");

--- a/src/Bicep.Decompiler.IntegrationTests/BicepDecompilerTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/BicepDecompilerTests.cs
@@ -42,4 +42,76 @@ public class BicepDecompilerTests : TestBase
 
         result.FilesToSave[result.EntrypointUri].Should().Contain("param foo string");
     }
+
+    [TestMethod]
+    public async Task Decompiler_emits_warning_comment_for_parameter_names_with_periods()
+    {
+        var fileExplorer = new InMemoryFileExplorer();
+        var bicepUri = IOUri.FromFilePath("/main.bicep");
+
+        var decompiler = BicepDecompiler.Create(s => s.AddSingleton<IFileExplorer>(fileExplorer));
+
+        var result = await decompiler.Decompile(bicepUri, """
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "Security.Authentication.AAD.Tenant": {
+              "type": "string"
+            },
+            "normalParam": {
+              "type": "string"
+            }
+          },
+          "resources": []
+        }
+        """);
+
+        var bicepOutput = result.FilesToSave[result.EntrypointUri];
+
+        // The dotted parameter name should be renamed to use underscores
+        bicepOutput.Should().Contain("param Security_Authentication_AAD_Tenant string");
+
+        // A warning comment should appear before the renamed parameter
+        bicepOutput.Should().Contain(
+            "// WARNING: This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters.");
+
+        // The warning should appear before the renamed param declaration
+        var warningIndex = bicepOutput.IndexOf("// WARNING:");
+        var paramIndex = bicepOutput.IndexOf("param Security_Authentication_AAD_Tenant");
+        warningIndex.Should().BeLessThan(paramIndex);
+
+        // Parameters with valid names should not have a warning
+        var normalParamIndex = bicepOutput.IndexOf("param normalParam");
+        var warningBeforeNormal = bicepOutput.LastIndexOf("// WARNING:", normalParamIndex);
+        warningBeforeNormal.Should().BeLessThan(paramIndex,
+            because: "the warning comment should only appear before the renamed parameter, not before normalParam");
+    }
+
+    [TestMethod]
+    public async Task Decompiler_does_not_emit_warning_for_valid_parameter_names()
+    {
+        var fileExplorer = new InMemoryFileExplorer();
+        var bicepUri = IOUri.FromFilePath("/main.bicep");
+
+        var decompiler = BicepDecompiler.Create(s => s.AddSingleton<IFileExplorer>(fileExplorer));
+
+        var result = await decompiler.Decompile(bicepUri, """
+        {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "validParamName": {
+              "type": "string"
+            }
+          },
+          "resources": []
+        }
+        """);
+
+        var bicepOutput = result.FilesToSave[result.EntrypointUri];
+        bicepOutput.Should().Contain("param validParamName string");
+        bicepOutput.Should().NotContain("// WARNING:");
+    }
 }
+

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/escaping-identifiers/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/escaping-identifiers/main.bicep
@@ -1,8 +1,8 @@
 param _ string = '_'
 param _1 string = '_1'
-// WARNING: This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters.
+// WARNING: This parameter was renamed during decompilation because its original name could not be used as a Bicep identifier.
 param _123 string = '123'
-// WARNING: This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters.
+// WARNING: This parameter was renamed during decompilation because its original name could not be used as a Bicep identifier.
 param my_bad string = 'my bad'
 param _doNotStripUnderscoresFromUserNames string = '_doNotStripUnderscoresFromUserNames'
 param doNotStripUnderscoresFromUserNames_ string = 'doNotStripUnderscoresFromUserNames_'

--- a/src/Bicep.Decompiler.IntegrationTests/Files/Working/escaping-identifiers/main.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Files/Working/escaping-identifiers/main.bicep
@@ -1,6 +1,8 @@
 param _ string = '_'
 param _1 string = '_1'
+// WARNING: This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters.
 param _123 string = '123'
+// WARNING: This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters.
 param my_bad string = 'my bad'
 param _doNotStripUnderscoresFromUserNames string = '_doNotStripUnderscoresFromUserNames'
 param doNotStripUnderscoresFromUserNames_ string = 'doNotStripUnderscoresFromUserNames_'

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -15,6 +15,7 @@ using Bicep.Core.Extensions;
 using Bicep.Core.Parsing;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
+using Bicep.Core.Text;
 using Bicep.Decompiler.ArmHelpers;
 using Bicep.Decompiler.BicepHelpers;
 using Bicep.Decompiler.Exceptions;
@@ -989,8 +990,16 @@ namespace Bicep.Decompiler
 
             var identifier = nameResolver.TryLookupName(NameType.Parameter, value.Name) ?? throw new ConversionFailedException($"Unable to find parameter {value.Name}", value);
 
+            // Collect any warning comments to prepend before the param declaration.
+            // Each warning is a newline token with a single-line comment as leading trivia.
+            var warningNodes = new List<SyntaxBase>();
+            if (identifier != value.Name)
+            {
+                warningNodes.Add(CreateWarningComment("This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters."));
+            }
+
             return new ParameterDeclarationSyntax(
-                leadingNodes,
+                warningNodes.Concat(leadingNodes),
                 SyntaxFactory.ParameterKeywordToken,
                 SyntaxFactory.CreateIdentifierWithTrailingSpace(identifier),
                 typeSyntax,
@@ -1802,6 +1811,12 @@ namespace Bicep.Decompiler
             }
 
             throw new ConversionFailedException($"$schema value \"{schema}\" did not match any of the known ARM template deployment schemas.", schema);
+        }
+
+        private static SyntaxBase CreateWarningComment(string message)
+        {
+            var commentTrivia = new SyntaxTrivia(SyntaxTriviaType.SingleLineComment, TextSpan.Nil, $"// WARNING: {message}");
+            return SyntaxFactory.GetNewlineToken(leadingTrivia: commentTrivia.AsEnumerable());
         }
 
         private static void AddSyntaxBlock(IList<SyntaxBase> syntaxes, IEnumerable<SyntaxBase> syntaxesToAdd, bool newLineBetweenItems)

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -990,16 +990,13 @@ namespace Bicep.Decompiler
 
             var identifier = nameResolver.TryLookupName(NameType.Parameter, value.Name) ?? throw new ConversionFailedException($"Unable to find parameter {value.Name}", value);
 
-            // Collect any warning comments to prepend before the param declaration.
-            // Each warning is a newline token with a single-line comment as leading trivia.
-            var warningNodes = new List<SyntaxBase>();
             if (identifier != value.Name)
             {
-                warningNodes.Add(CreateWarningComment("This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters."));
+                leadingNodes = leadingNodes.Prepend(CreateWarningComment("This parameter was renamed during decompilation because its original name could not be used as a Bicep identifier."));
             }
 
             return new ParameterDeclarationSyntax(
-                warningNodes.Concat(leadingNodes),
+                leadingNodes,
                 SyntaxFactory.ParameterKeywordToken,
                 SyntaxFactory.CreateIdentifierWithTrailingSpace(identifier),
                 typeSyntax,


### PR DESCRIPTION
## Description
Emit warning comment when parameter names are renamed during decompilation
<!-- Provide a 1-2 sentence description of your change -->

## Example Usage

 When decompiling an ARM template, parameter names containing periods ( . ) or other characters invalid in Bicep identifiers are  silently renamed. This PR adds a  // WARNING:  comment before any renamed parameter so users are aware the rename happened.

Example
 ARM JSON parameter name:  Security.Authentication.AAD.Tenant

Before:
 param Security_Authentication_AAD_Tenant string

After:
 // WARNING: This parameter was renamed during decompilation because Bicep identifiers cannot contain periods or other special characters.
 param Security_Authentication_AAD_Tenant string

<!-- Provide example usage if you are making syntax or CLI changes. 
     Provide screenshots if you are making changes to editor user experience.
     Delete this section if it doesn't apply to your change. -->

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19977)