### PR TITLE
[Bicep console] Handle MacOS key combination for jumping across words

### DIFF
--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -263,7 +263,10 @@ public class ConsoleCommand(
                     }
                     break;
 
-                case (ConsoleModifiers.Control, LeftArrow):
+                // referenced from how NodeJS REPL handles jumping between words for MacOS:
+                // https://github.com/nodejs/node/blob/0e2126d8b1c0eb93b105ac53c0939908392cbb42/lib/internal/readline/interface.js#L1435-L1445
+                // Option key in MacOS maps to Alt
+                case (ConsoleModifiers.Control, LeftArrow) or (ConsoleModifiers.Alt, B):
                     editor.MoveToWordBoundary(-1);
                     break;
 
@@ -271,10 +274,13 @@ public class ConsoleCommand(
                     editor.MoveLeft();
                     break;
 
-                case (ConsoleModifiers.Control, RightArrow):
+                // referenced from how NodeJS REPL handles jumping between words for MacOS:
+                // https://github.com/nodejs/node/blob/0e2126d8b1c0eb93b105ac53c0939908392cbb42/lib/internal/readline/interface.js#L1435-L1445
+                // Option key in MacOS maps to Alt
+                case (ConsoleModifiers.Control, RightArrow) or (ConsoleModifiers.Alt, F): 
                     editor.MoveToWordBoundary(+1);
                     break;
-
+                    
                 case (_, RightArrow):
                     editor.MoveRight();
                     break;


### PR DESCRIPTION
## Description

MacOS uses ⌥ (Option key) + B/F for jumping between words. 
Option key maps to `ConsoleModifiers.Alt` in .NET.
Implemented by referencing how [NodeJS REPL](https://github.com/nodejs/node/blob/0e2126d8b1c0eb93b105ac53c0939908392cbb42/lib/internal/readline/interface.js#L1435-L1445) and [CSharpRepl](https://github.com/waf/PrettyPrompt/blob/9d22b9d080bc928a85b919c5cc4368aa25f98e90/src/PrettyPrompt/Panes/CodePane.cs#L218-L223) handle this.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/19996)