### PR TITLE
Replace BCP Error with Warning for Nullable Types

### DIFF
--- a/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
@@ -240,4 +240,282 @@ output out array = split(first(input), 21)
             ("BCP070", DiagnosticLevel.Error, @"Argument of type ""21"" is not assignable to parameter of type ""array | string""."),
         });
     }
+
+    // https://github.com/Azure/bicep/issues/17284
+    [TestMethod]
+    public void Issue_17284_nullable_operand_in_binary_operator_raises_fixable_warning_instead_of_error()
+    {
+        var result = CompilationHelper.Compile(@"
+func hello(input int?) string? => input == null ? null : input > 60 ? 'Hello world ${input}' : 'Value is lower than 60'
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""input"" is of type ""int | null""."),
+        });
+
+        // ensure the emitted ARM expression is what the user actually intended (same as writing `input!` explicitly)
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['hello'].output.value",
+            "[if(equals(parameters('input'), null()), null(), if(greater(parameters('input'), 60), format('Hello world {0}', parameters('input')), 'Value is lower than 60'))]");
+    }
+
+    [TestMethod]
+    public void Nullable_operand_on_left_of_binary_comparison_raises_fixable_warning()
+    {
+        var templateWithNullable = @"
+func compareLeft(input int?) bool => input > 60
+";
+        var templateWithNonNullAssertion = @"
+func compareLeft(input int?) bool => input ! > 60
+";
+
+        var result = CompilationHelper.Compile(templateWithNullable);
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""input"" is of type ""int | null""."),
+        });
+
+        var warning = result.ExcludingLinterDiagnostics().Diagnostics.Single();
+        warning.Should().BeAssignableTo<IFixable>();
+        warning.As<IFixable>().Fixes.Single().Should().HaveResult(templateWithNullable, templateWithNonNullAssertion);
+
+        // roundtrip: applying the fix yields a template that compiles without any diagnostics
+        CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        // the emitted expression matches what the user would get with an explicit `!` non-null assertion
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['compareLeft'].output.value",
+            "[greater(parameters('input'), 60)]");
+    }
+
+    [TestMethod]
+    public void Nullable_operand_on_right_of_binary_comparison_raises_fixable_warning()
+    {
+        var templateWithNullable = @"
+func compareRight(input int?) bool => 60 > input
+";
+        var templateWithNonNullAssertion = @"
+func compareRight(input int?) bool => 60 > input!
+";
+
+        var result = CompilationHelper.Compile(templateWithNullable);
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""input"" is of type ""int | null""."),
+        });
+
+        var warning = result.ExcludingLinterDiagnostics().Diagnostics.Single();
+        warning.Should().BeAssignableTo<IFixable>();
+        warning.As<IFixable>().Fixes.Single().Should().HaveResult(templateWithNullable, templateWithNonNullAssertion);
+
+        // roundtrip: applying the fix yields a template that compiles without any diagnostics
+        CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        // the emitted expression matches what the user would get with an explicit `!` non-null assertion
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['compareRight'].output.value",
+            "[greater(60, parameters('input'))]");
+    }
+
+    [TestMethod]
+    public void Both_nullable_operands_in_binary_comparison_raise_two_fixable_warnings()
+    {
+        var result = CompilationHelper.Compile(@"
+func compareBoth(a int?, b int?) bool => a > b
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""a"" is of type ""int | null""."),
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""b"" is of type ""int | null""."),
+        });
+
+        // both operands still surface as parameters in the emitted expression
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['compareBoth'].output.value",
+            "[greater(parameters('a'), parameters('b'))]");
+    }
+
+    [TestMethod]
+    public void Nullable_operand_in_arithmetic_operator_raises_fixable_warning()
+    {
+        var result = CompilationHelper.Compile(@"
+func addOne(input int?) int => input + 1
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""input"" is of type ""int | null""."),
+        });
+
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['addOne'].output.value",
+            "[add(parameters('input'), 1)]");
+    }
+
+    [TestMethod]
+    public void Nullable_operand_in_binary_operator_with_non_null_assertion_raises_no_warning()
+    {
+        var result = CompilationHelper.Compile(@"
+func compareLeft(input int?) bool => input! > 60
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void Pure_null_operand_in_binary_operator_still_raises_error()
+    {
+        // pure `null` (not `T | null`) cannot be stripped by TryRemoveNullability, so BCP045 must still fire.
+        var result = CompilationHelper.Compile(@"
+var invalid = null + 's'
+");
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP045", DiagnosticLevel.Error, @"Cannot apply operator ""+"" to operands of type ""null"" and ""'s'""."),
+        });
+    }
+
+    [TestMethod]
+    public void Nullable_operand_in_unary_not_operator_raises_fixable_warning()
+    {
+        var templateWithNullable = @"
+func negate(input bool?) bool => !input
+";
+        var templateWithNonNullAssertion = @"
+func negate(input bool?) bool => !input!
+";
+
+        var result = CompilationHelper.Compile(templateWithNullable);
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""bool"" but the provided value ""input"" is of type ""bool | null""."),
+        });
+
+        var warning = result.ExcludingLinterDiagnostics().Diagnostics.Single();
+        warning.Should().BeAssignableTo<IFixable>();
+        warning.As<IFixable>().Fixes.Single().Should().HaveResult(templateWithNullable, templateWithNonNullAssertion);
+
+        // roundtrip: applying the fix yields a template that compiles without any diagnostics
+        CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        // the emitted expression matches what the user would get with an explicit `!` non-null assertion
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['negate'].output.value",
+            "[not(parameters('input'))]");
+    }
+
+    [TestMethod]
+    public void Nullable_operand_in_unary_minus_operator_raises_fixable_warning()
+    {
+        var result = CompilationHelper.Compile(@"
+func negate(input int?) int => -input
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""input"" is of type ""int | null""."),
+        });
+
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['negate'].output.value",
+            "[sub(0, parameters('input'))]");
+    }
+
+    [TestMethod]
+    public void Null_guarded_unary_operator_pattern_compiles_with_warning()
+    {
+        // User's expected null-guarded pattern from issue #17284 discussion — compiles (with a warning) instead of failing outright.
+        var result = CompilationHelper.Compile(@"
+func not(input bool?) bool => input != null ? !input : false
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""bool"" but the provided value ""input"" is of type ""bool | null""."),
+        });
+
+        // the emitted expression preserves the null-guard: if(input != null, !input, false)
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['not'].output.value",
+            "[if(not(equals(parameters('input'), null())), not(parameters('input')), false())]");
+    }
+
+    [TestMethod]
+    public void Nullable_operand_in_unary_operator_with_non_null_assertion_raises_no_warning()
+    {
+        var result = CompilationHelper.Compile(@"
+func negate(input bool?) bool => !input!
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void Pure_null_operand_in_unary_operator_still_raises_error()
+    {
+        // pure `null` (not `T | null`) cannot be stripped by TryRemoveNullability, so BCP044 must still fire.
+        var result = CompilationHelper.Compile(@"
+var invalid = !null
+");
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP044", DiagnosticLevel.Error, @"Cannot apply operator ""!"" to operand of type ""null""."),
+        });
+    }
+
+    [TestMethod]
+    public void Coalesce_operator_on_nullable_left_does_not_raise_nullability_warning()
+    {
+        // the `??` operator's signature is (Any, Any) and it handles nullability internally, so the exploratory
+        // strip-and-refold branch must never fire for it (no BCP321 false positives).
+        var result = CompilationHelper.Compile(@"
+func withDefault(input int?) int => input ?? 0
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['withDefault'].output.value",
+            "[coalesce(parameters('input'), 0)]");
+    }
+
+    [TestMethod]
+    public void Chained_nullable_arithmetic_raises_warnings_only_on_the_nullable_leaves()
+    {
+        // inner `a + b`: two nullable operands -> two BCP321s, folds to a non-nullable int type.
+        // outer `<inner> + 1`: inner result is already non-nullable, so no extra warning.
+        // this verifies the folded return type propagates as non-nullable up the expression tree.
+        var result = CompilationHelper.Compile(@"
+func sum(a int?, b int?) int => a + b + 1
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""a"" is of type ""int | null""."),
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""b"" is of type ""int | null""."),
+        });
+
+        result.Template.Should().HaveValueAtPath(
+            "$.functions[0].members['sum'].output.value",
+            "[add(add(parameters('a'), parameters('b')), 1)]");
+    }
 }

--- a/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
@@ -265,10 +265,10 @@ func hello(input int?) string? => input == null ? null : input > 60 ? 'Hello wor
     public void Nullable_operand_on_left_of_binary_comparison_raises_fixable_warning()
     {
         var templateWithNullable = @"
-func compareLeft(input int?) bool => input > 60
+func compareLeft(input int?) bool => input == null ? false : input > 60
 ";
         var templateWithNonNullAssertion = @"
-func compareLeft(input int?) bool => input ! > 60
+func compareLeft(input int?) bool => input == null ? false : input ! > 60
 ";
 
         var result = CompilationHelper.Compile(templateWithNullable);
@@ -286,20 +286,20 @@ func compareLeft(input int?) bool => input ! > 60
         // roundtrip: applying the fix yields a template that compiles without any diagnostics
         CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
 
-        // the emitted expression matches what the user would get with an explicit `!` non-null assertion
+        // the emitted expression preserves the null guard around the greater-than comparison
         result.Template.Should().HaveValueAtPath(
             "$.functions[0].members['compareLeft'].output.value",
-            "[greater(parameters('input'), 60)]");
+            "[if(equals(parameters('input'), null()), false(), greater(parameters('input'), 60))]");
     }
 
     [TestMethod]
     public void Nullable_operand_on_right_of_binary_comparison_raises_fixable_warning()
     {
         var templateWithNullable = @"
-func compareRight(input int?) bool => 60 > input
+func compareRight(input int?) bool => input == null ? false : 60 > input
 ";
         var templateWithNonNullAssertion = @"
-func compareRight(input int?) bool => 60 > input!
+func compareRight(input int?) bool => input == null ? false : 60 > input!
 ";
 
         var result = CompilationHelper.Compile(templateWithNullable);
@@ -317,17 +317,17 @@ func compareRight(input int?) bool => 60 > input!
         // roundtrip: applying the fix yields a template that compiles without any diagnostics
         CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
 
-        // the emitted expression matches what the user would get with an explicit `!` non-null assertion
+        // the emitted expression preserves the null guard around the greater-than comparison
         result.Template.Should().HaveValueAtPath(
             "$.functions[0].members['compareRight'].output.value",
-            "[greater(60, parameters('input'))]");
+            "[if(equals(parameters('input'), null()), false(), greater(60, parameters('input')))]");
     }
 
     [TestMethod]
     public void Both_nullable_operands_in_binary_comparison_raise_two_fixable_warnings()
     {
         var result = CompilationHelper.Compile(@"
-func compareBoth(a int?, b int?) bool => a > b
+func compareBoth(cond bool, a int?, b int?) bool => cond ? a > b : false
 ");
 
         result.Template.Should().NotBeNull();
@@ -337,17 +337,17 @@ func compareBoth(a int?, b int?) bool => a > b
             ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""b"" is of type ""int | null""."),
         });
 
-        // both operands still surface as parameters in the emitted expression
+        // both operands still surface as parameters in the emitted expression, gated by the ternary condition
         result.Template.Should().HaveValueAtPath(
             "$.functions[0].members['compareBoth'].output.value",
-            "[greater(parameters('a'), parameters('b'))]");
+            "[if(parameters('cond'), greater(parameters('a'), parameters('b')), false())]");
     }
 
     [TestMethod]
     public void Nullable_operand_in_arithmetic_operator_raises_fixable_warning()
     {
         var result = CompilationHelper.Compile(@"
-func addOne(input int?) int => input + 1
+func addOne(input int?) int => input == null ? 0 : input + 1
 ");
 
         result.Template.Should().NotBeNull();
@@ -358,7 +358,7 @@ func addOne(input int?) int => input + 1
 
         result.Template.Should().HaveValueAtPath(
             "$.functions[0].members['addOne'].output.value",
-            "[add(parameters('input'), 1)]");
+            "[if(equals(parameters('input'), null()), 0, add(parameters('input'), 1))]");
     }
 
     [TestMethod]
@@ -390,10 +390,10 @@ var invalid = null + 's'
     public void Nullable_operand_in_unary_not_operator_raises_fixable_warning()
     {
         var templateWithNullable = @"
-func negate(input bool?) bool => !input
+func negate(input bool?) bool => input == null ? false : !input
 ";
         var templateWithNonNullAssertion = @"
-func negate(input bool?) bool => !input!
+func negate(input bool?) bool => input == null ? false : !input!
 ";
 
         var result = CompilationHelper.Compile(templateWithNullable);
@@ -411,17 +411,17 @@ func negate(input bool?) bool => !input!
         // roundtrip: applying the fix yields a template that compiles without any diagnostics
         CompilationHelper.Compile(templateWithNonNullAssertion).ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
 
-        // the emitted expression matches what the user would get with an explicit `!` non-null assertion
+        // the emitted expression preserves the null guard around the negation
         result.Template.Should().HaveValueAtPath(
             "$.functions[0].members['negate'].output.value",
-            "[not(parameters('input'))]");
+            "[if(equals(parameters('input'), null()), false(), not(parameters('input')))]");
     }
 
     [TestMethod]
     public void Nullable_operand_in_unary_minus_operator_raises_fixable_warning()
     {
         var result = CompilationHelper.Compile(@"
-func negate(input int?) int => -input
+func negate(input int?) int => input == null ? 0 : -input
 ");
 
         result.Template.Should().NotBeNull();
@@ -432,27 +432,7 @@ func negate(input int?) int => -input
 
         result.Template.Should().HaveValueAtPath(
             "$.functions[0].members['negate'].output.value",
-            "[sub(0, parameters('input'))]");
-    }
-
-    [TestMethod]
-    public void Null_guarded_unary_operator_pattern_compiles_with_warning()
-    {
-        // User's expected null-guarded pattern from issue #17284 discussion — compiles (with a warning) instead of failing outright.
-        var result = CompilationHelper.Compile(@"
-func not(input bool?) bool => input != null ? !input : false
-");
-
-        result.Template.Should().NotBeNull();
-        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
-        {
-            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""bool"" but the provided value ""input"" is of type ""bool | null""."),
-        });
-
-        // the emitted expression preserves the null-guard: if(input != null, !input, false)
-        result.Template.Should().HaveValueAtPath(
-            "$.functions[0].members['not'].output.value",
-            "[if(not(equals(parameters('input'), null())), not(parameters('input')), false())]");
+            "[if(equals(parameters('input'), null()), 0, sub(0, parameters('input')))]");
     }
 
     [TestMethod]
@@ -504,7 +484,7 @@ func withDefault(input int?) int => input ?? 0
         // outer `<inner> + 1`: inner result is already non-nullable, so no extra warning.
         // this verifies the folded return type propagates as non-nullable up the expression tree.
         var result = CompilationHelper.Compile(@"
-func sum(a int?, b int?) int => a + b + 1
+func sum(cond bool, a int?, b int?) int => cond ? a + b + 1 : 0
 ");
 
         result.Template.Should().NotBeNull();
@@ -516,17 +496,17 @@ func sum(a int?, b int?) int => a + b + 1
 
         result.Template.Should().HaveValueAtPath(
             "$.functions[0].members['sum'].output.value",
-            "[add(add(parameters('a'), parameters('b')), 1)]");
+            "[if(parameters('cond'), add(add(parameters('a'), parameters('b')), 1), 0)]");
     }
 
     [TestMethod]
     public void Multi_line_nullable_operand_source_text_is_rendered_on_a_single_line_in_the_diagnostic_message()
     {
         // The offending operand spans multiple lines in the source. The BCP321 message must render on a single line
-        // (newlines replaced with spaces) so it stays readable in CLI/IDE output — indentation whitespace is preserved
+        // (newlines replaced with spaces) so it stays readable in CLI/IDE output — inter-token whitespace is preserved
         // as-is, we just guarantee the message never contains a raw newline.
         var result = CompilationHelper.Compile(@"
-func firstOrZero(input int[]) int => first(filter(
+func firstOrZero(input int[]) int => length(input) == 0 ? 0 : first(filter(
   input,
   x => x != 0
 )) + 1
@@ -536,6 +516,36 @@ func firstOrZero(input int[]) int => first(filter(
         result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
         {
             ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""first(filter(   input,   x => x != 0 ))"" is of type ""int | null""."),
+        });
+    }
+
+    [TestMethod]
+    public void Nullable_binary_operand_outside_ternary_branch_still_raises_BCP045_error()
+    {
+        // The strip-and-refold error->warning downgrade is intentionally gated on the operator being inside a
+        // ternary branch (rough proxy for "user has a guard"). Outside a ternary, the pre-PR BCP045 error still fires
+        // so the compiler doesn't silently succeed against a possibly-null runtime value.
+        var result = CompilationHelper.Compile(@"
+func addOne(input int?) int => input + 1
+");
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP045", DiagnosticLevel.Error, @"Cannot apply operator ""+"" to operands of type ""int | null"" and ""1""."),
+        });
+    }
+
+    [TestMethod]
+    public void Nullable_unary_operand_outside_ternary_branch_still_raises_BCP044_error()
+    {
+        // Same gating applies to unary operators: outside a ternary branch, the pre-PR BCP044 error still fires.
+        var result = CompilationHelper.Compile(@"
+func negate(input bool?) bool => !input
+");
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP044", DiagnosticLevel.Error, @"Cannot apply operator ""!"" to operand of type ""bool | null""."),
         });
     }
 }

--- a/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/NullabilityTests.cs
@@ -518,4 +518,24 @@ func sum(a int?, b int?) int => a + b + 1
             "$.functions[0].members['sum'].output.value",
             "[add(add(parameters('a'), parameters('b')), 1)]");
     }
+
+    [TestMethod]
+    public void Multi_line_nullable_operand_source_text_is_rendered_on_a_single_line_in_the_diagnostic_message()
+    {
+        // The offending operand spans multiple lines in the source. The BCP321 message must render on a single line
+        // (newlines replaced with spaces) so it stays readable in CLI/IDE output — indentation whitespace is preserved
+        // as-is, we just guarantee the message never contains a raw newline.
+        var result = CompilationHelper.Compile(@"
+func firstOrZero(input int[]) int => first(filter(
+  input,
+  x => x != 0
+)) + 1
+");
+
+        result.Template.Should().NotBeNull();
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP321", DiagnosticLevel.Warning, @"Expected a value of type ""int"" but the provided value ""first(filter(   input,   x => x != 0 ))"" is of type ""int | null""."),
+        });
+    }
 }

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -1511,11 +1511,21 @@ namespace Bicep.Core.Diagnostics
                 "BCP320",
                 "The properties of module output resources cannot be accessed directly. To use the properties of this resource, pass it as a resource-typed parameter to another module and access the parameter's properties therein.");
 
-            public Diagnostic PossibleNullReferenceAssignment(TypeSymbol expectedType, TypeSymbol actualType, SyntaxBase expression) => CoreWarning(
-                "BCP321",
-                $"Expected a value of type \"{expectedType}\" but the provided value is of type \"{actualType}\".")
-                with
-            { Fixes = [AsNonNullable(expression)] };
+            public Diagnostic PossibleNullReferenceAssignment(TypeSymbol expectedType, TypeSymbol actualType, SyntaxBase expression, bool includeSourceText = false)
+            {
+                // when the diagnostic underline covers more than just the offending expression (e.g. a binary/unary operator that
+                // spans multiple operands), the caller can opt in to include the source text of the offending value in the message
+                // itself so the reader can tell which sub-expression is nullable.
+                var providedValueClause = includeSourceText
+                    ? $"the provided value \"{expression.ToString().Trim()}\""
+                    : "the provided value";
+
+                return CoreWarning(
+                    "BCP321",
+                    $"Expected a value of type \"{expectedType}\" but {providedValueClause} is of type \"{actualType}\".")
+                    with
+                { Fixes = [AsNonNullable(expression)] };
+            }
 
             public Diagnostic SafeDereferenceNotPermittedOnInstanceFunctions() => CoreError(
                 "BCP322",

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -30,6 +30,10 @@ namespace Bicep.Core.Diagnostics
 
             private const string TypeInaccuracyClause = " If this is a resource type definition inaccuracy, report it using https://aka.ms/bicep-type-issues.";
 
+            // Upper bound (roughly a traditional terminal width) on source-text embedded in a diagnostic message;
+            // longer expressions are truncated with an ellipsis so the message stays readable in CLI/IDE output.
+            private const int MaxEmbeddedSourceTextLength = 80;
+
             public DiagnosticBuilderInternal(TextSpan textSpan)
             {
                 TextSpan = textSpan;
@@ -77,6 +81,17 @@ namespace Bicep.Core.Diagnostics
             private static string BuildInvalidOciArtifactReferenceClause(string? aliasName, string referenceValue) => aliasName is not null
                 ? $"The OCI artifact reference \"{referenceValue}\" after resolving alias \"{aliasName}\" is not valid."
                 : $"The specified OCI artifact reference \"{referenceValue}\" is not valid.";
+
+            /// <summary>
+            /// Formats a syntax node's source text for safe inclusion in a diagnostic message body:
+            /// newlines are replaced with spaces so the message stays on a single line, and the result is
+            /// truncated with an ellipsis if it exceeds <see cref="MaxEmbeddedSourceTextLength"/> characters
+            /// so very long expressions don't bloat the message.
+            /// </summary>
+            private static string FormatSourceTextForDiagnostic(SyntaxBase expression)
+                => SyntaxStringifier.Stringify(expression, newlineReplacement: " ")
+                    .Trim()
+                    .TruncateWithEllipses(MaxEmbeddedSourceTextLength);
 
             private static string BuildInvalidTemplateSpecReferenceClause(string? aliasName, string referenceValue) => aliasName is not null
                 ? $"The Template Spec reference \"{referenceValue}\" after resolving alias \"{aliasName}\" is not valid."
@@ -1517,7 +1532,7 @@ namespace Bicep.Core.Diagnostics
                 // spans multiple operands), the caller can opt in to include the source text of the offending value in the message
                 // itself so the reader can tell which sub-expression is nullable.
                 var providedValueClause = includeSourceText
-                    ? $"the provided value \"{expression.ToString().Trim()}\""
+                    ? $"the provided value \"{FormatSourceTextForDiagnostic(expression)}\""
                     : "the provided value";
 
                 return CoreWarning(

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -1664,6 +1664,28 @@ namespace Bicep.Core.TypeSystem
                     return result;
                 }
 
+                // if one or both operands are nullable and stripping nullability would let the operation match a known operator,
+                // emit a fixable warning per nullable operand and proceed as if it had been non-nullable.
+                // the diagnostic spans the whole binary operation (matching the position of the BCP045 error it replaces)
+                // so the operator context is visible, but the code fix still targets the individual operand.
+                var nonNullableOperand1 = TypeHelper.TryRemoveNullability(operandType1);
+                var nonNullableOperand2 = TypeHelper.TryRemoveNullability(operandType2);
+                if ((nonNullableOperand1 is not null || nonNullableOperand2 is not null) &&
+                    OperationReturnTypeEvaluator.TryFoldBinaryExpression(syntax, nonNullableOperand1 ?? operandType1, nonNullableOperand2 ?? operandType2, diagnostics) is { } nullableResult)
+                {
+                    if (nonNullableOperand1 is not null)
+                    {
+                        diagnostics.Write(DiagnosticBuilder.ForPosition(syntax)
+                            .PossibleNullReferenceAssignment(nonNullableOperand1, operandType1, syntax.LeftExpression, includeSourceText: true));
+                    }
+                    if (nonNullableOperand2 is not null)
+                    {
+                        diagnostics.Write(DiagnosticBuilder.ForPosition(syntax)
+                            .PossibleNullReferenceAssignment(nonNullableOperand2, operandType2, syntax.RightExpression, includeSourceText: true));
+                    }
+                    return nullableResult;
+                }
+
                 string? additionalInfo = null;
                 if (TypeValidator.AreTypesAssignable(operandType1, LanguageConstants.String) &&
                     TypeValidator.AreTypesAssignable(operandType2, LanguageConstants.String) &&
@@ -1695,6 +1717,18 @@ namespace Bicep.Core.TypeSystem
                 if (OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax.Operator, operandType, diagnostics) is { } result)
                 {
                     return result;
+                }
+
+                // if the operand is nullable and stripping nullability would let the operation match a known operator,
+                // emit a fixable warning and proceed as if it had been non-nullable.
+                // the diagnostic spans the whole unary operation (matching the position of the BCP044 error it replaces)
+                // so the operator context is visible, but the code fix still targets the operand.
+                if (TypeHelper.TryRemoveNullability(operandType) is { } nonNullableOperand &&
+                    OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax.Operator, nonNullableOperand, diagnostics) is { } nullableResult)
+                {
+                    diagnostics.Write(DiagnosticBuilder.ForPosition(syntax)
+                        .PossibleNullReferenceAssignment(nonNullableOperand, operandType, syntax.Expression, includeSourceText: true));
+                    return nullableResult;
                 }
 
                 return ErrorType.Create(DiagnosticBuilder.ForPosition(syntax).UnaryOperatorInvalidType(Operators.UnaryOperatorToText[syntax.Operator], operandType));

--- a/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/TypeAssignmentVisitor.cs
@@ -222,6 +222,26 @@ namespace Bicep.Core.TypeSystem
             var parent => throw new InvalidOperationException($"{syntax.GetType().Name} at {syntax.Span} has an unexpected parent of type {parent?.GetType().Name}"),
         };
 
+        // Walks the ancestor chain looking for a ternary operator that reaches the starting node through one of its
+        // branches (as opposed to its condition). This is used as a heuristic proxy for "the operator is arguably
+        // null-guarded"; note it does NOT verify that the ternary's condition actually null-checks the operand, so
+        // e.g. `unrelatedFlag ? input + 1 : 0` also returns true. A precise check requires flow-sensitive typing
+        // (tracked by https://github.com/Azure/bicep/issues/12121).
+        private bool IsInsideTernaryBranch(SyntaxBase syntax)
+        {
+            var current = syntax;
+            while (binder.GetParent(current) is { } parent)
+            {
+                if (parent is TernaryOperationSyntax ternary &&
+                    (ReferenceEquals(current, ternary.TrueExpression) || ReferenceEquals(current, ternary.FalseExpression)))
+                {
+                    return true;
+                }
+                current = parent;
+            }
+            return false;
+        }
+
         public override void VisitTypedLocalVariableSyntax(TypedLocalVariableSyntax syntax)
             => AssignTypeWithDiagnostics(syntax, diagnostics =>
             {
@@ -1668,9 +1688,13 @@ namespace Bicep.Core.TypeSystem
                 // emit a fixable warning per nullable operand and proceed as if it had been non-nullable.
                 // the diagnostic spans the whole binary operation (matching the position of the BCP045 error it replaces)
                 // so the operator context is visible, but the code fix still targets the individual operand.
+                // gated on IsInsideTernaryBranch so we only downgrade error -> warning when the operator sits inside a
+                // ternary branch (a rough proxy for "the user has some form of null-guard"); outside a ternary we still
+                // hard-fail with BCP045 rather than silently succeed against a possibly-null runtime value.
                 var nonNullableOperand1 = TypeHelper.TryRemoveNullability(operandType1);
                 var nonNullableOperand2 = TypeHelper.TryRemoveNullability(operandType2);
                 if ((nonNullableOperand1 is not null || nonNullableOperand2 is not null) &&
+                    IsInsideTernaryBranch(syntax) &&
                     OperationReturnTypeEvaluator.TryFoldBinaryExpression(syntax, nonNullableOperand1 ?? operandType1, nonNullableOperand2 ?? operandType2, diagnostics) is { } nullableResult)
                 {
                     if (nonNullableOperand1 is not null)
@@ -1723,7 +1747,11 @@ namespace Bicep.Core.TypeSystem
                 // emit a fixable warning and proceed as if it had been non-nullable.
                 // the diagnostic spans the whole unary operation (matching the position of the BCP044 error it replaces)
                 // so the operator context is visible, but the code fix still targets the operand.
+                // gated on IsInsideTernaryBranch so we only downgrade error -> warning when the operator sits inside a
+                // ternary branch (a rough proxy for "the user has some form of null-guard"); outside a ternary we still
+                // hard-fail with BCP044 rather than silently succeed against a possibly-null runtime value.
                 if (TypeHelper.TryRemoveNullability(operandType) is { } nonNullableOperand &&
+                    IsInsideTernaryBranch(syntax) &&
                     OperationReturnTypeEvaluator.TryFoldUnaryExpression(syntax.Operator, nonNullableOperand, diagnostics) is { } nullableResult)
                 {
                     diagnostics.Write(DiagnosticBuilder.ForPosition(syntax)


### PR DESCRIPTION
## Description

Updates https://github.com/Azure/bicep/issues/17284 to replace diagnostic error with warning 

## Example Usage

<img width="1270" height="137" alt="image" src="https://github.com/user-attachments/assets/d61e6e52-ea15-4816-b6c2-459bf891f5d9" />


## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20024)