### PR TITLE
Show version-specific docs links on resource hovers

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -334,7 +334,7 @@ resource test|Output string = 'str'
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my module  \n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my param  \n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my var  \n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my\nmultiline\nresource  \n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/discriminatortests?pivots=deployment-language-bicep)  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my\nmultiline\nresource  \n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/discriminatortests?pivots=deployment-language-bicep)  \n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my output  \n  \n"));
         }
 
@@ -539,13 +539,13 @@ resource m|adeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01' = {}
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource foo 'Test.Rp/basicTests@2020-01-01'
 ```  " + @"
-[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " + @"
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/basictests?pivots=deployment-language-bicep)  " + @"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource bar 'Test.Rp/basicTests@2020-01-01'
 ```  " + @"
 This resource also has a description!  " + @"
-[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " + @"
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/basictests?pivots=deployment-language-bicep)  " + @"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource madeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01'
@@ -573,13 +573,13 @@ resource madeUp 'Test.MadeUp/nonExistent|ResourceType@2020-01-01' = {}
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource foo 'Test.Rp/basicTests@2020-01-01'
 ```  " + @"
-[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " + @"
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/basictests?pivots=deployment-language-bicep)  " + @"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource bar 'Test.Rp/basicTests@2020-01-01'
 ```  " + @"
 This resource also has a description!  " + @"
-[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " + @"
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/basictests?pivots=deployment-language-bicep)  " + @"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource madeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01'

--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -555,6 +555,40 @@ resource madeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01'
         }
 
         [TestMethod]
+        public async Task Resource_type_hovers_should_include_documentation_links_for_known_resource_types()
+        {
+            // https://github.com/Azure/bicep/issues/16178 - the documentation link should also be
+            // discoverable by hovering over the resource type, not just the resource name.
+            var hovers = await RequestHoversAtCursorLocations(@"
+resource foo 'Test.Rp/basic|Tests@2020-01-01' = {}
+
+@description('This resource also has a description!')
+resource bar 'Test.Rp/basic|Tests@2020-01-01' = {}
+
+resource madeUp 'Test.MadeUp/nonExistent|ResourceType@2020-01-01' = {}
+",
+                '|');
+
+            hovers.Should().SatisfyRespectively(
+                h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
+resource foo 'Test.Rp/basicTests@2020-01-01'
+```  " + @"
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " + @"
+"),
+                h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
+resource bar 'Test.Rp/basicTests@2020-01-01'
+```  " + @"
+This resource also has a description!  " + @"
+[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/basictests?pivots=deployment-language-bicep)  " + @"
+"),
+                h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
+resource madeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01'
+```  " + @"
+  " + @"
+"));
+        }
+
+        [TestMethod]
         public async Task Function_hovers_display_without_descriptions_if_function_overload_has_not_been_resolved()
         {
             // using the any type, we don't know which particular overload has been selected, so we cannot show an accurate description.

--- a/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
@@ -346,10 +346,19 @@ namespace Bicep.LanguageServer.Handlers
                 resourceType.DeclaringNamespace.ExtensionNameEquals(AzNamespaceType.BuiltInName) &&
                 resourceType.DeclaringNamespace.ResourceTypeProvider.HasDefinedType(resourceType.TypeReference))
             {
-                var provider = resourceType.TypeReference.TypeSegments.First().ToLowerInvariant();
-                var typePath = resourceType.TypeReference.TypeSegments.Skip(1).Select(x => x.ToLowerInvariant());
+                var typeReference = resourceType.TypeReference;
+                var provider = typeReference.TypeSegments.First().ToLowerInvariant();
+                var typePath = string.Join('/', typeReference.TypeSegments.Skip(1).Select(x => x.ToLowerInvariant()));
 
-                return $"https://learn.microsoft.com/azure/templates/{provider}/{string.Join('/', typePath)}?pivots=deployment-language-bicep";
+                // Learn hosts a page per API version alongside a versionless page for the latest, so link
+                // to the pinned version's page to match the resource. ApiVersion is null only if no version
+                // was given, in which case we fall back to the versionless URL.
+                var apiVersion = typeReference.ApiVersion;
+                var versionSegment = string.IsNullOrEmpty(apiVersion)
+                    ? ""
+                    : $"{apiVersion.ToLowerInvariant()}/";
+
+                return $"https://learn.microsoft.com/azure/templates/{provider}/{versionSegment}{typePath}?pivots=deployment-language-bicep";
             }
 
             return null;

--- a/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepHoverHandler.cs
@@ -5,12 +5,15 @@ using System.Text;
 using Bicep.Core;
 using Bicep.Core.Extensions;
 using Bicep.Core.Navigation;
+using Bicep.Core.Parsing;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics;
 using Bicep.Core.Semantics.Namespaces;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Types;
+using Bicep.LanguageServer.CompilationManager;
+using Bicep.LanguageServer.Completions;
 using Bicep.LanguageServer.Providers;
 using Bicep.LanguageServer.Utils;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
@@ -24,23 +27,28 @@ namespace Bicep.LanguageServer.Handlers
         private readonly IModuleDispatcher moduleDispatcher;
         private readonly IArtifactRegistryProvider moduleRegistryProvider;
         private readonly ISymbolResolver symbolResolver;
+        private readonly ICompilationManager compilationManager;
         private readonly DocumentSelectorFactory documentSelectorFactory;
 
         public BicepHoverHandler(
             IModuleDispatcher moduleDispatcher,
             IArtifactRegistryProvider moduleRegistryProvider,
             ISymbolResolver symbolResolver,
+            ICompilationManager compilationManager,
             DocumentSelectorFactory documentSelectorFactory)
         {
             this.moduleDispatcher = moduleDispatcher;
             this.moduleRegistryProvider = moduleRegistryProvider;
             this.symbolResolver = symbolResolver;
+            this.compilationManager = compilationManager;
             this.documentSelectorFactory = documentSelectorFactory;
         }
 
         public override async Task<Hover?> Handle(HoverParams request, CancellationToken cancellationToken)
         {
-            var result = this.symbolResolver.ResolveSymbol(request.TextDocument.Uri, request.Position);
+            // ResolveSymbol returns null over a resource type string; fall back to show the resource hover there.
+            var result = this.symbolResolver.ResolveSymbol(request.TextDocument.Uri, request.Position)
+                ?? TryResolveResourceTypeSymbol(request);
             if (result == null)
             {
                 return null;
@@ -57,6 +65,33 @@ namespace Bicep.LanguageServer.Handlers
                 Contents = markdown,
                 Range = PositionHelper.GetNameRange(result.Context.LineStarts, result.Origin)
             };
+        }
+
+        // A resource type string is a type reference, not a symbol reference, so ResolveSymbol returns
+        // null over it. We handle it here rather than in ResolveSymbol because that resolver also backs
+        // rename, go-to-definition, find-references, and highlight, which shouldn't act on the resource
+        // from its type string. Resolving the enclosing declaration binds to the same symbol as a hover
+        // over the resource name.
+        private SymbolResolutionResult? TryResolveResourceTypeSymbol(HoverParams request)
+        {
+            var context = this.compilationManager.GetCompilation(request.TextDocument.Uri);
+            if (context is null)
+            {
+                return null;
+            }
+
+            var offset = PositionHelper.GetOffset(context.LineStarts, request.Position);
+            var matchingNodes = SyntaxMatcher.FindNodesMatchingOffset(context.ProgramSyntax, offset);
+
+            if (SyntaxMatcher.GetTailMatch<ResourceDeclarationSyntax, StringSyntax, Token>(matchingNodes) is not (var resourceDeclaration, var typeString, _) ||
+                resourceDeclaration.Type != typeString ||
+                context.Compilation.GetEntrypointSemanticModel().GetSymbolInfo(resourceDeclaration) is not ResourceSymbol resource)
+            {
+                return null;
+            }
+
+            // Report the type string as the origin so the hover highlights it (rather than the name).
+            return new SymbolResolutionResult(typeString, resource, context);
         }
 
         private static string? TryGetDescription(SymbolResolutionResult result, DeclaredSymbol symbol)

--- a/src/vscode-bicep/src/test/e2e/hover.test.ts
+++ b/src/vscode-bicep/src/test/e2e/hover.test.ts
@@ -65,7 +65,26 @@ describe("hover", (): void => {
       contents: [
         codeblockWithDescription(
           "resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01'",
-          "[View Documentation](https://learn.microsoft.com/azure/templates/microsoft.network/virtualnetworks?pivots=deployment-language-bicep)",
+          "[View Documentation](https://learn.microsoft.com/azure/templates/microsoft.network/2020-06-01/virtualnetworks?pivots=deployment-language-bicep)",
+        ),
+      ],
+    });
+  });
+
+  it("should reveal type signature and documentation link when hovering over a resource type", async () => {
+    // https://github.com/Azure/bicep/issues/16178 - the hover (and its documentation link) should
+    // also be discoverable over the resource type string, not just the symbolic name.
+    const hovers = await executeHoverProviderCommandWithRetry(document.uri, new vscode.Position(108, 30));
+
+    expectHovers(hovers, {
+      startLine: 108,
+      startCharacter: 14,
+      endLine: 108,
+      endCharacter: 60,
+      contents: [
+        codeblockWithDescription(
+          "resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01'",
+          "[View Documentation](https://learn.microsoft.com/azure/templates/microsoft.network/2020-06-01/virtualnetworks?pivots=deployment-language-bicep)",
         ),
       ],
     });


### PR DESCRIPTION
Fixes #16178.

We already render a **View Documentation** link when hovering a resource's
*name*, but as @anthony-c-martin noted it's hard to discover there. This PR
makes it discoverable and version-accurate:

- **Extend the hover to the resource *type* string** — as @majastrz suggested,
  the same hover (signature + docs link) now also shows when hovering over
  `Microsoft.Storage/storageAccounts@2023-01-01`, not just the symbol name.
- **Make the docs link version-specific** — as the opener @oricawalid
  requested, the link now points at the pinned API version's Learn page,
  e.g. `.../microsoft.storage/2023-01-01/storageaccounts?pivots=deployment-language-bicep`
  instead of the versionless "latest" page. It falls back to the versionless
  URL when a resource has no version.

### Why this is safe

The type-string hover is implemented as a **hover-only** fallback in
`BicepHoverHandler`; it does not touch the shared `BicepSymbolResolver`. That
resolver backs rename, references, definition, etc., so mapping the type string
to the resource symbol there would (for example) make "rename symbol" over the
type string silently rename the resource. Keeping it local to the hover handler
avoids that blast radius.

### Out of scope

The original issue also asked for **clicking** a resource type/ID/version to
open docs. After looking into it, opening an external URL on click of a symbol
isn't really a VS Code idiom — the discoverable, clickable link inside the hover
is the idiomatic surface for this, so we're intentionally not adding
click-to-open behavior here.

---
Drafted by Copilot (Claude Opus 4.8).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20016)