### PR TITLE
 any? property and parameter incorrectly marked as required

### DIFF
--- a/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
+++ b/src/Bicep.Core.IntegrationTests/UserDefinedTypeTests.cs
@@ -3,6 +3,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Types;
 using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
@@ -2032,5 +2034,51 @@ param myParam string
         result.Template.Should().NotBeNull();
         result.Template.Should().HaveValueAtPath("$.definitions.stringRdt.type", "securestring");
         result.Template.Should().HaveValueAtPath("$.definitions.objectRdt.type", "secureObject");
+    }
+
+    /// <summary>
+    /// A property typed as 'any?' should be optional (not required).
+    /// 'any | null' collapses to 'any', causing IsNullable() to return false,
+    /// which previously caused the property to be incorrectly treated as required.
+    /// </summary>
+    [TestMethod]
+    public void Optional_any_property_is_not_required()
+    {
+        var result = CompilationHelper.Compile("""
+            param foo fooType
+
+            type fooType = {
+              name: string
+              fooAny: any?
+            }
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        // 'fooAny' should emit nullable:true in the ARM template schema
+        result.Template.Should().NotBeNull();
+        result.Template.Should().HaveValueAtPath("$.definitions.fooType.properties.fooAny.nullable", true);
+
+        // 'name' is required, so omitting it should error; 'fooAny' is optional so omitting it must not error
+        var resultWithoutOptional = CompilationHelper.Compile("""
+            param foo fooType
+
+            type fooType = {
+              name: string
+              fooAny: any?
+            }
+
+            var test = foo.name
+            """);
+        resultWithoutOptional.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        // The SemanticModel should report fooAny as not required
+        var semanticModel = result.Compilation.GetEntrypointSemanticModel();
+        var fooTypeParam = semanticModel.Parameters["foo"];
+        fooTypeParam.IsRequired.Should().BeTrue(); // the param itself has no default
+        // The property inside the type must not be required
+        TypeHelper.IsRequired(
+            ((Bicep.Core.TypeSystem.Types.ObjectType)fooTypeParam.TypeReference.Type).Properties["fooAny"])
+            .Should().BeFalse();
     }
 }

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.bicep
@@ -99,6 +99,12 @@ type nullable = string?
 
 type nonNullable = nullable!
 
+type withOptionalAnyProp = {
+  requiredProp: string
+  @description('An optional any-typed property')
+  optionalAny: any?
+}
+
 type typeA = {
   type: 'a'
   value: string

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.diagnostics.bicep
@@ -103,6 +103,13 @@ type nullable = string?
 
 type nonNullable = nullable!
 
+type withOptionalAnyProp = {
+  requiredProp: string
+  @description('An optional any-typed property')
+  optionalAny: any?
+//@[15:18) [no-explicit-any (Warning)] Avoid using an explicit 'any' type whenever possible. (bicep core linter https://aka.ms/bicep/linter-diagnostics#no-explicit-any) |any|
+}
+
 type typeA = {
   type: 'a'
   value: string

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.formatted.bicep
@@ -97,6 +97,12 @@ type nullable = string?
 
 type nonNullable = nullable!
 
+type withOptionalAnyProp = {
+  requiredProp: string
+  @description('An optional any-typed property')
+  optionalAny: any?
+}
+
 type typeA = {
   type: 'a'
   value: string

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 @description('The foo type')
-//@[000:5153) ProgramExpression
+//@[000:5277) ProgramExpression
 //@[000:0299) ├─DeclaredTypeExpression { Name = foo }
 //@[013:0027) | ├─StringLiteralExpression { Value = The foo type }
 @sealed()
@@ -306,6 +306,20 @@ type nonNullable = nullable!
 //@[000:0028) ├─DeclaredTypeExpression { Name = nonNullable }
 //@[019:0028) | └─NonNullableTypeExpression { Name = null | string }
 //@[019:0027) |   └─TypeAliasReferenceExpression { Name = nullable }
+
+type withOptionalAnyProp = {
+//@[000:0122) ├─DeclaredTypeExpression { Name = withOptionalAnyProp }
+//@[027:0122) | └─ObjectTypeExpression { Name = { requiredProp: string, optionalAny: any } }
+  requiredProp: string
+//@[002:0022) |   ├─ObjectTypePropertyExpression
+//@[016:0022) |   | └─AmbientTypeReferenceExpression { Name = string }
+  @description('An optional any-typed property')
+//@[002:0068) |   └─ObjectTypePropertyExpression
+//@[015:0047) |     ├─StringLiteralExpression { Value = An optional any-typed property }
+  optionalAny: any?
+//@[015:0019) |     └─NullableTypeExpression { Name = any }
+//@[015:0018) |       └─AmbientTypeReferenceExpression { Name = any }
+}
 
 type typeA = {
 //@[000:0044) ├─DeclaredTypeExpression { Name = typeA }

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8162009081861809153"
+      "templateHash": "8297239895651820406"
     }
   },
   "definitions": {
@@ -214,6 +214,20 @@
     "nonNullable": {
       "$ref": "#/definitions/nullable",
       "nullable": false
+    },
+    "withOptionalAnyProp": {
+      "type": "object",
+      "properties": {
+        "requiredProp": {
+          "type": "string"
+        },
+        "optionalAny": {
+          "nullable": true,
+          "metadata": {
+            "description": "An optional any-typed property"
+          }
+        }
+      }
     },
     "typeA": {
       "type": "object",

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.sourcemap.bicep
@@ -372,6 +372,26 @@ type nonNullable = nullable!
 //@      "nullable": false
 //@    },
 
+type withOptionalAnyProp = {
+//@    "withOptionalAnyProp": {
+//@      "type": "object",
+//@      "properties": {
+//@      }
+//@    },
+  requiredProp: string
+//@        "requiredProp": {
+//@          "type": "string"
+//@        },
+  @description('An optional any-typed property')
+//@          "metadata": {
+//@            "description": "An optional any-typed property"
+//@          }
+  optionalAny: any?
+//@        "optionalAny": {
+//@          "nullable": true,
+//@        }
+}
+
 type typeA = {
 //@    "typeA": {
 //@      "type": "object",

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "8162009081861809153"
+      "templateHash": "8297239895651820406"
     }
   },
   "definitions": {
@@ -214,6 +214,20 @@
     "nonNullable": {
       "$ref": "#/definitions/nullable",
       "nullable": false
+    },
+    "withOptionalAnyProp": {
+      "type": "object",
+      "properties": {
+        "requiredProp": {
+          "type": "string"
+        },
+        "optionalAny": {
+          "nullable": true,
+          "metadata": {
+            "description": "An optional any-typed property"
+          }
+        }
+      }
     },
     "typeA": {
       "type": "object",

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.symbols.bicep
@@ -126,6 +126,13 @@ type nullable = string?
 type nonNullable = nullable!
 //@[5:16) TypeAlias nonNullable. Type: Type<string>. Declaration start char: 0, length: 28
 
+type withOptionalAnyProp = {
+//@[5:24) TypeAlias withOptionalAnyProp. Type: Type<{ requiredProp: string, optionalAny: any }>. Declaration start char: 0, length: 122
+  requiredProp: string
+  @description('An optional any-typed property')
+  optionalAny: any?
+}
+
 type typeA = {
 //@[5:10) TypeAlias typeA. Type: Type<{ type: 'a', value: string }>. Declaration start char: 0, length: 44
   type: 'a'

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 @description('The foo type')
-//@[000:5153) ProgramSyntax
+//@[000:5277) ProgramSyntax
 //@[000:0299) ├─TypeDeclarationSyntax
 //@[000:0028) | ├─DecoratorSyntax
 //@[000:0001) | | ├─Token(At) |@|
@@ -956,6 +956,51 @@ type nonNullable = nullable!
 //@[019:0027) |   |   └─Token(Identifier) |nullable|
 //@[027:0028) |   └─Token(Exclamation) |!|
 //@[028:0030) ├─Token(NewLine) |\n\n|
+
+type withOptionalAnyProp = {
+//@[000:0122) ├─TypeDeclarationSyntax
+//@[000:0004) | ├─Token(Identifier) |type|
+//@[005:0024) | ├─IdentifierSyntax
+//@[005:0024) | | └─Token(Identifier) |withOptionalAnyProp|
+//@[025:0026) | ├─Token(Assignment) |=|
+//@[027:0122) | └─ObjectTypeSyntax
+//@[027:0028) |   ├─Token(LeftBrace) |{|
+//@[028:0029) |   ├─Token(NewLine) |\n|
+  requiredProp: string
+//@[002:0022) |   ├─ObjectTypePropertySyntax
+//@[002:0014) |   | ├─IdentifierSyntax
+//@[002:0014) |   | | └─Token(Identifier) |requiredProp|
+//@[014:0015) |   | ├─Token(Colon) |:|
+//@[016:0022) |   | └─TypeVariableAccessSyntax
+//@[016:0022) |   |   └─IdentifierSyntax
+//@[016:0022) |   |     └─Token(Identifier) |string|
+//@[022:0023) |   ├─Token(NewLine) |\n|
+  @description('An optional any-typed property')
+//@[002:0068) |   ├─ObjectTypePropertySyntax
+//@[002:0048) |   | ├─DecoratorSyntax
+//@[002:0003) |   | | ├─Token(At) |@|
+//@[003:0048) |   | | └─FunctionCallSyntax
+//@[003:0014) |   | |   ├─IdentifierSyntax
+//@[003:0014) |   | |   | └─Token(Identifier) |description|
+//@[014:0015) |   | |   ├─Token(LeftParen) |(|
+//@[015:0047) |   | |   ├─FunctionArgumentSyntax
+//@[015:0047) |   | |   | └─StringSyntax
+//@[015:0047) |   | |   |   └─Token(StringComplete) |'An optional any-typed property'|
+//@[047:0048) |   | |   └─Token(RightParen) |)|
+//@[048:0049) |   | ├─Token(NewLine) |\n|
+  optionalAny: any?
+//@[002:0013) |   | ├─IdentifierSyntax
+//@[002:0013) |   | | └─Token(Identifier) |optionalAny|
+//@[013:0014) |   | ├─Token(Colon) |:|
+//@[015:0019) |   | └─NullableTypeSyntax
+//@[015:0018) |   |   ├─TypeVariableAccessSyntax
+//@[015:0018) |   |   | └─IdentifierSyntax
+//@[015:0018) |   |   |   └─Token(Identifier) |any|
+//@[018:0019) |   |   └─Token(Question) |?|
+//@[019:0020) |   ├─Token(NewLine) |\n|
+}
+//@[000:0001) |   └─Token(RightBrace) |}|
+//@[001:0003) ├─Token(NewLine) |\n\n|
 
 type typeA = {
 //@[000:0044) ├─TypeDeclarationSyntax

--- a/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/TypeDeclarations_LF/main.tokens.bicep
@@ -563,6 +563,34 @@ type nonNullable = nullable!
 //@[027:028) Exclamation |!|
 //@[028:030) NewLine |\n\n|
 
+type withOptionalAnyProp = {
+//@[000:004) Identifier |type|
+//@[005:024) Identifier |withOptionalAnyProp|
+//@[025:026) Assignment |=|
+//@[027:028) LeftBrace |{|
+//@[028:029) NewLine |\n|
+  requiredProp: string
+//@[002:014) Identifier |requiredProp|
+//@[014:015) Colon |:|
+//@[016:022) Identifier |string|
+//@[022:023) NewLine |\n|
+  @description('An optional any-typed property')
+//@[002:003) At |@|
+//@[003:014) Identifier |description|
+//@[014:015) LeftParen |(|
+//@[015:047) StringComplete |'An optional any-typed property'|
+//@[047:048) RightParen |)|
+//@[048:049) NewLine |\n|
+  optionalAny: any?
+//@[002:013) Identifier |optionalAny|
+//@[013:014) Colon |:|
+//@[015:018) Identifier |any|
+//@[018:019) Question |?|
+//@[019:020) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:003) NewLine |\n\n|
+
 type typeA = {
 //@[000:004) Identifier |type|
 //@[005:010) Identifier |typeA|

--- a/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
+++ b/src/Bicep.Core/Semantics/ArmTemplateSemanticModel.cs
@@ -84,7 +84,7 @@ namespace Bicep.Core.Semantics
                             return new ParameterMetadata(
                                 parameterProperty.Key,
                                 type,
-                                parameterProperty.Value.DefaultValue is null && !TypeHelper.IsNullable(type.Type),
+                                parameterProperty.Value.DefaultValue is null && !TypeHelper.IsNullable(type.Type) && ((ITemplateSchemaNode)parameterProperty.Value).Nullable?.Value != true,
                                 GetMostSpecificDescription(parameterProperty.Value));
                         },
                         LanguageConstants.IdentifierComparer);

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -132,7 +132,9 @@ namespace Bicep.Core.Semantics
                 foreach (var param in this.Root.ParameterDeclarations.DistinctBy(p => p.Name))
                 {
                     var description = DescriptionHelper.TryGetFromDecorator(this, param.DeclaringParameter);
-                    var isRequired = SyntaxHelper.TryGetDefaultValue(param.DeclaringParameter) == null && !TypeHelper.IsNullable(param.Type);
+                    var isRequired = SyntaxHelper.TryGetDefaultValue(param.DeclaringParameter) == null
+                        && !TypeHelper.IsNullable(param.Type)
+                        && param.DeclaringParameter.Type is not NullableTypeSyntax;
                     if (param.Type is ResourceType resourceType)
                     {
                         // Resource type parameters are a special case, we need to convert to a dedicated

--- a/src/Bicep.Core/TypeSystem/ArmTemplateTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/ArmTemplateTypeLoader.cs
@@ -299,7 +299,11 @@ public static class ArmTemplateTypeLoader
                 // or all of them are (but some may be nullable)
                 var required = context.TemplateLanguageVersion?.HasFeature(TemplateLanguageFeature.NullableParameters) == true
                     || (requiredProps?.Contains(propertyName) ?? false);
-                var propertyFlags = required ? TypePropertyFlags.Required : TypePropertyFlags.None;
+                // A property with nullable:true is optional. We must check this explicitly because some types (e.g 'any')
+                // 'any | null' collapses back to 'any', causing IsNullable() to return false.
+                var isSchemaExplicitlyNullable = context.TemplateLanguageVersion?.HasFeature(TemplateLanguageFeature.NullableParameters) == true
+                    && ((ITemplateSchemaNode)schema).Nullable?.Value == true;
+                var propertyFlags = (required && !isSchemaExplicitlyNullable) ? TypePropertyFlags.Required : TypePropertyFlags.None;
                 var description = GetDescriptionFromMetadata(schema.Metadata);
 
                 var (type, typeName) = GetDeferrableTypeInfo(context, schema);

--- a/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
+++ b/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs
@@ -660,7 +660,10 @@ namespace Bicep.Core.TypeSystem
                     }
                     propertyNamesEncountered.Add(propertyName);
 
-                    properties.Add(new(propertyName, propertyType, TypePropertyFlags.Required, DescriptionHelper.TryGetFromDecorator(binder, typeManager, prop)));
+                    // A property marked with '?' (NullableTypeSyntax) is optional, even if its resolved type collapses
+                    // nullability (e.g. 'any?' collapses to 'any', causing IsNullable() to return false).
+                    var propertyFlags = prop.Value is NullableTypeSyntax ? TypePropertyFlags.None : TypePropertyFlags.Required;
+                    properties.Add(new(propertyName, propertyType, propertyFlags, DescriptionHelper.TryGetFromDecorator(binder, typeManager, prop)));
                     nameBuilder.AppendProperty(propertyName, GetPropertyTypeName(prop.Value, propertyType));
                 }
                 else

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -709,6 +709,39 @@ module mod 'mod.bicep' = {
         }
 
         [TestMethod]
+        public async Task VerifyOptionalAnyPropertyIsNotIncludedInRequiredPropertiesCompletion()
+        {
+            var fileWithCursors = @"
+module mod 'mod.bicep' = {
+  name: 'mod'
+  params: |
+}
+";
+
+            var (text, cursors) = ParserHelper.GetFileWithCursors(fileWithCursors);
+            DocumentUri mainUri = "file:///main.bicep";
+            var files = new Dictionary<DocumentUri, string>
+            {
+                ["file:///mod.bicep"] = @"param foo {
+  requiredProperty: string
+  optionalAny: any?
+}",
+                [mainUri] = text
+            };
+
+            var bicepFile = new LanguageClientFile(mainUri, text);
+            using var helper = await LanguageServerHelper.StartServerWithText(this.TestContext, files, bicepFile.Uri);
+
+            var file = new FileRequestHelper(helper.Client, bicepFile);
+            var completions = await file.RequestCompletions(cursors);
+            completions.Count().Should().Be(1);
+
+            var withRequiredProps = file.ApplyCompletion(completions.Single(), "required-properties").Text;
+            withRequiredProps.Should().Contain("requiredProperty");
+            withRequiredProps.Should().NotContain("optionalAny");
+        }
+
+        [TestMethod]
         public async Task VerifyResourceBodyCompletionWithDiscriminatedObjectTypeContainsRequiredPropertiesSnippet()
         {
             string text = @"resource deploymentScripts 'Microsoft.Resources/deploymentScripts@2020-10-01'=";


### PR DESCRIPTION
## Description

`any?` collapses to `any` during union normalization (`any | null` → `any`), 
 causing `IsNullable(any)` to return `false` and the property/parameter to be 
 incorrectly flagged as required.

Fix:
Check nullability before type resolution (raw syntax `NullableTypeSyntax`) or 
from JSON schema metadata (`nullable: true`) before setting `TypePropertyFlags.Required`.

<!-- Provide a 1-2 sentence description of your change -->

## Example Usage

<!-- Provide example usage if you are making syntax or CLI changes. 
     Provide screenshots if you are making changes to editor user experience.
     Delete this section if it doesn't apply to your change. -->

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19990)