### PR TITLE
[Bicep console] Add line navigation features, and undo+redo handling

### DIFF
--- a/src/Bicep.Cli.UnitTests/Helpers/Repl/LineEditorTests.cs
+++ b/src/Bicep.Cli.UnitTests/Helpers/Repl/LineEditorTests.cs
@@ -1,0 +1,278 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using Bicep.Cli.Helpers.Repl;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Cli.UnitTests.Helpers.Repl;
+
+[TestClass]
+public class LineEditorTests
+{
+    private static LineEditor CreateEditor(string text = "")
+    {
+        var editor = new LineEditor();
+        Type(editor, text);
+        return editor;
+    }
+
+    private static void Type(LineEditor editor, string text)
+    {
+        foreach (var rune in text.EnumerateRunes())
+        {
+            editor.Insert(rune);
+        }
+    }
+
+    private static string GetText(LineEditor editor) => string.Concat(editor.Buffer);
+
+    [TestMethod]
+    public void Typing_inserts_at_the_end_and_advances_the_cursor()
+    {
+        var editor = CreateEditor("hello");
+
+        GetText(editor).Should().Be("hello");
+        editor.Cursor.Should().Be(5);
+    }
+
+    [TestMethod]
+    public void MoveToStart_and_MoveToEnd_move_the_cursor_to_the_line_boundaries()
+    {
+        var editor = CreateEditor("hello");
+
+        editor.MoveToStart();
+        editor.Cursor.Should().Be(0);
+
+        editor.MoveToEnd();
+        editor.Cursor.Should().Be(5);
+    }
+
+    [TestMethod]
+    public void MoveLeft_and_MoveRight_clamp_at_the_line_boundaries()
+    {
+        var editor = CreateEditor("ab");
+
+        editor.MoveToStart();
+        editor.MoveLeft();
+        editor.Cursor.Should().Be(0);
+
+        editor.MoveToEnd();
+        editor.MoveRight();
+        editor.Cursor.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void MoveToWordBoundary_jumps_between_words()
+    {
+        var editor = CreateEditor("foo bar");
+        editor.MoveToStart();
+
+        editor.MoveToWordBoundary(1);
+        editor.Cursor.Should().Be(4, "forward should skip whitespace and land at the start of 'bar'");
+
+        editor.MoveToWordBoundary(1);
+        editor.Cursor.Should().Be(7, "forward at the last word should land at the end of the line");
+
+        editor.MoveToWordBoundary(-1);
+        editor.Cursor.Should().Be(4, "backward should land at the start of 'bar'");
+
+        editor.MoveToWordBoundary(-1);
+        editor.Cursor.Should().Be(0, "backward should land at the start of 'foo'");
+    }
+
+    [TestMethod]
+    public void MoveToWordBoundary_stops_at_transitions_between_letters_and_symbols()
+    {
+        var editor = CreateEditor("ab+cd");
+        editor.MoveToStart();
+
+        editor.MoveToWordBoundary(1);
+        editor.Cursor.Should().Be(2, "forward should stop before the '+' symbol");
+
+        editor.MoveToWordBoundary(1);
+        editor.Cursor.Should().Be(3, "forward should stop after the '+' symbol");
+
+        editor.MoveToWordBoundary(1);
+        editor.Cursor.Should().Be(5, "forward should reach the end of the line");
+    }
+
+    [TestMethod]
+    public void Insert_inserts_at_the_cursor_position()
+    {
+        var editor = CreateEditor("ac");
+        editor.MoveToStart();
+        editor.MoveRight();
+
+        editor.Insert(new Rune('b'));
+
+        GetText(editor).Should().Be("abc");
+        editor.Cursor.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void Backspace_removes_the_character_before_the_cursor()
+    {
+        var editor = CreateEditor("abc");
+
+        editor.Backspace();
+
+        GetText(editor).Should().Be("ab");
+        editor.Cursor.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void Backspace_at_the_start_of_the_line_is_a_noop()
+    {
+        var editor = CreateEditor("abc");
+        editor.MoveToStart();
+
+        editor.Backspace();
+
+        GetText(editor).Should().Be("abc");
+        editor.Cursor.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Delete_removes_the_character_at_the_cursor()
+    {
+        var editor = CreateEditor("abc");
+        editor.MoveToStart();
+
+        editor.Delete();
+
+        GetText(editor).Should().Be("bc");
+        editor.Cursor.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Delete_at_the_end_of_the_line_is_a_noop()
+    {
+        var editor = CreateEditor("abc");
+
+        editor.Delete();
+
+        GetText(editor).Should().Be("abc");
+        editor.Cursor.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void Insert_and_Backspace_treat_a_supplementary_rune_as_a_single_unit()
+    {
+        var editor = new LineEditor();
+
+        editor.Insert(new Rune(0x1F4AA)); // 💪
+        editor.Buffer.Should().HaveCount(1);
+        editor.Cursor.Should().Be(1);
+
+        editor.Backspace();
+        editor.Buffer.Should().BeEmpty();
+        editor.Cursor.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Undo_reverts_the_last_tracked_edit()
+    {
+        var editor = new LineEditor();
+        editor.Insert(new Rune('a'));
+        editor.Track();
+        editor.Insert(new Rune('b'));
+        editor.Track();
+
+        editor.Undo();
+        GetText(editor).Should().Be("a");
+        editor.Cursor.Should().Be(1);
+
+        editor.Undo();
+        GetText(editor).Should().Be("");
+        editor.Cursor.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Undo_with_no_history_is_a_noop()
+    {
+        var editor = new LineEditor();
+
+        editor.Undo();
+
+        GetText(editor).Should().Be("");
+        editor.Cursor.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Redo_reapplies_an_undone_edit()
+    {
+        var editor = new LineEditor();
+        editor.Insert(new Rune('a'));
+        editor.Track();
+        editor.Insert(new Rune('b'));
+        editor.Track();
+
+        editor.Undo();
+        editor.Undo();
+        GetText(editor).Should().Be("");
+
+        editor.Redo();
+        GetText(editor).Should().Be("a");
+
+        editor.Redo();
+        GetText(editor).Should().Be("ab");
+    }
+
+    [TestMethod]
+    public void Editing_after_an_undo_discards_the_redo_history()
+    {
+        var editor = new LineEditor();
+        editor.Insert(new Rune('a'));
+        editor.Track();
+        editor.Insert(new Rune('b'));
+        editor.Track();
+
+        editor.Undo();
+        GetText(editor).Should().Be("a");
+
+        editor.Insert(new Rune('c'));
+        editor.Track();
+        GetText(editor).Should().Be("ac");
+
+        editor.Redo();
+        GetText(editor).Should().Be("ac", "there should be nothing to redo after a new edit");
+
+        editor.Undo();
+        GetText(editor).Should().Be("a");
+    }
+
+    [TestMethod]
+    public void Track_after_a_cursor_only_move_does_not_create_a_new_undo_entry()
+    {
+        var editor = new LineEditor();
+        editor.Insert(new Rune('a'));
+        editor.Track();
+        editor.Insert(new Rune('b'));
+        editor.Track();
+
+        editor.MoveToStart();
+        editor.Track();
+
+        editor.Undo();
+        GetText(editor).Should().Be("a", "a caret-only move should not add an undo step");
+    }
+
+    [TestMethod]
+    public void Reset_replaces_the_buffer_and_commits_an_undoable_snapshot()
+    {
+        var editor = new LineEditor();
+
+        editor.Reset("foo".EnumerateRunes());
+        GetText(editor).Should().Be("foo");
+        editor.Cursor.Should().Be(3);
+
+        editor.Insert(new Rune('x'));
+        editor.Track();
+        GetText(editor).Should().Be("foox");
+
+        editor.Undo();
+        GetText(editor).Should().Be("foo", "the reset line should be an undoable state");
+    }
+}

--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using Spectre.Console;
+using static System.ConsoleKey;
 
 namespace Bicep.Cli.Commands;
 
@@ -216,28 +217,26 @@ public class ConsoleCommand(
 
     private readonly record struct InputLine(string Text, bool StartedWithBufferedInput, bool HasBufferedInputAfterEnter);
 
-    private async Task<int> PrintHistory(StringBuilder buffer, List<Rune> lineBuffer, int cursorOffset, bool backwards)
+    private async Task<bool> PrintHistory(StringBuilder buffer, LineEditor editor, bool backwards)
     {
-        if (replEnvironment.TryGetHistory(backwards) is { } history)
+        if (replEnvironment.TryGetHistory(backwards) is not { } history)
         {
-            var prevBufferLineCount = buffer.ToString().Count(x => x == '\n');
-            buffer.Clear();
-            lineBuffer.Clear();
-
-            var finalNewline = history.LastIndexOf('\n');
-            var lineStart = finalNewline > -1 ? finalNewline + 1 : 0;
-
-            buffer.Append(history[..lineStart]);
-            lineBuffer.AddRange(GetRunes(history[lineStart..]));
-            cursorOffset = lineBuffer.Count;
-
-            var output2 = replEnvironment.HighlightInputLine(FirstLinePrefix, buffer.ToString(), lineBuffer, cursorOffset, printPrevLines: true);
-            await io.Output.Writer.WriteAsync(PrintHelper.MoveCursorUp(prevBufferLineCount));
-            await io.Output.Writer.WriteAsync(output2);
-            return cursorOffset;
+            return false;
         }
 
-        return -1;
+        var prevBufferLineCount = buffer.ToString().Count(x => x == '\n');
+        buffer.Clear();
+
+        var finalNewline = history.LastIndexOf('\n');
+        var lineStart = finalNewline > -1 ? finalNewline + 1 : 0;
+
+        buffer.Append(history[..lineStart]);
+        editor.Reset(GetRunes(history[lineStart..]));
+
+        var output = replEnvironment.HighlightInputLine(FirstLinePrefix, buffer.ToString(), editor.Buffer, editor.Cursor, printPrevLines: true);
+        await io.Output.Writer.WriteAsync(PrintHelper.MoveCursorUp(prevBufferLineCount));
+        await io.Output.Writer.WriteAsync(output);
+        return true;
     }
 
     private string GetPrefix(StringBuilder buffer)
@@ -247,75 +246,83 @@ public class ConsoleCommand(
     {
         await io.Output.Writer.WriteAsync(GetPrefix(buffer));
 
-        var lineBuffer = new List<Rune>();
-        var cursorOffset = 0;
+        var editor = new LineEditor();
         var startedWithBufferedInput = Console.KeyAvailable;
 
         while (true)
         {
             var keyInfo = Console.ReadKey(intercept: true);
-            var nextChar = keyInfo.KeyChar;
 
-            if (keyInfo.Key == ConsoleKey.UpArrow)
+            switch ((keyInfo.Modifiers, keyInfo.Key))
             {
-                if (await PrintHistory(buffer, lineBuffer, cursorOffset, backwards: true) is { } newOffset and not -1)
-                {
-                    cursorOffset = newOffset;
-                    continue;
-                }
-            }
-            if (keyInfo.Key == ConsoleKey.DownArrow)
-            {
-                if (await PrintHistory(buffer, lineBuffer, cursorOffset, backwards: false) is { } newOffset and not -1)
-                {
-                    cursorOffset = newOffset;
-                    continue;
-                }
-            }
-            if (keyInfo.Key == ConsoleKey.LeftArrow)
-            {
-                cursorOffset = Math.Max(cursorOffset - 1, 0);
-            }
-            if (keyInfo.Key == ConsoleKey.RightArrow)
-            {
-                cursorOffset = Math.Min(cursorOffset + 1, lineBuffer.Count);
-            }
-            if (keyInfo.Key == ConsoleKey.Enter)
-            {
-                await io.Output.Writer.FlushAsync();
-                break;
-            }
-            else if (keyInfo.Key == ConsoleKey.Backspace)
-            {
-                if (cursorOffset > 0 && cursorOffset <= lineBuffer.Count)
-                {
-                    lineBuffer.RemoveAt(cursorOffset - 1);
-                    cursorOffset = Math.Max(cursorOffset - 1, 0);
-                }
-            }
-            else if (keyInfo.Key == ConsoleKey.Delete)
-            {
-                if (cursorOffset < lineBuffer.Count)
-                {
-                    lineBuffer.RemoveAt(cursorOffset);
-                }
-            }
-            else if (keyInfo.Key == ConsoleKey.Escape)
-            {
-                return null;
-            }
-            else if (nextChar != 0)
-            {
-                lineBuffer.Insert(cursorOffset, ReadRune(nextChar));
-                cursorOffset += 1;
+                case (_, UpArrow) or (_, DownArrow):
+                    // History navigation re-renders the whole line itself, so skip the redraw below when it handled the key.
+                    if (await PrintHistory(buffer, editor, backwards: keyInfo.Key == UpArrow))
+                    {
+                        continue;
+                    }
+                    break;
+
+                case (ConsoleModifiers.Control, LeftArrow):
+                    editor.MoveToWordBoundary(-1);
+                    break;
+
+                case (_, LeftArrow):
+                    editor.MoveLeft();
+                    break;
+
+                case (ConsoleModifiers.Control, RightArrow):
+                    editor.MoveToWordBoundary(+1);
+                    break;
+
+                case (_, RightArrow):
+                    editor.MoveRight();
+                    break;
+
+                case (_, Home):
+                    editor.MoveToStart();
+                    break;
+
+                case (_, End):
+                    editor.MoveToEnd();
+                    break;
+
+                case (_, Enter):
+                    await io.Output.Writer.FlushAsync();
+                    await io.Output.Writer.WriteAsync("\n");
+                    return new(string.Concat(editor.Buffer), startedWithBufferedInput, Console.KeyAvailable);
+
+                case (_, Backspace):
+                    editor.Backspace();
+                    break;
+
+                case (_, Delete):
+                    editor.Delete();
+                    break;
+
+                case (ConsoleModifiers.Control, Z):
+                    editor.Undo();
+                    break;
+
+                case (ConsoleModifiers.Control, Y):
+                    editor.Redo();
+                    break;
+
+                case (_, Escape):
+                    return null;
+
+                default:
+                    if (keyInfo.KeyChar != 0)
+                    {
+                        editor.Insert(ReadRune(keyInfo.KeyChar));
+                    }
+                    break;
             }
 
-            var output = replEnvironment.HighlightInputLine(GetPrefix(buffer), buffer.ToString(), lineBuffer, cursorOffset, printPrevLines: false);
-            await io.Output.Writer.WriteAsync(output);
+            editor.Track();
+
+            await io.Output.Writer.WriteAsync(
+                replEnvironment.HighlightInputLine(GetPrefix(buffer), buffer.ToString(), editor.Buffer, editor.Cursor, printPrevLines: false));
         }
-
-        await io.Output.Writer.WriteAsync("\n");
-
-        return new(string.Concat(lineBuffer), startedWithBufferedInput, Console.KeyAvailable);
     }
 }

--- a/src/Bicep.Cli/Helpers/Repl/LineEditor.cs
+++ b/src/Bicep.Cli/Helpers/Repl/LineEditor.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Bicep.Cli.Helpers.Repl;
+
+/// <summary>
+/// Mutable single-line edit buffer: owns the runes on the current line and the cursor position, and
+/// exposes the small set of edit/navigation operations that the REPL key handler dispatches to. This is
+/// the extension point - add a new operation here (e.g. word jump, delete-to-end) and wire it to a key
+/// in the console command's key handler.
+/// </summary>
+public sealed class LineEditor
+{
+    private readonly record struct Snapshot(ImmutableArray<Rune> Runes, int Cursor);
+    private readonly List<Rune> buffer = [];
+    private readonly List<Snapshot> history = [new([], 0)];
+    private int historyIndex;
+
+    public IReadOnlyList<Rune> Buffer => buffer;
+
+    public int Cursor { get; private set; }
+
+    public void MoveLeft() => Cursor = Math.Max(Cursor - 1, 0);
+
+    public void MoveRight() => Cursor = Math.Min(Cursor + 1, buffer.Count);
+
+    public void MoveToStart() => Cursor = 0;
+
+    public void MoveToEnd() => Cursor = buffer.Count;
+
+    public void MoveToWordBoundary(int direction)
+    {
+        direction = Math.Sign(direction);
+
+        if (direction > 0)
+        {
+            for (var i = Cursor; i < buffer.Count - 1; i++)
+            {
+                if (IsWordBoundary(i, i + 1))
+                {
+                    Cursor = i + 1;
+                    return;
+                }
+            }
+            Cursor = buffer.Count;
+        }
+        else
+        {
+            for (var i = Math.Min(Cursor, buffer.Count) - 1; i > 0; i--)
+            {
+                if (IsWordBoundary(i - 1, i))
+                {
+                    Cursor = i;
+                    return;
+                }
+            }
+            Cursor = 0;
+        }
+
+        bool IsWordBoundary(int index1, int index2)
+        {
+            if (index2 >= buffer.Count)
+            {
+                return false;
+            }
+
+            var r1 = buffer[index1];
+            var r2 = buffer[index2];
+
+            var isWhitespace1 = Rune.IsWhiteSpace(r1);
+            var isWhitespace2 = Rune.IsWhiteSpace(r2);
+            if (isWhitespace1 && !isWhitespace2)
+            {
+                return true;
+            }
+            if (isWhitespace1 || isWhitespace2)
+            {
+                return false;
+            }
+
+            return Rune.IsLetterOrDigit(r1) != Rune.IsLetterOrDigit(r2);
+        }
+    }
+
+    public void Insert(Rune rune)
+    {
+        buffer.Insert(Cursor, rune);
+        Cursor++;
+    }
+
+    public void Backspace()
+    {
+        if (Cursor > 0 && Cursor <= buffer.Count)
+        {
+            buffer.RemoveAt(Cursor - 1);
+            Cursor = Math.Max(Cursor - 1, 0);
+        }
+    }
+
+    public void Delete()
+    {
+        if (Cursor < buffer.Count)
+        {
+            buffer.RemoveAt(Cursor);
+        }
+    }
+
+    public void Reset(IEnumerable<Rune> runes)
+    {
+        buffer.Clear();
+        buffer.AddRange(runes);
+        Cursor = buffer.Count;
+        // we commit a snapshot here so that the user is able to undo back to the original state of the line
+        // even if they haven't typed anything yet.
+        Track();
+    }
+
+    /// <summary>
+    /// Commits the current buffer/cursor to the undo history. If the text is unchanged since the last
+    /// commit, such as when only the caret moves, only the cursor position is updated in place; otherwise a new snapshot is appended and any redo
+    /// tail is discarded. Call after every edit/navigation.
+    /// </summary>
+    public void Track()
+    {
+        var current = history[historyIndex];
+        if (MatchesCurrentBuffer(current.Runes))
+        {
+            if (Cursor != current.Cursor)
+            {
+                history[historyIndex] = current with { Cursor = Cursor };
+            }
+            return;
+        }
+
+        // are there snapshots ahead of us? (i.e. we undid, then typed)
+        // if so, remove them, since they are no longer reachable from the current state.
+        if (historyIndex < history.Count - 1)
+        {
+            history.RemoveRange(historyIndex + 1, history.Count - historyIndex - 1);
+        }
+
+        history.Add(new Snapshot([.. buffer], Cursor));
+        historyIndex = history.Count - 1;
+    }
+
+    public void Undo()
+    {
+        if (historyIndex > 0)
+        {
+            Restore(history[--historyIndex]);
+        }
+    }
+
+    public void Redo()
+    {
+        if (historyIndex < history.Count - 1)
+        {
+            Restore(history[++historyIndex]);
+        }
+    }
+
+    private void Restore(Snapshot snapshot)
+    {
+        buffer.Clear();
+        buffer.AddRange(snapshot.Runes);
+        Cursor = snapshot.Cursor;
+    }
+
+    private bool MatchesCurrentBuffer(ImmutableArray<Rune> runes)
+    {
+        if (buffer.Count != runes.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < buffer.Count; i++)
+        {
+            if (buffer[i] != runes[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Description

For #19984.

Adds navigation features for:
- Home/End keys (for jumping to beginning/end of line)
- Ctrl+Arrow (for jumping between words)
- Ctrl+Z/R (for undo/redo)

## Example Usage

https://github.com/user-attachments/assets/fb309496-68b5-4493-8807-e6504ef1e408


## Checklist

- [ ] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19992)