### PR TITLE
Block non-pure functions in exported declarations

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -113,6 +113,47 @@ public class CompileTimeImportTests
     }
 
     [TestMethod]
+    public void Exporting_variable_that_references_non_pure_function_should_raise_diagnostic()
+    {
+        var result = CompilationHelper.Compile("""
+            @export()
+            var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP452", DiagnosticLevel.Error, "The \"@export()\" decorator may not be applied to variables or functions that reference deployment-context functions, either directly or indirectly. The target of this decorator contains direct or transitive references to the following functions: \"resourceId\"."),
+        });
+    }
+
+    [TestMethod]
+    public void Exporting_variable_that_transitively_references_non_pure_function_should_raise_diagnostic()
+    {
+        var result = CompilationHelper.Compile("""
+            var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+
+            @export()
+            var exportedSubnetId = defaultSubnetId
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP452", DiagnosticLevel.Error, "The \"@export()\" decorator may not be applied to variables or functions that reference deployment-context functions, either directly or indirectly. The target of this decorator contains direct or transitive references to the following functions: \"resourceId\"."),
+        });
+    }
+
+    [TestMethod]
+    public void Exporting_variable_that_references_pure_function_should_not_raise_diagnostic()
+    {
+        var result = CompilationHelper.Compile("""
+            @export()
+            var value = toLower('HELLO')
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
     public void Importing_non_template_should_not_raise_diagnostic()
     {
         var result = CompilationHelper.Compile(

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -585,7 +585,7 @@ param bar2 = externalInput('kind', foo)
     }
 
     [TestMethod]
-    public void ExternalInput_parameter_with_unevaluable_imported_variable_references_returns_diagnostic()
+    public void ExternalInput_parameter_with_non_pure_imported_variable_references_returns_diagnostic()
     {
         var result = CompilationHelper.CompileParams(
             ("parameters.bicepparam", @"
@@ -597,10 +597,37 @@ param bar2 = externalInput('kind', foo)
     @export()
     var foo = resourceGroup().location // cannot be evaluated in bicepparam file
     "));
-        result.Should().OnlyContainDiagnostic(
-            "BCP338",
-            DiagnosticLevel.Error,
-            "Failed to evaluate parameter \"foo2\": Failed to evaluate variable \"foo\": The template function 'RESOURCEGROUP' is not expected at this location. Please see https://aka.ms/arm-functions for usage details.");
+        result.Should().HaveDiagnostics(
+            [
+                ("BCP104", DiagnosticLevel.Error, "The referenced module has errors."),
+                ("BCP063", DiagnosticLevel.Error, "The name \"foo\" is not a parameter, variable, resource or module."),
+            ]);
+    }
+
+    [TestMethod]
+    public void Parameter_assignment_with_imported_resource_id_variable_returns_referenced_module_diagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("main.bicep", """
+                param subnetId string
+                """),
+            ("parameters.bicepparam", """
+                using 'main.bicep'
+
+                import { defaultSubnetId } from 'variables.bicep'
+
+                param subnetId = defaultSubnetId
+                """),
+            ("variables.bicep", """
+                @export()
+                var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+                """));
+
+        result.Should().HaveDiagnostics(
+            [
+                ("BCP104", DiagnosticLevel.Error, "The referenced module has errors."),
+                ("BCP063", DiagnosticLevel.Error, "The name \"defaultSubnetId\" is not a parameter, variable, resource or module."),
+            ]);
     }
 
     [TestMethod]
@@ -631,7 +658,7 @@ param bar2 = externalInput('kind', foo)
     }
 
     [TestMethod]
-    public void ExternalInput_parameter_with_unevaluable_imported_function_returns_diagnostics()
+    public void ExternalInput_parameter_with_non_pure_imported_function_returns_diagnostics()
     {
         var result = CompilationHelper.CompileParams(
             ("parameters.bicepparam", @"
@@ -643,10 +670,11 @@ param bar2 = externalInput('kind', foo)
     @export()
     func foo() string => resourceGroup().location // cannot be evaluated in bicepparam file
     "));
-        result.Should().OnlyContainDiagnostic(
-            "BCP338",
-            DiagnosticLevel.Error,
-            "Failed to evaluate parameter \"foo2\": The template function 'RESOURCEGROUP' is not expected at this location. Please see https://aka.ms/arm-functions for usage details.");
+        result.Should().HaveDiagnostics(
+            [
+                ("BCP104", DiagnosticLevel.Error, "The referenced module has errors."),
+                ("BCP059", DiagnosticLevel.Error, "The name \"foo\" is not a function."),
+            ]);
     }
 
     [TestMethod]

--- a/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
@@ -12,7 +12,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(value: any): any",
     "parameterTypeSignatures": [
       "value: any"
@@ -31,7 +31,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: any): array",
     "parameterTypeSignatures": [
       "valueToConvert: any"
@@ -50,7 +50,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(inputString: string): string",
     "parameterTypeSignatures": [
       "inputString: string"
@@ -69,7 +69,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(base64Value: string): any",
     "parameterTypeSignatures": [
       "base64Value: string"
@@ -88,7 +88,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(base64Value: string): string",
     "parameterTypeSignatures": [
       "base64Value: string"
@@ -107,7 +107,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(value: any): bool",
     "parameterTypeSignatures": [
       "value: any"
@@ -126,7 +126,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(components: parseUri): string",
     "parameterTypeSignatures": [
       "components: parseUri"
@@ -151,7 +151,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(network: string, hostIndex: int): string",
     "parameterTypeSignatures": [
       "network: string",
@@ -183,7 +183,7 @@
     ],
     "minimumArgumentCount": 3,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(network: string, cidr: int, subnetIndex: int): string",
     "parameterTypeSignatures": [
       "network: string",
@@ -202,7 +202,7 @@
       "type": "array",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : array): array",
     "parameterTypeSignatures": [
       "... : array"
@@ -219,7 +219,7 @@
       "type": "bool | int | string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : bool | int | string): string",
     "parameterTypeSignatures": [
       "... : bool | int | string"
@@ -244,7 +244,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object, propertyName: string): bool",
     "parameterTypeSignatures": [
       "object: object",
@@ -270,7 +270,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, itemToFind: any): bool",
     "parameterTypeSignatures": [
       "array: array",
@@ -296,7 +296,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(string: string, itemToFind: string): bool",
     "parameterTypeSignatures": [
       "string: string",
@@ -316,7 +316,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: any): string",
     "parameterTypeSignatures": [
       "valueToConvert: any"
@@ -335,7 +335,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(dataUriToConvert: string): string",
     "parameterTypeSignatures": [
       "dataUriToConvert: string"
@@ -366,7 +366,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(base: string, duration: string, [format: string]): string",
     "parameterTypeSignatures": [
       "base: string",
@@ -387,7 +387,7 @@
     ],
     "minimumArgumentCount": 0,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "([epochTime: int]): string",
     "parameterTypeSignatures": [
       "[epochTime: int]"
@@ -406,7 +406,7 @@
     ],
     "minimumArgumentCount": 0,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "([dateTime: string]): int",
     "parameterTypeSignatures": [
       "[dateTime: string]"
@@ -425,7 +425,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array): array",
     "parameterTypeSignatures": [
       "array: array"
@@ -444,7 +444,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(itemToTest: array | null | object | string): bool",
     "parameterTypeSignatures": [
       "itemToTest: array | null | object | string"
@@ -469,7 +469,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): bool",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -514,7 +514,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, predicate: (any[, int]) => bool): array",
     "parameterTypeSignatures": [
       "array: array",
@@ -534,7 +534,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array): any",
     "parameterTypeSignatures": [
       "array: array"
@@ -553,7 +553,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(string: string): string",
     "parameterTypeSignatures": [
       "string: string"
@@ -572,7 +572,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array[]): array",
     "parameterTypeSignatures": [
       "array: array[]"
@@ -596,7 +596,7 @@
       "type": "any",
       "minimumCount": 0
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(formatString: string, ... : any): string",
     "parameterTypeSignatures": [
       "formatString: string",
@@ -628,7 +628,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object",
     "parameterTypeSignatures": [
       "array: array",
@@ -647,7 +647,7 @@
       "type": "string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : string): string",
     "parameterTypeSignatures": [
       "... : string"
@@ -672,7 +672,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): int",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -698,7 +698,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, itemToFind: any): int",
     "parameterTypeSignatures": [
       "array: array",
@@ -718,7 +718,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: int | string): int",
     "parameterTypeSignatures": [
       "valueToConvert: int | string"
@@ -735,7 +735,7 @@
       "type": "object",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : object): object",
     "parameterTypeSignatures": [
       "... : object"
@@ -752,7 +752,7 @@
       "type": "array",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : array): array",
     "parameterTypeSignatures": [
       "... : array"
@@ -771,7 +771,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object): object[]",
     "parameterTypeSignatures": [
       "object: object"
@@ -796,7 +796,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(inputArray: (bool | int | string)[], delimiter: string): string",
     "parameterTypeSignatures": [
       "inputArray: (bool | int | string)[]",
@@ -816,7 +816,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(json: string): any",
     "parameterTypeSignatures": [
       "json: string"
@@ -835,7 +835,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array): any",
     "parameterTypeSignatures": [
       "array: array"
@@ -854,7 +854,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(string: string): string",
     "parameterTypeSignatures": [
       "string: string"
@@ -879,7 +879,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): int",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -905,7 +905,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, itemToFind: any): int",
     "parameterTypeSignatures": [
       "array: array",
@@ -925,7 +925,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(arg: object | string): int",
     "parameterTypeSignatures": [
       "arg: object | string"
@@ -944,7 +944,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(arg: array): int",
     "parameterTypeSignatures": [
       "arg: array"
@@ -969,7 +969,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(input: string, pattern: string): bool",
     "parameterTypeSignatures": [
       "input: string",
@@ -995,7 +995,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 2,
-    "flags": "generateIntermediateVariableAlways",
+    "flags": "generateIntermediateVariableAlways, pure",
     "typeSignature": "(directoryPath: string, [searchPattern: string]): any",
     "parameterTypeSignatures": [
       "directoryPath: string",
@@ -1015,7 +1015,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "generateIntermediateVariableOnIndirectAssignment",
+    "flags": "generateIntermediateVariableOnIndirectAssignment, pure",
     "typeSignature": "(filePath: string): string",
     "parameterTypeSignatures": [
       "filePath: string"
@@ -1046,7 +1046,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 3,
-    "flags": "generateIntermediateVariableAlways",
+    "flags": "generateIntermediateVariableAlways, pure",
     "typeSignature": "(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any",
     "parameterTypeSignatures": [
       "filePath: string",
@@ -1073,7 +1073,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 2,
-    "flags": "generateIntermediateVariableOnIndirectAssignment",
+    "flags": "generateIntermediateVariableOnIndirectAssignment, pure",
     "typeSignature": "(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string",
     "parameterTypeSignatures": [
       "filePath: string",
@@ -1105,7 +1105,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 3,
-    "flags": "generateIntermediateVariableAlways",
+    "flags": "generateIntermediateVariableAlways, pure",
     "typeSignature": "(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any",
     "parameterTypeSignatures": [
       "filePath: string",
@@ -1132,7 +1132,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, predicate: (any[, int]) => any): array",
     "parameterTypeSignatures": [
       "array: array",
@@ -1158,7 +1158,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object, predicate: any => any): array",
     "parameterTypeSignatures": [
       "object: object",
@@ -1176,7 +1176,7 @@
       "type": "int",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : int): int",
     "parameterTypeSignatures": [
       "... : int"
@@ -1195,7 +1195,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(intArray: int[]): int",
     "parameterTypeSignatures": [
       "intArray: int[]"
@@ -1212,7 +1212,7 @@
       "type": "int",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : int): int",
     "parameterTypeSignatures": [
       "... : int"
@@ -1231,7 +1231,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(intArray: int[]): int",
     "parameterTypeSignatures": [
       "intArray: int[]"
@@ -1250,7 +1250,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "isArgumentValueIndependent",
+    "flags": "argumentValueIndependent, pure",
     "typeSignature": "(symbol: any): string",
     "parameterTypeSignatures": [
       "symbol: any"
@@ -1279,7 +1279,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object): string[]",
     "parameterTypeSignatures": [
       "object: object"
@@ -1310,7 +1310,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string",
     "parameterTypeSignatures": [
       "valueToPad: int | string",
@@ -1331,7 +1331,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(network: string): parseCidr",
     "parameterTypeSignatures": [
       "network: string"
@@ -1350,7 +1350,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(baseUrl: string): parseUri",
     "parameterTypeSignatures": [
       "baseUrl: string"
@@ -1375,7 +1375,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(startIndex: int, count: int): int[]",
     "parameterTypeSignatures": [
       "startIndex: int",
@@ -1407,7 +1407,7 @@
     ],
     "minimumArgumentCount": 3,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, initialValue: any, predicate: (any, any[, int]) => any): any",
     "parameterTypeSignatures": [
       "array: array",
@@ -1440,7 +1440,7 @@
     ],
     "minimumArgumentCount": 3,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalString: string, oldString: string, newString: string): string",
     "parameterTypeSignatures": [
       "originalString: string",
@@ -1461,7 +1461,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(entries: object[]): object",
     "parameterTypeSignatures": [
       "entries: object[]"
@@ -1486,7 +1486,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: array, numberToSkip: int): array",
     "parameterTypeSignatures": [
       "originalValue: array",
@@ -1512,7 +1512,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: string, numberToSkip: int): string",
     "parameterTypeSignatures": [
       "originalValue: string",
@@ -1538,7 +1538,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, predicate: (any, any) => bool): array",
     "parameterTypeSignatures": [
       "array: array",
@@ -1564,7 +1564,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(inputString: string, delimiter: array | string): string[]",
     "parameterTypeSignatures": [
       "inputString: string",
@@ -1590,7 +1590,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): bool",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -1610,7 +1610,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: any): string",
     "parameterTypeSignatures": [
       "valueToConvert: any"
@@ -1641,7 +1641,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToParse: string, startIndex: int, [length: int]): string",
     "parameterTypeSignatures": [
       "stringToParse: string",
@@ -1668,7 +1668,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: array, numberToTake: int): array",
     "parameterTypeSignatures": [
       "originalValue: array",
@@ -1694,7 +1694,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: string, numberToTake: int): string",
     "parameterTypeSignatures": [
       "originalValue: string",
@@ -1714,7 +1714,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToChange: string): string",
     "parameterTypeSignatures": [
       "stringToChange: string"
@@ -1745,7 +1745,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object",
     "parameterTypeSignatures": [
       "array: array",
@@ -1766,7 +1766,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToChange: string): string",
     "parameterTypeSignatures": [
       "stringToChange: string"
@@ -1785,7 +1785,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToTrim: string): string",
     "parameterTypeSignatures": [
       "stringToTrim: string"
@@ -1802,7 +1802,7 @@
       "type": "object",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : object): object",
     "parameterTypeSignatures": [
       "... : object"
@@ -1819,7 +1819,7 @@
       "type": "array",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : array): array",
     "parameterTypeSignatures": [
       "... : array"
@@ -1836,7 +1836,7 @@
       "type": "string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : string): string",
     "parameterTypeSignatures": [
       "... : string"
@@ -1861,7 +1861,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(baseUri: string, relativeUri: string): string",
     "parameterTypeSignatures": [
       "baseUri: string",
@@ -1881,7 +1881,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToEncode: string): string",
     "parameterTypeSignatures": [
       "stringToEncode: string"
@@ -1900,7 +1900,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(uriEncodedString: string): string",
     "parameterTypeSignatures": [
       "uriEncodedString: string"

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -2043,6 +2043,10 @@ namespace Bicep.Core.Diagnostics
             public Diagnostic InvalidOciArtifactModuleAliasMapToFilePath(string? aliasName, string path, string reason) => CoreError(
                 "BCP451",
                 $"The OCI artifact module alias{(aliasName is not null ? $" \"{aliasName}\"" : "")} has an invalid \"mapToFilePath\" path \"{path}\": {reason}");
+
+            public Diagnostic ClosureContainsNonPureFunctions(IEnumerable<string> nonPureFunctions) => CoreError(
+                "BCP452",
+                @$"The ""@export()"" decorator may not be applied to variables or functions that reference deployment-context functions, either directly or indirectly. The target of this decorator contains direct or transitive references to the following functions: {ToQuotedString(nonPureFunctions)}.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/ForSyntaxValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/ForSyntaxValidatorVisitor.cs
@@ -264,7 +264,7 @@ namespace Bicep.Core.Emit
         public override void VisitFunctionCallSyntax(FunctionCallSyntax syntax)
         {
             var functionSymbol = semanticModel.GetSymbolInfo(syntax) as FunctionSymbol;
-            if (functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.IsArgumentValueIndependent))
+            if (functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.ArgumentValueIndependent))
             {
                 base.VisitFunctionCallSyntax(syntax);
             }
@@ -273,7 +273,7 @@ namespace Bicep.Core.Emit
         public override void VisitInstanceFunctionCallSyntax(InstanceFunctionCallSyntax syntax)
         {
             var functionSymbol = semanticModel.GetSymbolInfo(syntax) as FunctionSymbol;
-            if (functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.IsArgumentValueIndependent))
+            if (functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.ArgumentValueIndependent))
             {
                 base.VisitInstanceFunctionCallSyntax(syntax);
             }

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -452,6 +452,6 @@ namespace Bicep.Core.Emit
         }
 
         private static bool ShouldVisitFunctionArguments(FunctionSymbol? functionSymbol)
-            => functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.IsArgumentValueIndependent);
+            => functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.ArgumentValueIndependent);
     }
 }

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -70,6 +70,18 @@ namespace Bicep.Core.Semantics
 
         public string TypeSignature { get; }
 
+        public virtual FunctionOverload WithAdditionalFlags(FunctionFlags flags) => new(
+            Name,
+            GenericDescription,
+            Description,
+            ResultBuilder,
+            TypeSignatureSymbol,
+            FixedParameters,
+            VariableParameter,
+            Evaluator,
+            ArmExpressionEvaluator,
+            Flags | flags);
+
         public IEnumerable<string> ParameterTypeSignatures => this.FixedParameters
             .Select(fp => fp.Signature)
             .Concat(this.VariableParameter?.GenericSignature.AsEnumerable() ?? []);

--- a/src/Bicep.Core/Semantics/FunctionWildcardOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionWildcardOverload.cs
@@ -25,5 +25,18 @@ namespace Bicep.Core.Semantics
         }
 
         public Regex WildcardRegex { get; }
+
+        public override FunctionOverload WithAdditionalFlags(FunctionFlags flags) => new FunctionWildcardOverload(
+            Name,
+            GenericDescription,
+            Description,
+            WildcardRegex,
+            ResultBuilder,
+            TypeSignatureSymbol,
+            FixedParameters,
+            VariableParameter,
+            Evaluator,
+            ArmExpressionEvaluator,
+            Flags | flags);
     }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1258,7 +1258,7 @@ namespace Bicep.Core.Semantics.Namespaces
                             new StringLiteralType(returnValue, TypeSymbolValidationFlags.Default),
                             new StringLiteralExpression(argument, returnValue));
                     }, LanguageConstants.String)
-                    .WithFlags(FunctionFlags.IsArgumentValueIndependent)
+                    .WithFlags(FunctionFlags.ArgumentValueIndependent)
                     .Build();
 
                 yield return new FunctionOverloadBuilder("fail")

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Numerics;
@@ -15,6 +16,7 @@ using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
+using Bicep.Core.Syntax.Visitors;
 using Bicep.Core.Text;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Providers;
@@ -59,6 +61,20 @@ namespace Bicep.Core.Semantics.Namespaces
         private record NamespaceValue<T>(T Value, VisibilityDelegate IsVisible);
 
         private static readonly ImmutableArray<NamespaceValue<NamedTypeProperty>> AmbientSymbols = [.. GetSystemAmbientSymbols()];
+
+        private static readonly FrozenSet<string> NonPureSystemFunctionNames = new[]
+        {
+            "fail",
+            "newGuid",
+            "utcNow",
+        }.ToFrozenSet(LanguageConstants.IdentifierComparer);
+
+        private static FunctionOverload MarkPureIfAppropriate(FunctionOverload overload) =>
+            NonPureSystemFunctionNames.Contains(overload.Name) ||
+            overload.Flags.HasFlag(FunctionFlags.ParamDefaultsOnly) ||
+            overload.Flags.HasFlag(FunctionFlags.RequiresExternalInput)
+                ? overload
+                : overload.WithAdditionalFlags(FunctionFlags.Pure);
 
         private static IEnumerable<NamespaceValue<FunctionOverload>> GetSystemOverloads(IFeatureProvider featureProvider)
         {
@@ -1318,7 +1334,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .Build();
             }
 
-            foreach (var overload in GetAlwaysPermittedOverloads())
+            foreach (var overload in GetAlwaysPermittedOverloads().Select(MarkPureIfAppropriate))
             {
                 yield return new(overload, (_, _) => true);
             }
@@ -2128,7 +2144,7 @@ namespace Bicep.Core.Semantics.Namespaces
                         DeclaredFunctionExpression declaredFunction => declaredFunction with { Exported = functionCall },
                         _ => decorated,
                     })
-                    .WithValidator(static (decoratorName, decoratorSyntax, _, _, binder, _, diagnosticWriter) =>
+                    .WithValidator(static (decoratorName, decoratorSyntax, _, typeManager, binder, _, diagnosticWriter) =>
                     {
                         var decoratorTarget = binder.GetParent(decoratorSyntax);
 
@@ -2153,6 +2169,12 @@ namespace Bicep.Core.Semantics.Namespaces
                             if (nonExportableSymbolsInClosure.Any())
                             {
                                 diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).ClosureContainsNonExportableSymbols(nonExportableSymbolsInClosure));
+                            }
+
+                            var nonPureFunctionNamesInClosure = GetNonPureFunctionNamesInClosure(targetedDeclaration, typeManager, binder);
+                            if (nonPureFunctionNamesInClosure.Count > 0)
+                            {
+                                diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).ClosureContainsNonPureFunctions(nonPureFunctionNamesInClosure.Order(StringComparer.OrdinalIgnoreCase)));
                             }
                         }
                     })
@@ -2200,6 +2222,30 @@ namespace Bicep.Core.Semantics.Namespaces
                 yield return new(decorator, (_, sfk) => sfk == BicepSourceFileKind.BicepFile);
             }
         }
+
+        private static FrozenSet<string> GetNonPureFunctionNamesInClosure(DeclaredSymbol targetedDeclaration, ITypeManager typeManager, IBinder binder)
+            => binder.GetReferencedSymbolClosureFor(targetedDeclaration)
+                .Add(targetedDeclaration)
+                .SelectMany(GetValueSyntaxesToValidateForExport)
+                .SelectMany(syntax => SyntaxAggregator.AggregateByType<FunctionCallSyntaxBase>(syntax))
+                .Select(functionCall => new
+                {
+                    FunctionCall = functionCall,
+                    Symbol = SymbolHelper.TryGetSymbolInfo(binder, typeManager.GetDeclaredType, functionCall) as FunctionSymbol,
+                })
+                .Where(x => x.Symbol is not null && !IsPureFunctionCall(x.Symbol, x.FunctionCall, typeManager))
+                .Select(x => x.Symbol!.Name)
+                .ToFrozenSet(LanguageConstants.IdentifierComparer);
+
+        private static IEnumerable<SyntaxBase> GetValueSyntaxesToValidateForExport(DeclaredSymbol symbol) => symbol switch
+        {
+            VariableSymbol variable => [variable.DeclaringVariable.Value],
+            DeclaredFunctionSymbol function => [function.DeclaringFunction.Lambda],
+            _ => [],
+        };
+
+        private static bool IsPureFunctionCall(FunctionSymbol functionSymbol, FunctionCallSyntaxBase functionCall, ITypeManager typeManager)
+            => (typeManager.GetMatchedFunctionOverload(functionCall)?.Flags ?? functionSymbol.FunctionFlags).HasFlag(FunctionFlags.Pure);
 
         private static void ValidateTypeDiscriminator(string decoratorName, DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticLookup parsingErrorLookup, IDiagnosticWriter diagnosticWriter)
         {

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantDirectViolationVisitor.cs
@@ -174,7 +174,7 @@ namespace Bicep.Core.TypeSystem
         }
 
         protected bool ShouldVisitFunctionArguments(FunctionSymbol? functionSymbol)
-            => functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.IsArgumentValueIndependent);
+            => functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.ArgumentValueIndependent);
 
         protected void FlagIfFunctionRequiresInlining(FunctionSymbol? functionSymbol, FunctionCallSyntaxBase syntax)
         {

--- a/src/Bicep.Core/TypeSystem/DeployTimeConstantIndirectViolationVisitor.cs
+++ b/src/Bicep.Core/TypeSystem/DeployTimeConstantIndirectViolationVisitor.cs
@@ -197,7 +197,7 @@ namespace Bicep.Core.TypeSystem
         }
 
         protected bool ShouldVisitFunctionArguments(FunctionSymbol? functionSymbol)
-            => functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.IsArgumentValueIndependent);
+            => functionSymbol is null || !functionSymbol.FunctionFlags.HasFlag(FunctionFlags.ArgumentValueIndependent);
 
         protected void FlagIfFunctionRequiresInlining(FunctionSymbol? functionSymbol)
         {

--- a/src/Bicep.Core/TypeSystem/FunctionFlags.cs
+++ b/src/Bicep.Core/TypeSystem/FunctionFlags.cs
@@ -85,7 +85,7 @@ namespace Bicep.Core.TypeSystem
         /// <summary>
         /// The function does not depend on argument values - e.g. `nameof(foo)` does not depend on the value of `foo`.
         /// </summary>
-        IsArgumentValueIndependent = 1 << 15,
+        ArgumentValueIndependent = 1 << 15,
 
         /// <summary>
         /// The function depends on inputs provided by external tooling.

--- a/src/Bicep.Core/TypeSystem/FunctionFlags.cs
+++ b/src/Bicep.Core/TypeSystem/FunctionFlags.cs
@@ -93,6 +93,11 @@ namespace Bicep.Core.TypeSystem
         RequiresExternalInput = 1 << 16,
 
         /// <summary>
+        /// The function result is determined by its arguments and compile-time state.
+        /// </summary>
+        Pure = 1 << 17,
+
+        /// <summary>
         /// The function can be used as a resource or module decorator.
         /// </summary>
         ResourceOrModuleDecorator = ResourceDecorator | ModuleDecorator,

--- a/src/Bicep.Core/TypeSystem/FunctionFlags.cs
+++ b/src/Bicep.Core/TypeSystem/FunctionFlags.cs
@@ -93,7 +93,7 @@ namespace Bicep.Core.TypeSystem
         RequiresExternalInput = 1 << 16,
 
         /// <summary>
-        /// The function result is determined by its arguments and compile-time state.
+        /// The function result is determined only by its arguments and compile-time state.
         /// </summary>
         Pure = 1 << 17,
 


### PR DESCRIPTION
Fixes #17229

## Summary
- Rename `FunctionFlags.IsArgumentValueIndependent` to `ArgumentValueIndependent`
- Add `FunctionFlags.Pure` and mark deterministic `sys` overloads as pure
- Reject `@export()` variables/functions that directly or transitively reference non-pure functions

## Validation
- `dotnet build src/Bicep.Core/Bicep.Core.csproj /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary`
- `dotnet test src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj /p:BaseOutputPath=$testOut -- --filter "FullyQualifiedName~CompileTimeImportTests|FullyQualifiedName~ParameterFileTests"`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20025)