### PR TITLE
Fix Bicep playground WASM file handling

### DIFF
--- a/Bicep.sln
+++ b/Bicep.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31815.197
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11828.311 oobstable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bicep.Cli", "src\Bicep.Cli\Bicep.Cli.csproj", "{58F20140-729B-41E0-91F0-7004C4E0CB1E}"
 EndProject
@@ -120,6 +120,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.MSBuild.UnitTests", "src\Bicep.MSBuild.UnitTests\Bicep.MSBuild.UnitTests.csproj", "{64F80A63-FF29-4B66-89EB-3F94A0F33E3B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.McpServer.Core", "src\Bicep.McpServer.Core\Bicep.McpServer.Core.csproj", "{AAAC063A-C133-47AF-885D-8F6EBA608EC8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bicep.Wasm.UnitTests", "src\Bicep.Wasm.UnitTests\Bicep.Wasm.UnitTests.csproj", "{B887FEC4-2151-6199-35E5-688C1052BC06}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -267,6 +269,10 @@ Global
 		{AAAC063A-C133-47AF-885D-8F6EBA608EC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AAAC063A-C133-47AF-885D-8F6EBA608EC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AAAC063A-C133-47AF-885D-8F6EBA608EC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B887FEC4-2151-6199-35E5-688C1052BC06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B887FEC4-2151-6199-35E5-688C1052BC06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B887FEC4-2151-6199-35E5-688C1052BC06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B887FEC4-2151-6199-35E5-688C1052BC06}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -307,6 +313,7 @@ Global
 		{930BA3F9-160A-4EB6-80DC-AABFDE3BB919} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
 		{64F80A63-FF29-4B66-89EB-3F94A0F33E3B} = {38A0A11F-72BD-4512-A4A9-AC953936C09F}
 		{AAAC063A-C133-47AF-885D-8F6EBA608EC8} = {013E98B4-42CE-4009-BC62-2588ED9028CD}
+		{B887FEC4-2151-6199-35E5-688C1052BC06} = {9EBF2BF0-C968-4029-B21D-214D195EA148}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {21F77282-91E7-4304-B1EF-FADFA4F39E37}

--- a/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
+++ b/src/Bicep.Core/Registry/AzureContainerRegistryManager.cs
@@ -30,6 +30,8 @@ namespace Bicep.Core.Registry
         // (https://docs.docker.com/registry/spec/api/#content-digests)
         private static readonly string DigestAlgorithmIdentifier = OciDescriptor.AlgorithmIdentifierSha256;
 
+        private const int MaxConcurrentLayerDownloads = 5;
+
         public AzureContainerRegistryManager(IContainerRegistryClientFactory clientFactory)
         {
             this.clientFactory = clientFactory;
@@ -270,9 +272,7 @@ namespace Bicep.Core.Registry
             ValidateManifestResponse(manifestResult);
 
             var deserializedManifest = OciManifest.FromBinaryData(manifestResult.Manifest) ?? throw new InvalidOperationException("the manifest is not a valid OCI manifest");
-            var layerTasks = deserializedManifest.Layers.AsParallel().WithDegreeOfParallelism(5)
-                .Select(async layer => new OciArtifactLayer(layer.Digest, layer.MediaType, await PullLayerAsync(client, layer)));
-            var layers = await Task.WhenAll(layerTasks);
+            var layers = await PullLayersAsync(client, deserializedManifest.Layers);
 
             var config = !deserializedManifest.Config.IsEmpty() ?
                 new OciArtifactLayer(deserializedManifest.Config.Digest, deserializedManifest.Config.MediaType, await PullLayerAsync(client, deserializedManifest.Config)) :
@@ -284,6 +284,21 @@ namespace Bicep.Core.Registry
                 BicepMediaTypes.BicepExtensionArtifactType => new OciExtensionArtifactResult(manifestResult.Manifest, manifestResult.Digest, layers, config),
                 _ => throw new InvalidArtifactException($"artifacts of type: \'{deserializedManifest.ArtifactType}\' are not supported by this Bicep version. {OciModuleArtifactResult.NewerVersionMightBeRequired}")
             };
+        }
+
+        private static async Task<OciArtifactLayer[]> PullLayersAsync(ContainerRegistryContentClient client, IEnumerable<OciDescriptor> layers)
+        {
+            var pulledLayers = new List<OciArtifactLayer>();
+
+            foreach (var batch in layers.Chunk(MaxConcurrentLayerDownloads))
+            {
+                var pulledBatch = await Task.WhenAll(batch.Select(async layer =>
+                    new OciArtifactLayer(layer.Digest, layer.MediaType, await PullLayerAsync(client, layer))));
+
+                pulledLayers.AddRange(pulledBatch);
+            }
+
+            return [.. pulledLayers];
         }
 
         private static async Task<BinaryData> PullLayerAsync(ContainerRegistryContentClient client, OciDescriptor layer, CancellationToken cancellationToken = default)

--- a/src/Bicep.Wasm.UnitTests/Bicep.Wasm.UnitTests.csproj
+++ b/src/Bicep.Wasm.UnitTests/Bicep.Wasm.UnitTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bicep.Core.UnitTests\Bicep.Core.UnitTests.csproj" />
+    <ProjectReference Include="..\Bicep.Wasm\Bicep.Wasm.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/src/Bicep.Wasm.UnitTests/InteropTests.cs
+++ b/src/Bicep.Wasm.UnitTests/InteropTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO.Abstractions.TestingHelpers;
+using System.Text.Json;
+using Bicep.Core.Registry;
+using Bicep.Core.Registry.Catalog;
+using Bicep.Core.UnitTests.Utils;
+using Bicep.IO.Abstraction;
+using Bicep.IO.InMemory;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using static Bicep.Core.UnitTests.Utils.RegistryHelper;
+
+namespace Bicep.Wasm.UnitTests;
+
+[TestClass]
+public class InteropTests
+{
+    [TestMethod]
+    public async Task CompileAndEmitDiagnostics_WithQuickstartModules_LoadsModulesRecursively()
+    {
+        var quickstartFiles = new Dictionary<string, string>
+        {
+            ["example/modules/child.bicep"] = """
+                module grandchild '../shared/grandchild.bicep' = {
+                  name: 'grandchild'
+                }
+
+                output name string = grandchild.outputs.name
+                """,
+            ["example/shared/grandchild.bicep"] = """
+                output name string = 'from-grandchild'
+                """,
+        };
+
+        var jsRuntime = new MockJsRuntime(quickstartFiles);
+        var fileExplorer = new InMemoryFileExplorer();
+        using var serviceProvider = CreateServiceProvider(fileExplorer);
+        var interop = new Interop(jsRuntime, serviceProvider);
+
+        var result = await interop.CompileAndEmitDiagnostics(
+            """
+            module child './modules/child.bicep' = {
+              name: 'child'
+            }
+
+            output childName string = child.outputs.name
+            """,
+            "example/main.bicep");
+
+        using var template = JsonDocument.Parse(result.template);
+        template.RootElement.GetProperty("resources").GetArrayLength().Should().Be(1);
+        jsRuntime.LoadedPaths.Should().Equal(
+            "example/modules/child.bicep",
+            "example/shared/grandchild.bicep");
+        fileExplorer.GetFile(IOUri.FromFilePath("/quickstarts/example/modules/child.bicep")).Exists().Should().BeTrue();
+        fileExplorer.GetFile(IOUri.FromFilePath("/quickstarts/example/shared/grandchild.bicep")).Exists().Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task CompileAndEmitDiagnostics_WithRemoteOciModule_RestoresModule()
+    {
+        var clientFactory = await RegistryHelper.CreateMockRegistryClientWithPublishedModulesAsync(
+            new MockFileSystem(),
+            new ModuleToPublish(
+                "br:mcr.microsoft.com/bicep/test/module:v1",
+                "output name string = 'from-registry'"));
+
+        var jsRuntime = new MockJsRuntime(new Dictionary<string, string>());
+        var fileExplorer = new InMemoryFileExplorer();
+        using var serviceProvider = CreateServiceProvider(fileExplorer, clientFactory);
+        var interop = new Interop(jsRuntime, serviceProvider);
+
+        var result = await interop.CompileAndEmitDiagnostics(
+            """
+            module remote 'br:mcr.microsoft.com/bicep/test/module:v1' = {
+              name: 'remote'
+            }
+
+            output remoteName string = remote.outputs.name
+            """,
+            null);
+
+        using var template = JsonDocument.Parse(result.template);
+        template.RootElement.GetProperty("resources").GetArrayLength().Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task CompileAndEmitDiagnostics_WithEntrypointDiagnostic_MapsDiagnosticToEntrypointSpan()
+    {
+        var jsRuntime = new MockJsRuntime(new Dictionary<string, string>());
+        var fileExplorer = new InMemoryFileExplorer();
+        using var serviceProvider = CreateServiceProvider(fileExplorer);
+        var interop = new Interop(jsRuntime, serviceProvider);
+
+        var result = await interop.CompileAndEmitDiagnostics(
+            """
+            var value = 'hello'
+            output bad string = value.missing
+            """,
+            null);
+
+        var diagnostic = result.diagnostics.Should().BeAssignableTo<object[]>().Subject.Should().ContainSingle().Subject;
+
+        GetProperty<int>(diagnostic, "startLineNumber").Should().Be(2);
+    }
+
+    private static ServiceProvider CreateServiceProvider(IFileExplorer fileExplorer, IContainerRegistryClientFactory? clientFactory = null)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(fileExplorer);
+        services.AddSingleton<IArtifactRegistryProvider, WasmModuleRegistryProvider>();
+        services.AddSingleton<IPublicModuleMetadataProvider, WasmPublicModuleMetadataProvider>();
+
+        if (clientFactory is not null)
+        {
+            services.AddSingleton(clientFactory);
+        }
+
+        services.AddBicepCore();
+
+        return services.BuildServiceProvider();
+    }
+
+    private static T GetProperty<T>(object @object, string propertyName)
+        => (T)@object.GetType().GetProperty(propertyName)!.GetValue(@object)!;
+
+    private sealed class MockJsRuntime(IReadOnlyDictionary<string, string> files) : IJSRuntime
+    {
+        private readonly List<string> loadedPaths = [];
+
+        public IReadOnlyList<string> LoadedPaths => this.loadedPaths;
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+            => this.InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            identifier.Should().Be("LoadQuickstartsFile");
+            args.Should().NotBeNull();
+            args.Should().ContainSingle();
+
+            var filePath = args![0].Should().BeOfType<string>().Subject;
+            this.loadedPaths.Add(filePath);
+
+            files.TryGetValue(filePath, out var contents);
+
+            return ValueTask.FromResult((TValue)(object?)contents!);
+        }
+    }
+}

--- a/src/Bicep.Wasm/Bicep.Wasm.csproj
+++ b/src/Bicep.Wasm/Bicep.Wasm.csproj
@@ -2,7 +2,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="Microsoft.NET.Sdk.WebAssembly.Pack" />
   </ItemGroup>
 

--- a/src/Bicep.Wasm/Interop.cs
+++ b/src/Bicep.Wasm/Interop.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using Bicep.Core;
 using Bicep.Core.Diagnostics;
@@ -11,6 +10,7 @@ using Bicep.Core.Semantics;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.Text;
 using Bicep.Decompiler;
+using Bicep.IO.Abstraction;
 using Bicep.IO.InMemory;
 using Bicep.Wasm.LanguageHelpers;
 using Microsoft.JSInterop;
@@ -139,44 +139,44 @@ namespace Bicep.Wasm
         {
             using var serviceScope = serviceProvider.CreateScope();
             var compiler = serviceScope.ServiceProvider.GetRequiredService<BicepCompiler>();
-            var fileSystem = serviceScope.ServiceProvider.GetRequiredService<IFileSystem>();
+            var fileExplorer = serviceScope.ServiceProvider.GetRequiredService<IFileExplorer>();
 
             var fileUri = string.IsNullOrEmpty(sourcePath)
-                ? new Uri("file:///main.bicep")
-                : new Uri($"file://{QuickstartsRootPath}{sourcePath.TrimStart('/')}");
+                ? IOUri.FromFilePath("/main.bicep")
+                : IOUri.FromFilePath($"{QuickstartsRootPath}{sourcePath.TrimStart('/')}");
 
-            EnsureParentDirectoryExists(fileSystem, fileUri.LocalPath);
-            await fileSystem.File.WriteAllTextAsync(fileUri.LocalPath, fileContents);
+            await WriteFileAsync(fileExplorer, fileUri, fileContents);
 
             if (!string.IsNullOrEmpty(sourcePath))
             {
-                await WriteModuleFilesRecursively(fileSystem, fileUri, fileContents, [fileUri.LocalPath]);
+                await WriteModuleFilesRecursively(fileExplorer, fileUri, fileContents, [fileUri]);
             }
 
-            return await compiler.CreateCompilation(fileUri.ToIOUri());
+            return await compiler.CreateCompilation(fileUri);
         }
 
-        private async Task WriteModuleFilesRecursively(IFileSystem fileSystem, Uri sourceFileUri, string sourceContent, HashSet<string> loadedPaths)
+        private async Task WriteModuleFilesRecursively(IFileExplorer fileExplorer, IOUri sourceFileUri, string sourceContent, HashSet<IOUri> loadedUris)
         {
             foreach (var modulePath in GetLocalModulePaths(sourceContent))
             {
-                var moduleUri = new Uri(sourceFileUri, modulePath);
+                var moduleUri = sourceFileUri.Resolve(modulePath);
 
-                if (!moduleUri.LocalPath.StartsWith(QuickstartsRootPath, StringComparison.Ordinal) ||
-                    !loadedPaths.Add(moduleUri.LocalPath))
+                if (!moduleUri.Path.StartsWith(QuickstartsRootPath, StringComparison.Ordinal) ||
+                    !loadedUris.Add(moduleUri))
                 {
                     continue;
                 }
 
                 string? moduleContents;
+                var moduleFile = fileExplorer.GetFile(moduleUri);
 
-                if (fileSystem.File.Exists(moduleUri.LocalPath))
+                if (moduleFile.Exists())
                 {
-                    moduleContents = await fileSystem.File.ReadAllTextAsync(moduleUri.LocalPath);
+                    moduleContents = await moduleFile.ReadAllTextAsync();
                 }
                 else
                 {
-                    var quickstartsPath = moduleUri.LocalPath[QuickstartsRootPath.Length..];
+                    var quickstartsPath = moduleUri.Path[QuickstartsRootPath.Length..];
                     moduleContents = await jsRuntime.InvokeAsync<string?>("LoadQuickstartsFile", quickstartsPath);
 
                     if (moduleContents is null)
@@ -184,22 +184,19 @@ namespace Bicep.Wasm
                         continue;
                     }
 
-                    EnsureParentDirectoryExists(fileSystem, moduleUri.LocalPath);
-                    await fileSystem.File.WriteAllTextAsync(moduleUri.LocalPath, moduleContents);
+                    await WriteFileAsync(fileExplorer, moduleUri, moduleContents);
                 }
 
-                await WriteModuleFilesRecursively(fileSystem, moduleUri, moduleContents, loadedPaths);
+                await WriteModuleFilesRecursively(fileExplorer, moduleUri, moduleContents, loadedUris);
             }
         }
 
-        private static void EnsureParentDirectoryExists(IFileSystem fileSystem, string filePath)
+        private static async Task WriteFileAsync(IFileExplorer fileExplorer, IOUri fileUri, string fileContents)
         {
-            var parentDirectory = fileSystem.Path.GetDirectoryName(filePath);
+            var file = fileExplorer.GetFile(fileUri);
+            file.GetParent().EnsureExists();
 
-            if (parentDirectory is not null)
-            {
-                fileSystem.Directory.CreateDirectory(parentDirectory);
-            }
+            await file.WriteAllTextAsync(fileContents);
         }
 
         private static IEnumerable<string> GetLocalModulePaths(string sourceContent)
@@ -209,17 +206,25 @@ namespace Bicep.Wasm
                 .Where(path => !path.StartsWith("br:", StringComparison.OrdinalIgnoreCase))
                 .Where(path => !path.StartsWith("ts:", StringComparison.OrdinalIgnoreCase))
                 .Where(path => !path.StartsWith("az:", StringComparison.OrdinalIgnoreCase))
-                .Where(path => !Uri.TryCreate(path, UriKind.Absolute, out _));
+                .Where(path => !HasAbsoluteSchemePrefix(path));
+
+        private static bool HasAbsoluteSchemePrefix(string path) => GetAbsoluteSchemePrefixRegex().IsMatch(path);
 
         [GeneratedRegex("^\\s*module\\s+\\w+\\s+'(?<path>[^']+)'", RegexOptions.Multiline)]
         private static partial Regex GetModulePathRegex();
 
+        [GeneratedRegex("^[A-Za-z][A-Za-z0-9+.-]*:")]
+        private static partial Regex GetAbsoluteSchemePrefixRegex();
+
         private static object ToMonacoDiagnostic(IDiagnostic diagnostic, SourceFileGrouping sourceFileGrouping)
         {
-            if (diagnostic.Uri is { } diagnosticUri &&
-                diagnosticUri != sourceFileGrouping.EntryPoint.Uri)
+            var diagnosticUri = diagnostic.Uri?.ToIOUri();
+            var diagnosticSourceFile = GetSourceFile(sourceFileGrouping, diagnosticUri);
+
+            if (diagnosticSourceFile is not null &&
+                diagnosticSourceFile.FileHandle.Uri != sourceFileGrouping.EntryPoint.FileHandle.Uri)
             {
-                var sourcePath = GetDiagnosticSourcePath(diagnosticUri);
+                var sourcePath = GetDiagnosticSourcePath(diagnosticSourceFile.FileHandle.Uri);
 
                 // The playground editor only displays markers in the entrypoint model.
                 // For diagnostics from referenced module files, pin a marker to line 1
@@ -236,8 +241,7 @@ namespace Bicep.Wasm
                 };
             }
 
-            var lineStarts = GetLineStarts(sourceFileGrouping, diagnostic.Uri)
-                ?? sourceFileGrouping.EntryPoint.LineStarts;
+            var lineStarts = diagnosticSourceFile?.LineStarts ?? sourceFileGrouping.EntryPoint.LineStarts;
             var (startLine, startChar) = TextCoordinateConverter.GetPosition(lineStarts, diagnostic.Span.Position);
             var (endLine, endChar) = TextCoordinateConverter.GetPosition(lineStarts, diagnostic.GetEndPosition());
 
@@ -253,22 +257,22 @@ namespace Bicep.Wasm
             };
         }
 
-        private static IReadOnlyList<int>? GetLineStarts(SourceFileGrouping sourceFileGrouping, Uri? diagnosticUri)
+        private static BicepSourceFile? GetSourceFile(SourceFileGrouping sourceFileGrouping, IOUri? diagnosticUri)
         {
             if (diagnosticUri is null ||
-                !sourceFileGrouping.SourceFileLookup.TryGetValue(diagnosticUri.ToIOUri(), out var sourceFileResult) ||
+                !sourceFileGrouping.SourceFileLookup.TryGetValue(diagnosticUri, out var sourceFileResult) ||
                 !sourceFileResult.IsSuccess(out var sourceFile) ||
                 sourceFile is not BicepSourceFile bicepSourceFile)
             {
                 return null;
             }
 
-            return bicepSourceFile.LineStarts;
+            return bicepSourceFile;
         }
 
-        private static string GetDiagnosticSourcePath(Uri diagnosticUri)
+        private static string GetDiagnosticSourcePath(IOUri diagnosticUri)
         {
-            var sourcePath = diagnosticUri.LocalPath;
+            var sourcePath = diagnosticUri.Path;
 
             if (sourcePath.StartsWith(QuickstartsRootPath, StringComparison.Ordinal))
             {

--- a/src/Bicep.Wasm/Program.cs
+++ b/src/Bicep.Wasm/Program.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.IO.Abstractions;
-using System.IO.Abstractions.TestingHelpers;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Catalog;
+using Bicep.IO.Abstraction;
+using Bicep.IO.InMemory;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.JSInterop;
 
@@ -15,8 +16,9 @@ public class Program
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
-        builder.Services.AddSingleton<IFileSystem, MockFileSystem>();
+        builder.Services.AddSingleton<IFileExplorer, InMemoryFileExplorer>();
         builder.Services.AddSingleton<IArtifactRegistryProvider, WasmModuleRegistryProvider>();
+        builder.Services.AddSingleton<IPublicModuleMetadataProvider, WasmPublicModuleMetadataProvider>();
         builder.Services.AddBicepCore();
         builder.Services.AddBicepDecompiler();
 

--- a/src/Bicep.Wasm/WasmModuleRegistryProvider.cs
+++ b/src/Bicep.Wasm/WasmModuleRegistryProvider.cs
@@ -1,14 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Configuration;
 using Bicep.Core.Registry;
+using Bicep.Core.Registry.Catalog;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Wasm
 {
     public class WasmModuleRegistryProvider : ArtifactRegistryProvider
     {
-        public WasmModuleRegistryProvider()
-            : base([new LocalModuleRegistry()])
+        public WasmModuleRegistryProvider(
+            RegistryConfiguration registryConfiguration,
+            IPublicModuleMetadataProvider publicModuleMetadataProvider,
+            IContainerRegistryClientFactory clientFactory,
+            IFileExplorer fileExplorer)
+            : base([
+                new LocalModuleRegistry(),
+                new OciArtifactRegistry(registryConfiguration, clientFactory, publicModuleMetadataProvider, fileExplorer),
+            ])
         {
         }
     }

--- a/src/Bicep.Wasm/WasmPublicModuleMetadataProvider.cs
+++ b/src/Bicep.Wasm/WasmPublicModuleMetadataProvider.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core;
+using Bicep.Core.Registry.Catalog;
+using Bicep.Core.Registry.Catalog.Implementation;
+
+namespace Bicep.Wasm
+{
+    public sealed class WasmPublicModuleMetadataProvider : IPublicModuleMetadataProvider
+    {
+        public string Registry => LanguageConstants.BicepPublicMcrRegistry;
+
+        public bool IsCached => true;
+
+        public string? DownloadError => null;
+
+        public void StartCache()
+        {
+        }
+
+        public Task TryAwaitCache(bool forceUpdate = false) => Task.CompletedTask;
+
+        public Task<ImmutableArray<IRegistryModuleMetadata>> TryGetModulesAsync() => Task.FromResult(ImmutableArray<IRegistryModuleMetadata>.Empty);
+
+        public ImmutableArray<IRegistryModuleMetadata> GetCachedModules() => [];
+    }
+}


### PR DESCRIPTION
## Summary
- Use the Bicep IO abstraction in `Bicep.Wasm` by switching playground file handling to `IFileExplorer`/`IOUri` with `InMemoryFileExplorer`.
- Fix playground diagnostic URI handling so documentation URIs are not treated as source file URIs, keeping entrypoint diagnostics on the correct span.
- Add focused WASM interop tests for quickstart module loading, remote OCI restore plumbing, and diagnostic URI mapping.

Closes #19266

## Validation
- `dotnet test src/Bicep.Wasm.UnitTests/Bicep.Wasm.UnitTests.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary`
- `git diff --check`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20023)