### PR TITLE
Fix description not showing for template spec module

### DIFF
--- a/src/Bicep.Core.UnitTests/Semantics/DescriptionHelperTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/DescriptionHelperTests.cs
@@ -3,6 +3,8 @@
 
 using System.Text;
 using Bicep.Core.Semantics;
+using Bicep.Core.SourceGraph;
+using Bicep.IO.InMemory;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -184,5 +186,62 @@ public class DescriptionHelperTests
         var description = DescriptionHelper.TryGetFromTemplateSpec(stream);
 
         description.Should().Be(expectedDescription);
+    }
+
+    [DataTestMethod]
+    [DataRow(
+        @"{
+          ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+          ""contentVersion"": ""1.0.0.0"",
+          ""metadata"": {
+            ""description"": ""arm template description""
+          },
+          ""resources"": []
+        }",
+        "arm template description"
+    )]
+    [DataRow(
+        @"{
+          ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+          ""contentVersion"": ""1.0.0.0"",
+          ""resources"": []
+        }",
+        null
+    )]
+    public void TryGetFromSemanticModel_ArmTemplate(string json, string? expectedDescription)
+    {
+        var sourceFile = BicepTestConstants.SourceFileFactory.CreateArmTemplateFile(DummyFileHandle.Default, json);
+        var model = new ArmTemplateSemanticModel(sourceFile);
+
+        DescriptionHelper.TryGetFromSemanticModel(model).Should().Be(expectedDescription);
+    }
+
+    [DataTestMethod]
+    [DataRow(
+        @"{
+          ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+          ""contentVersion"": ""1.0.0.0"",
+          ""metadata"": {
+            ""description"": ""templatespec description""
+          },
+          ""resources"": []
+        }",
+        "templatespec description"
+    )]
+    [DataRow(
+        @"{
+          ""$schema"": ""https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#"",
+          ""contentVersion"": ""1.0.0.0"",
+          ""resources"": []
+        }",
+        null
+    )]
+    public void TryGetFromSemanticModel_TemplateSpec(string mainTemplateJson, string? expectedDescription)
+    {
+        var mainTemplateFile = BicepTestConstants.SourceFileFactory.CreateArmTemplateFile(DummyFileHandle.Default, mainTemplateJson);
+        var sourceFile = new TemplateSpecFile(DummyFileHandle.Default, mainTemplateJson, "dummyTemplateSpecId", mainTemplateFile);
+        var model = new TemplateSpecSemanticModel(sourceFile);
+
+        DescriptionHelper.TryGetFromSemanticModel(model).Should().Be(expectedDescription);
     }
 }

--- a/src/Bicep.Core/Semantics/DescriptionHelper.cs
+++ b/src/Bicep.Core/Semantics/DescriptionHelper.cs
@@ -60,7 +60,12 @@ namespace Bicep.Core.Semantics
             else if (semanticModel is ArmTemplateSemanticModel armSemanticModel)
             {
                 // JSON - search for top-level "metadata.description" property
-                return armSemanticModel.SourceFile.Template?.Metadata.TryGetValue(LanguageConstants.MetadataDescriptionPropertyName)?.Value.ToString();
+                return armSemanticModel.SourceFile.Template?.Metadata?.TryGetValue(LanguageConstants.MetadataDescriptionPropertyName)?.Value.ToString();
+            }
+            else if (semanticModel is TemplateSpecSemanticModel templateSpecSemanticModel)
+            {
+                // Template spec - search for the main template's top-level "metadata.description" property
+                return templateSpecSemanticModel.SourceFile.MainTemplateFile.Template?.Metadata?.TryGetValue(LanguageConstants.MetadataDescriptionPropertyName)?.Value.ToString();
             }
 
             return null;


### PR DESCRIPTION
## Description

For #16120.

Show template spec module description when hovering on the module symbol.

## Example Usage

<img width="681" height="161" alt="image" src="https://github.com/user-attachments/assets/e74329a4-428b-47fa-b83b-20e181cabf73" />


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20026)