### PR TITLE
add '=' completion after module path string (Ctrl+Space)

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1339,6 +1339,40 @@ resource base64 'Microsoft.Foo/foos@2020-09-01' existing | {}
         }
 
         [TestMethod]
+        public async Task ModulePathFollowerCompletionsOffersEquals()
+        {
+            var fileWithCursors = @"
+module dummy 'modules/dummy.bicep' |
+
+module dummy 'modules/dummy.bicep' | {}
+";
+
+            static void AssertEqualsOperatorCompletion(CompletionItem item)
+            {
+                item.Label.Should().Be("=");
+                item.Documentation.Should().BeNull();
+                item.Kind.Should().Be(CompletionItemKind.Operator);
+                item.Preselect.Should().BeTrue();
+                item.TextEdit!.TextEdit!.NewText.Should().Be("=");
+                item.CommitCharacters.Should().BeNull();
+            }
+
+            await RunCompletionScenarioTest(
+                this.TestContext,
+                ServerWithBuiltInTypes,
+                fileWithCursors,
+                completions =>
+                    completions.Should().SatisfyRespectively(
+                        x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
+                            d => AssertEqualsOperatorCompletion(d)
+                        ),
+                        x => x!.OrderBy(d => d.SortText).Should().SatisfyRespectively(
+                            d => AssertEqualsOperatorCompletion(d)
+                        )),
+                '|');
+        }
+
+        [TestMethod]
         public async Task OutputTypeFollowerWithoCompletionsOffersEquals()
         {
             var fileWithCursors = @"

--- a/src/Bicep.LangServer.UnitTests/Completions/BicepCompletionContextTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Completions/BicepCompletionContextTests.cs
@@ -201,6 +201,16 @@ resource foo 'Microsoft.Foo/bar@2020-01-01' = {
         }
 
         [DataTestMethod]
+        [DataRow("module dummy 'modules/dummy.bicep' |")]
+        [DataRow("module dummy 'modules/dummy.bicep' | {}")]
+        public void ContextKind_Is_ModulePathFollower(string text)
+        {
+            var context = CreateContextFromTextWithCursor(text);
+            context.Kind.Should().HaveFlag(BicepCompletionContextKind.ModulePathFollower,
+                $"cursor in '{text}' should be a module path follower context");
+        }
+
+        [DataTestMethod]
         [DataRow("var foo1 = [a |]")]
         [DataRow("var foo2 = [| a]")]
         [DataRow("var foo3 = [aSymbol, b |]")]

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -223,6 +223,7 @@ namespace Bicep.LanguageServer.Completions
                 ConvertFlag(IsNestedResourceStartContext(matchingNodes, topLevelDeclarationInfo, objectInfo, offset), BicepCompletionContextKind.NestedResourceDeclarationStart) |
                 GetDeclarationTypeFlags(matchingNodes, offset) |
                 ConvertFlag(IsResourceTypeFollowerContext(matchingNodes, offset), BicepCompletionContextKind.ResourceTypeFollower) |
+                ConvertFlag(IsModulePathFollowerContext(matchingNodes, offset), BicepCompletionContextKind.ModulePathFollower) |
                 GetObjectPropertyNameFlags(matchingNodes, objectInfo, offset) |
                 ConvertFlag(IsMemberAccessContext(matchingNodes, propertyAccessInfo, offset), BicepCompletionContextKind.MemberAccess) |
                 ConvertFlag(IsResourceAccessContext(matchingNodes, resourceAccessInfo, offset), BicepCompletionContextKind.ResourceAccess) |
@@ -463,6 +464,14 @@ namespace Bicep.LanguageServer.Completions
             SyntaxMatcher.IsTailMatch<ResourceDeclarationSyntax, SkippedTriviaSyntax, Token>(matchingNodes, (resource, skipped, token) => resource.Assignment == skipped && token.Type == TokenType.Identifier) ||
             // resource foo '...' |=
             SyntaxMatcher.IsTailMatch<ResourceDeclarationSyntax, Token>(matchingNodes, (resource, token) => IsAtTokenStart(resource.Assignment, token, offset) && token.Type == TokenType.Assignment);
+
+        private static bool IsModulePathFollowerContext(List<SyntaxBase> matchingNodes, int offset) =>
+            // module foo '...' |
+            // OR
+            // module foo '...' | = {
+            SyntaxMatcher.IsTailMatch<ModuleDeclarationSyntax>(matchingNodes, module => offset > module.Path.GetEndPosition() && offset <= module.Assignment.Span.Position) ||
+            // module foo '...' |=
+            SyntaxMatcher.IsTailMatch<ModuleDeclarationSyntax, Token>(matchingNodes, (module, token) => IsAtTokenStart(module.Assignment, token, offset) && token.Type == TokenType.Assignment);
 
         private static bool IsVariableNameFollowerContext(List<SyntaxBase> matchingNodes, int offset) =>
             // var foo |

--- a/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContextKind.cs
@@ -288,5 +288,10 @@ namespace Bicep.LanguageServer.Completions
         /// The current location is after '#restore-diagnostics |'.
         /// </summary>
         RestoreDiagnosticsCodes = 1UL << 53,
+
+        /// <summary>
+        /// The current location is after the module path string: 'module foo '...' |'
+        /// </summary>
+        ModulePathFollower = 1UL << 54,
     }
 }

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -67,6 +67,7 @@ namespace Bicep.LanguageServer.Completions
                 .Concat(GetArrayItemCompletions(model, context))
                 .Concat(GetResourceTypeCompletions(model, context))
                 .Concat(GetResourceTypeFollowerCompletions(context))
+                .Concat(GetModulePathFollowerCompletions(context))
                 .Concat(GetLocalModulePathCompletions(model, context))
                 .Concat(GetModuleBodyCompletions(model, context))
                 .Concat(GetTestBodyCompletions(model, context))
@@ -524,6 +525,19 @@ namespace Bicep.LanguageServer.Completions
                 {
                     const string existing = "existing";
                     yield return CreateKeywordCompletion(existing, existing, context.ReplacementRange);
+                }
+            }
+        }
+
+        private static IEnumerable<CompletionItem> GetModulePathFollowerCompletions(BicepCompletionContext context)
+        {
+            if (context.Kind.HasFlag(BicepCompletionContextKind.ModulePathFollower))
+            {
+                if (context.EnclosingDeclaration is ModuleDeclarationSyntax module &&
+                    module.Assignment is SkippedTriviaSyntax { Elements: { IsDefaultOrEmpty: true } })
+                {
+                    const string equals = "=";
+                    yield return CreateOperatorCompletion(equals, context.ReplacementRange, preselect: true);
                 }
             }
         }


### PR DESCRIPTION
## Description
Issue:
When typing a module declaration and pressing Ctrl+Space after the path string, no completions were offered. Resources correctly showed  =  and  existing , but modules showed nothing.

Fix: 
Added  ModulePathFollower  as a new completion context kind ,  mirroring the existing resource pattern:

BicepCompletionContextKind.cs  --> new  ModulePathFollower  flag
BicepCompletionContext.cs  --> new  IsModulePathFollowerContext  detection method
BicepCompletionProvider.cs  --> new  GetModulePathFollowerCompletions  method that offers  '=' 

Before:

module dummy 'modules/dummy.bicep' |     Ctrl+Space ->No suggestions

After:

module dummy 'modules/dummy.bicep' |      Ctrl+Space -> = 
<!-- Provide a 1-2 sentence description of your change -->

## Example Usage

<!-- Provide example usage if you are making syntax or CLI changes. 
     Provide screenshots if you are making changes to editor user experience.
     Delete this section if it doesn't apply to your change. -->

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20022)