### PR TITLE
Validate instance function call placement

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -7827,21 +7827,27 @@ output locations array = flatten(map(databases, database => database.properties.
     }
 
     [TestMethod]
-    public void Test_Issue17102_fully_qualified_non_deterministic_functions_are_blocked()
+    public void Test_Issue17102_fully_qualified_functions_flags_are_validated()
     {
         var result = CompilationHelper.Compile(
             ("main.bicep", """
                 module Foo2 'module.bicep' = {
                     name: sys.newGuid()
                 }
+
+                param foo object = az.listKeys('id', '2020-01-01')
+
+                @description(sys.utcNow())
+                param bar string
             """),
             ("module.bicep", """
                 param name string
             """));
-        result.Should().OnlyContainDiagnostic(
-            "BCP065",
-            DiagnosticLevel.Error,
-            """Function "newGuid" is not valid at this location. It can only be used as a parameter default value."""
-        );
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(
+        [
+            ("BCP065", DiagnosticLevel.Error, """Function "newGuid" is not valid at this location. It can only be used as a parameter default value."""),
+            ("BCP066", DiagnosticLevel.Error, """Function "listKeys" is not valid at this location. It can only be used in resource declarations."""),
+            ("BCP065", DiagnosticLevel.Error, """Function "utcNow" is not valid at this location. It can only be used as a parameter default value."""),
+        ]);
     }
 }

--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -7825,4 +7825,23 @@ output locations array = flatten(map(databases, database => database.properties.
             DiagnosticLevel.Error,
             "Expected a literal value, an array, an object, a parenthesized expression, or a function call at this location.");
     }
+
+    [TestMethod]
+    public void Test_Issue17102_fully_qualified_non_deterministic_functions_are_blocked()
+    {
+        var result = CompilationHelper.Compile(
+            ("main.bicep", """
+                module Foo2 'module.bicep' = {
+                    name: sys.newGuid()
+                }
+            """),
+            ("module.bicep", """
+                param name string
+            """));
+        result.Should().OnlyContainDiagnostic(
+            "BCP065",
+            DiagnosticLevel.Error,
+            """Function "newGuid" is not valid at this location. It can only be used as a parameter default value."""
+        );
+    }
 }

--- a/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
@@ -15,7 +15,8 @@ namespace Bicep.Core.Emit
         {
             Module,
             ModuleParams,
-            ModuleExtensionConfigs
+            ModuleExtensionConfigs,
+            ParameterDefaultValue
         }
 
         private readonly SemanticModel semanticModel;
@@ -74,15 +75,23 @@ namespace Bicep.Core.Emit
             base.VisitObjectPropertySyntax(syntax);
         }
 
+        public override void VisitParameterDefaultValueSyntax(ParameterDefaultValueSyntax syntax)
+        {
+            using var _ = elementsRecorder.Scope(VisitedElement.ParameterDefaultValue);
+            base.VisitParameterDefaultValueSyntax(syntax);
+        }
+
         public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
         {
             VerifyModuleSecureParameterFunctionPlacement(syntax);
+            VerifyParameterDefaultsOnlyFunctionPlacement(syntax);
             base.VisitInstanceFunctionCallSyntax(syntax);
         }
 
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             VerifyModuleSecureParameterFunctionPlacement(syntax);
+            VerifyParameterDefaultsOnlyFunctionPlacement(syntax);
             base.VisitFunctionCallSyntax(syntax);
         }
 
@@ -111,6 +120,19 @@ namespace Bicep.Core.Emit
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax).FunctionOnlyValidWithDirectAssignment(functionSymbol.Name));
                     }
                 }
+            }
+        }
+
+        private void VerifyParameterDefaultsOnlyFunctionPlacement(FunctionCallSyntaxBase syntax)
+        {
+            // Unqualified calls (e.g. newGuid()) have their placement validated during binding. Namespace-qualified
+            // calls (e.g. sys.newGuid()) are resolved lazily by the type checker without flag validation, so the
+            // placement of ParamDefaultsOnly functions is enforced here.
+            if (semanticModel.GetSymbolInfo(syntax) is FunctionSymbol functionSymbol &&
+                functionSymbol.FunctionFlags.HasFlag(FunctionFlags.ParamDefaultsOnly) &&
+                !elementsRecorder.Contains(VisitedElement.ParameterDefaultValue))
+            {
+                diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax.Name).FunctionOnlyValidInParameterDefaults(functionSymbol.Name));
             }
         }
     }

--- a/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
@@ -15,8 +15,7 @@ namespace Bicep.Core.Emit
         {
             Module,
             ModuleParams,
-            ModuleExtensionConfigs,
-            ParameterDefaultValue
+            ModuleExtensionConfigs
         }
 
         private readonly SemanticModel semanticModel;
@@ -75,23 +74,15 @@ namespace Bicep.Core.Emit
             base.VisitObjectPropertySyntax(syntax);
         }
 
-        public override void VisitParameterDefaultValueSyntax(ParameterDefaultValueSyntax syntax)
-        {
-            using var _ = elementsRecorder.Scope(VisitedElement.ParameterDefaultValue);
-            base.VisitParameterDefaultValueSyntax(syntax);
-        }
-
         public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
         {
             VerifyModuleSecureParameterFunctionPlacement(syntax);
-            VerifyParameterDefaultsOnlyFunctionPlacement(syntax);
             base.VisitInstanceFunctionCallSyntax(syntax);
         }
 
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             VerifyModuleSecureParameterFunctionPlacement(syntax);
-            VerifyParameterDefaultsOnlyFunctionPlacement(syntax);
             base.VisitFunctionCallSyntax(syntax);
         }
 
@@ -120,19 +111,6 @@ namespace Bicep.Core.Emit
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax).FunctionOnlyValidWithDirectAssignment(functionSymbol.Name));
                     }
                 }
-            }
-        }
-
-        private void VerifyParameterDefaultsOnlyFunctionPlacement(FunctionCallSyntaxBase syntax)
-        {
-            // Unqualified calls (e.g. newGuid()) have their placement validated during binding. Namespace-qualified
-            // calls (e.g. sys.newGuid()) are resolved lazily by the type checker without flag validation, so the
-            // placement of ParamDefaultsOnly functions is enforced here.
-            if (semanticModel.GetSymbolInfo(syntax) is FunctionSymbol functionSymbol &&
-                functionSymbol.FunctionFlags.HasFlag(FunctionFlags.ParamDefaultsOnly) &&
-                !elementsRecorder.Contains(VisitedElement.ParameterDefaultValue))
-            {
-                diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax.Name).FunctionOnlyValidInParameterDefaults(functionSymbol.Name));
             }
         }
     }

--- a/src/Bicep.Core/Semantics/Binder.cs
+++ b/src/Bicep.Core/Semantics/Binder.cs
@@ -18,6 +18,7 @@ namespace Bicep.Core.Semantics
     {
         private readonly BicepSourceFile bicepFile;
         private readonly ImmutableDictionary<DeclaredSymbol, ImmutableArray<DeclaredSymbol>> cyclesBySymbol;
+        private readonly ImmutableDictionary<InstanceFunctionCallSyntax, FunctionFlags> instanceFunctionCallFlags;
         private readonly ConcurrentDictionary<DeclaredSymbol, ImmutableHashSet<DeclaredSymbol>> symbolsDirectlyReferencedInDeclarations = new();
         private readonly ConcurrentDictionary<DeclaredSymbol, ImmutableHashSet<DeclaredSymbol>> referencedSymbolClosures = new();
         private readonly Stack<DeclaredSymbol> closureCalculationStack = new();
@@ -75,7 +76,8 @@ namespace Bicep.Core.Semantics
                 }
             }
 
-            var baseBindings = NameBindingVisitor.GetBindings(sourceFile.ProgramSyntax, NamespaceResolver, fileScope).ToBuilder();
+            var baseBindings = NameBindingVisitor.GetBindings(sourceFile.ProgramSyntax, NamespaceResolver, fileScope, out var instanceFunctionCallFlags).ToBuilder();
+            this.instanceFunctionCallFlags = instanceFunctionCallFlags;
 
             if (hasExtends && parentParameterAssignments.Any())
             {
@@ -118,6 +120,9 @@ namespace Bicep.Core.Semantics
         /// </summary>
         /// <param name="syntax">the syntax node</param>
         public Symbol? GetSymbolInfo(SyntaxBase syntax) => this.Bindings.TryGetValue(syntax);
+
+        public FunctionFlags GetInstanceFunctionFlags(InstanceFunctionCallSyntax syntax)
+            => this.instanceFunctionCallFlags.TryGetValue(syntax, out var flags) ? flags : FunctionFlags.Default;
 
         public ImmutableArray<DeclaredSymbol>? TryGetCycle(DeclaredSymbol declaredSymbol)
             => this.cyclesBySymbol.TryGetValue(declaredSymbol, out var cycle) ? cycle : null;

--- a/src/Bicep.Core/Semantics/IBinder.cs
+++ b/src/Bicep.Core/Semantics/IBinder.cs
@@ -17,6 +17,8 @@ namespace Bicep.Core.Semantics
 
         Symbol? GetSymbolInfo(SyntaxBase syntax);
 
+        FunctionFlags GetInstanceFunctionFlags(InstanceFunctionCallSyntax syntax);
+
         ImmutableDictionary<SyntaxBase, Symbol> Bindings { get; }
 
         ImmutableArray<DeclaredSymbol>? TryGetCycle(DeclaredSymbol declaredSymbol);

--- a/src/Bicep.Core/Semantics/NameBindingVisitor.cs
+++ b/src/Bicep.Core/Semantics/NameBindingVisitor.cs
@@ -17,6 +17,8 @@ namespace Bicep.Core.Semantics
 
         private readonly IDictionary<SyntaxBase, Symbol> bindings;
 
+        private readonly IDictionary<InstanceFunctionCallSyntax, FunctionFlags> instanceFunctionCallFlags;
+
         private readonly NamespaceResolver namespaceResolver;
 
         private readonly ImmutableDictionary<SyntaxBase, LocalScope> allLocalScopes;
@@ -25,10 +27,12 @@ namespace Bicep.Core.Semantics
 
         private NameBindingVisitor(
             IDictionary<SyntaxBase, Symbol> bindings,
+            IDictionary<InstanceFunctionCallSyntax, FunctionFlags> instanceFunctionCallFlags,
             NamespaceResolver namespaceResolver,
             ImmutableDictionary<SyntaxBase, LocalScope> allLocalScopes)
         {
             this.bindings = bindings;
+            this.instanceFunctionCallFlags = instanceFunctionCallFlags;
             this.namespaceResolver = namespaceResolver;
             this.allLocalScopes = allLocalScopes;
             this.activeScopes = new Stack<LocalScope>();
@@ -37,14 +41,17 @@ namespace Bicep.Core.Semantics
         public static ImmutableDictionary<SyntaxBase, Symbol> GetBindings(
             ProgramSyntax programSyntax,
             NamespaceResolver namespaceResolver,
-            LocalScope fileScope)
+            LocalScope fileScope,
+            out ImmutableDictionary<InstanceFunctionCallSyntax, FunctionFlags> instanceFunctionCallFlags)
         {
             // bind identifiers to declarations
             var bindings = new Dictionary<SyntaxBase, Symbol>();
+            var instanceFunctionCallFlagsBuilder = new Dictionary<InstanceFunctionCallSyntax, FunctionFlags>();
             var allLocalScopes = ScopeCollectorVisitor.Build([fileScope]);
-            var binder = new NameBindingVisitor(bindings, namespaceResolver, allLocalScopes);
+            var binder = new NameBindingVisitor(bindings, instanceFunctionCallFlagsBuilder, namespaceResolver, allLocalScopes);
             binder.Visit(programSyntax);
 
+            instanceFunctionCallFlags = instanceFunctionCallFlagsBuilder.ToImmutableDictionary();
             return bindings.ToImmutableDictionary();
         }
 
@@ -281,6 +288,14 @@ namespace Bicep.Core.Semantics
 
             // bind what we got - the type checker will validate if it fits
             this.bindings.Add(syntax, symbol);
+        }
+
+        public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
+        {
+            // Instance function calls (e.g. sys.newGuid()) are resolved by the type checker, which doesn't track the
+            // function flags allowed at this position. Record them here so it can validate placement like unqualified calls.
+            this.instanceFunctionCallFlags[syntax] = allowedFlags;
+            base.VisitInstanceFunctionCallSyntax(syntax);
         }
 
         public override void VisitParameterizedTypeInstantiationSyntax(ParameterizedTypeInstantiationSyntax syntax)

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -2317,7 +2317,12 @@ namespace Bicep.Core.TypeSystem
                 else
                 {
                     var resolvedSymbol = objectType.MethodResolver.TryGetSymbol(syntax.Name);
-                    foundSymbol = SymbolValidator.ResolveObjectQualifiedFunctionWithoutValidatingFlags(resolvedSymbol, syntax.Name, objectType);
+                    foundSymbol = objectType is NamespaceType namespaceType
+                        // For namespace-qualified function calls (e.g. sys.newGuid(), az.listKeys()), validate the
+                        // placement flags (e.g. ParamDefaultsOnly, RequiresInlining) using the context the binder
+                        // captured for this call site, so they are restricted like their unqualified counterparts.
+                        ? SymbolValidator.ResolveNamespaceQualifiedFunction(binder.GetInstanceFunctionFlags(syntax), resolvedSymbol, syntax.Name, namespaceType)
+                        : SymbolValidator.ResolveObjectQualifiedFunctionWithoutValidatingFlags(resolvedSymbol, syntax.Name, objectType);
                 }
 
                 switch (foundSymbol)


### PR DESCRIPTION
## Description

For #17102.

Introduces improvements to how namespace-qualified functions (like `sys.newGuid()`) are validated, ensuring their usage is restricted to valid locations, just like unqualified function calls. The main change involves tracking and enforcing function placement flags for instance function calls, preventing misuse in module declarations and similar contexts.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19980)