### PR TITLE
Add secure-params-in-parameters-file linter rule

### DIFF
--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecureParamsInParametersFileRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecureParamsInParametersFileRuleTests.cs
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Analyzers.Linter.Rules;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
+{
+    [TestClass]
+    public class SecureParamsInParametersFileRuleTests : LinterRuleTestsBase
+    {
+        private static readonly Uri MainUri = new("file:///main.bicep");
+        private static readonly Uri ParamsUri = new("file:///main.bicepparam");
+
+        private static ServiceBuilder ServiceBuilder => new ServiceBuilder()
+            .WithConfiguration(BicepTestConstants.BuiltInConfigurationWithStableAnalyzers)
+            .WithEmptyAzResources();
+
+        private static Compilation Compile(string mainBicep, string paramsBicep)
+        {
+            var files = new Dictionary<Uri, string>
+            {
+                [MainUri] = mainBicep,
+                [ParamsUri] = paramsBicep,
+            };
+
+            return ServiceBuilder.BuildCompilation(files, ParamsUri);
+        }
+
+        [TestMethod]
+        public void InsecureParamAssignedSecureParamValue_IsFlagged()
+        {
+            var compilation = Compile(
+                """
+                @secure()
+                param secureParam string
+
+                param insecureParam string
+                """,
+                """
+                using 'main.bicep'
+
+                param secureParam = 'MYSECRET'
+                param insecureParam = secureParam
+                """);
+
+            compilation.GetSourceFileDiagnostics(ParamsUri).Should().ContainSingleDiagnostic(
+                SecureParamsInParametersFileRule.Code,
+                DiagnosticLevel.Warning,
+                "Insecure parameter 'insecureParam' is assigned a value that references secure parameter(s) 'secureParam', which could expose their values in deployment history.");
+        }
+
+        [TestMethod]
+        public void SecureParamAssignedSecureParamValue_IsNotFlagged()
+        {
+            var compilation = Compile(
+                """
+                @secure()
+                param secureParam string
+
+                @secure()
+                param anotherSecureParam string
+                """,
+                """
+                using 'main.bicep'
+
+                param secureParam = 'MYSECRET'
+                param anotherSecureParam = secureParam
+                """);
+
+            compilation.GetSourceFileDiagnostics(ParamsUri).Should().NotContainDiagnostic(SecureParamsInParametersFileRule.Code);
+        }
+
+        [TestMethod]
+        public void InsecureParamAssignedLiteralValue_IsNotFlagged()
+        {
+            var compilation = Compile(
+                """
+                @secure()
+                param secureParam string
+
+                param insecureParam string
+                """,
+                """
+                using 'main.bicep'
+
+                param secureParam = 'MYSECRET'
+                param insecureParam = 'not a secret'
+                """);
+
+            compilation.GetSourceFileDiagnostics(ParamsUri).Should().NotContainDiagnostic(SecureParamsInParametersFileRule.Code);
+        }
+
+        [TestMethod]
+        public void InsecureParamAssignedInsecureParamValue_IsNotFlagged()
+        {
+            var compilation = Compile(
+                """
+                param firstParam string
+
+                param secondParam string
+                """,
+                """
+                using 'main.bicep'
+
+                param firstParam = 'value'
+                param secondParam = firstParam
+                """);
+
+            compilation.GetSourceFileDiagnostics(ParamsUri).Should().NotContainDiagnostic(SecureParamsInParametersFileRule.Code);
+        }
+
+        [TestMethod]
+        public void InsecureParamTransitivelyReferencingSecureParam_IsFlagged()
+        {
+            var compilation = Compile(
+                """
+                @secure()
+                param secureParam string
+
+                param insecureParam string
+                """,
+                """
+                using 'main.bicep'
+
+                param secureParam = 'MYSECRET'
+                var derived = secureParam
+                param insecureParam = derived
+                """);
+
+            compilation.GetSourceFileDiagnostics(ParamsUri).Should().ContainSingleDiagnostic(
+                SecureParamsInParametersFileRule.Code,
+                DiagnosticLevel.Warning,
+                "Insecure parameter 'insecureParam' is assigned a value that references secure parameter(s) 'secureParam', which could expose their values in deployment history.");
+        }
+
+        [TestMethod]
+        public void InsecureParamAssignedSecureParamInInterpolation_IsFlagged()
+        {
+            var compilation = Compile(
+                """
+                @secure()
+                param secureParam string
+
+                param insecureParam string
+                """,
+                """
+                using 'main.bicep'
+
+                param secureParam = 'MYSECRET'
+                param insecureParam = 'prefix-${secureParam}'
+                """);
+
+            compilation.GetSourceFileDiagnostics(ParamsUri).Should().ContainSingleDiagnostic(
+                SecureParamsInParametersFileRule.Code,
+                DiagnosticLevel.Warning,
+                "Insecure parameter 'insecureParam' is assigned a value that references secure parameter(s) 'secureParam', which could expose their values in deployment history.");
+        }
+
+        [TestMethod]
+        public void SecureObjectParam_ReferencedByInsecureParam_IsFlagged()
+        {
+            var compilation = Compile(
+                """
+                @secure()
+                param secureObj object
+
+                param insecureParam object
+                """,
+                """
+                using 'main.bicep'
+
+                param secureObj = { key: 'MYSECRET' }
+                param insecureParam = secureObj
+                """);
+
+            compilation.GetSourceFileDiagnostics(ParamsUri).Should().ContainSingleDiagnostic(
+                SecureParamsInParametersFileRule.Code,
+                DiagnosticLevel.Warning,
+                "Insecure parameter 'insecureParam' is assigned a value that references secure parameter(s) 'secureObj', which could expose their values in deployment history.");
+        }
+
+        [TestMethod]
+        public void Rule_DoesNotRunOnBicepFiles()
+        {
+            var compilation = ServiceBuilder.BuildCompilation(
+                new Dictionary<Uri, string>
+                {
+                    [MainUri] = """
+                        @secure()
+                        param secureParam string
+
+                        var insecureVar = secureParam
+
+                        output insecureOutput string = insecureVar
+                        """,
+                },
+                MainUri);
+
+            compilation.GetSourceFileDiagnostics(MainUri).Should().NotContainDiagnostic(SecureParamsInParametersFileRule.Code);
+        }
+    }
+}

--- a/src/Bicep.Core/Analyzers/Linter/Rules/SecureParamsInParametersFileRule.cs
+++ b/src/Bicep.Core/Analyzers/Linter/Rules/SecureParamsInParametersFileRule.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.SourceGraph;
+using Bicep.Core.Syntax;
+using Bicep.Core.Syntax.Visitors;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Providers.Az;
+using Bicep.Core.TypeSystem.Types;
+
+namespace Bicep.Core.Analyzers.Linter.Rules
+{
+    public sealed class SecureParamsInParametersFileRule : LinterRuleBase
+    {
+        public new const string Code = "secure-params-in-parameters-file";
+
+        public SecureParamsInParametersFileRule() : base(
+            code: Code,
+            description: CoreResources.SecureParamsInParametersFileRule_Description,
+            LinterRuleCategory.Security)
+        { }
+
+        public override string FormatMessage(params object[] values)
+            => string.Format(CoreResources.SecureParamsInParametersFileRule_MessageFormat, values);
+
+        public override IEnumerable<IDiagnostic> AnalyzeInternal(SemanticModel model, DiagnosticLevel diagnosticLevel)
+        {
+            if (model.SourceFile.FileKind != BicepSourceFileKind.ParamsFile)
+            {
+                yield break;
+            }
+
+            foreach (var assignment in model.Root.ParameterAssignments)
+            {
+                // skip if the target param is itself secure (secure -> secure is fine)
+                if (model.TryGetParameterMetadata(assignment) is not { } targetMetadata ||
+                     IsSecure(targetMetadata))
+                {
+                    continue;
+                }
+
+                // does the assigned value transitively reference a secure parameter
+                var secureRefs = model.Binder.GetReferencedSymbolClosureFor(assignment)
+                    .OfType<ParameterAssignmentSymbol>()
+                    .Where(p => model.TryGetParameterMetadata(p) is { } metadata && IsSecure(metadata))
+                    .ToArray();
+
+                if (secureRefs.Length > 0)
+                {
+                    yield return CreateDiagnosticForSpan(
+                        diagnosticLevel,
+                        assignment.DeclaringParameterAssignment.Value.Span,
+                        assignment.Name,
+                        string.Join(", ", secureRefs.Select(p => $"'{p.Name}'")));
+                }
+            }
+        }
+
+        private static bool IsSecure(Semantics.Metadata.ParameterMetadata targetMetadata)
+        {
+            return TypeHelper.IsOrContainsSecureType(targetMetadata.TypeReference.Type);
+        }
+    }
+}

--- a/src/Bicep.Core/CoreResources.Designer.cs
+++ b/src/Bicep.Core/CoreResources.Designer.cs
@@ -790,6 +790,24 @@ namespace Bicep.Core {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Secure parameter values should not be assigned to insecure parameters in a parameters file..
+        /// </summary>
+        internal static string SecureParamsInParametersFileRule_Description {
+            get {
+                return ResourceManager.GetString("SecureParamsInParametersFileRule_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Insecure parameter &apos;{0}&apos; is assigned a value that references secure parameter(s) {1}, which could expose their values in deployment history..
+        /// </summary>
+        internal static string SecureParamsInParametersFileRule_MessageFormat {
+            get {
+                return ResourceManager.GetString("SecureParamsInParametersFileRule_MessageFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Either set the deployment&apos;s properties.expressionEvaluationOptions.scope to &apos;inner&apos; or use a Bicep module instead..
         /// </summary>
         internal static string SecureParamsInNestedDeployRule_Solution {

--- a/src/Bicep.Core/CoreResources.resx
+++ b/src/Bicep.Core/CoreResources.resx
@@ -359,6 +359,13 @@
   <data name="SecureParamsInNestedDeployRule_Solution" xml:space="preserve">
     <value>Either set the deployment's properties.expressionEvaluationOptions.scope to 'inner' or use a Bicep module instead.</value>
   </data>
+  <data name="SecureParamsInParametersFileRule_Description" xml:space="preserve">
+    <value>Secure parameter values should not be assigned to insecure parameters in a parameters file.</value>
+  </data>
+  <data name="SecureParamsInParametersFileRule_MessageFormat" xml:space="preserve">
+    <value>Insecure parameter '{0}' is assigned a value that references secure parameter(s) {1}, which could expose their values in deployment history.</value>
+    <comment>{0} = programmatic name of the insecure parameter, {1} = comma-separated list of secure parameter names</comment>
+  </data>
   <data name="UseResourceSymbolReferenceRule_Description" xml:space="preserve">
     <value>Use a direct resource symbol reference instead of 'reference' or 'list*' functions.</value>
   </data>

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -695,6 +695,16 @@
                     }
                   ]
                 },
+                "secure-params-in-parameters-file": {
+                  "allOf": [
+                    {
+                      "description": "Secure parameter values should not be assigned to insecure parameters in a parameters file. Defaults to 'Warning'. See https://aka.ms/bicep/linter-diagnostics#secure-params-in-parameters-file"
+                    },
+                    {
+                      "$ref": "#/definitions/rule-def-level-warning"
+                    }
+                  ]
+                },
                 "secure-secrets-in-params": {
                   "allOf": [
                     {


### PR DESCRIPTION
## Summary

Adds a new linter rule `secure-params-in-parameters-file` that flags `.bicepparam` assignments where a value derived from a `@secure()` parameter is assigned to a non-secure parameter. 
Fixes #16253

## Example

Given:

```bicep
// main.bicep
@secure()
param secureParam string
param insecureParam string
```

```bicep
// main.bicepparam
using 'main.bicep'
param secureParam = 'MYSECRET'
param insecureParam = secureParam  // <-- now flagged (Warning)
```

The rule reports:

> Insecure parameter 'insecureParam' is assigned a value that references secure parameter(s) 'secureParam', which could expose their values in deployment history.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20021)