### PR TITLE
Fix invalid rename location errors

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
+++ b/src/Bicep.LangServer.IntegrationTests/Helpers/ServerRequestHelper.cs
@@ -93,6 +93,15 @@ namespace Bicep.LangServer.IntegrationTests
             });
         }
 
+        public async Task<RangeOrPlaceholderRange?> RequestPrepareRename(int cursor)
+        {
+            return await client.PrepareRename(new PrepareRenameParams
+            {
+                TextDocument = new TextDocumentIdentifier(bicepFile.Uri),
+                Position = PositionHelper.GetPosition(bicepFile.LineStarts, cursor),
+            });
+        }
+
         public async Task<CodeLensContainer?> RequestCodeLens(int cursor)
         {
             return await client.RequestCodeLens(new CodeLensParams

--- a/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/RenameSymbolTests.cs
@@ -7,6 +7,8 @@ using Bicep.Core.UnitTests.Utils;
 using Bicep.LangServer.IntegrationTests.Helpers;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OmniSharp.Extensions.JsonRpc.Server;
+using LspRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace Bicep.LangServer.IntegrationTests;
 
@@ -58,13 +60,55 @@ var test = 'asdf'
 var asdf = test
 var blah = '${test}'
 """)]
-    public async Task RenamingFunctionsShouldProduceEmptyEdit(string inputWithCursor)
+    public async Task Rename_WithInvalidLocation_ThrowsRequestFailed(string inputWithCursor)
     {
         var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
         var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
 
-        var edit = await file.RequestRename(cursor, "NewIdentifier");
+        Func<Task> request = async () => await file.RequestRename(cursor, "NewIdentifier");
 
-        edit.Should().BeNull();
+        var exception = await request.Should().ThrowAsync<JsonRpcException>()
+            .WithMessage("The selected location does not contain a renameable Bicep symbol.");
+        exception.Which.Error.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    [DataRow("""
+var te|st = 'asdf'
+
+var asdf = test
+var blah = '${test}'
+""")]
+    public async Task PrepareRename_WithRenameableSymbol_ReturnsIdentifierRange(string inputWithCursor)
+    {
+        var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
+
+        var result = await file.RequestPrepareRename(cursor);
+
+        result.Should().NotBeNull();
+        result!.IsPlaceholderRange.Should().BeTrue();
+        result.PlaceholderRange.Should().NotBeNull();
+        result.PlaceholderRange!.Range.Should().Be(new LspRange(0, 4, 0, 8));
+        result.PlaceholderRange!.Placeholder.Should().Be("test");
+    }
+
+    [TestMethod]
+    [DataRow("""
+var test = 'asdf'
+|
+var asdf = test
+var blah = '${test}'
+""")]
+    public async Task PrepareRename_WithInvalidLocation_ThrowsRequestFailed(string inputWithCursor)
+    {
+        var (contents, cursor) = ParserHelper.GetFileWithSingleCursor(inputWithCursor);
+        var file = await new ServerRequestHelper(TestContext, DefaultServer).OpenFile(contents);
+
+        Func<Task> request = async () => await file.RequestPrepareRename(cursor);
+
+        var exception = await request.Should().ThrowAsync<JsonRpcException>()
+            .WithMessage("The selected location does not contain a renameable Bicep symbol.");
+        exception.Which.Error.Should().BeEmpty();
     }
 }

--- a/src/Bicep.LangServer/Handlers/BicepPrepareRenameHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepPrepareRenameHandler.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using Bicep.LanguageServer.Extensions;
+using Bicep.LanguageServer.Providers;
+using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace Bicep.LanguageServer.Handlers
+{
+    public class BicepPrepareRenameHandler : PrepareRenameHandlerBase
+    {
+        private readonly ISymbolResolver symbolResolver;
+        private readonly DocumentSelectorFactory documentSelectorFactory;
+
+        public BicepPrepareRenameHandler(ISymbolResolver symbolResolver, DocumentSelectorFactory documentSelectorFactory)
+        {
+            this.symbolResolver = symbolResolver;
+            this.documentSelectorFactory = documentSelectorFactory;
+        }
+
+        public override Task<RangeOrPlaceholderRange?> Handle(PrepareRenameParams request, CancellationToken cancellationToken)
+        {
+            var result = BicepRenameHandler.ResolveRenameableSymbol(this.symbolResolver, request.TextDocument.Uri, request.Position);
+
+            var identifier = BicepRenameHandler.GetIdentifier(result.Origin);
+            if (identifier is null || !identifier.IsValid)
+            {
+                throw BicepRenameHandler.CreateRenameError(BicepRenameHandler.CannotRenameSymbolMessage);
+            }
+
+            return Task.FromResult<RangeOrPlaceholderRange?>(new PlaceholderRange
+            {
+                Range = identifier.ToRange(result.Context.LineStarts),
+                Placeholder = identifier.IdentifierName
+            });
+        }
+
+        protected override RenameRegistrationOptions CreateRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities) => new()
+        {
+            // textDocument/prepareRename is advertised through renameProvider.prepareProvider.
+            // BicepRenameHandler owns that advertisement; registering a second document selector here
+            // causes VS Code to create a second matching rename provider and call prepareRename twice.
+            DocumentSelector = new([]),
+            PrepareProvider = false
+        };
+    }
+}

--- a/src/Bicep.LangServer/Handlers/BicepRenameHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepRenameHandler.cs
@@ -7,6 +7,8 @@ using Bicep.Core.Syntax;
 using Bicep.LanguageServer.Extensions;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Utils;
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.JsonRpc.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
@@ -14,30 +16,30 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace Bicep.LanguageServer.Handlers
 {
-    public class BicepRenameHandler(ISymbolResolver symbolResolver, DocumentSelectorFactory documentSelectorFactory) : RenameHandlerBase
+    public class BicepRenameHandler : RenameHandlerBase
     {
+        internal const string CannotRenameSymbolMessage = "The selected location does not contain a renameable Bicep symbol.";
+        private const string InvalidIdentifierMessage = "The new name must be a valid Bicep identifier.";
+
+        private readonly ISymbolResolver symbolResolver;
+        private readonly DocumentSelectorFactory documentSelectorFactory;
+
+        public BicepRenameHandler(ISymbolResolver symbolResolver, DocumentSelectorFactory documentSelectorFactory)
+        {
+            this.symbolResolver = symbolResolver;
+            this.documentSelectorFactory = documentSelectorFactory;
+        }
+
         public override Task<WorkspaceEdit?> Handle(RenameParams request, CancellationToken cancellationToken)
         {
-            var result = symbolResolver.ResolveSymbol(request.TextDocument.Uri, request.Position);
-            if (result == null || !(result.Symbol is DeclaredSymbol))
-            {
-                // result is not a symbol or it's a built-in symbol that was not declared by the user (namespaces, functions, for example)
-                // symbols that are not declared by the user cannot be renamed
-                return Task.FromResult<WorkspaceEdit?>(null);
-            }
-
-            if (result.Symbol is PropertySymbol)
-            {
-                // TODO: Implement for PropertySymbol
-                return Task.FromResult<WorkspaceEdit?>(null);
-            }
+            // Re-validate here even though BicepPrepareRenameHandler already checks the location. textDocument/prepareRename
+            // is only an optional preflight - clients are not required to call it before textDocument/rename, and some don't.
+            // So the rename request must be self-sufficient and cannot rely on prepare having rejected invalid locations.
+            var result = ResolveRenameableSymbol(this.symbolResolver, request.TextDocument.Uri, request.Position);
 
             if (!Lexer.IsValidIdentifier(request.NewName))
             {
-                // if the value that the user wants to rename to is invalid (contains characters, etc.), the rename will fail.
-                // despite there being a way for errors to be represented in LSP (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename),
-                // we are failing here as Omnisharp doesn't handle returning error messages.
-                return Task.FromResult<WorkspaceEdit?>(null);
+                throw CreateRenameError(InvalidIdentifierMessage);
             }
 
             var textEdits = result.Context.Compilation.GetEntrypointSemanticModel()
@@ -59,7 +61,20 @@ namespace Bicep.LanguageServer.Handlers
             });
         }
 
-        private static IdentifierSyntax? GetIdentifier(SyntaxBase syntax)
+        internal static SymbolResolutionResult ResolveRenameableSymbol(ISymbolResolver symbolResolver, DocumentUri uri, Position position)
+        {
+            var result = symbolResolver.ResolveSymbol(uri, position);
+            if (result is null || result.Symbol is not DeclaredSymbol || result.Symbol is PropertySymbol)
+            {
+                throw CreateRenameError(CannotRenameSymbolMessage);
+            }
+
+            return result;
+        }
+
+        internal static RpcErrorException CreateRenameError(string message) => new(ErrorCodes.RequestFailed, string.Empty, message);
+
+        internal static IdentifierSyntax? GetIdentifier(SyntaxBase syntax)
         {
             switch (syntax)
             {
@@ -82,8 +97,8 @@ namespace Bicep.LanguageServer.Handlers
 
         protected override RenameRegistrationOptions CreateRegistrationOptions(RenameCapability capability, ClientCapabilities clientCapabilities) => new()
         {
-            DocumentSelector = documentSelectorFactory.CreateForBicepAndParams(),
-            PrepareProvider = false
+            DocumentSelector = this.documentSelectorFactory.CreateForBicepAndParams(),
+            PrepareProvider = true
         };
     }
 }

--- a/src/Bicep.LangServer/Server.cs
+++ b/src/Bicep.LangServer/Server.cs
@@ -46,6 +46,7 @@ namespace Bicep.LanguageServer
                     .WithHandler<BicepDocumentHighlightHandler>()
                     .WithHandler<BicepDocumentFormattingHandler>()
                     .WithHandler<BicepRenameHandler>()
+                    .WithHandler<BicepPrepareRenameHandler>()
                     .WithHandler<BicepHoverHandler>()
                     .WithHandler<BicepCompletionHandler>()
                     .WithHandler<BicepCodeActionHandler>()


### PR DESCRIPTION
Fixes #266

## Summary
- Adds `textDocument/prepareRename` support for Bicep so VS Code can validate rename locations before showing the rename input.
- Returns a clear request error from `textDocument/rename` for clients that skip prepare rename, invalid locations, or invalid new identifiers.
- Avoids duplicate prepare-rename prompts by letting `BicepRenameHandler` own `renameProvider.prepareProvider` advertisement while `BicepPrepareRenameHandler` only handles the prepare request.
- Adds focused integration coverage for valid prepare rename, invalid prepare rename, invalid direct rename, and successful rename edits.

## Screenshot
Manual validation screenshot: invoking rename at an invalid Bicep location now shows a single inline editor message:

<img width="392" height="110" alt="image" src="https://github.com/user-attachments/assets/1a676028-0fd0-43fd-a0ae-c0d2195e8f54" />

## Validation
```powershell
dotnet build .\src\Bicep.LangServer\Bicep.LangServer.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary
dotnet test .\src\Bicep.LangServer.IntegrationTests\Bicep.LangServer.IntegrationTests.csproj --no-restore -- --filter FullyQualifiedName~RenameSymbolTests
```

Note: the screenshot image was provided in the Copilot chat and is represented here by its visible validation result because the PR creation API accepts Markdown text but does not expose the raw chat attachment as an uploadable image URL.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20015)