### PR TITLE
Fix nested resource reference completions

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -5936,6 +5936,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6002,6 +6019,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -5900,6 +5900,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5966,6 +5983,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -5928,6 +5928,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5994,6 +6011,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -6159,6 +6159,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6225,6 +6242,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -6159,6 +6159,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6225,6 +6242,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -6159,6 +6159,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6225,6 +6242,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -6159,6 +6159,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6225,6 +6242,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -6393,6 +6393,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6459,6 +6476,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -6393,6 +6393,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6459,6 +6476,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -6393,6 +6393,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6459,6 +6476,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -6393,6 +6393,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6459,6 +6476,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -5914,6 +5914,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5980,6 +5997,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -5914,6 +5914,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5980,6 +5997,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -5914,6 +5914,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5980,6 +5997,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -5914,6 +5914,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5980,6 +5997,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -5907,6 +5907,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5973,6 +5990,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -5886,6 +5886,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5952,6 +5969,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -5916,6 +5916,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5982,6 +5999,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -6012,6 +6012,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6078,6 +6095,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -5903,6 +5903,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5969,6 +5986,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -5900,6 +5900,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5966,6 +5983,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -5900,6 +5900,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5966,6 +5983,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -5931,6 +5931,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6011,6 +6028,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -5967,6 +5967,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -6033,6 +6050,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -5931,6 +5931,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5997,6 +6014,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -5931,6 +5931,23 @@
     ]
   },
   {
+    "label": "sqlServer5::sqlDatabase",
+    "kind": "interface",
+    "detail": "sqlServer5::sqlDatabase",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_sqlServer5::sqlDatabase",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "sqlServer5::sqlDatabase"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
     "label": "startedTypingTypeWithQuotes",
     "kind": "interface",
     "detail": "startedTypingTypeWithQuotes",
@@ -5997,6 +6014,23 @@
     "textEdit": {
       "range": {},
       "newText": "storage"
+    },
+    "commitCharacters": [
+      ":"
+    ]
+  },
+  {
+    "label": "storage::blobServices",
+    "kind": "interface",
+    "detail": "storage::blobServices",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_storage::blobServices",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "storage::blobServices"
     },
     "commitCharacters": [
       ":"

--- a/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/BicepCompletionProviderTests.cs
@@ -216,6 +216,47 @@ output o int = 42
         }
 
         [TestMethod]
+        public async Task GetFilteredCompletions_WithNestedResourceDeclarations_ReturnsQualifiedResourceReferences()
+        {
+            var compilation = Services.BuildCompilation(@"
+resource parent 'Microsoft.Foo/foos@2020-09-01' = {
+  name: 'foo'
+
+  resource child 'bars' = {
+    name: 'bar'
+
+    resource grandchild 'bazs' = {
+      name: 'baz'
+    }
+  }
+}
+
+var v =
+");
+            var offset = compilation.GetEntrypointSemanticModel().Root.VariableDeclarations.Select(x => x.DeclaringVariable).Single().Value.Span.Position;
+
+            var context = BicepCompletionContext.Create(compilation, offset);
+            var completionProvider = CreateProvider();
+            var completions = (await completionProvider.GetFilteredCompletions(compilation, context, CancellationToken.None)).ToList();
+
+            var resourceCompletions = completions
+                .Where(c => c.Kind == SymbolKind.Resource.ToCompletionItemKind())
+                .ToDictionary(c => c.Label);
+
+            resourceCompletions.Keys.Should().BeEquivalentTo([
+                "parent",
+                "parent::child",
+                "parent::child::grandchild",
+            ]);
+
+            var nestedResourceCompletion = resourceCompletions["parent::child::grandchild"];
+            nestedResourceCompletion.InsertTextFormat.Should().Be(InsertTextFormat.PlainText);
+            nestedResourceCompletion.TextEdit!.TextEdit!.NewText.Should().Be("parent::child::grandchild");
+            nestedResourceCompletion.CommitCharacters.Should().BeEquivalentTo([":",]);
+            nestedResourceCompletion.Detail.Should().Be("parent::child::grandchild");
+        }
+
+        [TestMethod]
         public async Task CompletionsForOneLinerParameterDefaultValueShouldIncludeFunctionsValidInDefaultValues()
         {
             var compilation = Services.BuildCompilation(@"param p string = ");

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -1043,6 +1043,37 @@ namespace Bicep.LanguageServer.Completions
                 }
             }
 
+            void AddNestedResourceCompletions(IDictionary<string, CompletionItem> result)
+            {
+                foreach (var resource in model.DeclaredResources)
+                {
+                    var resourceNameComponents = model.ResourceAncestors.GetAncestors(resource)
+                        .Where(ancestor => ancestor.AncestorType == ResourceAncestorGraph.ResourceAncestorType.Nested)
+                        .Select(ancestor => ancestor.Resource.Symbol)
+                        .Append(resource.Symbol)
+                        .ToArray();
+
+                    if (resourceNameComponents.Length == 1 ||
+                        resourceNameComponents.Any(symbol => !symbol.NameSource.IsValid || !symbol.CanBeReferenced()) ||
+                        !ShouldSymbolBeIncludedInCompletion(resource.Symbol, model, context, enclosingDecorableSymbol))
+                    {
+                        continue;
+                    }
+
+                    var qualifiedResourceName = string.Join("::", resourceNameComponents.Select(symbol => symbol.Name));
+                    if (!result.ContainsKey(qualifiedResourceName))
+                    {
+                        var priority = GetContextualCompletionPriority(resource.Symbol, model, context, enclosingDecorableSymbol);
+                        result.Add(qualifiedResourceName, CreateSymbolCompletion(
+                            resource.Symbol,
+                            context.ReplacementRange,
+                            priority: priority,
+                            model: model,
+                            insertText: qualifiedResourceName));
+                    }
+                }
+            }
+
             // local function
             IEnumerable<FunctionSymbol> GetAccessibleDecoratorFunctionsWithCache(NamespaceType namespaceType)
             {
@@ -1085,6 +1116,8 @@ namespace Bicep.LanguageServer.Completions
                         symbolFilter = symbol => symbol is VariableSymbol or ImportedVariableSymbol or DeclaredFunctionSymbol or ImportedFunctionSymbol or WildcardImportSymbol or ResourceSymbol;
                     }
                 }
+
+                AddNestedResourceCompletions(completions);
             }
             else
             {


### PR DESCRIPTION
Adds qualified nested resource references to expression completions so nested resources can be selected from the top-level completion list as `parent::child` and deeper chains.

Fixes #3502

Validation:
- `dotnet test .\src\Bicep.LangServer.UnitTests\Bicep.LangServer.UnitTests.csproj --no-restore -- --filter FullyQualifiedName~BicepCompletionProviderTests`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20017)