### PR TITLE
docs: direct product documentation to azure-docs-pr in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,14 @@ If you'd like to start contributing to Bicep, you can search for issues tagged a
 * If a significant amount of design is required, please include a proposal in the issue and wait for approval before working on code. If there's anything you're not sure about, please feel free to discuss this in the issue. We'd much rather all be on the same page at the start, so that there's less chance that drastic changes will be needed when your pull request is reviewed.
 * We report on code coverage; please ensure any new code you add is sufficiently covered by tests.
 
+### Documentation
+
+User-facing Bicep product documentation (the content published to Microsoft Learn) lives in the [azure-docs-pr](https://github.com/MicrosoftDocs/azure-docs-pr) repository under `articles/azure-resource-manager/bicep/`, not in this repository. If your change needs documentation:
+
+* Do not open a documentation-only PR here. Open it directly in azure-docs-pr so it lands in the repo that publishes to Learn and is routed to the docs owners for review.
+* For a code change that needs docs, keep the code PR here and apply the `📘 Docs Needed` label. The documentation is authored separately in azure-docs-pr and tracked back to your PR. Once the docs merge, the label moves to `📘 Docs Completed`.
+* In-repo engineering docs (design notes, proposals, and contributor guides under `./docs`) still belong in this repository.
+
 ### Example Files
 
 We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.


### PR DESCRIPTION
## Description

Adds a **Documentation** subsection to the Pull Requests section of `CONTRIBUTING.md` that directs user-facing Bicep product documentation to the [azure-docs-pr](https://github.com/MicrosoftDocs/azure-docs-pr) repo (which publishes to Microsoft Learn), instead of opening documentation-only PRs in this repository.

### Why

Contributors sometimes open docs requests as PRs in this repo. Those belong in azure-docs-pr under `articles/azure-resource-manager/bicep/`, where they land in the repo that publishes to Learn and get routed to the docs owners. This note codifies the process so it does not keep recurring. It also clarifies that the existing `📘 Docs Needed` label workflow on code PRs is unchanged, and that in-repo engineering docs under `./docs` still belong here.

### Scope

Documentation only. One file changed, 8 lines added, no wording removed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19989)