### PR TITLE
Bump Azure.Bicep.Types.Az to 0.2.881

### DIFF
--- a/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Completions/resourceTypes.json
@@ -42,6 +42,132 @@
     }
   },
   {
+    "label": "'Commvault.ContentStore/cloudAccounts'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Commvault.ContentStore/cloudAccounts`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000002",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Commvault.ContentStore/cloudAccounts@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Commvault.ContentStore/cloudAccounts/plans'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Commvault.ContentStore/cloudAccounts/plans`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000003",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Commvault.ContentStore/cloudAccounts/plans@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Commvault.ContentStore/cloudAccounts/protectionGroups'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Commvault.ContentStore/cloudAccounts/protectionGroups`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000004",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Commvault.ContentStore/cloudAccounts/protectionGroups@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Commvault.ContentStore/cloudAccounts/protectionGroups/protectedItems'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Commvault.ContentStore/cloudAccounts/protectionGroups/protectedItems`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000005",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Commvault.ContentStore/cloudAccounts/protectionGroups/protectedItems@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Commvault.ContentStore/cloudAccounts/roleMappings'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Commvault.ContentStore/cloudAccounts/roleMappings`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000006",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Commvault.ContentStore/cloudAccounts/roleMappings@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Commvault.ContentStore/cloudAccounts/storages'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Commvault.ContentStore/cloudAccounts/storages`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000007",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Commvault.ContentStore/cloudAccounts/storages@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
     "label": "'Dell.Storage/filesystems'",
     "kind": "class",
     "documentation": {
@@ -50,7 +176,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000002",
+    "sortText": "00000008",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -71,7 +197,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000003",
+    "sortText": "00000009",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -92,7 +218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000004",
+    "sortText": "0000000a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -113,7 +239,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000005",
+    "sortText": "0000000b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -134,7 +260,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000006",
+    "sortText": "0000000c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -155,7 +281,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000007",
+    "sortText": "0000000d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -176,7 +302,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000008",
+    "sortText": "0000000e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -197,7 +323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000009",
+    "sortText": "0000000f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -218,7 +344,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000000a",
+    "sortText": "00000010",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -239,7 +365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000000b",
+    "sortText": "00000011",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -260,7 +386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000000c",
+    "sortText": "00000012",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -281,7 +407,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000151",
+    "sortText": "00000157",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -302,7 +428,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000152",
+    "sortText": "00000158",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -323,7 +449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000153",
+    "sortText": "00000159",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -344,7 +470,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000154",
+    "sortText": "0000015a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -365,7 +491,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000155",
+    "sortText": "0000015b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -386,7 +512,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000156",
+    "sortText": "0000015c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -407,7 +533,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000157",
+    "sortText": "0000015d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -428,7 +554,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000158",
+    "sortText": "0000015e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -449,7 +575,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000159",
+    "sortText": "0000015f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -470,7 +596,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015a",
+    "sortText": "00000160",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -491,7 +617,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015b",
+    "sortText": "00000161",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -512,7 +638,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015c",
+    "sortText": "00000162",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -533,7 +659,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015d",
+    "sortText": "00000163",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -554,7 +680,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015e",
+    "sortText": "00000164",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -575,7 +701,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000015f",
+    "sortText": "00000165",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -596,7 +722,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000160",
+    "sortText": "00000166",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -617,7 +743,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000161",
+    "sortText": "00000167",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -638,7 +764,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000162",
+    "sortText": "00000168",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -659,7 +785,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000163",
+    "sortText": "00000169",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -680,7 +806,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000164",
+    "sortText": "0000016a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -701,7 +827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000165",
+    "sortText": "0000016b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -722,7 +848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000166",
+    "sortText": "0000016c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -743,7 +869,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000167",
+    "sortText": "0000016d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -764,7 +890,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000168",
+    "sortText": "0000016e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -785,7 +911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000169",
+    "sortText": "0000016f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -806,7 +932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016a",
+    "sortText": "00000170",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -827,7 +953,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016b",
+    "sortText": "00000171",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -848,7 +974,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016c",
+    "sortText": "00000172",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -869,7 +995,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016d",
+    "sortText": "00000173",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -890,7 +1016,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000012",
+    "sortText": "00000018",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -911,7 +1037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000013",
+    "sortText": "00000019",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -932,7 +1058,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000014",
+    "sortText": "0000001a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -953,7 +1079,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000015",
+    "sortText": "0000001b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -974,7 +1100,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000016",
+    "sortText": "0000001c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -995,7 +1121,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000017",
+    "sortText": "0000001d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1016,7 +1142,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000018",
+    "sortText": "0000001e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1037,7 +1163,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000019",
+    "sortText": "0000001f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1058,7 +1184,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001a",
+    "sortText": "00000020",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1079,7 +1205,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001b",
+    "sortText": "00000021",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1100,7 +1226,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001c",
+    "sortText": "00000022",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1121,7 +1247,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001d",
+    "sortText": "00000023",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1142,7 +1268,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001e",
+    "sortText": "00000024",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1163,7 +1289,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000001f",
+    "sortText": "00000025",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1184,7 +1310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000020",
+    "sortText": "00000026",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1205,7 +1331,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000021",
+    "sortText": "00000027",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1226,7 +1352,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000022",
+    "sortText": "00000028",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1247,7 +1373,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000023",
+    "sortText": "00000029",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1268,7 +1394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000024",
+    "sortText": "0000002a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1289,7 +1415,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000025",
+    "sortText": "0000002b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1310,7 +1436,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000026",
+    "sortText": "0000002c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1331,7 +1457,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000027",
+    "sortText": "0000002d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1352,7 +1478,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000028",
+    "sortText": "0000002e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1373,7 +1499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002a",
+    "sortText": "00000030",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1394,7 +1520,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002b",
+    "sortText": "00000031",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1415,7 +1541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002c",
+    "sortText": "00000032",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1436,7 +1562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002d",
+    "sortText": "00000033",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1457,7 +1583,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002e",
+    "sortText": "00000034",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1478,7 +1604,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000002f",
+    "sortText": "00000035",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1499,7 +1625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000030",
+    "sortText": "00000036",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1520,7 +1646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000035",
+    "sortText": "0000003b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1541,7 +1667,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000031",
+    "sortText": "00000037",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1562,7 +1688,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000032",
+    "sortText": "00000038",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1583,7 +1709,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000033",
+    "sortText": "00000039",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1604,7 +1730,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000034",
+    "sortText": "0000003a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1625,7 +1751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000036",
+    "sortText": "0000003c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1646,7 +1772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000037",
+    "sortText": "0000003d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1667,7 +1793,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000038",
+    "sortText": "0000003e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1688,7 +1814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000039",
+    "sortText": "0000003f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1709,7 +1835,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003a",
+    "sortText": "00000040",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1730,7 +1856,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003b",
+    "sortText": "00000041",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1751,7 +1877,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003c",
+    "sortText": "00000042",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1772,7 +1898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004f",
+    "sortText": "00000055",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1793,7 +1919,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003d",
+    "sortText": "00000043",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1814,7 +1940,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003e",
+    "sortText": "00000044",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1835,7 +1961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000003f",
+    "sortText": "00000045",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1856,7 +1982,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000040",
+    "sortText": "00000046",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1877,7 +2003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000041",
+    "sortText": "00000047",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1898,7 +2024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000042",
+    "sortText": "00000048",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1919,7 +2045,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000043",
+    "sortText": "00000049",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1940,7 +2066,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000044",
+    "sortText": "0000004a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1961,7 +2087,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000045",
+    "sortText": "0000004b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -1982,7 +2108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000046",
+    "sortText": "0000004c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2003,7 +2129,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000047",
+    "sortText": "0000004d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2024,7 +2150,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000048",
+    "sortText": "0000004e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2045,7 +2171,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000049",
+    "sortText": "0000004f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2066,7 +2192,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004a",
+    "sortText": "00000050",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2087,7 +2213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004b",
+    "sortText": "00000051",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2108,7 +2234,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004c",
+    "sortText": "00000052",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2129,7 +2255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004d",
+    "sortText": "00000053",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2150,7 +2276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000004e",
+    "sortText": "00000054",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2171,7 +2297,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000050",
+    "sortText": "00000056",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2192,7 +2318,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000051",
+    "sortText": "00000057",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2213,7 +2339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000052",
+    "sortText": "00000058",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2234,7 +2360,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000053",
+    "sortText": "00000059",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2255,7 +2381,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000054",
+    "sortText": "0000005a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2276,7 +2402,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000055",
+    "sortText": "0000005b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2297,7 +2423,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000056",
+    "sortText": "0000005c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2318,7 +2444,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000057",
+    "sortText": "0000005d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2339,7 +2465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000058",
+    "sortText": "0000005e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2360,7 +2486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000059",
+    "sortText": "0000005f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2381,7 +2507,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005a",
+    "sortText": "00000060",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2402,7 +2528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005b",
+    "sortText": "00000061",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2423,7 +2549,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005c",
+    "sortText": "00000062",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2444,7 +2570,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005d",
+    "sortText": "00000063",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2465,7 +2591,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005e",
+    "sortText": "00000064",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2486,7 +2612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000005f",
+    "sortText": "00000065",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2507,7 +2633,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000060",
+    "sortText": "00000066",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2528,7 +2654,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000061",
+    "sortText": "00000067",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2549,7 +2675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000062",
+    "sortText": "00000068",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2570,7 +2696,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000063",
+    "sortText": "00000069",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2591,7 +2717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000064",
+    "sortText": "0000006a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2612,7 +2738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000065",
+    "sortText": "0000006b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2633,7 +2759,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000066",
+    "sortText": "0000006c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2654,7 +2780,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000067",
+    "sortText": "0000006d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2675,7 +2801,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000068",
+    "sortText": "0000006e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2696,7 +2822,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000069",
+    "sortText": "0000006f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2717,7 +2843,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006a",
+    "sortText": "00000070",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2738,7 +2864,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006b",
+    "sortText": "00000071",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2759,7 +2885,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006c",
+    "sortText": "00000072",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2780,7 +2906,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006d",
+    "sortText": "00000073",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2801,7 +2927,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006e",
+    "sortText": "00000074",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2822,7 +2948,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000070",
+    "sortText": "00000076",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2843,7 +2969,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000006f",
+    "sortText": "00000075",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2864,7 +2990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000071",
+    "sortText": "00000077",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2885,7 +3011,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000072",
+    "sortText": "00000078",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2906,7 +3032,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000073",
+    "sortText": "00000079",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2927,7 +3053,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000074",
+    "sortText": "0000007a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2948,7 +3074,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000075",
+    "sortText": "0000007b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2969,7 +3095,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000076",
+    "sortText": "0000007c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -2990,7 +3116,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000077",
+    "sortText": "0000007d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3011,7 +3137,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000078",
+    "sortText": "0000007e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3032,7 +3158,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000079",
+    "sortText": "0000007f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3053,7 +3179,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007a",
+    "sortText": "00000080",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3074,7 +3200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007b",
+    "sortText": "00000081",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3095,7 +3221,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007c",
+    "sortText": "00000082",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3116,7 +3242,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007d",
+    "sortText": "00000083",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3137,7 +3263,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007e",
+    "sortText": "00000084",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3158,7 +3284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000007f",
+    "sortText": "00000085",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3179,7 +3305,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000080",
+    "sortText": "00000086",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3200,7 +3326,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000081",
+    "sortText": "00000087",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3221,7 +3347,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000082",
+    "sortText": "00000088",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3242,7 +3368,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000083",
+    "sortText": "00000089",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3263,7 +3389,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000084",
+    "sortText": "0000008a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3284,7 +3410,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000085",
+    "sortText": "0000008b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3305,7 +3431,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000086",
+    "sortText": "0000008c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3326,7 +3452,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000087",
+    "sortText": "0000008d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3347,7 +3473,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000088",
+    "sortText": "0000008e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3368,7 +3494,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000089",
+    "sortText": "0000008f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3389,7 +3515,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000091",
+    "sortText": "00000097",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3410,7 +3536,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008a",
+    "sortText": "00000090",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3431,7 +3557,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008b",
+    "sortText": "00000091",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3452,7 +3578,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008c",
+    "sortText": "00000092",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3473,7 +3599,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008d",
+    "sortText": "00000093",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3494,7 +3620,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008e",
+    "sortText": "00000094",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3515,7 +3641,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000008f",
+    "sortText": "00000095",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3536,7 +3662,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000090",
+    "sortText": "00000096",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3557,7 +3683,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000092",
+    "sortText": "00000098",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3578,7 +3704,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000093",
+    "sortText": "00000099",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3599,7 +3725,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000094",
+    "sortText": "0000009a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3620,7 +3746,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000095",
+    "sortText": "0000009b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3641,7 +3767,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000096",
+    "sortText": "0000009c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3662,7 +3788,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000097",
+    "sortText": "0000009d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3683,7 +3809,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000098",
+    "sortText": "0000009e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3704,7 +3830,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000099",
+    "sortText": "0000009f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3725,7 +3851,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009a",
+    "sortText": "000000a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3746,7 +3872,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009b",
+    "sortText": "000000a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3767,7 +3893,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009c",
+    "sortText": "000000a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3788,7 +3914,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009d",
+    "sortText": "000000a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3809,7 +3935,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009e",
+    "sortText": "000000a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3830,7 +3956,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000009f",
+    "sortText": "000000a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3851,7 +3977,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a0",
+    "sortText": "000000a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3872,7 +3998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a1",
+    "sortText": "000000a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3893,7 +4019,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a2",
+    "sortText": "000000a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3914,7 +4040,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a3",
+    "sortText": "000000a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3935,7 +4061,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a4",
+    "sortText": "000000aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3956,7 +4082,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a5",
+    "sortText": "000000ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3977,7 +4103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a6",
+    "sortText": "000000ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -3998,7 +4124,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a7",
+    "sortText": "000000ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -4019,7 +4145,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000aa",
+    "sortText": "000000b0",
     "filterText": "'Microsoft.App/agentSpaces containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4041,7 +4167,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ab",
+    "sortText": "000000b1",
     "filterText": "'Microsoft.App/agentSpaces/connectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4063,7 +4189,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a8",
+    "sortText": "000000ae",
     "filterText": "'Microsoft.App/agents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4085,7 +4211,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000a9",
+    "sortText": "000000af",
     "filterText": "'Microsoft.App/agents/connectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4107,7 +4233,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ac",
+    "sortText": "000000b2",
     "filterText": "'Microsoft.App/builders containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4129,7 +4255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ad",
+    "sortText": "000000b3",
     "filterText": "'Microsoft.App/builders/builds containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4151,7 +4277,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ae",
+    "sortText": "000000b4",
     "filterText": "'Microsoft.App/connectedEnvironments containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4173,7 +4299,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000af",
+    "sortText": "000000b5",
     "filterText": "'Microsoft.App/connectedEnvironments/certificates containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4195,7 +4321,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b0",
+    "sortText": "000000b6",
     "filterText": "'Microsoft.App/connectedEnvironments/daprComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4217,7 +4343,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b1",
+    "sortText": "000000b7",
     "filterText": "'Microsoft.App/connectedEnvironments/storages containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4239,7 +4365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b2",
+    "sortText": "000000b8",
     "filterText": "'Microsoft.App/containerApps containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4261,7 +4387,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b3",
+    "sortText": "000000b9",
     "filterText": "'Microsoft.App/containerApps/authConfigs containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4283,7 +4409,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b4",
+    "sortText": "000000ba",
     "filterText": "'Microsoft.App/containerApps/builds containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4305,7 +4431,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b5",
+    "sortText": "000000bb",
     "filterText": "'Microsoft.App/containerApps/detectorProperties containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4327,7 +4453,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b6",
+    "sortText": "000000bc",
     "filterText": "'Microsoft.App/containerApps/detectorProperties/revisions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4349,7 +4475,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b7",
+    "sortText": "000000bd",
     "filterText": "'Microsoft.App/containerApps/detectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4371,7 +4497,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b8",
+    "sortText": "000000be",
     "filterText": "'Microsoft.App/containerApps/functions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4393,7 +4519,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000b9",
+    "sortText": "000000bf",
     "filterText": "'Microsoft.App/containerApps/labelHistory containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4415,7 +4541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ba",
+    "sortText": "000000c0",
     "filterText": "'Microsoft.App/containerApps/patches containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4437,7 +4563,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bb",
+    "sortText": "000000c1",
     "filterText": "'Microsoft.App/containerApps/resiliencyPolicies containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4459,7 +4585,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bc",
+    "sortText": "000000c2",
     "filterText": "'Microsoft.App/containerApps/revisions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4481,7 +4607,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bd",
+    "sortText": "000000c3",
     "filterText": "'Microsoft.App/containerApps/revisions/functions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4503,7 +4629,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000be",
+    "sortText": "000000c4",
     "filterText": "'Microsoft.App/containerApps/revisions/replicas containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4525,7 +4651,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000bf",
+    "sortText": "000000c5",
     "filterText": "'Microsoft.App/containerApps/sourcecontrols containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4547,7 +4673,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c0",
+    "sortText": "000000c6",
     "filterText": "'Microsoft.App/jobs containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4569,7 +4695,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c1",
+    "sortText": "000000c7",
     "filterText": "'Microsoft.App/jobs/detectorProperties containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4591,7 +4717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c2",
+    "sortText": "000000c8",
     "filterText": "'Microsoft.App/jobs/detectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4613,7 +4739,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c3",
+    "sortText": "000000c9",
     "filterText": "'Microsoft.App/jobs/executions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4635,7 +4761,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c4",
+    "sortText": "000000ca",
     "filterText": "'Microsoft.App/logicApps containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4657,7 +4783,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c5",
+    "sortText": "000000cb",
     "filterText": "'Microsoft.App/logicApps/workflows containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4679,7 +4805,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c6",
+    "sortText": "000000cc",
     "filterText": "'Microsoft.App/managedEnvironments containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4701,7 +4827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c7",
+    "sortText": "000000cd",
     "filterText": "'Microsoft.App/managedEnvironments/certificates containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4723,7 +4849,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c8",
+    "sortText": "000000ce",
     "filterText": "'Microsoft.App/managedEnvironments/daprComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4745,7 +4871,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000c9",
+    "sortText": "000000cf",
     "filterText": "'Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4767,7 +4893,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ca",
+    "sortText": "000000d0",
     "filterText": "'Microsoft.App/managedEnvironments/daprSubscriptions containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4789,7 +4915,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cb",
+    "sortText": "000000d1",
     "filterText": "'Microsoft.App/managedEnvironments/detectorProperties containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4811,7 +4937,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cc",
+    "sortText": "000000d2",
     "filterText": "'Microsoft.App/managedEnvironments/detectors containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4833,7 +4959,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cd",
+    "sortText": "000000d3",
     "filterText": "'Microsoft.App/managedEnvironments/dotNetComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4855,7 +4981,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ce",
+    "sortText": "000000d4",
     "filterText": "'Microsoft.App/managedEnvironments/httpRouteConfigs containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4877,7 +5003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000cf",
+    "sortText": "000000d5",
     "filterText": "'Microsoft.App/managedEnvironments/javaComponents containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4899,7 +5025,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d0",
+    "sortText": "000000d6",
     "filterText": "'Microsoft.App/managedEnvironments/maintenanceConfigurations containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4921,7 +5047,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d1",
+    "sortText": "000000d7",
     "filterText": "'Microsoft.App/managedEnvironments/managedCertificates containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4943,7 +5069,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d2",
+    "sortText": "000000d8",
     "filterText": "'Microsoft.App/managedEnvironments/privateEndpointConnections containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4965,7 +5091,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d3",
+    "sortText": "000000d9",
     "filterText": "'Microsoft.App/managedEnvironments/storages containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -4987,7 +5113,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d4",
+    "sortText": "000000da",
     "filterText": "'Microsoft.App/sessionPools containerapp'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -5009,7 +5135,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d5",
+    "sortText": "000000db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5030,7 +5156,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d6",
+    "sortText": "000000dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5051,7 +5177,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d7",
+    "sortText": "000000dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5072,7 +5198,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d8",
+    "sortText": "000000de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5093,7 +5219,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000d9",
+    "sortText": "000000df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5114,7 +5240,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000da",
+    "sortText": "000000e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5135,7 +5261,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000db",
+    "sortText": "000000e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5156,7 +5282,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000dc",
+    "sortText": "000000e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5177,7 +5303,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000dd",
+    "sortText": "000000e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5198,7 +5324,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000de",
+    "sortText": "000000e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5219,7 +5345,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000df",
+    "sortText": "000000e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5240,7 +5366,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e0",
+    "sortText": "000000e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5261,7 +5387,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e1",
+    "sortText": "000000e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5282,7 +5408,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e2",
+    "sortText": "000000e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5303,7 +5429,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e3",
+    "sortText": "000000e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5324,7 +5450,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e4",
+    "sortText": "000000ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5345,7 +5471,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fc",
+    "sortText": "00000102",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5366,7 +5492,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e5",
+    "sortText": "000000eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5387,7 +5513,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e6",
+    "sortText": "000000ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5408,7 +5534,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e7",
+    "sortText": "000000ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5429,7 +5555,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e8",
+    "sortText": "000000ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5450,7 +5576,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000e9",
+    "sortText": "000000ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5471,7 +5597,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ea",
+    "sortText": "000000f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5492,7 +5618,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000eb",
+    "sortText": "000000f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5513,7 +5639,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ec",
+    "sortText": "000000f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5534,7 +5660,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ed",
+    "sortText": "000000f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5555,7 +5681,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ee",
+    "sortText": "000000f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5576,7 +5702,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ef",
+    "sortText": "000000f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5597,7 +5723,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f0",
+    "sortText": "000000f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5618,7 +5744,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f1",
+    "sortText": "000000f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5639,7 +5765,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f2",
+    "sortText": "000000f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5660,7 +5786,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f3",
+    "sortText": "000000f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5681,7 +5807,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f4",
+    "sortText": "000000fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5702,7 +5828,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f5",
+    "sortText": "000000fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5723,7 +5849,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f6",
+    "sortText": "000000fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5744,7 +5870,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f7",
+    "sortText": "000000fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5765,7 +5891,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f8",
+    "sortText": "000000fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5786,7 +5912,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000f9",
+    "sortText": "000000ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5807,7 +5933,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fa",
+    "sortText": "00000100",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5828,7 +5954,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fb",
+    "sortText": "00000101",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5849,7 +5975,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fd",
+    "sortText": "00000103",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5870,7 +5996,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000fe",
+    "sortText": "00000104",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5891,7 +6017,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000000ff",
+    "sortText": "00000105",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5912,7 +6038,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000100",
+    "sortText": "00000106",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5933,7 +6059,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000101",
+    "sortText": "00000107",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5954,7 +6080,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000102",
+    "sortText": "00000108",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5975,7 +6101,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000103",
+    "sortText": "00000109",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -5996,7 +6122,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000104",
+    "sortText": "0000010a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6017,7 +6143,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000105",
+    "sortText": "0000010b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6038,7 +6164,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000106",
+    "sortText": "0000010c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6059,7 +6185,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000107",
+    "sortText": "0000010d",
     "filterText": "'Microsoft.Authorization/accessReviewHistoryDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6081,7 +6207,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000108",
+    "sortText": "0000010e",
     "filterText": "'Microsoft.Authorization/accessReviewScheduleDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6103,7 +6229,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000109",
+    "sortText": "0000010f",
     "filterText": "'Microsoft.Authorization/accessReviewScheduleDefinitions/instances rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6125,7 +6251,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010a",
+    "sortText": "00000110",
     "filterText": "'Microsoft.Authorization/accessReviewScheduleDefinitions/instances/decisions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6147,7 +6273,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010b",
+    "sortText": "00000111",
     "filterText": "'Microsoft.Authorization/accessReviewScheduleSettings rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6169,7 +6295,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010c",
+    "sortText": "00000112",
     "filterText": "'Microsoft.Authorization/attributeNamespaces rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6191,7 +6317,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010d",
+    "sortText": "00000113",
     "filterText": "'Microsoft.Authorization/dataPolicyManifests rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6213,7 +6339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010e",
+    "sortText": "00000114",
     "filterText": "'Microsoft.Authorization/denyAssignments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6235,7 +6361,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000010f",
+    "sortText": "00000115",
     "filterText": "'Microsoft.Authorization/locks rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6257,7 +6383,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000110",
+    "sortText": "00000116",
     "filterText": "'Microsoft.Authorization/policyAssignments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6279,7 +6405,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000111",
+    "sortText": "00000117",
     "filterText": "'Microsoft.Authorization/policyDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6301,7 +6427,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000112",
+    "sortText": "00000118",
     "filterText": "'Microsoft.Authorization/policyDefinitions/versions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6323,7 +6449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000113",
+    "sortText": "00000119",
     "filterText": "'Microsoft.Authorization/policyEnrollments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6345,7 +6471,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000114",
+    "sortText": "0000011a",
     "filterText": "'Microsoft.Authorization/policyExemptions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6367,7 +6493,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000115",
+    "sortText": "0000011b",
     "filterText": "'Microsoft.Authorization/policySetDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6389,7 +6515,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000116",
+    "sortText": "0000011c",
     "filterText": "'Microsoft.Authorization/policySetDefinitions/versions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6411,7 +6537,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000117",
+    "sortText": "0000011d",
     "filterText": "'Microsoft.Authorization/privateLinkAssociations rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6433,7 +6559,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000118",
+    "sortText": "0000011e",
     "filterText": "'Microsoft.Authorization/resourceManagementPrivateLinks rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6455,7 +6581,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000119",
+    "sortText": "0000011f",
     "filterText": "'Microsoft.Authorization/roleAssignmentApprovals rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6477,7 +6603,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011a",
+    "sortText": "00000120",
     "filterText": "'Microsoft.Authorization/roleAssignmentApprovals/stages rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6499,7 +6625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011c",
+    "sortText": "00000122",
     "filterText": "'Microsoft.Authorization/roleAssignmentScheduleInstances rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6521,7 +6647,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011d",
+    "sortText": "00000123",
     "filterText": "'Microsoft.Authorization/roleAssignmentScheduleRequests rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6543,7 +6669,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011e",
+    "sortText": "00000124",
     "filterText": "'Microsoft.Authorization/roleAssignmentSchedules rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6565,7 +6691,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011b",
+    "sortText": "00000121",
     "filterText": "'Microsoft.Authorization/roleAssignments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6587,7 +6713,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000011f",
+    "sortText": "00000125",
     "filterText": "'Microsoft.Authorization/roleDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6609,7 +6735,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000120",
+    "sortText": "00000126",
     "filterText": "'Microsoft.Authorization/roleEligibilityScheduleInstances rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6631,7 +6757,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000121",
+    "sortText": "00000127",
     "filterText": "'Microsoft.Authorization/roleEligibilityScheduleRequests rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6653,7 +6779,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000122",
+    "sortText": "00000128",
     "filterText": "'Microsoft.Authorization/roleEligibilitySchedules rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6675,7 +6801,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000123",
+    "sortText": "00000129",
     "filterText": "'Microsoft.Authorization/roleManagementAlertConfigurations rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6697,7 +6823,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000124",
+    "sortText": "0000012a",
     "filterText": "'Microsoft.Authorization/roleManagementAlertDefinitions rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6719,7 +6845,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000125",
+    "sortText": "0000012b",
     "filterText": "'Microsoft.Authorization/roleManagementAlerts rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6741,7 +6867,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000126",
+    "sortText": "0000012c",
     "filterText": "'Microsoft.Authorization/roleManagementAlerts/alertIncidents rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6763,7 +6889,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000127",
+    "sortText": "0000012d",
     "filterText": "'Microsoft.Authorization/roleManagementPolicies rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6785,7 +6911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000128",
+    "sortText": "0000012e",
     "filterText": "'Microsoft.Authorization/roleManagementPolicyAssignments rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6807,7 +6933,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000129",
+    "sortText": "0000012f",
     "filterText": "'Microsoft.Authorization/variables rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6829,7 +6955,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012a",
+    "sortText": "00000130",
     "filterText": "'Microsoft.Authorization/variables/values rbac'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -6851,7 +6977,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012b",
+    "sortText": "00000131",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6872,7 +6998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012c",
+    "sortText": "00000132",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6893,7 +7019,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012d",
+    "sortText": "00000133",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6914,7 +7040,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012e",
+    "sortText": "00000134",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6935,7 +7061,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000012f",
+    "sortText": "00000135",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6956,7 +7082,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000130",
+    "sortText": "00000136",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6977,7 +7103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000131",
+    "sortText": "00000137",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -6998,7 +7124,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000132",
+    "sortText": "00000138",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7019,7 +7145,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000133",
+    "sortText": "00000139",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7040,7 +7166,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000134",
+    "sortText": "0000013a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7061,7 +7187,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000135",
+    "sortText": "0000013b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7082,7 +7208,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000136",
+    "sortText": "0000013c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7103,7 +7229,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000137",
+    "sortText": "0000013d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7124,7 +7250,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000139",
+    "sortText": "0000013f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7145,7 +7271,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000138",
+    "sortText": "0000013e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7166,7 +7292,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013a",
+    "sortText": "00000140",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7187,7 +7313,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013b",
+    "sortText": "00000141",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7208,7 +7334,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013c",
+    "sortText": "00000142",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7229,7 +7355,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013e",
+    "sortText": "00000144",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7250,7 +7376,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013d",
+    "sortText": "00000143",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7271,7 +7397,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000013f",
+    "sortText": "00000145",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7292,7 +7418,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000140",
+    "sortText": "00000146",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7313,7 +7439,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000141",
+    "sortText": "00000147",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7334,7 +7460,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000142",
+    "sortText": "00000148",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7355,7 +7481,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000143",
+    "sortText": "00000149",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7376,7 +7502,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000144",
+    "sortText": "0000014a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7397,7 +7523,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000145",
+    "sortText": "0000014b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7418,7 +7544,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000146",
+    "sortText": "0000014c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7439,7 +7565,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000147",
+    "sortText": "0000014d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7460,7 +7586,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000148",
+    "sortText": "0000014e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7481,7 +7607,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000149",
+    "sortText": "0000014f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7502,7 +7628,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014a",
+    "sortText": "00000150",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7523,7 +7649,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014b",
+    "sortText": "00000151",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7544,7 +7670,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014c",
+    "sortText": "00000152",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7565,7 +7691,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014d",
+    "sortText": "00000153",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7586,7 +7712,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014e",
+    "sortText": "00000154",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7607,7 +7733,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000014f",
+    "sortText": "00000155",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7628,7 +7754,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000150",
+    "sortText": "00000156",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7649,7 +7775,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016e",
+    "sortText": "00000174",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7670,7 +7796,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000016f",
+    "sortText": "00000175",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7691,7 +7817,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000170",
+    "sortText": "00000176",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7712,7 +7838,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000171",
+    "sortText": "00000177",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7733,7 +7859,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000172",
+    "sortText": "00000178",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7754,7 +7880,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000173",
+    "sortText": "00000179",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7775,7 +7901,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000175",
+    "sortText": "0000017b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7796,7 +7922,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000174",
+    "sortText": "0000017a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7817,7 +7943,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000176",
+    "sortText": "0000017c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7838,7 +7964,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000177",
+    "sortText": "0000017d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7859,7 +7985,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000178",
+    "sortText": "0000017e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7880,7 +8006,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000179",
+    "sortText": "0000017f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7901,7 +8027,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017a",
+    "sortText": "00000180",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7922,7 +8048,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017c",
+    "sortText": "00000182",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7943,7 +8069,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017b",
+    "sortText": "00000181",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7964,7 +8090,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017d",
+    "sortText": "00000183",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -7985,7 +8111,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017e",
+    "sortText": "00000184",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8006,7 +8132,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000017f",
+    "sortText": "00000185",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8027,7 +8153,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000180",
+    "sortText": "00000186",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8048,7 +8174,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000181",
+    "sortText": "00000187",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8069,7 +8195,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000182",
+    "sortText": "00000188",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8090,7 +8216,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000183",
+    "sortText": "00000189",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8111,7 +8237,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000184",
+    "sortText": "0000018a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8132,7 +8258,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000185",
+    "sortText": "0000018b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8153,7 +8279,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000187",
+    "sortText": "0000018d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8174,7 +8300,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000186",
+    "sortText": "0000018c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8195,7 +8321,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000188",
+    "sortText": "0000018e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8216,7 +8342,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000189",
+    "sortText": "0000018f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8237,7 +8363,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018a",
+    "sortText": "00000190",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8258,7 +8384,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018b",
+    "sortText": "00000191",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8279,7 +8405,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018c",
+    "sortText": "00000192",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8300,7 +8426,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018d",
+    "sortText": "00000193",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8321,7 +8447,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018e",
+    "sortText": "00000194",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8342,7 +8468,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000018f",
+    "sortText": "00000195",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8363,7 +8489,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000191",
+    "sortText": "00000197",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8384,7 +8510,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000192",
+    "sortText": "00000198",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8405,7 +8531,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000190",
+    "sortText": "00000196",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8426,7 +8552,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000193",
+    "sortText": "00000199",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8447,7 +8573,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000194",
+    "sortText": "0000019a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8468,7 +8594,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000195",
+    "sortText": "0000019b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8489,7 +8615,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000196",
+    "sortText": "0000019c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8510,7 +8636,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000197",
+    "sortText": "0000019d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8531,7 +8657,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000198",
+    "sortText": "0000019e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8552,7 +8678,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000199",
+    "sortText": "0000019f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8573,7 +8699,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019a",
+    "sortText": "000001a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8594,7 +8720,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019b",
+    "sortText": "000001a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8615,7 +8741,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019c",
+    "sortText": "000001a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8636,7 +8762,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019d",
+    "sortText": "000001a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8657,7 +8783,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019e",
+    "sortText": "000001a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8678,7 +8804,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000019f",
+    "sortText": "000001a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8699,7 +8825,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a0",
+    "sortText": "000001a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8720,7 +8846,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a1",
+    "sortText": "000001a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8741,7 +8867,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a2",
+    "sortText": "000001a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8762,7 +8888,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a3",
+    "sortText": "000001a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8783,7 +8909,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a4",
+    "sortText": "000001aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8804,7 +8930,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a5",
+    "sortText": "000001ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8825,7 +8951,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a6",
+    "sortText": "000001ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8846,7 +8972,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a7",
+    "sortText": "000001ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8867,7 +8993,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a8",
+    "sortText": "000001ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8888,7 +9014,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001a9",
+    "sortText": "000001af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8909,7 +9035,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001aa",
+    "sortText": "000001b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8930,7 +9056,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ab",
+    "sortText": "000001b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8951,7 +9077,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ac",
+    "sortText": "000001b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8972,7 +9098,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ad",
+    "sortText": "000001b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -8993,7 +9119,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ae",
+    "sortText": "000001b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9014,7 +9140,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001af",
+    "sortText": "000001b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9035,7 +9161,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b0",
+    "sortText": "000001b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9056,7 +9182,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b1",
+    "sortText": "000001b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9077,7 +9203,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b2",
+    "sortText": "000001b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9098,7 +9224,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b3",
+    "sortText": "000001b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9119,7 +9245,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b4",
+    "sortText": "000001ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9140,7 +9266,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b5",
+    "sortText": "000001bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9161,7 +9287,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b6",
+    "sortText": "000001bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9182,7 +9308,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b7",
+    "sortText": "000001bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9203,7 +9329,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b8",
+    "sortText": "000001be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9224,7 +9350,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001b9",
+    "sortText": "000001bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9245,7 +9371,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ba",
+    "sortText": "000001c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9266,7 +9392,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bb",
+    "sortText": "000001c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9287,7 +9413,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bc",
+    "sortText": "000001c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9308,7 +9434,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bd",
+    "sortText": "000001c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9329,7 +9455,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001be",
+    "sortText": "000001c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9350,7 +9476,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001bf",
+    "sortText": "000001c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9371,7 +9497,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c0",
+    "sortText": "000001c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9392,7 +9518,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c1",
+    "sortText": "000001c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9413,7 +9539,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c2",
+    "sortText": "000001c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9434,7 +9560,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c3",
+    "sortText": "000001c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9455,7 +9581,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c4",
+    "sortText": "000001ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9476,7 +9602,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c5",
+    "sortText": "000001cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9497,7 +9623,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c6",
+    "sortText": "000001cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9518,7 +9644,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c7",
+    "sortText": "000001cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9539,7 +9665,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c8",
+    "sortText": "000001ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9560,7 +9686,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001c9",
+    "sortText": "000001cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9581,7 +9707,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ca",
+    "sortText": "000001d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9602,7 +9728,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cb",
+    "sortText": "000001d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9623,7 +9749,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cc",
+    "sortText": "000001d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9644,7 +9770,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cd",
+    "sortText": "000001d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9665,7 +9791,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ce",
+    "sortText": "000001d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9686,7 +9812,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001cf",
+    "sortText": "000001d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9707,7 +9833,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d0",
+    "sortText": "000001d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9728,7 +9854,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d1",
+    "sortText": "000001d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9749,7 +9875,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d2",
+    "sortText": "000001d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9770,7 +9896,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d3",
+    "sortText": "000001d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9791,7 +9917,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d4",
+    "sortText": "000001da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9812,7 +9938,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d5",
+    "sortText": "000001db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9833,7 +9959,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d6",
+    "sortText": "000001dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9854,7 +9980,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d7",
+    "sortText": "000001dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9875,7 +10001,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d8",
+    "sortText": "000001de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9896,7 +10022,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001d9",
+    "sortText": "000001df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9917,7 +10043,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001da",
+    "sortText": "000001e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9938,7 +10064,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001db",
+    "sortText": "000001e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9959,7 +10085,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001dd",
+    "sortText": "000001e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -9980,7 +10106,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001dc",
+    "sortText": "000001e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10001,7 +10127,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001de",
+    "sortText": "000001e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10022,7 +10148,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001df",
+    "sortText": "000001e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10043,7 +10169,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e0",
+    "sortText": "000001e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10064,7 +10190,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e1",
+    "sortText": "000001e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10085,7 +10211,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e2",
+    "sortText": "000001e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10106,7 +10232,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e3",
+    "sortText": "000001e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10127,7 +10253,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e4",
+    "sortText": "000001ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10148,7 +10274,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e5",
+    "sortText": "000001eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10169,7 +10295,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e6",
+    "sortText": "000001ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10190,7 +10316,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e7",
+    "sortText": "000001ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10211,7 +10337,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e8",
+    "sortText": "000001ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10232,7 +10358,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001e9",
+    "sortText": "000001ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10253,7 +10379,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ea",
+    "sortText": "000001f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10274,7 +10400,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001eb",
+    "sortText": "000001f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10295,7 +10421,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ec",
+    "sortText": "000001f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10316,7 +10442,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ed",
+    "sortText": "000001f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10337,7 +10463,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ee",
+    "sortText": "000001f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10358,7 +10484,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ef",
+    "sortText": "000001f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10379,7 +10505,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f0",
+    "sortText": "000001f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10400,7 +10526,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f1",
+    "sortText": "000001f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10421,7 +10547,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f2",
+    "sortText": "000001f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10442,7 +10568,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f3",
+    "sortText": "000001f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10463,7 +10589,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f4",
+    "sortText": "000001fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10484,7 +10610,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f5",
+    "sortText": "000001fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10505,7 +10631,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f6",
+    "sortText": "000001fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10526,7 +10652,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f7",
+    "sortText": "000001fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10547,7 +10673,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f8",
+    "sortText": "000001fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10568,7 +10694,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001f9",
+    "sortText": "000001ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10589,7 +10715,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fa",
+    "sortText": "00000200",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10610,7 +10736,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fb",
+    "sortText": "00000201",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10631,7 +10757,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fc",
+    "sortText": "00000202",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10652,7 +10778,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fd",
+    "sortText": "00000203",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10673,7 +10799,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001fe",
+    "sortText": "00000204",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10694,7 +10820,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000001ff",
+    "sortText": "00000205",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10715,7 +10841,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000200",
+    "sortText": "00000206",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10736,7 +10862,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000201",
+    "sortText": "00000207",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10757,7 +10883,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000202",
+    "sortText": "00000208",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10778,7 +10904,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000203",
+    "sortText": "00000209",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10799,7 +10925,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000204",
+    "sortText": "0000020a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10820,7 +10946,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000205",
+    "sortText": "0000020b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10841,7 +10967,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000206",
+    "sortText": "0000020c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10862,7 +10988,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000207",
+    "sortText": "0000020d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10883,7 +11009,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000208",
+    "sortText": "0000020e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10904,7 +11030,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000209",
+    "sortText": "0000020f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10925,7 +11051,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020a",
+    "sortText": "00000210",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10946,7 +11072,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020b",
+    "sortText": "00000211",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10967,7 +11093,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020c",
+    "sortText": "00000212",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -10988,7 +11114,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020d",
+    "sortText": "00000213",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11009,7 +11135,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020e",
+    "sortText": "00000214",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11030,7 +11156,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000020f",
+    "sortText": "00000215",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11051,7 +11177,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000210",
+    "sortText": "00000216",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11072,7 +11198,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000211",
+    "sortText": "00000217",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11093,7 +11219,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000212",
+    "sortText": "00000218",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11114,7 +11240,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000213",
+    "sortText": "00000219",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11135,7 +11261,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000214",
+    "sortText": "0000021a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11156,7 +11282,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000215",
+    "sortText": "0000021b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11177,7 +11303,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000216",
+    "sortText": "0000021c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11198,7 +11324,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000217",
+    "sortText": "0000021d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11219,7 +11345,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000218",
+    "sortText": "0000021e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11240,7 +11366,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000219",
+    "sortText": "0000021f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11261,7 +11387,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021a",
+    "sortText": "00000220",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11282,7 +11408,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021b",
+    "sortText": "00000221",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11303,7 +11429,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021c",
+    "sortText": "00000222",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11324,7 +11450,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021d",
+    "sortText": "00000223",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11345,7 +11471,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021e",
+    "sortText": "00000224",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11366,7 +11492,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000021f",
+    "sortText": "00000225",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11387,7 +11513,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000220",
+    "sortText": "00000226",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11408,7 +11534,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000221",
+    "sortText": "00000227",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11429,7 +11555,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000224",
+    "sortText": "0000022a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11450,7 +11576,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000222",
+    "sortText": "00000228",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11471,7 +11597,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000223",
+    "sortText": "00000229",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11492,7 +11618,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000225",
+    "sortText": "0000022b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11513,7 +11639,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000226",
+    "sortText": "0000022c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11534,7 +11660,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000227",
+    "sortText": "0000022d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11555,12 +11681,117 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000228",
+    "sortText": "0000022e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.AzureStackHCI/edgeMachines@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/disks'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/disks`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "0000022f",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/disks@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/disks/jobs'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/disks/jobs`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000230",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/disks/jobs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/disks/privilegedJobs'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/disks/privilegedJobs`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000231",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/disks/privilegedJobs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/gpus'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/gpus`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000232",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/gpus@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/gpus/jobs'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/gpus/jobs`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000233",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/gpus/jobs@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -11576,12 +11807,96 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000229",
+    "sortText": "00000234",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.AzureStackHCI/edgeMachines/jobs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/networkAdapters'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/networkAdapters`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000235",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/networkAdapters@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/networkAdapters/jobs'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/networkAdapters/jobs`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000236",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/networkAdapters/jobs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/updates'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/updates`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000237",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/updates@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.AzureStackHCI/edgeMachines/volumes'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.AzureStackHCI/edgeMachines/volumes`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000238",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.AzureStackHCI/edgeMachines/volumes@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -11597,7 +11912,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022a",
+    "sortText": "00000239",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11618,7 +11933,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022b",
+    "sortText": "0000023a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11639,7 +11954,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022c",
+    "sortText": "0000023b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11660,7 +11975,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022d",
+    "sortText": "0000023c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11681,7 +11996,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022e",
+    "sortText": "0000023d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11702,7 +12017,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000022f",
+    "sortText": "0000023e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11723,7 +12038,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000230",
+    "sortText": "0000023f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11744,7 +12059,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000231",
+    "sortText": "00000240",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11765,7 +12080,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000232",
+    "sortText": "00000241",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11786,7 +12101,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000233",
+    "sortText": "00000242",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11807,7 +12122,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000234",
+    "sortText": "00000243",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11828,7 +12143,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000235",
+    "sortText": "00000244",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11849,7 +12164,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000236",
+    "sortText": "00000245",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11870,7 +12185,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000237",
+    "sortText": "00000246",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11891,7 +12206,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000238",
+    "sortText": "00000247",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11912,7 +12227,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000239",
+    "sortText": "00000248",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11933,7 +12248,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023a",
+    "sortText": "00000249",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11954,7 +12269,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023b",
+    "sortText": "0000024a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11975,7 +12290,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023c",
+    "sortText": "0000024b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -11996,7 +12311,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023d",
+    "sortText": "0000024c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12017,7 +12332,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023e",
+    "sortText": "0000024d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12038,7 +12353,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000023f",
+    "sortText": "0000024e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12059,7 +12374,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000240",
+    "sortText": "0000024f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12080,7 +12395,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000241",
+    "sortText": "00000250",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12101,7 +12416,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000242",
+    "sortText": "00000251",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12122,7 +12437,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000243",
+    "sortText": "00000252",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12143,7 +12458,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000244",
+    "sortText": "00000253",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12164,7 +12479,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000245",
+    "sortText": "00000254",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12185,7 +12500,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000246",
+    "sortText": "00000255",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12206,7 +12521,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000247",
+    "sortText": "00000256",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12227,7 +12542,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000248",
+    "sortText": "00000257",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12248,7 +12563,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000249",
+    "sortText": "00000258",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12269,7 +12584,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024a",
+    "sortText": "00000259",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12290,7 +12605,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024b",
+    "sortText": "0000025a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12311,7 +12626,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024c",
+    "sortText": "0000025b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12332,7 +12647,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024d",
+    "sortText": "0000025c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12353,7 +12668,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024e",
+    "sortText": "0000025d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12374,7 +12689,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000024f",
+    "sortText": "0000025e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12395,7 +12710,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000250",
+    "sortText": "0000025f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12416,7 +12731,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000251",
+    "sortText": "00000260",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12437,7 +12752,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000252",
+    "sortText": "00000261",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12458,7 +12773,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000253",
+    "sortText": "00000262",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12479,7 +12794,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000254",
+    "sortText": "00000263",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12500,7 +12815,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000255",
+    "sortText": "00000264",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12521,7 +12836,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000256",
+    "sortText": "00000265",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12542,7 +12857,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000257",
+    "sortText": "00000266",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12563,7 +12878,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000258",
+    "sortText": "00000267",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12584,7 +12899,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000259",
+    "sortText": "00000268",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12605,7 +12920,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025a",
+    "sortText": "00000269",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12626,7 +12941,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025b",
+    "sortText": "0000026a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12647,7 +12962,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025c",
+    "sortText": "0000026b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12668,7 +12983,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025d",
+    "sortText": "0000026c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12689,7 +13004,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025e",
+    "sortText": "0000026d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12710,7 +13025,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000025f",
+    "sortText": "0000026e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12731,7 +13046,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000260",
+    "sortText": "0000026f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12752,7 +13067,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000262",
+    "sortText": "00000271",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12773,7 +13088,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000263",
+    "sortText": "00000272",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12794,7 +13109,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000264",
+    "sortText": "00000273",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12815,7 +13130,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000265",
+    "sortText": "00000274",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12836,7 +13151,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000266",
+    "sortText": "00000275",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12857,7 +13172,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000267",
+    "sortText": "00000276",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12878,7 +13193,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000261",
+    "sortText": "00000270",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12899,7 +13214,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000268",
+    "sortText": "00000277",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12920,7 +13235,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000269",
+    "sortText": "00000278",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12941,7 +13256,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026a",
+    "sortText": "00000279",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12962,7 +13277,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026b",
+    "sortText": "0000027a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -12983,7 +13298,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026c",
+    "sortText": "0000027b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13004,7 +13319,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026d",
+    "sortText": "0000027c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13025,7 +13340,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026e",
+    "sortText": "0000027d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13046,7 +13361,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000026f",
+    "sortText": "0000027e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13067,7 +13382,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000270",
+    "sortText": "0000027f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13088,7 +13403,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000271",
+    "sortText": "00000280",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13109,7 +13424,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000272",
+    "sortText": "00000281",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13130,7 +13445,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000273",
+    "sortText": "00000282",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13151,7 +13466,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000274",
+    "sortText": "00000283",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13172,7 +13487,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000275",
+    "sortText": "00000284",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13193,7 +13508,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000276",
+    "sortText": "00000285",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13214,7 +13529,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000277",
+    "sortText": "00000286",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13235,7 +13550,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000278",
+    "sortText": "00000287",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13256,7 +13571,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000279",
+    "sortText": "00000288",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13277,7 +13592,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027b",
+    "sortText": "0000028a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13298,7 +13613,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027c",
+    "sortText": "0000028b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13319,7 +13634,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027d",
+    "sortText": "0000028c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13340,7 +13655,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027a",
+    "sortText": "00000289",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13361,7 +13676,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027e",
+    "sortText": "0000028d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13382,7 +13697,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000027f",
+    "sortText": "0000028e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13403,7 +13718,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000280",
+    "sortText": "0000028f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13424,7 +13739,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000281",
+    "sortText": "00000290",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13445,7 +13760,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000282",
+    "sortText": "00000291",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13466,7 +13781,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000283",
+    "sortText": "00000292",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13487,7 +13802,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000284",
+    "sortText": "00000293",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13508,7 +13823,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000285",
+    "sortText": "00000294",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13529,7 +13844,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000286",
+    "sortText": "00000295",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13550,7 +13865,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000287",
+    "sortText": "00000296",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13571,7 +13886,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000288",
+    "sortText": "00000297",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13592,7 +13907,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000289",
+    "sortText": "00000298",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13613,7 +13928,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028a",
+    "sortText": "00000299",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13634,7 +13949,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028b",
+    "sortText": "0000029a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13655,7 +13970,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028c",
+    "sortText": "0000029b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13676,7 +13991,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028d",
+    "sortText": "0000029c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13697,7 +14012,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028e",
+    "sortText": "0000029d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13718,7 +14033,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000028f",
+    "sortText": "0000029e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13739,7 +14054,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000290",
+    "sortText": "0000029f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13760,7 +14075,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000291",
+    "sortText": "000002a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13781,7 +14096,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000292",
+    "sortText": "000002a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13802,7 +14117,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000293",
+    "sortText": "000002a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13823,7 +14138,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000294",
+    "sortText": "000002a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13844,7 +14159,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000295",
+    "sortText": "000002a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13865,7 +14180,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000296",
+    "sortText": "000002a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13886,7 +14201,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000297",
+    "sortText": "000002a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13907,7 +14222,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000298",
+    "sortText": "000002a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13928,7 +14243,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000299",
+    "sortText": "000002a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13949,7 +14264,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029a",
+    "sortText": "000002a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13970,7 +14285,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029b",
+    "sortText": "000002aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -13991,7 +14306,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029c",
+    "sortText": "000002ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14012,7 +14327,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029d",
+    "sortText": "000002ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14033,12 +14348,54 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029e",
+    "sortText": "000002ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.BillingBenefits/savingsPlanOrders/savingsPlans@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.BillingTrust/assessments'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.BillingTrust/assessments`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000002ae",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.BillingTrust/assessments@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.BillingTrust/assessments/rules'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.BillingTrust/assessments/rules`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000002af",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.BillingTrust/assessments/rules@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -14054,7 +14411,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000029f",
+    "sortText": "000002b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14075,7 +14432,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a0",
+    "sortText": "000002b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14096,7 +14453,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a1",
+    "sortText": "000002b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14117,7 +14474,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a2",
+    "sortText": "000002b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14138,7 +14495,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a3",
+    "sortText": "000002b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14159,7 +14516,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a4",
+    "sortText": "000002b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14180,7 +14537,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a5",
+    "sortText": "000002b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14201,7 +14558,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a6",
+    "sortText": "000002b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14222,7 +14579,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a7",
+    "sortText": "000002b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14243,7 +14600,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a8",
+    "sortText": "000002b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14264,7 +14621,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002a9",
+    "sortText": "000002ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14285,7 +14642,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002aa",
+    "sortText": "000002bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14306,7 +14663,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ab",
+    "sortText": "000002bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14327,7 +14684,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ac",
+    "sortText": "000002bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14348,7 +14705,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ad",
+    "sortText": "000002be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14369,7 +14726,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ae",
+    "sortText": "000002bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14390,7 +14747,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002af",
+    "sortText": "000002c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14411,7 +14768,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b0",
+    "sortText": "000002c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14432,7 +14789,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b1",
+    "sortText": "000002c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14453,7 +14810,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b2",
+    "sortText": "000002c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14474,7 +14831,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b3",
+    "sortText": "000002c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14495,7 +14852,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b4",
+    "sortText": "000002c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14516,7 +14873,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b5",
+    "sortText": "000002c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14537,7 +14894,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b6",
+    "sortText": "000002c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14558,7 +14915,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b7",
+    "sortText": "000002c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14579,7 +14936,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b8",
+    "sortText": "000002c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14600,7 +14957,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002b9",
+    "sortText": "000002ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14621,7 +14978,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ba",
+    "sortText": "000002cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14642,7 +14999,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bb",
+    "sortText": "000002cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14663,7 +15020,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bc",
+    "sortText": "000002cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14684,7 +15041,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bd",
+    "sortText": "000002ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14705,7 +15062,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002be",
+    "sortText": "000002cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14726,7 +15083,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002bf",
+    "sortText": "000002d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14747,7 +15104,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c0",
+    "sortText": "000002d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14768,7 +15125,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c1",
+    "sortText": "000002d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14789,7 +15146,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c2",
+    "sortText": "000002d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14810,7 +15167,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c3",
+    "sortText": "000002d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14831,7 +15188,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c4",
+    "sortText": "000002d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14852,7 +15209,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c5",
+    "sortText": "000002d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14873,7 +15230,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c6",
+    "sortText": "000002d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14894,7 +15251,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c7",
+    "sortText": "000002d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14915,7 +15272,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c8",
+    "sortText": "000002d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14936,7 +15293,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002c9",
+    "sortText": "000002da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14957,7 +15314,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ca",
+    "sortText": "000002db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14978,7 +15335,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cb",
+    "sortText": "000002dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -14999,7 +15356,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cc",
+    "sortText": "000002dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15020,7 +15377,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cd",
+    "sortText": "000002de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15041,7 +15398,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ce",
+    "sortText": "000002df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15062,7 +15419,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002cf",
+    "sortText": "000002e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15083,7 +15440,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d0",
+    "sortText": "000002e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15104,7 +15461,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d1",
+    "sortText": "000002e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15125,7 +15482,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d2",
+    "sortText": "000002e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15146,7 +15503,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d3",
+    "sortText": "000002e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15167,7 +15524,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d4",
+    "sortText": "000002e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15188,7 +15545,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d5",
+    "sortText": "000002e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15209,7 +15566,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d6",
+    "sortText": "000002e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15230,7 +15587,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d7",
+    "sortText": "000002e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15251,7 +15608,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d8",
+    "sortText": "000002e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15272,7 +15629,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002d9",
+    "sortText": "000002ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15293,7 +15650,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002da",
+    "sortText": "000002eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15314,7 +15671,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002db",
+    "sortText": "000002ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15335,7 +15692,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002dc",
+    "sortText": "000002ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15356,7 +15713,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002dd",
+    "sortText": "000002ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15377,7 +15734,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002de",
+    "sortText": "000002ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15398,7 +15755,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002df",
+    "sortText": "000002f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15419,7 +15776,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e0",
+    "sortText": "000002f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15440,7 +15797,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e1",
+    "sortText": "000002f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15461,7 +15818,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e2",
+    "sortText": "000002f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15482,7 +15839,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e3",
+    "sortText": "000002f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15503,7 +15860,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e4",
+    "sortText": "000002f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15524,7 +15881,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e5",
+    "sortText": "000002f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15545,7 +15902,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e6",
+    "sortText": "000002f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15566,7 +15923,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e7",
+    "sortText": "000002f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15587,7 +15944,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e8",
+    "sortText": "000002f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15608,7 +15965,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002e9",
+    "sortText": "000002fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15629,7 +15986,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ea",
+    "sortText": "000002fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15650,7 +16007,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002eb",
+    "sortText": "000002fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15671,7 +16028,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ec",
+    "sortText": "000002fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15692,7 +16049,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ed",
+    "sortText": "000002fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15713,7 +16070,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ee",
+    "sortText": "000002ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15734,7 +16091,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ef",
+    "sortText": "00000300",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15755,7 +16112,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f0",
+    "sortText": "00000301",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15776,7 +16133,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f1",
+    "sortText": "00000302",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15797,7 +16154,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f2",
+    "sortText": "00000303",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15818,7 +16175,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f3",
+    "sortText": "00000304",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15839,7 +16196,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f4",
+    "sortText": "00000305",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15860,7 +16217,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f5",
+    "sortText": "00000306",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15881,7 +16238,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f6",
+    "sortText": "00000307",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15902,7 +16259,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f7",
+    "sortText": "00000308",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15923,7 +16280,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f8",
+    "sortText": "00000309",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15944,7 +16301,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002f9",
+    "sortText": "0000030a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15965,7 +16322,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fa",
+    "sortText": "0000030b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -15986,7 +16343,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fb",
+    "sortText": "0000030c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16007,7 +16364,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fc",
+    "sortText": "0000030d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16028,7 +16385,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fd",
+    "sortText": "0000030e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16049,7 +16406,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002fe",
+    "sortText": "0000030f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16070,7 +16427,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000002ff",
+    "sortText": "00000310",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16091,7 +16448,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000300",
+    "sortText": "00000311",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16112,7 +16469,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000301",
+    "sortText": "00000312",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16133,7 +16490,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000302",
+    "sortText": "00000313",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16154,7 +16511,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000303",
+    "sortText": "00000314",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16175,7 +16532,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000304",
+    "sortText": "00000315",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16196,7 +16553,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000305",
+    "sortText": "00000316",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16217,7 +16574,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000306",
+    "sortText": "00000317",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16238,7 +16595,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000307",
+    "sortText": "00000318",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16259,7 +16616,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000308",
+    "sortText": "00000319",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16280,7 +16637,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000309",
+    "sortText": "0000031a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16301,7 +16658,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030a",
+    "sortText": "0000031b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16322,7 +16679,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030b",
+    "sortText": "0000031c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16343,7 +16700,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030c",
+    "sortText": "0000031d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16364,7 +16721,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030d",
+    "sortText": "0000031e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16385,7 +16742,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030e",
+    "sortText": "0000031f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16406,7 +16763,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000030f",
+    "sortText": "00000320",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16427,7 +16784,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000310",
+    "sortText": "00000321",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16448,7 +16805,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000311",
+    "sortText": "00000322",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16469,7 +16826,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000312",
+    "sortText": "00000323",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16490,7 +16847,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000313",
+    "sortText": "00000324",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16511,7 +16868,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000314",
+    "sortText": "00000325",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16532,7 +16889,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000315",
+    "sortText": "00000326",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16553,7 +16910,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000316",
+    "sortText": "00000327",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16574,7 +16931,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000317",
+    "sortText": "00000328",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16595,7 +16952,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000318",
+    "sortText": "00000329",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16616,7 +16973,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000319",
+    "sortText": "0000032a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16637,7 +16994,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031a",
+    "sortText": "0000032b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16658,7 +17015,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031b",
+    "sortText": "0000032c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16679,7 +17036,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031c",
+    "sortText": "0000032d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16700,7 +17057,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031d",
+    "sortText": "0000032e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16721,7 +17078,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031e",
+    "sortText": "0000032f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16742,7 +17099,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000031f",
+    "sortText": "00000330",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16763,7 +17120,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000320",
+    "sortText": "00000331",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16784,7 +17141,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000321",
+    "sortText": "00000332",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16805,7 +17162,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000324",
+    "sortText": "00000335",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16826,7 +17183,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000325",
+    "sortText": "00000336",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16847,7 +17204,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000326",
+    "sortText": "00000337",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16868,7 +17225,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000327",
+    "sortText": "00000338",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16889,7 +17246,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000328",
+    "sortText": "00000339",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16910,7 +17267,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000329",
+    "sortText": "0000033a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16931,7 +17288,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032a",
+    "sortText": "0000033b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16952,7 +17309,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032b",
+    "sortText": "0000033c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16973,7 +17330,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032c",
+    "sortText": "0000033d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -16994,7 +17351,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032d",
+    "sortText": "0000033e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17015,7 +17372,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032e",
+    "sortText": "0000033f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17036,7 +17393,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000032f",
+    "sortText": "00000340",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17057,7 +17414,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000330",
+    "sortText": "00000341",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17078,7 +17435,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000331",
+    "sortText": "00000342",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17099,7 +17456,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000332",
+    "sortText": "00000343",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17120,7 +17477,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000333",
+    "sortText": "00000344",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17141,12 +17498,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000334",
+    "sortText": "00000345",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Compute/images@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Compute/interconnectBlocks'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Compute/interconnectBlocks`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000346",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Compute/interconnectBlocks@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -17162,7 +17540,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000335",
+    "sortText": "00000347",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17183,7 +17561,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000336",
+    "sortText": "00000348",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17204,7 +17582,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000337",
+    "sortText": "00000349",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17225,7 +17603,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000338",
+    "sortText": "0000034a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17246,7 +17624,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000339",
+    "sortText": "0000034b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17267,7 +17645,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033a",
+    "sortText": "0000034c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17288,7 +17666,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033b",
+    "sortText": "0000034d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17309,7 +17687,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033c",
+    "sortText": "0000034e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17330,7 +17708,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033d",
+    "sortText": "0000034f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17351,7 +17729,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033e",
+    "sortText": "00000350",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17372,7 +17750,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000033f",
+    "sortText": "00000351",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17393,7 +17771,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000340",
+    "sortText": "00000352",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17414,7 +17792,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000341",
+    "sortText": "00000353",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17435,7 +17813,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000345",
+    "sortText": "00000357",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17456,7 +17834,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000346",
+    "sortText": "00000358",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17477,7 +17855,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000347",
+    "sortText": "00000359",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17498,7 +17876,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000348",
+    "sortText": "0000035a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17519,7 +17897,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000349",
+    "sortText": "0000035b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17540,7 +17918,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034a",
+    "sortText": "0000035c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17561,7 +17939,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034d",
+    "sortText": "0000035f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17582,7 +17960,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034e",
+    "sortText": "00000360",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17603,7 +17981,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000342",
+    "sortText": "00000354",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17624,7 +18002,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000343",
+    "sortText": "00000355",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17645,7 +18023,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000344",
+    "sortText": "00000356",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17666,7 +18044,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034f",
+    "sortText": "00000361",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17687,7 +18065,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000350",
+    "sortText": "00000362",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17708,12 +18086,54 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000351",
+    "sortText": "00000363",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.ComputeLimit/locations/guestSubscriptions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.ComputeLimit/locations/sharedLimitCaps'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.ComputeLimit/locations/sharedLimitCaps`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000364",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.ComputeLimit/locations/sharedLimitCaps@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.ComputeLimit/locations/sharedLimitCaps/memberCapOverrides'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.ComputeLimit/locations/sharedLimitCaps/memberCapOverrides`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000365",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.ComputeLimit/locations/sharedLimitCaps/memberCapOverrides@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -17729,7 +18149,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000352",
+    "sortText": "00000366",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17750,7 +18170,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000353",
+    "sortText": "00000367",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17771,7 +18191,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000354",
+    "sortText": "00000368",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17792,7 +18212,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000355",
+    "sortText": "00000369",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17813,7 +18233,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000356",
+    "sortText": "0000036a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17834,7 +18254,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000357",
+    "sortText": "0000036b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17855,7 +18275,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000358",
+    "sortText": "0000036c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17876,7 +18296,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000359",
+    "sortText": "0000036d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17897,7 +18317,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035a",
+    "sortText": "0000036e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17918,7 +18338,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035b",
+    "sortText": "0000036f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17939,7 +18359,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035c",
+    "sortText": "00000370",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17960,7 +18380,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035d",
+    "sortText": "00000371",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -17981,7 +18401,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035e",
+    "sortText": "00000372",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18002,7 +18422,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000035f",
+    "sortText": "00000373",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18023,7 +18443,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000360",
+    "sortText": "00000374",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18044,7 +18464,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000361",
+    "sortText": "00000375",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18065,7 +18485,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000362",
+    "sortText": "00000376",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18086,7 +18506,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000363",
+    "sortText": "00000377",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18107,7 +18527,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000364",
+    "sortText": "00000378",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18128,7 +18548,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000365",
+    "sortText": "00000379",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18149,7 +18569,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000366",
+    "sortText": "0000037a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18170,7 +18590,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000367",
+    "sortText": "0000037b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18191,7 +18611,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000368",
+    "sortText": "0000037c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18212,7 +18632,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000369",
+    "sortText": "0000037d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18233,7 +18653,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036a",
+    "sortText": "0000037e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18254,7 +18674,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036b",
+    "sortText": "0000037f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18275,7 +18695,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036c",
+    "sortText": "00000380",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18296,7 +18716,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036d",
+    "sortText": "00000381",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18317,7 +18737,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036e",
+    "sortText": "00000382",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18338,7 +18758,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000373",
+    "sortText": "00000387",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18359,7 +18779,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000036f",
+    "sortText": "00000383",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18380,7 +18800,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000370",
+    "sortText": "00000384",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18401,7 +18821,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000371",
+    "sortText": "00000385",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18422,7 +18842,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000372",
+    "sortText": "00000386",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18443,7 +18863,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000374",
+    "sortText": "00000388",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18464,7 +18884,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000375",
+    "sortText": "00000389",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18485,7 +18905,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000376",
+    "sortText": "0000038a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18506,7 +18926,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000377",
+    "sortText": "0000038b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18527,7 +18947,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000378",
+    "sortText": "0000038c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18548,7 +18968,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000379",
+    "sortText": "0000038d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18569,7 +18989,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037a",
+    "sortText": "0000038e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18590,7 +19010,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037b",
+    "sortText": "0000038f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18611,7 +19031,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037c",
+    "sortText": "00000390",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18632,7 +19052,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037d",
+    "sortText": "00000391",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18653,7 +19073,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037e",
+    "sortText": "00000392",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18674,7 +19094,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000037f",
+    "sortText": "00000393",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18695,7 +19115,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000380",
+    "sortText": "00000394",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18716,7 +19136,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000381",
+    "sortText": "00000395",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18737,7 +19157,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000382",
+    "sortText": "00000396",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18758,7 +19178,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000383",
+    "sortText": "00000397",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18779,7 +19199,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000384",
+    "sortText": "00000398",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18800,7 +19220,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000385",
+    "sortText": "00000399",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18821,7 +19241,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000386",
+    "sortText": "0000039a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18842,7 +19262,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000387",
+    "sortText": "0000039b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18863,7 +19283,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000388",
+    "sortText": "0000039c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18884,7 +19304,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000389",
+    "sortText": "0000039d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18905,7 +19325,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038a",
+    "sortText": "0000039e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18926,7 +19346,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038b",
+    "sortText": "0000039f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18947,7 +19367,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038c",
+    "sortText": "000003a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18968,7 +19388,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038d",
+    "sortText": "000003a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -18989,7 +19409,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038e",
+    "sortText": "000003a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19010,7 +19430,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000038f",
+    "sortText": "000003a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19031,7 +19451,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000390",
+    "sortText": "000003a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19052,7 +19472,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000391",
+    "sortText": "000003a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19073,7 +19493,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000392",
+    "sortText": "000003a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -19094,7 +19514,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000393",
+    "sortText": "000003a7",
     "filterText": "'Microsoft.ContainerService/aiManagers aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19116,7 +19536,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000394",
+    "sortText": "000003a8",
     "filterText": "'Microsoft.ContainerService/aiManagers/modelSources aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19138,7 +19558,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000395",
+    "sortText": "000003a9",
     "filterText": "'Microsoft.ContainerService/aiManagers/namespaces aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19160,7 +19580,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000396",
+    "sortText": "000003aa",
     "filterText": "'Microsoft.ContainerService/aiManagers/namespaces/modelDeployments aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19182,7 +19602,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000397",
+    "sortText": "000003ab",
     "filterText": "'Microsoft.ContainerService/containerServices aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19204,7 +19624,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000398",
+    "sortText": "000003ac",
     "filterText": "'Microsoft.ContainerService/deploymentSafeguards aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19226,7 +19646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000399",
+    "sortText": "000003ad",
     "filterText": "'Microsoft.ContainerService/fleets aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19248,7 +19668,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039a",
+    "sortText": "000003ae",
     "filterText": "'Microsoft.ContainerService/fleets/autoUpgradeProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19270,7 +19690,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039b",
+    "sortText": "000003af",
     "filterText": "'Microsoft.ContainerService/fleets/clusterMeshProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19292,7 +19712,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039c",
+    "sortText": "000003b0",
     "filterText": "'Microsoft.ContainerService/fleets/gates aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19314,7 +19734,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039d",
+    "sortText": "000003b1",
     "filterText": "'Microsoft.ContainerService/fleets/managedNamespaces aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19336,7 +19756,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039e",
+    "sortText": "000003b2",
     "filterText": "'Microsoft.ContainerService/fleets/members aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19358,7 +19778,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000039f",
+    "sortText": "000003b3",
     "filterText": "'Microsoft.ContainerService/fleets/updateRuns aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19380,7 +19800,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a0",
+    "sortText": "000003b4",
     "filterText": "'Microsoft.ContainerService/fleets/updateStrategies aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19402,7 +19822,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a1",
+    "sortText": "000003b5",
     "filterText": "'Microsoft.ContainerService/locations/aiModels aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19424,7 +19844,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a2",
+    "sortText": "000003b6",
     "filterText": "'Microsoft.ContainerService/locations/guardrailsVersions aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19446,7 +19866,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a3",
+    "sortText": "000003b7",
     "filterText": "'Microsoft.ContainerService/locations/meshRevisionProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19468,13 +19888,35 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a4",
+    "sortText": "000003b8",
     "filterText": "'Microsoft.ContainerService/locations/safeguardsVersions aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.ContainerService/locations/safeguardsVersions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.ContainerService/maintenanceWindows'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.ContainerService/maintenanceWindows`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000003b9",
+    "filterText": "'Microsoft.ContainerService/maintenanceWindows aks kubernetes k8s cluster'",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.ContainerService/maintenanceWindows@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -19490,7 +19932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a5",
+    "sortText": "000003ba",
     "filterText": "'Microsoft.ContainerService/managedClusters aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19512,7 +19954,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a6",
+    "sortText": "000003bb",
     "filterText": "'Microsoft.ContainerService/managedClusters/accessProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19534,7 +19976,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a7",
+    "sortText": "000003bc",
     "filterText": "'Microsoft.ContainerService/managedClusters/agentPools aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19556,7 +19998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a8",
+    "sortText": "000003bd",
     "filterText": "'Microsoft.ContainerService/managedClusters/agentPools/machines aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19578,7 +20020,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003a9",
+    "sortText": "000003be",
     "filterText": "'Microsoft.ContainerService/managedClusters/agentPools/upgradeProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19600,7 +20042,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003aa",
+    "sortText": "000003bf",
     "filterText": "'Microsoft.ContainerService/managedClusters/identityBindings aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19622,7 +20064,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ab",
+    "sortText": "000003c0",
     "filterText": "'Microsoft.ContainerService/managedClusters/jwtAuthenticators aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19644,7 +20086,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ac",
+    "sortText": "000003c1",
     "filterText": "'Microsoft.ContainerService/managedClusters/loadBalancers aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19666,7 +20108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ad",
+    "sortText": "000003c2",
     "filterText": "'Microsoft.ContainerService/managedClusters/maintenanceConfigurations aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19688,7 +20130,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ae",
+    "sortText": "000003c3",
     "filterText": "'Microsoft.ContainerService/managedClusters/managedNamespaces aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19710,7 +20152,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003af",
+    "sortText": "000003c4",
     "filterText": "'Microsoft.ContainerService/managedClusters/meshMemberships aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19732,7 +20174,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b0",
+    "sortText": "000003c5",
     "filterText": "'Microsoft.ContainerService/managedClusters/meshUpgradeProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19754,7 +20196,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b1",
+    "sortText": "000003c6",
     "filterText": "'Microsoft.ContainerService/managedClusters/namespaces aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19776,7 +20218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b2",
+    "sortText": "000003c7",
     "filterText": "'Microsoft.ContainerService/managedClusters/privateEndpointConnections aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19798,7 +20240,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b3",
+    "sortText": "000003c8",
     "filterText": "'Microsoft.ContainerService/managedClusters/trustedAccessRoleBindings aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19820,7 +20262,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b4",
+    "sortText": "000003c9",
     "filterText": "'Microsoft.ContainerService/managedClusters/upgradeProfiles aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19842,7 +20284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b5",
+    "sortText": "000003ca",
     "filterText": "'Microsoft.ContainerService/managedclustersnapshots aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19864,7 +20306,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b6",
+    "sortText": "000003cb",
     "filterText": "'Microsoft.ContainerService/nodeCustomizations aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19886,7 +20328,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b7",
+    "sortText": "000003cc",
     "filterText": "'Microsoft.ContainerService/nodeCustomizations/versions aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19908,7 +20350,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b8",
+    "sortText": "000003cd",
     "filterText": "'Microsoft.ContainerService/openShiftManagedClusters aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19930,7 +20372,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003b9",
+    "sortText": "000003ce",
     "filterText": "'Microsoft.ContainerService/preparedImageSpecifications aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19952,7 +20394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ba",
+    "sortText": "000003cf",
     "filterText": "'Microsoft.ContainerService/preparedImageSpecifications/versions aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19974,7 +20416,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bb",
+    "sortText": "000003d0",
     "filterText": "'Microsoft.ContainerService/snapshots aks kubernetes k8s cluster'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -19996,7 +20438,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bc",
+    "sortText": "000003d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20017,7 +20459,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bd",
+    "sortText": "000003d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20038,7 +20480,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003be",
+    "sortText": "000003d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20059,7 +20501,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003bf",
+    "sortText": "000003d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20080,7 +20522,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c0",
+    "sortText": "000003d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20101,7 +20543,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c1",
+    "sortText": "000003d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20122,7 +20564,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c2",
+    "sortText": "000003d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20143,7 +20585,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c3",
+    "sortText": "000003d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20164,7 +20606,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c4",
+    "sortText": "000003d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20185,7 +20627,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c5",
+    "sortText": "000003da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20206,7 +20648,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c6",
+    "sortText": "000003db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20227,7 +20669,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c7",
+    "sortText": "000003dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20248,7 +20690,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c8",
+    "sortText": "000003dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20269,7 +20711,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003c9",
+    "sortText": "000003de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20290,7 +20732,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ca",
+    "sortText": "000003df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20311,7 +20753,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cb",
+    "sortText": "000003e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20332,7 +20774,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cc",
+    "sortText": "000003e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20353,7 +20795,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cd",
+    "sortText": "000003e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20374,7 +20816,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ce",
+    "sortText": "000003e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20395,7 +20837,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003cf",
+    "sortText": "000003e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20416,7 +20858,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d0",
+    "sortText": "000003e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20437,7 +20879,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003df",
+    "sortText": "000003f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20458,7 +20900,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e0",
+    "sortText": "000003f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20479,7 +20921,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d1",
+    "sortText": "000003e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20500,7 +20942,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d2",
+    "sortText": "000003e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20521,7 +20963,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d3",
+    "sortText": "000003e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20542,7 +20984,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d4",
+    "sortText": "000003e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20563,7 +21005,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d5",
+    "sortText": "000003ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20584,7 +21026,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d6",
+    "sortText": "000003eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20605,7 +21047,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d7",
+    "sortText": "000003ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20626,7 +21068,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d8",
+    "sortText": "000003ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20647,7 +21089,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003d9",
+    "sortText": "000003ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20668,7 +21110,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003da",
+    "sortText": "000003ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20689,7 +21131,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003db",
+    "sortText": "000003f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20710,7 +21152,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003dc",
+    "sortText": "000003f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20731,7 +21173,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003dd",
+    "sortText": "000003f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20752,7 +21194,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003de",
+    "sortText": "000003f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20773,7 +21215,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046e",
+    "sortText": "00000484",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20794,7 +21236,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000459",
+    "sortText": "0000046e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20815,7 +21257,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045a",
+    "sortText": "0000046f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20836,7 +21278,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045b",
+    "sortText": "00000470",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20857,7 +21299,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045c",
+    "sortText": "00000471",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20878,7 +21320,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045d",
+    "sortText": "00000472",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20899,7 +21341,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045e",
+    "sortText": "00000473",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20920,7 +21362,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000045f",
+    "sortText": "00000474",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20941,7 +21383,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000460",
+    "sortText": "00000475",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20962,7 +21404,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000461",
+    "sortText": "00000476",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -20983,7 +21425,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000462",
+    "sortText": "00000477",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21004,7 +21446,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000463",
+    "sortText": "00000478",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21025,7 +21467,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000464",
+    "sortText": "00000479",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21046,7 +21488,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000465",
+    "sortText": "0000047a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21067,7 +21509,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000466",
+    "sortText": "0000047b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21088,7 +21530,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000467",
+    "sortText": "0000047c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21109,7 +21551,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000468",
+    "sortText": "0000047d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21130,7 +21572,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000469",
+    "sortText": "0000047e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21151,7 +21593,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046a",
+    "sortText": "0000047f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21172,7 +21614,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046b",
+    "sortText": "00000480",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21193,12 +21635,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046c",
+    "sortText": "00000481",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.DBforMySQL/flexibleServers/databases@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.DBforMySQL/flexibleServers/fabricMirroringSettings'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.DBforMySQL/flexibleServers/fabricMirroringSettings`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000482",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.DBforMySQL/flexibleServers/fabricMirroringSettings@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -21214,7 +21677,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046d",
+    "sortText": "00000483",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21235,7 +21698,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000046f",
+    "sortText": "00000485",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21256,7 +21719,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000470",
+    "sortText": "00000486",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21277,7 +21740,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000471",
+    "sortText": "00000487",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21298,7 +21761,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000472",
+    "sortText": "00000488",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21319,7 +21782,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000473",
+    "sortText": "00000489",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21340,7 +21803,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000474",
+    "sortText": "0000048a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21361,7 +21824,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000475",
+    "sortText": "0000048b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21382,7 +21845,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000476",
+    "sortText": "0000048c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21403,7 +21866,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000477",
+    "sortText": "0000048d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21424,7 +21887,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000478",
+    "sortText": "0000048e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21445,7 +21908,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000479",
+    "sortText": "0000048f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21466,7 +21929,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047a",
+    "sortText": "00000490",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21487,7 +21950,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047b",
+    "sortText": "00000491",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21508,7 +21971,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047c",
+    "sortText": "00000492",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21529,7 +21992,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047d",
+    "sortText": "00000493",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21550,7 +22013,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047e",
+    "sortText": "00000494",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21571,7 +22034,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000047f",
+    "sortText": "00000495",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21592,7 +22055,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000480",
+    "sortText": "00000496",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21613,7 +22076,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000481",
+    "sortText": "00000497",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21634,7 +22097,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000482",
+    "sortText": "00000498",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21655,7 +22118,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000483",
+    "sortText": "00000499",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21676,7 +22139,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000484",
+    "sortText": "0000049a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21697,7 +22160,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000485",
+    "sortText": "0000049b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21718,7 +22181,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000486",
+    "sortText": "0000049c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21739,7 +22202,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000487",
+    "sortText": "0000049d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21760,7 +22223,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000488",
+    "sortText": "0000049e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21781,7 +22244,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000489",
+    "sortText": "0000049f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21802,7 +22265,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048a",
+    "sortText": "000004a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21823,7 +22286,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048b",
+    "sortText": "000004a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21844,7 +22307,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048c",
+    "sortText": "000004a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21865,7 +22328,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048d",
+    "sortText": "000004a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21886,7 +22349,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048e",
+    "sortText": "000004a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21907,7 +22370,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000048f",
+    "sortText": "000004a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21928,7 +22391,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000490",
+    "sortText": "000004a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21949,7 +22412,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000491",
+    "sortText": "000004a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21970,7 +22433,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000492",
+    "sortText": "000004a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -21991,7 +22454,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000493",
+    "sortText": "000004a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22012,7 +22475,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000494",
+    "sortText": "000004aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22033,7 +22496,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000495",
+    "sortText": "000004ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22054,7 +22517,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000496",
+    "sortText": "000004ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22075,7 +22538,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000497",
+    "sortText": "000004ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22096,7 +22559,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000498",
+    "sortText": "000004ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22117,7 +22580,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000499",
+    "sortText": "000004af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22138,7 +22601,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049a",
+    "sortText": "000004b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22159,7 +22622,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049b",
+    "sortText": "000004b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22180,7 +22643,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049c",
+    "sortText": "000004b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22201,7 +22664,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049d",
+    "sortText": "000004b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22222,7 +22685,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049e",
+    "sortText": "000004b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22243,7 +22706,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000049f",
+    "sortText": "000004b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22264,7 +22727,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a0",
+    "sortText": "000004b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22285,7 +22748,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a1",
+    "sortText": "000004b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22306,7 +22769,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a2",
+    "sortText": "000004b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22327,7 +22790,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a3",
+    "sortText": "000004b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22348,7 +22811,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a4",
+    "sortText": "000004ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22369,7 +22832,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a5",
+    "sortText": "000004bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22390,7 +22853,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a6",
+    "sortText": "000004bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22411,7 +22874,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a7",
+    "sortText": "000004bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22432,7 +22895,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a8",
+    "sortText": "000004be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22453,7 +22916,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004a9",
+    "sortText": "000004bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22474,7 +22937,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004aa",
+    "sortText": "000004c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22495,7 +22958,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e1",
+    "sortText": "000003f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22516,7 +22979,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e2",
+    "sortText": "000003f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22537,7 +23000,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e3",
+    "sortText": "000003f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22558,7 +23021,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e4",
+    "sortText": "000003f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22579,7 +23042,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e5",
+    "sortText": "000003fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22600,7 +23063,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e6",
+    "sortText": "000003fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22621,7 +23084,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e7",
+    "sortText": "000003fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22642,7 +23105,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f2",
+    "sortText": "00000407",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22663,7 +23126,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f3",
+    "sortText": "00000408",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22684,7 +23147,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f4",
+    "sortText": "00000409",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22705,7 +23168,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f5",
+    "sortText": "0000040a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22726,7 +23189,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f6",
+    "sortText": "0000040b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22747,7 +23210,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f7",
+    "sortText": "0000040c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22768,7 +23231,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f8",
+    "sortText": "0000040d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22789,7 +23252,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f9",
+    "sortText": "0000040e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22810,7 +23273,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fa",
+    "sortText": "0000040f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22831,7 +23294,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fb",
+    "sortText": "00000410",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22852,7 +23315,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fc",
+    "sortText": "00000411",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22873,7 +23336,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fd",
+    "sortText": "00000412",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22894,7 +23357,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003fe",
+    "sortText": "00000413",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22915,7 +23378,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ff",
+    "sortText": "00000414",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22936,7 +23399,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000400",
+    "sortText": "00000415",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22957,7 +23420,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000401",
+    "sortText": "00000416",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22978,7 +23441,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000402",
+    "sortText": "00000417",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -22999,7 +23462,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000403",
+    "sortText": "00000418",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23020,7 +23483,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000404",
+    "sortText": "00000419",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23041,7 +23504,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000405",
+    "sortText": "0000041a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23062,7 +23525,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000406",
+    "sortText": "0000041b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23083,7 +23546,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000407",
+    "sortText": "0000041c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23104,7 +23567,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040d",
+    "sortText": "00000422",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23125,7 +23588,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000413",
+    "sortText": "00000428",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23146,7 +23609,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000414",
+    "sortText": "00000429",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23167,7 +23630,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000415",
+    "sortText": "0000042a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23188,7 +23651,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000416",
+    "sortText": "0000042b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23209,7 +23672,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000417",
+    "sortText": "0000042c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23230,7 +23693,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000418",
+    "sortText": "0000042d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23251,7 +23714,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000419",
+    "sortText": "0000042e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23272,7 +23735,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041a",
+    "sortText": "0000042f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23293,7 +23756,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041b",
+    "sortText": "00000430",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23314,7 +23777,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041c",
+    "sortText": "00000431",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23335,7 +23798,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041d",
+    "sortText": "00000432",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23356,7 +23819,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041e",
+    "sortText": "00000433",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23377,7 +23840,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000041f",
+    "sortText": "00000434",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23398,7 +23861,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000420",
+    "sortText": "00000435",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23419,7 +23882,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000421",
+    "sortText": "00000436",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23440,7 +23903,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000422",
+    "sortText": "00000437",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23461,7 +23924,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000423",
+    "sortText": "00000438",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23482,7 +23945,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000424",
+    "sortText": "00000439",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23503,7 +23966,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000425",
+    "sortText": "0000043a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23524,7 +23987,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000426",
+    "sortText": "0000043b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23545,7 +24008,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000427",
+    "sortText": "0000043c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23566,7 +24029,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000428",
+    "sortText": "0000043d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23587,7 +24050,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000429",
+    "sortText": "0000043e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23608,7 +24071,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042a",
+    "sortText": "0000043f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23629,7 +24092,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042b",
+    "sortText": "00000440",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23650,7 +24113,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042c",
+    "sortText": "00000441",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23671,7 +24134,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042d",
+    "sortText": "00000442",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23692,7 +24155,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042e",
+    "sortText": "00000443",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23713,7 +24176,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000042f",
+    "sortText": "00000444",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23734,7 +24197,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000430",
+    "sortText": "00000445",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23755,7 +24218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000431",
+    "sortText": "00000446",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23776,7 +24239,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000432",
+    "sortText": "00000447",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23797,7 +24260,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000433",
+    "sortText": "00000448",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23818,7 +24281,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000434",
+    "sortText": "00000449",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23839,7 +24302,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000435",
+    "sortText": "0000044a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23860,7 +24323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000436",
+    "sortText": "0000044b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23881,7 +24344,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000437",
+    "sortText": "0000044c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23902,7 +24365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000438",
+    "sortText": "0000044d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23923,7 +24386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000439",
+    "sortText": "0000044e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23944,7 +24407,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043a",
+    "sortText": "0000044f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23965,7 +24428,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043b",
+    "sortText": "00000450",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -23986,7 +24449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043c",
+    "sortText": "00000451",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24007,7 +24470,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043d",
+    "sortText": "00000452",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24028,7 +24491,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043e",
+    "sortText": "00000453",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24049,7 +24512,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000043f",
+    "sortText": "00000454",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24070,7 +24533,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000440",
+    "sortText": "00000455",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24091,7 +24554,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000441",
+    "sortText": "00000456",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24112,7 +24575,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000442",
+    "sortText": "00000457",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24133,7 +24596,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000443",
+    "sortText": "00000458",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24154,7 +24617,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000444",
+    "sortText": "00000459",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24175,7 +24638,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000445",
+    "sortText": "0000045a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24196,7 +24659,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000446",
+    "sortText": "0000045b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24217,7 +24680,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000447",
+    "sortText": "0000045c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24238,7 +24701,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000448",
+    "sortText": "0000045d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24259,7 +24722,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000449",
+    "sortText": "0000045e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24280,7 +24743,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044a",
+    "sortText": "0000045f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24301,7 +24764,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044b",
+    "sortText": "00000460",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24322,7 +24785,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044c",
+    "sortText": "00000461",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24343,7 +24806,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044d",
+    "sortText": "00000462",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24364,7 +24827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044e",
+    "sortText": "00000463",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24385,7 +24848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000044f",
+    "sortText": "00000464",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24406,7 +24869,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000455",
+    "sortText": "0000046a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24427,7 +24890,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000456",
+    "sortText": "0000046b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24448,7 +24911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000457",
+    "sortText": "0000046c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24469,7 +24932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000450",
+    "sortText": "00000465",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24490,7 +24953,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000451",
+    "sortText": "00000466",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24511,7 +24974,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000452",
+    "sortText": "00000467",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24532,7 +24995,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000453",
+    "sortText": "00000468",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24553,7 +25016,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000454",
+    "sortText": "00000469",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24574,7 +25037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000458",
+    "sortText": "0000046d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24595,7 +25058,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e8",
+    "sortText": "000003fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24616,7 +25079,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003e9",
+    "sortText": "000003fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24637,7 +25100,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ea",
+    "sortText": "000003ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24658,7 +25121,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003eb",
+    "sortText": "00000400",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24679,7 +25142,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ec",
+    "sortText": "00000401",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24700,7 +25163,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ed",
+    "sortText": "00000402",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24721,7 +25184,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ee",
+    "sortText": "00000403",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24742,7 +25205,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003ef",
+    "sortText": "00000404",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24763,7 +25226,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f0",
+    "sortText": "00000405",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24784,7 +25247,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000003f1",
+    "sortText": "00000406",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24805,7 +25268,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000408",
+    "sortText": "0000041d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24826,7 +25289,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000409",
+    "sortText": "0000041e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24847,7 +25310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040a",
+    "sortText": "0000041f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24868,7 +25331,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040b",
+    "sortText": "00000420",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24889,7 +25352,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040c",
+    "sortText": "00000421",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24910,7 +25373,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040e",
+    "sortText": "00000423",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24931,7 +25394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000040f",
+    "sortText": "00000424",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24952,7 +25415,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000410",
+    "sortText": "00000425",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24973,7 +25436,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000411",
+    "sortText": "00000426",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -24994,7 +25457,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000412",
+    "sortText": "00000427",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25015,7 +25478,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ab",
+    "sortText": "000004c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25036,7 +25499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ac",
+    "sortText": "000004c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25057,7 +25520,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ad",
+    "sortText": "000004c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25078,7 +25541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ae",
+    "sortText": "000004c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25099,7 +25562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004af",
+    "sortText": "000004c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25120,7 +25583,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b0",
+    "sortText": "000004c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25141,7 +25604,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b1",
+    "sortText": "000004c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25162,7 +25625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b2",
+    "sortText": "000004c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25183,7 +25646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b3",
+    "sortText": "000004c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25204,7 +25667,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b4",
+    "sortText": "000004ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25225,7 +25688,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b5",
+    "sortText": "000004cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25246,7 +25709,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b6",
+    "sortText": "000004cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25267,7 +25730,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b7",
+    "sortText": "000004cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25288,7 +25751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b8",
+    "sortText": "000004ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25309,7 +25772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004b9",
+    "sortText": "000004cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25330,7 +25793,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ba",
+    "sortText": "000004d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25351,7 +25814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bb",
+    "sortText": "000004d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25372,7 +25835,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bc",
+    "sortText": "000004d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25393,7 +25856,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bd",
+    "sortText": "000004d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25414,7 +25877,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004be",
+    "sortText": "000004d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25435,7 +25898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004bf",
+    "sortText": "000004d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25456,7 +25919,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c0",
+    "sortText": "000004d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25477,7 +25940,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c1",
+    "sortText": "000004d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25498,7 +25961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c2",
+    "sortText": "000004d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25519,7 +25982,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c3",
+    "sortText": "000004d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25540,7 +26003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c4",
+    "sortText": "000004da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25561,7 +26024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c5",
+    "sortText": "000004db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25582,7 +26045,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c6",
+    "sortText": "000004dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25603,7 +26066,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c7",
+    "sortText": "000004dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25624,7 +26087,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c8",
+    "sortText": "000004de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25645,7 +26108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004c9",
+    "sortText": "000004df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25666,7 +26129,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ca",
+    "sortText": "000004e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25687,7 +26150,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cb",
+    "sortText": "000004e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25708,7 +26171,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cc",
+    "sortText": "000004e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25729,7 +26192,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cd",
+    "sortText": "000004e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25750,7 +26213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ce",
+    "sortText": "000004e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25771,7 +26234,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004cf",
+    "sortText": "000004e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25792,7 +26255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d0",
+    "sortText": "000004e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25813,7 +26276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d1",
+    "sortText": "000004e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25834,7 +26297,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d2",
+    "sortText": "000004e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25855,7 +26318,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d3",
+    "sortText": "000004e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25876,7 +26339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d4",
+    "sortText": "000004ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25897,7 +26360,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d5",
+    "sortText": "000004eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25918,7 +26381,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d6",
+    "sortText": "000004ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25939,7 +26402,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d7",
+    "sortText": "000004ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25960,7 +26423,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d8",
+    "sortText": "000004ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -25981,7 +26444,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004d9",
+    "sortText": "000004ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26002,7 +26465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004da",
+    "sortText": "000004f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26023,7 +26486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004db",
+    "sortText": "000004f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26044,7 +26507,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004dc",
+    "sortText": "000004f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26065,7 +26528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004dd",
+    "sortText": "000004f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26086,7 +26549,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004de",
+    "sortText": "000004f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26107,7 +26570,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004df",
+    "sortText": "000004f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26128,7 +26591,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e0",
+    "sortText": "000004f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26149,7 +26612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e1",
+    "sortText": "000004f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26170,7 +26633,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e2",
+    "sortText": "000004f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26191,7 +26654,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e3",
+    "sortText": "000004f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26212,7 +26675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e4",
+    "sortText": "000004fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26233,7 +26696,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e5",
+    "sortText": "000004fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26254,7 +26717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e6",
+    "sortText": "000004fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26275,7 +26738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e7",
+    "sortText": "000004fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26296,7 +26759,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e8",
+    "sortText": "000004fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26317,7 +26780,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004e9",
+    "sortText": "000004ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26338,7 +26801,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ea",
+    "sortText": "00000500",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26359,7 +26822,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004eb",
+    "sortText": "00000501",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26380,7 +26843,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ec",
+    "sortText": "00000502",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26401,7 +26864,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ed",
+    "sortText": "00000503",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26422,7 +26885,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050a",
+    "sortText": "00000520",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26443,7 +26906,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050b",
+    "sortText": "00000521",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26464,7 +26927,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050c",
+    "sortText": "00000522",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26485,7 +26948,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050d",
+    "sortText": "00000523",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26506,7 +26969,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050e",
+    "sortText": "00000524",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26527,7 +26990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000050f",
+    "sortText": "00000525",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26548,7 +27011,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000510",
+    "sortText": "00000526",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26569,7 +27032,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000511",
+    "sortText": "00000527",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26590,7 +27053,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000512",
+    "sortText": "00000528",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26611,7 +27074,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000513",
+    "sortText": "00000529",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26632,7 +27095,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000514",
+    "sortText": "0000052a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26653,7 +27116,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000515",
+    "sortText": "0000052b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26674,7 +27137,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000516",
+    "sortText": "0000052c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26695,7 +27158,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000517",
+    "sortText": "0000052d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26716,7 +27179,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000518",
+    "sortText": "0000052e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26737,7 +27200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000519",
+    "sortText": "0000052f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26758,7 +27221,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051a",
+    "sortText": "00000530",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26779,7 +27242,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051b",
+    "sortText": "00000531",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26800,7 +27263,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051c",
+    "sortText": "00000532",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26821,7 +27284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051d",
+    "sortText": "00000533",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26842,7 +27305,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051e",
+    "sortText": "00000534",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26863,7 +27326,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000051f",
+    "sortText": "00000535",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26884,7 +27347,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000520",
+    "sortText": "00000536",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26905,7 +27368,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000521",
+    "sortText": "00000537",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26926,7 +27389,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000522",
+    "sortText": "00000538",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26947,7 +27410,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ee",
+    "sortText": "00000504",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26968,7 +27431,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ef",
+    "sortText": "00000505",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -26989,7 +27452,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f0",
+    "sortText": "00000506",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27010,7 +27473,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f1",
+    "sortText": "00000507",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27031,7 +27494,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f2",
+    "sortText": "00000508",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27052,7 +27515,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f3",
+    "sortText": "00000509",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27073,7 +27536,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f4",
+    "sortText": "0000050a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27094,7 +27557,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f5",
+    "sortText": "0000050b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27115,7 +27578,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f6",
+    "sortText": "0000050c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27136,7 +27599,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f7",
+    "sortText": "0000050d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27157,7 +27620,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f8",
+    "sortText": "0000050e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27178,7 +27641,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004f9",
+    "sortText": "0000050f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27199,7 +27662,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fa",
+    "sortText": "00000510",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27220,7 +27683,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fb",
+    "sortText": "00000511",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27241,7 +27704,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fc",
+    "sortText": "00000512",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27262,7 +27725,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000505",
+    "sortText": "0000051b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27283,7 +27746,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000506",
+    "sortText": "0000051c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27304,7 +27767,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000507",
+    "sortText": "0000051d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27325,7 +27788,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000508",
+    "sortText": "0000051e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27346,7 +27809,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000509",
+    "sortText": "0000051f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27367,7 +27830,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fd",
+    "sortText": "00000513",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27388,7 +27851,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004fe",
+    "sortText": "00000514",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27409,7 +27872,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000004ff",
+    "sortText": "00000515",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27430,7 +27893,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000500",
+    "sortText": "00000516",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27451,7 +27914,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000501",
+    "sortText": "00000517",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27472,7 +27935,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000502",
+    "sortText": "00000518",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27493,7 +27956,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000503",
+    "sortText": "00000519",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27514,7 +27977,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000504",
+    "sortText": "0000051a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27535,7 +27998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000523",
+    "sortText": "00000539",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27556,7 +28019,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000524",
+    "sortText": "0000053a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27577,7 +28040,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000525",
+    "sortText": "0000053b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27598,7 +28061,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000526",
+    "sortText": "0000053c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27619,7 +28082,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000527",
+    "sortText": "0000053d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27640,7 +28103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000528",
+    "sortText": "0000053e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27661,7 +28124,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000529",
+    "sortText": "0000053f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27682,7 +28145,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052a",
+    "sortText": "00000540",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27703,7 +28166,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052b",
+    "sortText": "00000541",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27724,7 +28187,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052c",
+    "sortText": "00000542",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27745,7 +28208,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052d",
+    "sortText": "00000543",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27766,7 +28229,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052e",
+    "sortText": "00000544",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27787,7 +28250,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000052f",
+    "sortText": "00000545",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27808,7 +28271,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000530",
+    "sortText": "00000546",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27829,7 +28292,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000531",
+    "sortText": "00000547",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27850,7 +28313,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000532",
+    "sortText": "00000548",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27871,7 +28334,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000533",
+    "sortText": "00000549",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -27892,7 +28355,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000534",
+    "sortText": "0000054a",
     "filterText": "'Microsoft.DocumentDB/cassandraClusters cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -27914,7 +28377,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000535",
+    "sortText": "0000054b",
     "filterText": "'Microsoft.DocumentDB/cassandraClusters/backups cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -27936,7 +28399,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000536",
+    "sortText": "0000054c",
     "filterText": "'Microsoft.DocumentDB/cassandraClusters/dataCenters cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -27958,7 +28421,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000537",
+    "sortText": "0000054d",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -27980,7 +28443,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000538",
+    "sortText": "0000054e",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28002,7 +28465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000539",
+    "sortText": "0000054f",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/collections cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28024,7 +28487,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053a",
+    "sortText": "00000550",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/collections/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28046,7 +28509,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053b",
+    "sortText": "00000551",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/containers cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28068,7 +28531,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053c",
+    "sortText": "00000552",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/containers/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28090,7 +28553,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053d",
+    "sortText": "00000553",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28112,7 +28575,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053e",
+    "sortText": "00000554",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/graphs/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28134,7 +28597,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000053f",
+    "sortText": "00000555",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/databases/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28156,7 +28619,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000540",
+    "sortText": "00000556",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28178,7 +28641,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000541",
+    "sortText": "00000557",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28200,7 +28663,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000542",
+    "sortText": "00000558",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28222,7 +28685,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000543",
+    "sortText": "00000559",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces/tables/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28244,7 +28707,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000544",
+    "sortText": "0000055a",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28266,7 +28729,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000545",
+    "sortText": "0000055b",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/apis/tables/settings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28288,7 +28751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000546",
+    "sortText": "0000055c",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28310,7 +28773,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000547",
+    "sortText": "0000055d",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28332,7 +28795,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000548",
+    "sortText": "0000055e",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/tables/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28354,7 +28817,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000549",
+    "sortText": "0000055f",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28376,7 +28839,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054a",
+    "sortText": "00000560",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28398,7 +28861,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054b",
+    "sortText": "00000561",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraKeyspaces/views/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28420,7 +28883,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054c",
+    "sortText": "00000562",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraRoleAssignments cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28442,7 +28905,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054d",
+    "sortText": "00000563",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/cassandraRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28464,7 +28927,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054e",
+    "sortText": "00000564",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/chaosFaults cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28486,7 +28949,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000054f",
+    "sortText": "00000565",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/copyJobs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28508,7 +28971,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000550",
+    "sortText": "00000566",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/dataTransferJobs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28530,7 +28993,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000551",
+    "sortText": "00000567",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/graphs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28552,7 +29015,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000552",
+    "sortText": "00000568",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28574,7 +29037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000553",
+    "sortText": "00000569",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28596,7 +29059,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000554",
+    "sortText": "0000056a",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/graphs/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28618,7 +29081,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000555",
+    "sortText": "0000056b",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinDatabases/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28640,7 +29103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000556",
+    "sortText": "0000056c",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinRoleAssignments cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28662,7 +29125,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000557",
+    "sortText": "0000056d",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/gremlinRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28684,7 +29147,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055e",
+    "sortText": "00000574",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongoMIRoleAssignments cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28706,7 +29169,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055f",
+    "sortText": "00000575",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongoMIRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28728,7 +29191,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000558",
+    "sortText": "0000056e",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28750,7 +29213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000559",
+    "sortText": "0000056f",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28772,7 +29235,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055a",
+    "sortText": "00000570",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/collections/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28794,7 +29257,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055b",
+    "sortText": "00000571",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28816,7 +29279,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055c",
+    "sortText": "00000572",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28838,7 +29301,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000055d",
+    "sortText": "00000573",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/mongodbUserDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28860,7 +29323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000560",
+    "sortText": "00000576",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/networkSecurityPerimeterConfigurations cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28882,7 +29345,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000561",
+    "sortText": "00000577",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/notebookWorkspaces cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28904,7 +29367,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000562",
+    "sortText": "00000578",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/privateEndpointConnections cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28926,7 +29389,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000563",
+    "sortText": "00000579",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/privateLinkResources cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28948,7 +29411,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000564",
+    "sortText": "0000057a",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/services cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28970,7 +29433,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000565",
+    "sortText": "0000057b",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -28992,7 +29455,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000566",
+    "sortText": "0000057c",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/clientEncryptionKeys cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29014,7 +29477,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000567",
+    "sortText": "0000057d",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29036,7 +29499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000568",
+    "sortText": "0000057e",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/storedProcedures cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29058,7 +29521,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000569",
+    "sortText": "0000057f",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29080,7 +29543,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056a",
+    "sortText": "00000580",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/triggers cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29102,7 +29565,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056b",
+    "sortText": "00000581",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/userDefinedFunctions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29124,7 +29587,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056c",
+    "sortText": "00000582",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29146,7 +29609,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056d",
+    "sortText": "00000583",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29168,7 +29631,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056e",
+    "sortText": "00000584",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29190,7 +29653,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000056f",
+    "sortText": "00000585",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/tableRoleAssignments cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29212,7 +29675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000570",
+    "sortText": "00000586",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/tableRoleDefinitions cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29234,7 +29697,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000571",
+    "sortText": "00000587",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/tables cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29256,7 +29719,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000572",
+    "sortText": "00000588",
     "filterText": "'Microsoft.DocumentDB/databaseAccounts/tables/throughputSettings cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29278,7 +29741,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000573",
+    "sortText": "00000589",
     "filterText": "'Microsoft.DocumentDB/fleets cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29300,7 +29763,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000574",
+    "sortText": "0000058a",
     "filterText": "'Microsoft.DocumentDB/fleets/fleetAnalytics cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29322,7 +29785,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000575",
+    "sortText": "0000058b",
     "filterText": "'Microsoft.DocumentDB/fleets/fleetspaces cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29344,7 +29807,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000576",
+    "sortText": "0000058c",
     "filterText": "'Microsoft.DocumentDB/fleets/fleetspaces/fleetspaceAccounts cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29366,7 +29829,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000577",
+    "sortText": "0000058d",
     "filterText": "'Microsoft.DocumentDB/garnetClusters cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29388,7 +29851,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000578",
+    "sortText": "0000058e",
     "filterText": "'Microsoft.DocumentDB/locations cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29410,7 +29873,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000579",
+    "sortText": "0000058f",
     "filterText": "'Microsoft.DocumentDB/locations/restorableDatabaseAccounts cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29432,7 +29895,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057a",
+    "sortText": "00000590",
     "filterText": "'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29454,7 +29917,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057b",
+    "sortText": "00000591",
     "filterText": "'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29476,7 +29939,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057c",
+    "sortText": "00000592",
     "filterText": "'Microsoft.DocumentDB/locations/softDeletedDatabaseAccounts/softDeletedSqlDatabases/softDeletedSqlContainers cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29498,7 +29961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057d",
+    "sortText": "00000593",
     "filterText": "'Microsoft.DocumentDB/mongoClusters cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29520,7 +29983,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057e",
+    "sortText": "00000594",
     "filterText": "'Microsoft.DocumentDB/mongoClusters/firewallRules cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29542,7 +30005,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000057f",
+    "sortText": "00000595",
     "filterText": "'Microsoft.DocumentDB/mongoClusters/privateEndpointConnections cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29564,7 +30027,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000580",
+    "sortText": "00000596",
     "filterText": "'Microsoft.DocumentDB/mongoClusters/users cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29586,7 +30049,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000581",
+    "sortText": "00000597",
     "filterText": "'Microsoft.DocumentDB/throughputPools cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29608,7 +30071,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000582",
+    "sortText": "00000598",
     "filterText": "'Microsoft.DocumentDB/throughputPools/throughputPoolAccounts cosmosdb'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -29630,7 +30093,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000583",
+    "sortText": "00000599",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29651,7 +30114,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000584",
+    "sortText": "0000059a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29672,7 +30135,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000585",
+    "sortText": "0000059b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29693,7 +30156,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000586",
+    "sortText": "0000059c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29714,7 +30177,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000587",
+    "sortText": "0000059d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29735,7 +30198,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000588",
+    "sortText": "0000059e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29756,7 +30219,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000589",
+    "sortText": "0000059f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29777,7 +30240,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058a",
+    "sortText": "000005a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29798,12 +30261,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058b",
+    "sortText": "000005a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.DurableTask/schedulers/taskHubs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.DurableTask/schedulers/transparentDataEncryptions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.DurableTask/schedulers/transparentDataEncryptions`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005a2",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.DurableTask/schedulers/transparentDataEncryptions@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -29819,7 +30303,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058c",
+    "sortText": "000005a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29840,7 +30324,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058d",
+    "sortText": "000005a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29861,7 +30345,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058e",
+    "sortText": "000005a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29882,7 +30366,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000058f",
+    "sortText": "000005a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29903,12 +30387,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000590",
+    "sortText": "000005a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Edge/configTemplates@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/configTemplates/configTemplateMetadatas'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/configTemplates/configTemplateMetadatas`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005a8",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/configTemplates/configTemplateMetadatas@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -29924,12 +30429,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000591",
+    "sortText": "000005a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Edge/configTemplates/versions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/configTemplates/versions/configTemplateSchemas'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/configTemplates/versions/configTemplateSchemas`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005aa",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/configTemplates/versions/configTemplateSchemas@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -29945,7 +30471,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000592",
+    "sortText": "000005ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29966,7 +30492,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000593",
+    "sortText": "000005ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -29987,7 +30513,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000594",
+    "sortText": "000005ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30008,7 +30534,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000595",
+    "sortText": "000005ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30029,7 +30555,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000596",
+    "sortText": "000005af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30050,7 +30576,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000597",
+    "sortText": "000005b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30071,7 +30597,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000598",
+    "sortText": "000005b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30092,7 +30618,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000599",
+    "sortText": "000005b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30113,7 +30639,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059a",
+    "sortText": "000005b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30134,7 +30660,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059b",
+    "sortText": "000005b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30155,7 +30681,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059c",
+    "sortText": "000005b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30176,7 +30702,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059d",
+    "sortText": "000005b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30197,7 +30723,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059e",
+    "sortText": "000005b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30218,12 +30744,54 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000059f",
+    "sortText": "000005b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Edge/disconnectedOperations/images/artifacts@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/hierarchyConfigurationMetadatas'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/hierarchyConfigurationMetadatas`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005b9",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/hierarchyConfigurationMetadatas@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/hierarchyConfigurationMetadatas/versions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/hierarchyConfigurationMetadatas/versions`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005ba",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/hierarchyConfigurationMetadatas/versions@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -30239,7 +30807,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a0",
+    "sortText": "000005bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30260,7 +30828,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a1",
+    "sortText": "000005bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30281,7 +30849,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a2",
+    "sortText": "000005bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30302,7 +30870,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a3",
+    "sortText": "000005be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30323,7 +30891,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a4",
+    "sortText": "000005bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30344,7 +30912,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a5",
+    "sortText": "000005c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30365,12 +30933,54 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a6",
+    "sortText": "000005c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Edge/sites@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/solutionMetadatas'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/solutionMetadatas`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005c2",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/solutionMetadatas@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/solutionMetadatas/versions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/solutionMetadatas/versions`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005c3",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/solutionMetadatas/versions@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -30386,7 +30996,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a7",
+    "sortText": "000005c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30407,12 +31017,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a8",
+    "sortText": "000005c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Edge/solutionTemplates/versions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/solutionTemplates/versions/solutionSchemas'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/solutionTemplates/versions/solutionSchemas`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005c6",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/solutionTemplates/versions/solutionSchemas@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -30428,7 +31059,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005a9",
+    "sortText": "000005c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30449,7 +31080,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005aa",
+    "sortText": "000005c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30470,7 +31101,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ab",
+    "sortText": "000005c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30491,7 +31122,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ac",
+    "sortText": "000005ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30512,12 +31143,75 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ad",
+    "sortText": "000005cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Edge/targets/solutions/versions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/workflows'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/workflows`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005cc",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/workflows@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/workflows/versions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/workflows/versions`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005cd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/workflows/versions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Edge/workflows/versions/executions'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Edge/workflows/versions/executions`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000005ce",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Edge/workflows/versions/executions@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -30533,7 +31227,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ae",
+    "sortText": "000005cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30554,7 +31248,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005af",
+    "sortText": "000005d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30575,7 +31269,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b0",
+    "sortText": "000005d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30596,7 +31290,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b1",
+    "sortText": "000005d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30617,7 +31311,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b2",
+    "sortText": "000005d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30638,7 +31332,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b3",
+    "sortText": "000005d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30659,7 +31353,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b4",
+    "sortText": "000005d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30680,7 +31374,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b5",
+    "sortText": "000005d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30701,7 +31395,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b6",
+    "sortText": "000005d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30722,7 +31416,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b7",
+    "sortText": "000005d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30743,7 +31437,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b8",
+    "sortText": "000005d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30764,7 +31458,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005b9",
+    "sortText": "000005da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30785,7 +31479,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ba",
+    "sortText": "000005db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30806,7 +31500,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bb",
+    "sortText": "000005dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30827,7 +31521,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bc",
+    "sortText": "000005dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30848,7 +31542,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bd",
+    "sortText": "000005de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30869,7 +31563,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005be",
+    "sortText": "000005df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30890,7 +31584,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005bf",
+    "sortText": "000005e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30911,7 +31605,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c0",
+    "sortText": "000005e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30932,7 +31626,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c1",
+    "sortText": "000005e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30953,7 +31647,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c2",
+    "sortText": "000005e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30974,7 +31668,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c3",
+    "sortText": "000005e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -30995,7 +31689,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c4",
+    "sortText": "000005e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31016,7 +31710,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c5",
+    "sortText": "000005e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31037,7 +31731,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c6",
+    "sortText": "000005e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31058,7 +31752,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c7",
+    "sortText": "000005e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31079,7 +31773,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c8",
+    "sortText": "000005e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31100,7 +31794,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005c9",
+    "sortText": "000005ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31121,7 +31815,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ca",
+    "sortText": "000005eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31142,7 +31836,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cb",
+    "sortText": "000005ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31163,7 +31857,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cc",
+    "sortText": "000005ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31184,7 +31878,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cd",
+    "sortText": "000005ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31205,7 +31899,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ce",
+    "sortText": "000005ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31226,7 +31920,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005cf",
+    "sortText": "000005f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31247,7 +31941,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d0",
+    "sortText": "000005f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31268,7 +31962,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d1",
+    "sortText": "000005f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31289,7 +31983,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d4",
+    "sortText": "000005f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31310,7 +32004,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d2",
+    "sortText": "000005f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31331,7 +32025,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d3",
+    "sortText": "000005f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31352,7 +32046,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d5",
+    "sortText": "000005f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31373,7 +32067,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d6",
+    "sortText": "000005f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31394,7 +32088,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d7",
+    "sortText": "000005f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31415,7 +32109,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d8",
+    "sortText": "000005f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31436,7 +32130,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005d9",
+    "sortText": "000005fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31457,7 +32151,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005da",
+    "sortText": "000005fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31478,7 +32172,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005db",
+    "sortText": "000005fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31499,7 +32193,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005dc",
+    "sortText": "000005fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31520,7 +32214,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005dd",
+    "sortText": "000005fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31541,7 +32235,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005de",
+    "sortText": "000005ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31562,7 +32256,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005df",
+    "sortText": "00000600",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31583,7 +32277,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e3",
+    "sortText": "00000604",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31604,7 +32298,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e0",
+    "sortText": "00000601",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31625,7 +32319,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e1",
+    "sortText": "00000602",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31646,7 +32340,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e2",
+    "sortText": "00000603",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31667,7 +32361,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e4",
+    "sortText": "00000605",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31688,7 +32382,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e5",
+    "sortText": "00000606",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31709,7 +32403,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e6",
+    "sortText": "00000607",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31730,7 +32424,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e7",
+    "sortText": "00000608",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31751,7 +32445,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e8",
+    "sortText": "00000609",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31772,7 +32466,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005e9",
+    "sortText": "0000060a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31793,7 +32487,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ea",
+    "sortText": "0000060b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31814,7 +32508,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005eb",
+    "sortText": "0000060c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31835,7 +32529,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ec",
+    "sortText": "0000060d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31856,7 +32550,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ed",
+    "sortText": "0000060e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31877,7 +32571,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ee",
+    "sortText": "0000060f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31898,7 +32592,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ef",
+    "sortText": "00000610",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31919,7 +32613,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f0",
+    "sortText": "00000611",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31940,7 +32634,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f1",
+    "sortText": "00000612",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31961,7 +32655,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f2",
+    "sortText": "00000613",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -31982,7 +32676,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f3",
+    "sortText": "00000614",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32003,7 +32697,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f4",
+    "sortText": "00000615",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32024,7 +32718,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f5",
+    "sortText": "00000616",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32045,7 +32739,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f6",
+    "sortText": "00000617",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32066,7 +32760,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f7",
+    "sortText": "00000618",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32087,7 +32781,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f8",
+    "sortText": "00000619",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32108,7 +32802,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005f9",
+    "sortText": "0000061a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32129,7 +32823,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fa",
+    "sortText": "0000061b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32150,7 +32844,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fb",
+    "sortText": "0000061c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32171,7 +32865,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fc",
+    "sortText": "0000061d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32192,7 +32886,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fd",
+    "sortText": "0000061e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32213,7 +32907,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005fe",
+    "sortText": "0000061f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32234,7 +32928,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000005ff",
+    "sortText": "00000620",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32255,7 +32949,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000600",
+    "sortText": "00000621",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32276,7 +32970,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000601",
+    "sortText": "00000622",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32297,7 +32991,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000602",
+    "sortText": "00000623",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32318,7 +33012,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000603",
+    "sortText": "00000624",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32339,7 +33033,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000604",
+    "sortText": "00000625",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32360,7 +33054,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000605",
+    "sortText": "00000626",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32381,7 +33075,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000606",
+    "sortText": "00000627",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32402,7 +33096,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000607",
+    "sortText": "00000628",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32423,7 +33117,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000608",
+    "sortText": "00000629",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32444,7 +33138,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000609",
+    "sortText": "0000062a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32465,7 +33159,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060a",
+    "sortText": "0000062b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32486,7 +33180,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060b",
+    "sortText": "0000062c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32507,7 +33201,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060c",
+    "sortText": "0000062d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32528,7 +33222,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060d",
+    "sortText": "0000062e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32549,7 +33243,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060e",
+    "sortText": "0000062f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32570,7 +33264,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000060f",
+    "sortText": "00000630",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32591,7 +33285,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000610",
+    "sortText": "00000631",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32612,7 +33306,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000611",
+    "sortText": "00000632",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32633,7 +33327,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000612",
+    "sortText": "00000633",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32654,7 +33348,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000613",
+    "sortText": "00000634",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32675,7 +33369,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000614",
+    "sortText": "00000635",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32696,7 +33390,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000615",
+    "sortText": "00000636",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32717,7 +33411,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000616",
+    "sortText": "00000637",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32738,7 +33432,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000617",
+    "sortText": "00000638",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32759,7 +33453,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000619",
+    "sortText": "0000063a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32780,7 +33474,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061a",
+    "sortText": "0000063b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32801,7 +33495,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000621",
+    "sortText": "00000642",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32822,7 +33516,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000622",
+    "sortText": "00000643",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32843,7 +33537,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000623",
+    "sortText": "00000644",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32864,7 +33558,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000624",
+    "sortText": "00000645",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32885,7 +33579,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061b",
+    "sortText": "0000063c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32906,7 +33600,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061c",
+    "sortText": "0000063d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32927,7 +33621,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061d",
+    "sortText": "0000063e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32948,7 +33642,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061e",
+    "sortText": "0000063f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32969,7 +33663,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000061f",
+    "sortText": "00000640",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -32990,7 +33684,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000620",
+    "sortText": "00000641",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33011,7 +33705,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000625",
+    "sortText": "00000646",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33032,7 +33726,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000631",
+    "sortText": "00000652",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33053,7 +33747,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000632",
+    "sortText": "00000653",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33074,7 +33768,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000626",
+    "sortText": "00000647",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33095,7 +33789,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000627",
+    "sortText": "00000648",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33116,7 +33810,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000628",
+    "sortText": "00000649",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33137,7 +33831,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000629",
+    "sortText": "0000064a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33158,7 +33852,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062a",
+    "sortText": "0000064b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33179,7 +33873,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062b",
+    "sortText": "0000064c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33200,7 +33894,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062c",
+    "sortText": "0000064d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33221,7 +33915,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062d",
+    "sortText": "0000064e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33242,7 +33936,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062e",
+    "sortText": "0000064f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33263,7 +33957,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000062f",
+    "sortText": "00000650",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33284,7 +33978,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000630",
+    "sortText": "00000651",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33305,7 +33999,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000633",
+    "sortText": "00000654",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33326,7 +34020,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000634",
+    "sortText": "00000655",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33347,7 +34041,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000635",
+    "sortText": "00000656",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33368,7 +34062,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000636",
+    "sortText": "00000657",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33389,7 +34083,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000637",
+    "sortText": "00000658",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33410,7 +34104,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000638",
+    "sortText": "00000659",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33431,7 +34125,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000639",
+    "sortText": "0000065a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33452,7 +34146,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063a",
+    "sortText": "0000065b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33473,7 +34167,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063b",
+    "sortText": "0000065c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33494,7 +34188,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063c",
+    "sortText": "0000065d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33515,7 +34209,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063d",
+    "sortText": "0000065e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33536,7 +34230,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063e",
+    "sortText": "0000065f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33557,7 +34251,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000063f",
+    "sortText": "00000660",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33578,7 +34272,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000640",
+    "sortText": "00000661",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33599,7 +34293,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000641",
+    "sortText": "00000662",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33620,7 +34314,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000642",
+    "sortText": "00000663",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33641,7 +34335,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000643",
+    "sortText": "00000664",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33662,7 +34356,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000644",
+    "sortText": "00000665",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33683,7 +34377,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000645",
+    "sortText": "00000666",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33704,7 +34398,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000646",
+    "sortText": "00000667",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33725,7 +34419,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000647",
+    "sortText": "00000668",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33746,7 +34440,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000648",
+    "sortText": "00000669",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33767,7 +34461,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000649",
+    "sortText": "0000066a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33788,7 +34482,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064a",
+    "sortText": "0000066b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33809,7 +34503,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064b",
+    "sortText": "0000066c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33830,7 +34524,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064c",
+    "sortText": "0000066d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33851,7 +34545,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064d",
+    "sortText": "0000066e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33872,7 +34566,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064e",
+    "sortText": "0000066f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33893,7 +34587,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000064f",
+    "sortText": "00000670",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33914,7 +34608,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000650",
+    "sortText": "00000671",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33935,7 +34629,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000651",
+    "sortText": "00000672",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33956,7 +34650,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000652",
+    "sortText": "00000673",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33977,7 +34671,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000653",
+    "sortText": "00000674",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -33998,7 +34692,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000654",
+    "sortText": "00000675",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34019,7 +34713,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000655",
+    "sortText": "00000676",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34040,7 +34734,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000656",
+    "sortText": "00000677",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34061,7 +34755,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000657",
+    "sortText": "00000678",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34082,7 +34776,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000658",
+    "sortText": "00000679",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34103,7 +34797,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000659",
+    "sortText": "0000067a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34124,7 +34818,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065a",
+    "sortText": "0000067b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34145,7 +34839,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065b",
+    "sortText": "0000067c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34166,7 +34860,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065c",
+    "sortText": "0000067d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34187,7 +34881,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065d",
+    "sortText": "0000067e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34208,7 +34902,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065e",
+    "sortText": "0000067f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34229,7 +34923,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000065f",
+    "sortText": "00000680",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34250,7 +34944,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000660",
+    "sortText": "00000681",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34271,7 +34965,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000661",
+    "sortText": "00000682",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34292,7 +34986,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000662",
+    "sortText": "00000683",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34313,7 +35007,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000663",
+    "sortText": "00000684",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34334,7 +35028,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000664",
+    "sortText": "00000685",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34355,7 +35049,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000665",
+    "sortText": "00000686",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34376,7 +35070,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000666",
+    "sortText": "00000687",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34397,7 +35091,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000667",
+    "sortText": "00000688",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34418,7 +35112,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000668",
+    "sortText": "00000689",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34439,7 +35133,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000669",
+    "sortText": "0000068a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34460,7 +35154,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066a",
+    "sortText": "0000068b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34481,7 +35175,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066b",
+    "sortText": "0000068c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34502,7 +35196,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066c",
+    "sortText": "0000068d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34523,7 +35217,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066d",
+    "sortText": "0000068e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34544,7 +35238,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066e",
+    "sortText": "0000068f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34565,7 +35259,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000066f",
+    "sortText": "00000690",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34586,7 +35280,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000670",
+    "sortText": "00000691",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34607,7 +35301,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000671",
+    "sortText": "00000692",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34628,7 +35322,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000672",
+    "sortText": "00000693",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34649,7 +35343,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000673",
+    "sortText": "00000694",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34670,7 +35364,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000674",
+    "sortText": "00000695",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34691,7 +35385,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000675",
+    "sortText": "00000696",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34712,7 +35406,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000676",
+    "sortText": "00000697",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34733,7 +35427,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000677",
+    "sortText": "00000698",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34754,7 +35448,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000678",
+    "sortText": "00000699",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34775,7 +35469,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000679",
+    "sortText": "0000069a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34796,7 +35490,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067a",
+    "sortText": "0000069b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34817,7 +35511,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067b",
+    "sortText": "0000069c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34838,7 +35532,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000682",
+    "sortText": "000006a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34859,7 +35553,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067d",
+    "sortText": "0000069e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34880,7 +35574,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067e",
+    "sortText": "0000069f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34901,7 +35595,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000683",
+    "sortText": "000006a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34922,7 +35616,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000684",
+    "sortText": "000006a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34943,7 +35637,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000685",
+    "sortText": "000006a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34964,7 +35658,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000686",
+    "sortText": "000006a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -34985,7 +35679,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000687",
+    "sortText": "000006a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35006,7 +35700,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000688",
+    "sortText": "000006a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35027,7 +35721,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068b",
+    "sortText": "000006ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35048,7 +35742,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068c",
+    "sortText": "000006ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35069,7 +35763,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068d",
+    "sortText": "000006ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35090,7 +35784,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068e",
+    "sortText": "000006af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35111,7 +35805,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068f",
+    "sortText": "000006b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35132,7 +35826,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000690",
+    "sortText": "000006b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35153,7 +35847,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000691",
+    "sortText": "000006b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35174,7 +35868,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000692",
+    "sortText": "000006b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35195,7 +35889,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000693",
+    "sortText": "000006b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35216,7 +35910,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000694",
+    "sortText": "000006b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35237,7 +35931,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000695",
+    "sortText": "000006b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35258,7 +35952,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000696",
+    "sortText": "000006b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35279,7 +35973,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000697",
+    "sortText": "000006b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35300,7 +35994,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000698",
+    "sortText": "000006b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35321,7 +36015,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000699",
+    "sortText": "000006ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35342,7 +36036,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069a",
+    "sortText": "000006bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35363,7 +36057,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069b",
+    "sortText": "000006bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35384,7 +36078,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069c",
+    "sortText": "000006bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35405,7 +36099,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069d",
+    "sortText": "000006be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35426,7 +36120,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069e",
+    "sortText": "000006bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35447,7 +36141,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000069f",
+    "sortText": "000006c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35468,7 +36162,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a0",
+    "sortText": "000006c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35489,7 +36183,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a1",
+    "sortText": "000006c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35510,7 +36204,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a2",
+    "sortText": "000006c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35531,7 +36225,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a3",
+    "sortText": "000006c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35552,7 +36246,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a4",
+    "sortText": "000006c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35573,7 +36267,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a5",
+    "sortText": "000006c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35594,7 +36288,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a6",
+    "sortText": "000006c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35615,7 +36309,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a7",
+    "sortText": "000006c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35636,7 +36330,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a8",
+    "sortText": "000006c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35657,7 +36351,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006a9",
+    "sortText": "000006ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35678,7 +36372,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006aa",
+    "sortText": "000006cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35699,7 +36393,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ab",
+    "sortText": "000006cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35720,7 +36414,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ac",
+    "sortText": "000006cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35741,7 +36435,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ad",
+    "sortText": "000006ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35762,7 +36456,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ae",
+    "sortText": "000006cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35783,7 +36477,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006af",
+    "sortText": "000006d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35804,7 +36498,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b0",
+    "sortText": "000006d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35825,7 +36519,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b1",
+    "sortText": "000006d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35846,7 +36540,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b2",
+    "sortText": "000006d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35867,7 +36561,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b3",
+    "sortText": "000006d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35888,7 +36582,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b4",
+    "sortText": "000006d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35909,7 +36603,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b5",
+    "sortText": "000006d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35930,7 +36624,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b6",
+    "sortText": "000006d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35951,7 +36645,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b7",
+    "sortText": "000006d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35972,7 +36666,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b8",
+    "sortText": "000006d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -35993,7 +36687,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006b9",
+    "sortText": "000006da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36014,7 +36708,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ba",
+    "sortText": "000006db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36035,7 +36729,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bb",
+    "sortText": "000006dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36056,7 +36750,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bc",
+    "sortText": "000006dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36077,7 +36771,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bd",
+    "sortText": "000006de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36098,7 +36792,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006be",
+    "sortText": "000006df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36119,7 +36813,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006bf",
+    "sortText": "000006e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36140,7 +36834,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c0",
+    "sortText": "000006e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36161,7 +36855,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c1",
+    "sortText": "000006e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36182,7 +36876,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c2",
+    "sortText": "000006e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36203,7 +36897,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c3",
+    "sortText": "000006e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36224,7 +36918,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c4",
+    "sortText": "000006e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36245,7 +36939,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c5",
+    "sortText": "000006e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36266,7 +36960,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c6",
+    "sortText": "000006e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36287,7 +36981,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c7",
+    "sortText": "000006e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36308,7 +37002,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c8",
+    "sortText": "000006e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36329,7 +37023,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006c9",
+    "sortText": "000006ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36350,7 +37044,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ca",
+    "sortText": "000006eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36371,7 +37065,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cb",
+    "sortText": "000006ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36392,7 +37086,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cc",
+    "sortText": "000006ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36413,7 +37107,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cd",
+    "sortText": "000006ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36434,7 +37128,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ce",
+    "sortText": "000006ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36455,7 +37149,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006cf",
+    "sortText": "000006f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36476,7 +37170,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d0",
+    "sortText": "000006f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36497,7 +37191,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d1",
+    "sortText": "000006f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36518,7 +37212,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d2",
+    "sortText": "000006f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36539,7 +37233,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d3",
+    "sortText": "000006f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36560,7 +37254,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d4",
+    "sortText": "000006f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36581,7 +37275,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d5",
+    "sortText": "000006f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36602,7 +37296,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d6",
+    "sortText": "000006f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36623,7 +37317,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d7",
+    "sortText": "000006f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36644,7 +37338,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d8",
+    "sortText": "000006f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36665,7 +37359,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006d9",
+    "sortText": "000006fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36686,7 +37380,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006da",
+    "sortText": "000006fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36707,7 +37401,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006db",
+    "sortText": "000006fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36728,7 +37422,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006dc",
+    "sortText": "000006fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36749,7 +37443,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006de",
+    "sortText": "000006ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36770,7 +37464,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006df",
+    "sortText": "00000700",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36791,7 +37485,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006dd",
+    "sortText": "000006fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36812,7 +37506,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e0",
+    "sortText": "00000701",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36833,7 +37527,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e1",
+    "sortText": "00000702",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36854,7 +37548,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e2",
+    "sortText": "00000703",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36875,7 +37569,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e3",
+    "sortText": "00000704",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36896,7 +37590,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e4",
+    "sortText": "00000705",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36917,7 +37611,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e5",
+    "sortText": "00000706",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36938,7 +37632,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e6",
+    "sortText": "00000707",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36959,7 +37653,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e7",
+    "sortText": "00000708",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -36980,7 +37674,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e8",
+    "sortText": "00000709",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37001,7 +37695,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006e9",
+    "sortText": "0000070a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37022,7 +37716,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ea",
+    "sortText": "0000070b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37043,7 +37737,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006eb",
+    "sortText": "0000070c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37064,7 +37758,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ec",
+    "sortText": "0000070d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37085,7 +37779,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ed",
+    "sortText": "0000070e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37106,7 +37800,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ee",
+    "sortText": "0000070f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37127,7 +37821,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ef",
+    "sortText": "00000710",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37148,7 +37842,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f0",
+    "sortText": "00000711",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37169,7 +37863,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f1",
+    "sortText": "00000712",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37190,7 +37884,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f2",
+    "sortText": "00000713",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37211,7 +37905,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f3",
+    "sortText": "00000714",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37232,7 +37926,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f4",
+    "sortText": "00000715",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37253,7 +37947,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f5",
+    "sortText": "00000716",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37274,7 +37968,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f6",
+    "sortText": "00000717",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37295,7 +37989,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fd",
+    "sortText": "0000071e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37316,7 +38010,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fe",
+    "sortText": "0000071f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37337,7 +38031,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f7",
+    "sortText": "00000718",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37358,7 +38052,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f8",
+    "sortText": "00000719",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37379,7 +38073,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006f9",
+    "sortText": "0000071a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37400,7 +38094,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fa",
+    "sortText": "0000071b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37421,7 +38115,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fb",
+    "sortText": "0000071c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37442,7 +38136,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006fc",
+    "sortText": "0000071d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37463,7 +38157,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000006ff",
+    "sortText": "00000720",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37484,7 +38178,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000700",
+    "sortText": "00000721",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37505,7 +38199,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000701",
+    "sortText": "00000722",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37526,7 +38220,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000702",
+    "sortText": "00000723",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37547,7 +38241,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000703",
+    "sortText": "00000724",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37568,7 +38262,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000704",
+    "sortText": "00000725",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37589,7 +38283,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000705",
+    "sortText": "00000726",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37610,7 +38304,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000706",
+    "sortText": "00000727",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37631,7 +38325,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000707",
+    "sortText": "00000728",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37652,7 +38346,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000708",
+    "sortText": "00000729",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37673,7 +38367,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000709",
+    "sortText": "0000072a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37694,7 +38388,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070a",
+    "sortText": "0000072b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37715,7 +38409,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070b",
+    "sortText": "0000072c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37736,7 +38430,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070c",
+    "sortText": "0000072d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37757,7 +38451,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070d",
+    "sortText": "0000072e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37778,7 +38472,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070e",
+    "sortText": "0000072f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37799,7 +38493,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000070f",
+    "sortText": "00000730",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37820,7 +38514,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000710",
+    "sortText": "00000731",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37841,7 +38535,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000711",
+    "sortText": "00000732",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37862,7 +38556,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000712",
+    "sortText": "00000733",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37883,7 +38577,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000713",
+    "sortText": "00000734",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37904,7 +38598,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000714",
+    "sortText": "00000735",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37925,7 +38619,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000715",
+    "sortText": "00000736",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37946,7 +38640,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000716",
+    "sortText": "00000737",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37967,7 +38661,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000717",
+    "sortText": "00000738",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -37988,7 +38682,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000718",
+    "sortText": "00000739",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38009,7 +38703,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000719",
+    "sortText": "0000073a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38030,7 +38724,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071a",
+    "sortText": "0000073b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38051,7 +38745,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071b",
+    "sortText": "0000073c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38072,7 +38766,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071c",
+    "sortText": "0000073d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38093,7 +38787,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071d",
+    "sortText": "0000073e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38114,7 +38808,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071e",
+    "sortText": "0000073f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38135,7 +38829,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000071f",
+    "sortText": "00000740",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38156,7 +38850,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000720",
+    "sortText": "00000741",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38177,7 +38871,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000721",
+    "sortText": "00000742",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38198,7 +38892,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000722",
+    "sortText": "00000743",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38219,7 +38913,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000723",
+    "sortText": "00000744",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38240,7 +38934,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000724",
+    "sortText": "00000745",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38261,7 +38955,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000725",
+    "sortText": "00000746",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38282,7 +38976,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000726",
+    "sortText": "00000747",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38303,7 +38997,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000727",
+    "sortText": "00000748",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38324,7 +39018,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000728",
+    "sortText": "00000749",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38345,7 +39039,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000729",
+    "sortText": "0000074a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38366,7 +39060,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072a",
+    "sortText": "0000074b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38387,7 +39081,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072b",
+    "sortText": "0000074c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38408,7 +39102,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072c",
+    "sortText": "0000074d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38429,7 +39123,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072d",
+    "sortText": "0000074e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38450,7 +39144,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072e",
+    "sortText": "0000074f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38471,7 +39165,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000072f",
+    "sortText": "00000750",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38492,7 +39186,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000730",
+    "sortText": "00000751",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38513,7 +39207,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000731",
+    "sortText": "00000752",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38534,7 +39228,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000732",
+    "sortText": "00000753",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38555,7 +39249,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000733",
+    "sortText": "00000754",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38576,7 +39270,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000734",
+    "sortText": "00000755",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38597,7 +39291,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000735",
+    "sortText": "00000756",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38618,7 +39312,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000736",
+    "sortText": "00000757",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38639,7 +39333,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000737",
+    "sortText": "00000758",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38660,7 +39354,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000738",
+    "sortText": "00000759",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38681,7 +39375,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000739",
+    "sortText": "0000075a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38702,7 +39396,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073a",
+    "sortText": "0000075b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38723,7 +39417,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073b",
+    "sortText": "0000075c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38744,7 +39438,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073c",
+    "sortText": "0000075d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38765,7 +39459,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073d",
+    "sortText": "0000075e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38786,7 +39480,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073e",
+    "sortText": "0000075f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38807,7 +39501,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000073f",
+    "sortText": "00000760",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38828,7 +39522,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000740",
+    "sortText": "00000761",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38849,7 +39543,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000741",
+    "sortText": "00000762",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38870,7 +39564,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000742",
+    "sortText": "00000763",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38891,7 +39585,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000743",
+    "sortText": "00000764",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38912,7 +39606,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000744",
+    "sortText": "00000765",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38933,7 +39627,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000745",
+    "sortText": "00000766",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38954,7 +39648,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000746",
+    "sortText": "00000767",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38975,7 +39669,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000747",
+    "sortText": "00000768",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -38996,7 +39690,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000748",
+    "sortText": "00000769",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39017,7 +39711,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000749",
+    "sortText": "0000076a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39038,7 +39732,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074a",
+    "sortText": "0000076b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39059,7 +39753,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074b",
+    "sortText": "0000076c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39080,7 +39774,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074c",
+    "sortText": "0000076d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39101,7 +39795,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074d",
+    "sortText": "0000076e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39122,7 +39816,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074e",
+    "sortText": "0000076f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39143,7 +39837,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000074f",
+    "sortText": "00000770",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39164,7 +39858,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000750",
+    "sortText": "00000771",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39185,7 +39879,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000751",
+    "sortText": "00000772",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39206,7 +39900,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000752",
+    "sortText": "00000773",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39227,7 +39921,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000753",
+    "sortText": "00000774",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39248,7 +39942,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000754",
+    "sortText": "00000775",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39269,7 +39963,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000755",
+    "sortText": "00000776",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39290,7 +39984,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000756",
+    "sortText": "00000777",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39311,7 +40005,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000757",
+    "sortText": "00000778",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39332,7 +40026,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000758",
+    "sortText": "00000779",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39353,7 +40047,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000759",
+    "sortText": "0000077a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39374,7 +40068,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075a",
+    "sortText": "0000077b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39395,7 +40089,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075b",
+    "sortText": "0000077c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39416,7 +40110,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075c",
+    "sortText": "0000077d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39437,7 +40131,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075d",
+    "sortText": "0000077e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39458,7 +40152,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075e",
+    "sortText": "0000077f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39479,7 +40173,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000075f",
+    "sortText": "00000780",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39500,7 +40194,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000760",
+    "sortText": "00000781",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39521,7 +40215,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000761",
+    "sortText": "00000782",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39542,7 +40236,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000762",
+    "sortText": "00000783",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39563,7 +40257,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000763",
+    "sortText": "00000784",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39584,7 +40278,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000764",
+    "sortText": "00000785",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39605,7 +40299,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000765",
+    "sortText": "00000786",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39626,7 +40320,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000766",
+    "sortText": "00000787",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39647,7 +40341,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000767",
+    "sortText": "00000788",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39668,7 +40362,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000768",
+    "sortText": "00000789",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39689,7 +40383,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000769",
+    "sortText": "0000078a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39710,7 +40404,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076a",
+    "sortText": "0000078b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39731,7 +40425,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076b",
+    "sortText": "0000078c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39752,7 +40446,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076c",
+    "sortText": "0000078d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39773,7 +40467,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076d",
+    "sortText": "0000078e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39794,7 +40488,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076e",
+    "sortText": "0000078f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39815,7 +40509,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000076f",
+    "sortText": "00000790",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39836,7 +40530,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000770",
+    "sortText": "00000791",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39857,7 +40551,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000771",
+    "sortText": "00000792",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39878,7 +40572,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000772",
+    "sortText": "00000793",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39899,7 +40593,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000773",
+    "sortText": "00000794",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39920,7 +40614,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000774",
+    "sortText": "00000795",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39941,7 +40635,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000775",
+    "sortText": "00000796",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39962,7 +40656,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000776",
+    "sortText": "00000797",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -39983,7 +40677,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000777",
+    "sortText": "00000798",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40004,7 +40698,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000778",
+    "sortText": "00000799",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40025,7 +40719,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000779",
+    "sortText": "0000079a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40046,7 +40740,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077a",
+    "sortText": "0000079b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40067,7 +40761,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077b",
+    "sortText": "0000079c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40088,7 +40782,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077c",
+    "sortText": "0000079d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40109,7 +40803,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077d",
+    "sortText": "0000079e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40130,7 +40824,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077e",
+    "sortText": "0000079f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40151,7 +40845,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000077f",
+    "sortText": "000007a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40172,7 +40866,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000780",
+    "sortText": "000007a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40193,7 +40887,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000781",
+    "sortText": "000007a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40214,7 +40908,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000782",
+    "sortText": "000007a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40235,7 +40929,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000783",
+    "sortText": "000007a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40256,7 +40950,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000784",
+    "sortText": "000007a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40277,7 +40971,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000785",
+    "sortText": "000007a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40298,7 +40992,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000786",
+    "sortText": "000007a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40319,7 +41013,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000787",
+    "sortText": "000007a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40340,7 +41034,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000788",
+    "sortText": "000007a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40361,7 +41055,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000789",
+    "sortText": "000007aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40382,7 +41076,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078a",
+    "sortText": "000007ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40403,7 +41097,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078b",
+    "sortText": "000007ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40424,7 +41118,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078c",
+    "sortText": "000007ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40445,7 +41139,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078f",
+    "sortText": "000007b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40466,7 +41160,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078d",
+    "sortText": "000007ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40487,7 +41181,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000078e",
+    "sortText": "000007af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40508,7 +41202,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000790",
+    "sortText": "000007b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40529,7 +41223,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000793",
+    "sortText": "000007b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40550,7 +41244,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000791",
+    "sortText": "000007b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40571,7 +41265,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000792",
+    "sortText": "000007b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40592,7 +41286,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000794",
+    "sortText": "000007b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40613,7 +41307,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000795",
+    "sortText": "000007b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40634,7 +41328,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000797",
+    "sortText": "000007b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40655,7 +41349,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000796",
+    "sortText": "000007b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40676,7 +41370,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000798",
+    "sortText": "000007b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40697,7 +41391,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000799",
+    "sortText": "000007ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40718,7 +41412,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079a",
+    "sortText": "000007bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40739,7 +41433,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079b",
+    "sortText": "000007bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40760,7 +41454,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079c",
+    "sortText": "000007bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40781,7 +41475,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079d",
+    "sortText": "000007be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40802,7 +41496,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079e",
+    "sortText": "000007bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40823,7 +41517,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000079f",
+    "sortText": "000007c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40844,7 +41538,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a0",
+    "sortText": "000007c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40865,7 +41559,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a1",
+    "sortText": "000007c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40886,7 +41580,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a2",
+    "sortText": "000007c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40907,7 +41601,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a3",
+    "sortText": "000007c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40928,7 +41622,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a4",
+    "sortText": "000007c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40949,7 +41643,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a5",
+    "sortText": "000007c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40970,7 +41664,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a6",
+    "sortText": "000007c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -40991,7 +41685,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a7",
+    "sortText": "000007c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41012,7 +41706,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a8",
+    "sortText": "000007c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41033,7 +41727,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007a9",
+    "sortText": "000007ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41054,7 +41748,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007aa",
+    "sortText": "000007cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41075,7 +41769,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ab",
+    "sortText": "000007cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41096,7 +41790,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ac",
+    "sortText": "000007cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41117,7 +41811,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ad",
+    "sortText": "000007ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41138,7 +41832,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ae",
+    "sortText": "000007cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41159,7 +41853,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007af",
+    "sortText": "000007d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41180,7 +41874,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b0",
+    "sortText": "000007d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41201,7 +41895,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b1",
+    "sortText": "000007d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41222,7 +41916,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b2",
+    "sortText": "000007d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41243,7 +41937,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b3",
+    "sortText": "000007d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41264,7 +41958,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b4",
+    "sortText": "000007d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41285,7 +41979,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b5",
+    "sortText": "000007d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41306,7 +42000,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b6",
+    "sortText": "000007d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41327,7 +42021,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b7",
+    "sortText": "000007d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41348,7 +42042,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b8",
+    "sortText": "000007d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41369,7 +42063,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007b9",
+    "sortText": "000007da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41390,7 +42084,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ba",
+    "sortText": "000007db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41411,7 +42105,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bb",
+    "sortText": "000007dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41432,7 +42126,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bc",
+    "sortText": "000007dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41453,7 +42147,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bd",
+    "sortText": "000007de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41474,7 +42168,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007be",
+    "sortText": "000007df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41495,7 +42189,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007bf",
+    "sortText": "000007e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41516,7 +42210,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c0",
+    "sortText": "000007e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41537,7 +42231,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c1",
+    "sortText": "000007e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41558,7 +42252,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c2",
+    "sortText": "000007e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41579,7 +42273,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c3",
+    "sortText": "000007e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41600,7 +42294,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c4",
+    "sortText": "000007e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41621,7 +42315,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c5",
+    "sortText": "000007e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41642,7 +42336,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c6",
+    "sortText": "000007e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41663,7 +42357,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c7",
+    "sortText": "000007e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41684,7 +42378,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c8",
+    "sortText": "000007e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41705,7 +42399,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007c9",
+    "sortText": "000007ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41726,7 +42420,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ca",
+    "sortText": "000007eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41747,7 +42441,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cb",
+    "sortText": "000007ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41768,7 +42462,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cc",
+    "sortText": "000007ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41789,7 +42483,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cd",
+    "sortText": "000007ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41810,7 +42504,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ce",
+    "sortText": "000007ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41831,7 +42525,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007cf",
+    "sortText": "000007f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41852,7 +42546,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d0",
+    "sortText": "000007f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41873,7 +42567,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d1",
+    "sortText": "000007f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41894,7 +42588,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d2",
+    "sortText": "000007f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41915,7 +42609,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d3",
+    "sortText": "000007f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41936,7 +42630,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d4",
+    "sortText": "000007f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41957,7 +42651,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d5",
+    "sortText": "000007f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41978,7 +42672,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d6",
+    "sortText": "000007f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -41999,7 +42693,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d7",
+    "sortText": "000007f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42020,7 +42714,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d8",
+    "sortText": "000007f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42041,7 +42735,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007d9",
+    "sortText": "000007fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42062,7 +42756,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007da",
+    "sortText": "000007fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42083,7 +42777,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007db",
+    "sortText": "000007fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42104,7 +42798,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007dd",
+    "sortText": "000007fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42125,7 +42819,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007dc",
+    "sortText": "000007fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42146,7 +42840,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007de",
+    "sortText": "000007ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42167,7 +42861,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007df",
+    "sortText": "00000800",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42188,7 +42882,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e0",
+    "sortText": "00000801",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42209,7 +42903,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e1",
+    "sortText": "00000802",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42230,7 +42924,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e2",
+    "sortText": "00000803",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42251,7 +42945,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e3",
+    "sortText": "00000804",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42272,7 +42966,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e4",
+    "sortText": "00000805",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42293,7 +42987,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e5",
+    "sortText": "00000806",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42314,7 +43008,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e6",
+    "sortText": "00000807",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42335,7 +43029,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e7",
+    "sortText": "00000808",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42356,7 +43050,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e8",
+    "sortText": "00000809",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42377,7 +43071,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007e9",
+    "sortText": "0000080a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42398,7 +43092,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ea",
+    "sortText": "0000080b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42419,7 +43113,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007eb",
+    "sortText": "0000080c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42440,7 +43134,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ec",
+    "sortText": "0000080d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42461,7 +43155,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ed",
+    "sortText": "0000080e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42482,7 +43176,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ee",
+    "sortText": "0000080f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42503,7 +43197,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ef",
+    "sortText": "00000810",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42524,7 +43218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f0",
+    "sortText": "00000811",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42545,7 +43239,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f1",
+    "sortText": "00000812",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42566,7 +43260,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f2",
+    "sortText": "00000813",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42587,7 +43281,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f3",
+    "sortText": "00000814",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42608,7 +43302,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f4",
+    "sortText": "00000815",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42629,7 +43323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f5",
+    "sortText": "00000816",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42650,7 +43344,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f6",
+    "sortText": "00000817",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42671,7 +43365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f7",
+    "sortText": "00000818",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42692,7 +43386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f8",
+    "sortText": "00000819",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42713,7 +43407,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007f9",
+    "sortText": "0000081a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42734,7 +43428,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fa",
+    "sortText": "0000081b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42755,7 +43449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fb",
+    "sortText": "0000081c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42776,7 +43470,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fc",
+    "sortText": "0000081d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42797,7 +43491,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fd",
+    "sortText": "0000081e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42818,7 +43512,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007fe",
+    "sortText": "0000081f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42839,7 +43533,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000007ff",
+    "sortText": "00000820",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42860,7 +43554,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000800",
+    "sortText": "00000821",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42881,7 +43575,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000801",
+    "sortText": "00000822",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42902,7 +43596,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000802",
+    "sortText": "00000823",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42923,7 +43617,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000803",
+    "sortText": "00000824",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42944,7 +43638,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000804",
+    "sortText": "00000825",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42965,7 +43659,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000805",
+    "sortText": "00000826",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -42986,7 +43680,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000806",
+    "sortText": "00000827",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43007,7 +43701,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000807",
+    "sortText": "00000828",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43028,7 +43722,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000808",
+    "sortText": "00000829",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43049,7 +43743,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000809",
+    "sortText": "0000082a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43070,12 +43764,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080a",
+    "sortText": "0000082b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Mission/communities/communityEndpoints@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Mission/communities/dedicatedHubs'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Mission/communities/dedicatedHubs`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "0000082c",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Mission/communities/dedicatedHubs@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -43091,7 +43806,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080b",
+    "sortText": "0000082d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43112,7 +43827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080c",
+    "sortText": "0000082e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43133,7 +43848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080d",
+    "sortText": "0000082f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43154,7 +43869,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080e",
+    "sortText": "00000830",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43175,7 +43890,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000080f",
+    "sortText": "00000831",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43196,7 +43911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000810",
+    "sortText": "00000832",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43217,7 +43932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000811",
+    "sortText": "00000833",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43238,7 +43953,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000812",
+    "sortText": "00000834",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43259,7 +43974,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000813",
+    "sortText": "00000835",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43280,7 +43995,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000814",
+    "sortText": "00000836",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43301,7 +44016,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000815",
+    "sortText": "00000837",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43322,7 +44037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000816",
+    "sortText": "00000838",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43343,7 +44058,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000817",
+    "sortText": "00000839",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43364,12 +44079,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000818",
+    "sortText": "0000083a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Monitor/accounts/metricsContainers@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Monitor/observabilityAgents'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Monitor/observabilityAgents`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "0000083b",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Monitor/observabilityAgents@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -43385,7 +44121,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000819",
+    "sortText": "0000083c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43406,7 +44142,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081a",
+    "sortText": "0000083d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43427,7 +44163,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081b",
+    "sortText": "0000083e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43448,7 +44184,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081d",
+    "sortText": "00000840",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43469,7 +44205,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081c",
+    "sortText": "0000083f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43490,7 +44226,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081e",
+    "sortText": "00000841",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43511,7 +44247,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000081f",
+    "sortText": "00000842",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43532,7 +44268,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000820",
+    "sortText": "00000843",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43553,7 +44289,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000821",
+    "sortText": "00000844",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43574,7 +44310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000822",
+    "sortText": "00000845",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43595,7 +44331,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000823",
+    "sortText": "00000846",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43616,7 +44352,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000824",
+    "sortText": "00000847",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43637,7 +44373,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000825",
+    "sortText": "00000848",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43658,7 +44394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000826",
+    "sortText": "00000849",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43679,7 +44415,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000827",
+    "sortText": "0000084a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43700,7 +44436,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000828",
+    "sortText": "0000084b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43721,7 +44457,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000829",
+    "sortText": "0000084c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43742,7 +44478,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082a",
+    "sortText": "0000084d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43763,7 +44499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082b",
+    "sortText": "0000084e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43784,7 +44520,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082c",
+    "sortText": "0000084f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43805,7 +44541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082d",
+    "sortText": "00000850",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43826,7 +44562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082e",
+    "sortText": "00000851",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43847,7 +44583,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000082f",
+    "sortText": "00000852",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43868,7 +44604,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000830",
+    "sortText": "00000853",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43889,7 +44625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000831",
+    "sortText": "00000854",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43910,7 +44646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000832",
+    "sortText": "00000855",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43931,7 +44667,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000833",
+    "sortText": "00000856",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43952,7 +44688,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000834",
+    "sortText": "00000857",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43973,7 +44709,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000835",
+    "sortText": "00000858",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -43994,7 +44730,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000836",
+    "sortText": "00000859",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44015,7 +44751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000837",
+    "sortText": "0000085a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44036,7 +44772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000838",
+    "sortText": "0000085b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44057,7 +44793,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000839",
+    "sortText": "0000085c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44078,7 +44814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083a",
+    "sortText": "0000085d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44099,7 +44835,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083b",
+    "sortText": "0000085e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44120,7 +44856,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000840",
+    "sortText": "00000863",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44141,7 +44877,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000086d",
+    "sortText": "00000890",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44162,7 +44898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000086f",
+    "sortText": "00000892",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44183,7 +44919,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000870",
+    "sortText": "00000893",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44204,7 +44940,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000087b",
+    "sortText": "0000089e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44225,7 +44961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000087f",
+    "sortText": "000008a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44246,7 +44982,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000088c",
+    "sortText": "000008af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44267,7 +45003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000088d",
+    "sortText": "000008b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44288,7 +45024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083c",
+    "sortText": "0000085f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44309,7 +45045,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083d",
+    "sortText": "00000860",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44330,7 +45066,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083e",
+    "sortText": "00000861",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44351,7 +45087,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000083f",
+    "sortText": "00000862",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44372,7 +45108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000841",
+    "sortText": "00000864",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44393,7 +45129,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000842",
+    "sortText": "00000865",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44414,7 +45150,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000843",
+    "sortText": "00000866",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44435,7 +45171,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000844",
+    "sortText": "00000867",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44456,7 +45192,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000845",
+    "sortText": "00000868",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44477,7 +45213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000846",
+    "sortText": "00000869",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44498,7 +45234,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000847",
+    "sortText": "0000086a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44519,7 +45255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000848",
+    "sortText": "0000086b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44540,7 +45276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000849",
+    "sortText": "0000086c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44561,7 +45297,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084a",
+    "sortText": "0000086d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44582,7 +45318,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084b",
+    "sortText": "0000086e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44603,7 +45339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084c",
+    "sortText": "0000086f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44624,7 +45360,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084d",
+    "sortText": "00000870",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44645,7 +45381,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084e",
+    "sortText": "00000871",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44666,7 +45402,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000084f",
+    "sortText": "00000872",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44687,7 +45423,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000850",
+    "sortText": "00000873",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44708,7 +45444,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000851",
+    "sortText": "00000874",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44729,7 +45465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000852",
+    "sortText": "00000875",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44750,7 +45486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000853",
+    "sortText": "00000876",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44771,7 +45507,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000854",
+    "sortText": "00000877",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44792,7 +45528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000855",
+    "sortText": "00000878",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44813,7 +45549,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000856",
+    "sortText": "00000879",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44834,7 +45570,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000857",
+    "sortText": "0000087a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44855,7 +45591,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000858",
+    "sortText": "0000087b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44876,7 +45612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000085a",
+    "sortText": "0000087d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44897,7 +45633,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000085b",
+    "sortText": "0000087e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44918,7 +45654,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000085c",
+    "sortText": "0000087f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44939,7 +45675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000085d",
+    "sortText": "00000880",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44960,7 +45696,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000085e",
+    "sortText": "00000881",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -44981,7 +45717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000085f",
+    "sortText": "00000882",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45002,7 +45738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000860",
+    "sortText": "00000883",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45023,7 +45759,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000861",
+    "sortText": "00000884",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45044,7 +45780,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000862",
+    "sortText": "00000885",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45065,7 +45801,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000859",
+    "sortText": "0000087c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45086,7 +45822,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000863",
+    "sortText": "00000886",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45107,7 +45843,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000864",
+    "sortText": "00000887",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45128,7 +45864,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000865",
+    "sortText": "00000888",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45149,7 +45885,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000866",
+    "sortText": "00000889",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45170,7 +45906,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000867",
+    "sortText": "0000088a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45191,7 +45927,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000868",
+    "sortText": "0000088b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45212,7 +45948,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000869",
+    "sortText": "0000088c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45233,7 +45969,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000086a",
+    "sortText": "0000088d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45254,7 +45990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000086b",
+    "sortText": "0000088e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45275,7 +46011,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000086c",
+    "sortText": "0000088f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45296,7 +46032,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000086e",
+    "sortText": "00000891",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45317,7 +46053,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000871",
+    "sortText": "00000894",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45338,7 +46074,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000872",
+    "sortText": "00000895",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45359,7 +46095,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000873",
+    "sortText": "00000896",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45380,7 +46116,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000874",
+    "sortText": "00000897",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45401,7 +46137,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000875",
+    "sortText": "00000898",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45422,7 +46158,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000876",
+    "sortText": "00000899",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45443,7 +46179,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000877",
+    "sortText": "0000089a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45464,7 +46200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000878",
+    "sortText": "0000089b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45485,7 +46221,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000879",
+    "sortText": "0000089c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45506,7 +46242,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000087a",
+    "sortText": "0000089d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45527,7 +46263,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000087c",
+    "sortText": "0000089f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45548,7 +46284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000087d",
+    "sortText": "000008a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45569,7 +46305,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000087e",
+    "sortText": "000008a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45590,7 +46326,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000880",
+    "sortText": "000008a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45611,7 +46347,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000881",
+    "sortText": "000008a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45632,7 +46368,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000882",
+    "sortText": "000008a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45653,7 +46389,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000883",
+    "sortText": "000008a6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45674,7 +46410,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000884",
+    "sortText": "000008a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45695,7 +46431,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000885",
+    "sortText": "000008a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45716,7 +46452,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000886",
+    "sortText": "000008a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45737,7 +46473,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000887",
+    "sortText": "000008aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45758,7 +46494,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000888",
+    "sortText": "000008ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45779,7 +46515,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000889",
+    "sortText": "000008ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45800,7 +46536,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000088a",
+    "sortText": "000008ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45821,7 +46557,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000088b",
+    "sortText": "000008ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45842,7 +46578,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000088e",
+    "sortText": "000008b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45863,7 +46599,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000088f",
+    "sortText": "000008b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45884,7 +46620,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000890",
+    "sortText": "000008b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45905,7 +46641,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000891",
+    "sortText": "000008b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45926,7 +46662,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000892",
+    "sortText": "000008b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45947,7 +46683,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000893",
+    "sortText": "000008b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45968,7 +46704,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000894",
+    "sortText": "000008b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -45989,7 +46725,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000895",
+    "sortText": "000008b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46010,7 +46746,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000896",
+    "sortText": "000008b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46031,7 +46767,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000897",
+    "sortText": "000008ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46052,7 +46788,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000898",
+    "sortText": "000008bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46073,7 +46809,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000899",
+    "sortText": "000008bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46094,7 +46830,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000089a",
+    "sortText": "000008bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46115,7 +46851,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000089b",
+    "sortText": "000008be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46136,7 +46872,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000089c",
+    "sortText": "000008bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46157,7 +46893,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000089d",
+    "sortText": "000008c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46178,7 +46914,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000089e",
+    "sortText": "000008c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46199,7 +46935,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000089f",
+    "sortText": "000008c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46220,7 +46956,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a0",
+    "sortText": "000008c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46241,7 +46977,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a1",
+    "sortText": "000008c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46262,7 +46998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a2",
+    "sortText": "000008c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46283,7 +47019,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a3",
+    "sortText": "000008c6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46304,7 +47040,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a4",
+    "sortText": "000008c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46325,7 +47061,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a5",
+    "sortText": "000008c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46346,7 +47082,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a6",
+    "sortText": "000008c9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46367,7 +47103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a7",
+    "sortText": "000008ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46388,7 +47124,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a8",
+    "sortText": "000008cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46409,7 +47145,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008a9",
+    "sortText": "000008cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46430,7 +47166,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008aa",
+    "sortText": "000008cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46451,7 +47187,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ab",
+    "sortText": "000008ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46472,7 +47208,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ac",
+    "sortText": "000008cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46493,7 +47229,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ad",
+    "sortText": "000008d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46514,7 +47250,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ae",
+    "sortText": "000008d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46535,7 +47271,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008af",
+    "sortText": "000008d2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46556,7 +47292,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b0",
+    "sortText": "000008d3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46577,7 +47313,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b5",
+    "sortText": "000008d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46598,7 +47334,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b1",
+    "sortText": "000008d4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46619,7 +47355,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b2",
+    "sortText": "000008d5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46640,7 +47376,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b3",
+    "sortText": "000008d6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46661,7 +47397,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b4",
+    "sortText": "000008d7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46682,7 +47418,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b6",
+    "sortText": "000008d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46703,7 +47439,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b7",
+    "sortText": "000008da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46724,7 +47460,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b8",
+    "sortText": "000008db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46745,7 +47481,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008b9",
+    "sortText": "000008dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46766,7 +47502,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ba",
+    "sortText": "000008dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46787,7 +47523,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008bb",
+    "sortText": "000008de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46808,7 +47544,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008bc",
+    "sortText": "000008df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46829,7 +47565,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008bd",
+    "sortText": "000008e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46850,7 +47586,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008be",
+    "sortText": "000008e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46871,7 +47607,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008bf",
+    "sortText": "000008e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46892,7 +47628,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c0",
+    "sortText": "000008e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46913,7 +47649,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c1",
+    "sortText": "000008e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46934,7 +47670,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c2",
+    "sortText": "000008e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46955,7 +47691,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c3",
+    "sortText": "000008e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46976,7 +47712,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c4",
+    "sortText": "000008e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -46997,7 +47733,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c5",
+    "sortText": "000008e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47018,7 +47754,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c6",
+    "sortText": "000008e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47039,7 +47775,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c7",
+    "sortText": "000008ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47060,7 +47796,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c8",
+    "sortText": "000008eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47081,7 +47817,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008c9",
+    "sortText": "000008ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47102,7 +47838,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ca",
+    "sortText": "000008ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47123,7 +47859,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008cb",
+    "sortText": "000008ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47144,7 +47880,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008cc",
+    "sortText": "000008ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47165,7 +47901,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008cd",
+    "sortText": "000008f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47186,7 +47922,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ce",
+    "sortText": "000008f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47207,7 +47943,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008cf",
+    "sortText": "000008f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47228,7 +47964,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d0",
+    "sortText": "000008f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47249,7 +47985,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d1",
+    "sortText": "000008f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47270,7 +48006,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d2",
+    "sortText": "000008f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47291,7 +48027,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d3",
+    "sortText": "000008f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47312,7 +48048,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d9",
+    "sortText": "000008fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47333,7 +48069,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d4",
+    "sortText": "000008f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47354,7 +48090,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d5",
+    "sortText": "000008f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47375,7 +48111,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d6",
+    "sortText": "000008f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47396,7 +48132,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d8",
+    "sortText": "000008fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47417,7 +48153,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008d7",
+    "sortText": "000008fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47438,7 +48174,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008da",
+    "sortText": "000008fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47459,7 +48195,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008db",
+    "sortText": "000008fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47480,7 +48216,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008dc",
+    "sortText": "000008ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47501,7 +48237,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008dd",
+    "sortText": "00000900",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47522,7 +48258,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008de",
+    "sortText": "00000901",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47543,7 +48279,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008df",
+    "sortText": "00000902",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47564,7 +48300,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e0",
+    "sortText": "00000903",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47585,7 +48321,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e1",
+    "sortText": "00000904",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47606,7 +48342,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e2",
+    "sortText": "00000905",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47627,7 +48363,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e3",
+    "sortText": "00000906",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47648,7 +48384,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e4",
+    "sortText": "00000907",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47669,7 +48405,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e5",
+    "sortText": "00000908",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47690,7 +48426,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e9",
+    "sortText": "0000090c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47711,7 +48447,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e6",
+    "sortText": "00000909",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47732,7 +48468,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e7",
+    "sortText": "0000090a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47753,7 +48489,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008e8",
+    "sortText": "0000090b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47774,7 +48510,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ea",
+    "sortText": "0000090d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47795,7 +48531,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008eb",
+    "sortText": "0000090e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47816,7 +48552,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ec",
+    "sortText": "0000090f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47837,7 +48573,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ed",
+    "sortText": "00000910",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47858,7 +48594,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ee",
+    "sortText": "00000911",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47879,7 +48615,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ef",
+    "sortText": "00000912",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47900,7 +48636,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f0",
+    "sortText": "00000913",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47921,7 +48657,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f1",
+    "sortText": "00000914",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47942,7 +48678,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f2",
+    "sortText": "00000915",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47963,7 +48699,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f3",
+    "sortText": "00000916",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -47984,7 +48720,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f4",
+    "sortText": "00000917",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48005,7 +48741,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f5",
+    "sortText": "00000918",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48026,7 +48762,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f6",
+    "sortText": "00000919",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48047,7 +48783,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f7",
+    "sortText": "0000091a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48068,7 +48804,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f8",
+    "sortText": "0000091b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48089,7 +48825,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008f9",
+    "sortText": "0000091c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48110,7 +48846,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008fa",
+    "sortText": "0000091d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48131,7 +48867,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008fb",
+    "sortText": "0000091e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48152,7 +48888,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008fc",
+    "sortText": "0000091f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48173,7 +48909,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008fd",
+    "sortText": "00000920",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48194,7 +48930,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008fe",
+    "sortText": "00000921",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48215,7 +48951,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000008ff",
+    "sortText": "00000922",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48236,7 +48972,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000900",
+    "sortText": "00000923",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48257,7 +48993,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000901",
+    "sortText": "00000924",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48278,7 +49014,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000902",
+    "sortText": "00000925",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48299,7 +49035,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000903",
+    "sortText": "00000926",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48320,7 +49056,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000904",
+    "sortText": "00000927",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48341,7 +49077,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000906",
+    "sortText": "00000929",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48362,7 +49098,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000905",
+    "sortText": "00000928",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48383,7 +49119,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000907",
+    "sortText": "0000092a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48404,7 +49140,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000908",
+    "sortText": "0000092b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48425,7 +49161,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000909",
+    "sortText": "0000092c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48446,7 +49182,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000090a",
+    "sortText": "0000092d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48467,7 +49203,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000090b",
+    "sortText": "0000092e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48488,7 +49224,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000090c",
+    "sortText": "0000092f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48509,7 +49245,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000090d",
+    "sortText": "00000930",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48530,7 +49266,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000090e",
+    "sortText": "00000931",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48551,7 +49287,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000090f",
+    "sortText": "00000932",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48572,7 +49308,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000910",
+    "sortText": "00000933",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48593,7 +49329,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000911",
+    "sortText": "00000934",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48614,7 +49350,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000912",
+    "sortText": "00000935",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48635,7 +49371,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000913",
+    "sortText": "00000936",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48656,7 +49392,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000914",
+    "sortText": "00000937",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48677,7 +49413,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000915",
+    "sortText": "00000938",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48698,7 +49434,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000916",
+    "sortText": "00000939",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48719,7 +49455,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000917",
+    "sortText": "0000093a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48740,7 +49476,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000918",
+    "sortText": "0000093b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48761,7 +49497,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000919",
+    "sortText": "0000093c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48782,7 +49518,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000091a",
+    "sortText": "0000093d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48803,7 +49539,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000091b",
+    "sortText": "0000093e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48824,7 +49560,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000091c",
+    "sortText": "0000093f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48845,7 +49581,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000091d",
+    "sortText": "00000940",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48866,7 +49602,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000091e",
+    "sortText": "00000941",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48887,7 +49623,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000091f",
+    "sortText": "00000942",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48908,7 +49644,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000920",
+    "sortText": "00000943",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48929,7 +49665,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000921",
+    "sortText": "00000944",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48950,7 +49686,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000922",
+    "sortText": "00000945",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48971,7 +49707,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000923",
+    "sortText": "00000946",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -48992,7 +49728,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000924",
+    "sortText": "00000947",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49013,7 +49749,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000925",
+    "sortText": "00000948",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49034,7 +49770,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000926",
+    "sortText": "00000949",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49055,7 +49791,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000927",
+    "sortText": "0000094a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49076,7 +49812,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000928",
+    "sortText": "0000094b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49097,7 +49833,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000929",
+    "sortText": "0000094c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49118,7 +49854,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000092a",
+    "sortText": "0000094d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49139,7 +49875,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000092b",
+    "sortText": "0000094e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49160,7 +49896,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000092c",
+    "sortText": "0000094f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49181,7 +49917,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000092d",
+    "sortText": "00000950",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49202,7 +49938,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000092e",
+    "sortText": "00000951",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49223,7 +49959,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000092f",
+    "sortText": "00000952",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49244,7 +49980,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000930",
+    "sortText": "00000953",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49265,7 +50001,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000931",
+    "sortText": "00000954",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49286,7 +50022,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000932",
+    "sortText": "00000955",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49307,7 +50043,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000933",
+    "sortText": "00000956",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49328,7 +50064,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000934",
+    "sortText": "00000957",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49349,7 +50085,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000935",
+    "sortText": "00000958",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49370,7 +50106,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000936",
+    "sortText": "00000959",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49391,7 +50127,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000937",
+    "sortText": "0000095a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49412,7 +50148,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000938",
+    "sortText": "0000095b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49433,7 +50169,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000939",
+    "sortText": "0000095c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49454,7 +50190,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000093a",
+    "sortText": "0000095d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49475,7 +50211,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000093b",
+    "sortText": "0000095e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49496,7 +50232,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000093c",
+    "sortText": "0000095f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49517,7 +50253,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000093d",
+    "sortText": "00000960",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49538,7 +50274,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000093e",
+    "sortText": "00000961",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49559,7 +50295,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000093f",
+    "sortText": "00000962",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49580,7 +50316,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000940",
+    "sortText": "00000963",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49601,7 +50337,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000941",
+    "sortText": "00000964",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49622,7 +50358,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000942",
+    "sortText": "00000965",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49643,7 +50379,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000943",
+    "sortText": "00000966",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49664,7 +50400,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000944",
+    "sortText": "00000967",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49685,7 +50421,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000945",
+    "sortText": "00000968",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49706,7 +50442,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000946",
+    "sortText": "00000969",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49727,7 +50463,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000947",
+    "sortText": "0000096a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49748,7 +50484,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000948",
+    "sortText": "0000096b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49769,7 +50505,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000949",
+    "sortText": "0000096c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49790,7 +50526,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000094a",
+    "sortText": "0000096d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49811,7 +50547,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000094b",
+    "sortText": "0000096e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -49832,7 +50568,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000094c",
+    "sortText": "0000096f",
     "filterText": "'Microsoft.OperationalInsights/workspaces loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -49854,7 +50590,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000094d",
+    "sortText": "00000970",
     "filterText": "'Microsoft.OperationalInsights/workspaces/dataCollectorLogs loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -49876,7 +50612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000094e",
+    "sortText": "00000971",
     "filterText": "'Microsoft.OperationalInsights/workspaces/dataExports loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -49898,7 +50634,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000094f",
+    "sortText": "00000972",
     "filterText": "'Microsoft.OperationalInsights/workspaces/dataSources loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -49920,7 +50656,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000950",
+    "sortText": "00000973",
     "filterText": "'Microsoft.OperationalInsights/workspaces/features/clientGroups loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -49942,7 +50678,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000951",
+    "sortText": "00000974",
     "filterText": "'Microsoft.OperationalInsights/workspaces/features/machineGroups loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -49964,7 +50700,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000952",
+    "sortText": "00000975",
     "filterText": "'Microsoft.OperationalInsights/workspaces/features/machines loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -49986,7 +50722,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000953",
+    "sortText": "00000976",
     "filterText": "'Microsoft.OperationalInsights/workspaces/features/machines/ports loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50008,7 +50744,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000954",
+    "sortText": "00000977",
     "filterText": "'Microsoft.OperationalInsights/workspaces/features/machines/processes loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50030,7 +50766,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000955",
+    "sortText": "00000978",
     "filterText": "'Microsoft.OperationalInsights/workspaces/features/summaries loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50052,7 +50788,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000956",
+    "sortText": "00000979",
     "filterText": "'Microsoft.OperationalInsights/workspaces/linkedServices loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50074,7 +50810,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000957",
+    "sortText": "0000097a",
     "filterText": "'Microsoft.OperationalInsights/workspaces/linkedStorageAccounts loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50096,7 +50832,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000958",
+    "sortText": "0000097b",
     "filterText": "'Microsoft.OperationalInsights/workspaces/networkSecurityPerimeterConfigurations loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50118,7 +50854,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000959",
+    "sortText": "0000097c",
     "filterText": "'Microsoft.OperationalInsights/workspaces/savedSearches loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50140,7 +50876,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000095a",
+    "sortText": "0000097d",
     "filterText": "'Microsoft.OperationalInsights/workspaces/storageInsightConfigs loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50162,7 +50898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000095b",
+    "sortText": "0000097e",
     "filterText": "'Microsoft.OperationalInsights/workspaces/summaryLogs loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50184,7 +50920,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000095c",
+    "sortText": "0000097f",
     "filterText": "'Microsoft.OperationalInsights/workspaces/tables loganalytics'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -50206,7 +50942,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000095d",
+    "sortText": "00000980",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50227,7 +50963,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000095e",
+    "sortText": "00000981",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50248,7 +50984,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000095f",
+    "sortText": "00000982",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50269,7 +51005,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000960",
+    "sortText": "00000983",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50290,7 +51026,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000961",
+    "sortText": "00000984",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50311,7 +51047,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000962",
+    "sortText": "00000985",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50332,7 +51068,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000963",
+    "sortText": "00000986",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50353,7 +51089,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000964",
+    "sortText": "00000987",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50374,7 +51110,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000965",
+    "sortText": "00000988",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50395,7 +51131,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000966",
+    "sortText": "00000989",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50416,7 +51152,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000967",
+    "sortText": "0000098a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50437,7 +51173,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000096b",
+    "sortText": "0000098e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50458,7 +51194,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000096c",
+    "sortText": "0000098f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50479,7 +51215,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000096d",
+    "sortText": "00000990",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50500,7 +51236,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000968",
+    "sortText": "0000098b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50521,7 +51257,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000969",
+    "sortText": "0000098c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50542,7 +51278,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000096a",
+    "sortText": "0000098d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50563,7 +51299,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000096e",
+    "sortText": "00000991",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50584,7 +51320,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000096f",
+    "sortText": "00000992",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50605,7 +51341,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000970",
+    "sortText": "00000993",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50626,7 +51362,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000971",
+    "sortText": "00000994",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50647,7 +51383,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000972",
+    "sortText": "00000995",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50668,7 +51404,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000973",
+    "sortText": "00000996",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50689,7 +51425,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000974",
+    "sortText": "00000997",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50710,7 +51446,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000975",
+    "sortText": "00000998",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50731,7 +51467,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000976",
+    "sortText": "00000999",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50752,7 +51488,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000977",
+    "sortText": "0000099a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50773,7 +51509,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000978",
+    "sortText": "0000099b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50794,7 +51530,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000979",
+    "sortText": "0000099c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50815,7 +51551,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000097a",
+    "sortText": "0000099d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50836,7 +51572,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000097b",
+    "sortText": "0000099e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50857,7 +51593,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000097c",
+    "sortText": "0000099f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50878,7 +51614,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000097d",
+    "sortText": "000009a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50899,7 +51635,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000097e",
+    "sortText": "000009a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50920,7 +51656,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000097f",
+    "sortText": "000009a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50941,7 +51677,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000980",
+    "sortText": "000009a3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50962,7 +51698,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000981",
+    "sortText": "000009a4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -50983,12 +51719,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000982",
+    "sortText": "000009a5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.ProfessionalService/resources@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.ProgramEnrollment/eduEnrollments'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.ProgramEnrollment/eduEnrollments`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009a6",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.ProgramEnrollment/eduEnrollments@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -51004,7 +51761,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000983",
+    "sortText": "000009a7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51025,7 +51782,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000984",
+    "sortText": "000009a8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51046,7 +51803,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000985",
+    "sortText": "000009a9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51067,7 +51824,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000986",
+    "sortText": "000009aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51088,7 +51845,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000987",
+    "sortText": "000009ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51109,7 +51866,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000988",
+    "sortText": "000009ac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51130,7 +51887,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000989",
+    "sortText": "000009ad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51151,7 +51908,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000098a",
+    "sortText": "000009ae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51172,7 +51929,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000098b",
+    "sortText": "000009af",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51193,7 +51950,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000098c",
+    "sortText": "000009b0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51214,7 +51971,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000098d",
+    "sortText": "000009b1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51235,7 +51992,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000098e",
+    "sortText": "000009b2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51256,7 +52013,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000098f",
+    "sortText": "000009b3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51277,7 +52034,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000990",
+    "sortText": "000009b4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51298,7 +52055,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000991",
+    "sortText": "000009b5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51319,7 +52076,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000992",
+    "sortText": "000009b6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51340,7 +52097,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000993",
+    "sortText": "000009b7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51361,7 +52118,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000994",
+    "sortText": "000009b8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51382,7 +52139,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000995",
+    "sortText": "000009b9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51403,7 +52160,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000996",
+    "sortText": "000009ba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51424,7 +52181,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000997",
+    "sortText": "000009bb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51445,7 +52202,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000998",
+    "sortText": "000009bc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51466,7 +52223,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000999",
+    "sortText": "000009bd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51487,7 +52244,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000099a",
+    "sortText": "000009be",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51508,7 +52265,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000099b",
+    "sortText": "000009bf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51529,7 +52286,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000099c",
+    "sortText": "000009c0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51550,7 +52307,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000099d",
+    "sortText": "000009c1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51571,7 +52328,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000099e",
+    "sortText": "000009c2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51592,7 +52349,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000099f",
+    "sortText": "000009c3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51613,7 +52370,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a0",
+    "sortText": "000009c4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51634,12 +52391,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a1",
+    "sortText": "000009c5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Quota/groupQuotas/subscriptions@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Quota/incomingQuotaTransfers'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Quota/incomingQuotaTransfers`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009c6",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Quota/incomingQuotaTransfers@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -51655,12 +52433,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a2",
+    "sortText": "000009c7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.Quota/quotaRequests@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.Quota/quotaTransfers'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.Quota/quotaTransfers`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009c9",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.Quota/quotaTransfers@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -51676,7 +52475,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a3",
+    "sortText": "000009c8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51697,7 +52496,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a4",
+    "sortText": "000009ca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51718,7 +52517,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a5",
+    "sortText": "000009cb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51739,7 +52538,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a6",
+    "sortText": "000009cc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51760,7 +52559,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a7",
+    "sortText": "000009cd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51781,7 +52580,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a8",
+    "sortText": "000009ce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51802,7 +52601,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009a9",
+    "sortText": "000009cf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51823,12 +52622,138 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009aa",
+    "sortText": "000009d0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.RecoveryServices/vaults@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009d2",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009d3",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems/operationResults'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems/operationResults`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009d4",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems/operationResults@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems/recoveryPoints'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems/recoveryPoints`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009d5",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupFabrics/protectionContainers/protectedItems/recoveryPoints@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupJobs'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupJobs`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009d6",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/backupJobs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/vaultCredentials/operationResults'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/vaultCredentials/operationResults`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "000009d7",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.RecoveryServices/vaults/backupCrossTenantVaultMappings/vaultCredentials/operationResults@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -51844,7 +52769,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ac",
+    "sortText": "000009d8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51865,7 +52790,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ad",
+    "sortText": "000009d9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51886,7 +52811,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ae",
+    "sortText": "000009da",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51907,7 +52832,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009af",
+    "sortText": "000009db",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51928,7 +52853,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b0",
+    "sortText": "000009dc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51949,7 +52874,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b1",
+    "sortText": "000009dd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51970,7 +52895,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b2",
+    "sortText": "000009de",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -51991,7 +52916,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b3",
+    "sortText": "000009df",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52012,7 +52937,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b4",
+    "sortText": "000009e0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52033,7 +52958,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b5",
+    "sortText": "000009e1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52054,7 +52979,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b6",
+    "sortText": "000009e2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52075,7 +53000,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b7",
+    "sortText": "000009e3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52096,7 +53021,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ab",
+    "sortText": "000009d1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52117,7 +53042,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b8",
+    "sortText": "000009e4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52138,7 +53063,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009b9",
+    "sortText": "000009e5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52159,7 +53084,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ba",
+    "sortText": "000009e6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52180,7 +53105,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009bb",
+    "sortText": "000009e7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52201,7 +53126,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009bc",
+    "sortText": "000009e8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52222,7 +53147,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009bd",
+    "sortText": "000009e9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52243,7 +53168,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009be",
+    "sortText": "000009ea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52264,7 +53189,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009bf",
+    "sortText": "000009eb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52285,7 +53210,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c0",
+    "sortText": "000009ec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52306,7 +53231,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c1",
+    "sortText": "000009ed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52327,7 +53252,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c2",
+    "sortText": "000009ee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52348,7 +53273,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c3",
+    "sortText": "000009ef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52369,7 +53294,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c4",
+    "sortText": "000009f0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52390,7 +53315,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c5",
+    "sortText": "000009f1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52411,7 +53336,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c6",
+    "sortText": "000009f2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52432,7 +53357,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c7",
+    "sortText": "000009f3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52453,7 +53378,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c8",
+    "sortText": "000009f4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52474,7 +53399,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009c9",
+    "sortText": "000009f5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52495,7 +53420,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ca",
+    "sortText": "000009f6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52516,7 +53441,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009cb",
+    "sortText": "000009f7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52537,7 +53462,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009cc",
+    "sortText": "000009f8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52558,7 +53483,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009cd",
+    "sortText": "000009f9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52579,7 +53504,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ce",
+    "sortText": "000009fa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52600,7 +53525,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009cf",
+    "sortText": "000009fb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52621,7 +53546,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d0",
+    "sortText": "000009fc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52642,7 +53567,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d1",
+    "sortText": "000009fd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52663,7 +53588,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d2",
+    "sortText": "000009fe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52684,7 +53609,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d3",
+    "sortText": "000009ff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52705,7 +53630,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d4",
+    "sortText": "00000a00",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52726,7 +53651,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d5",
+    "sortText": "00000a01",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52747,7 +53672,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d6",
+    "sortText": "00000a02",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52768,7 +53693,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d7",
+    "sortText": "00000a03",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52789,7 +53714,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d8",
+    "sortText": "00000a04",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52810,7 +53735,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009d9",
+    "sortText": "00000a05",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52831,7 +53756,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009da",
+    "sortText": "00000a06",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52852,7 +53777,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009db",
+    "sortText": "00000a07",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52873,7 +53798,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009dc",
+    "sortText": "00000a08",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52894,7 +53819,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009dd",
+    "sortText": "00000a09",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52915,7 +53840,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009de",
+    "sortText": "00000a0a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52936,7 +53861,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009df",
+    "sortText": "00000a0b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52957,7 +53882,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e0",
+    "sortText": "00000a0c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52978,7 +53903,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e1",
+    "sortText": "00000a0d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -52999,7 +53924,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e2",
+    "sortText": "00000a0e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53020,7 +53945,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e3",
+    "sortText": "00000a0f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53041,7 +53966,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e4",
+    "sortText": "00000a10",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53062,7 +53987,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e5",
+    "sortText": "00000a11",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53083,7 +54008,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e6",
+    "sortText": "00000a12",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53104,7 +54029,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e7",
+    "sortText": "00000a13",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53125,7 +54050,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e8",
+    "sortText": "00000a14",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53146,7 +54071,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009e9",
+    "sortText": "00000a15",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53167,7 +54092,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ea",
+    "sortText": "00000a16",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53188,7 +54113,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009eb",
+    "sortText": "00000a17",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53209,7 +54134,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ec",
+    "sortText": "00000a18",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53230,7 +54155,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ed",
+    "sortText": "00000a19",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53251,7 +54176,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ee",
+    "sortText": "00000a1a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53272,7 +54197,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ef",
+    "sortText": "00000a1b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53293,7 +54218,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f0",
+    "sortText": "00000a1c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53314,7 +54239,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f1",
+    "sortText": "00000a1d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53335,7 +54260,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f3",
+    "sortText": "00000a1f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53356,7 +54281,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f4",
+    "sortText": "00000a20",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53377,7 +54302,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f5",
+    "sortText": "00000a21",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53398,7 +54323,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f6",
+    "sortText": "00000a22",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53419,7 +54344,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f2",
+    "sortText": "00000a1e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53440,7 +54365,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f7",
+    "sortText": "00000a23",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53461,7 +54386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f8",
+    "sortText": "00000a24",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53482,7 +54407,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009f9",
+    "sortText": "00000a25",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53503,7 +54428,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009fa",
+    "sortText": "00000a26",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53524,7 +54449,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009fb",
+    "sortText": "00000a27",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53545,7 +54470,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a01",
+    "sortText": "00000a2d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53566,7 +54491,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a02",
+    "sortText": "00000a2e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53587,7 +54512,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a03",
+    "sortText": "00000a2f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53608,7 +54533,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a04",
+    "sortText": "00000a30",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53629,7 +54554,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a05",
+    "sortText": "00000a31",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53650,7 +54575,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a0a",
+    "sortText": "00000a36",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53671,7 +54596,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a06",
+    "sortText": "00000a32",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53692,7 +54617,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a07",
+    "sortText": "00000a33",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53713,7 +54638,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a08",
+    "sortText": "00000a34",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53734,7 +54659,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a09",
+    "sortText": "00000a35",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53755,7 +54680,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a0b",
+    "sortText": "00000a37",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53776,7 +54701,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a0c",
+    "sortText": "00000a38",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53797,7 +54722,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a0d",
+    "sortText": "00000a39",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53818,7 +54743,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009fc",
+    "sortText": "00000a28",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53839,7 +54764,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009fd",
+    "sortText": "00000a29",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53860,7 +54785,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009fe",
+    "sortText": "00000a2a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53881,7 +54806,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "000009ff",
+    "sortText": "00000a2b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53902,7 +54827,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a00",
+    "sortText": "00000a2c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53923,7 +54848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a0e",
+    "sortText": "00000a3a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53944,7 +54869,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a0f",
+    "sortText": "00000a3b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53965,7 +54890,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a10",
+    "sortText": "00000a3c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -53986,7 +54911,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a11",
+    "sortText": "00000a3d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54007,7 +54932,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a12",
+    "sortText": "00000a3e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54028,7 +54953,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a13",
+    "sortText": "00000a3f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54049,7 +54974,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a14",
+    "sortText": "00000a40",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54070,7 +54995,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a15",
+    "sortText": "00000a41",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54091,7 +55016,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a16",
+    "sortText": "00000a42",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54112,7 +55037,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a17",
+    "sortText": "00000a43",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54133,7 +55058,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a18",
+    "sortText": "00000a44",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54154,7 +55079,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a19",
+    "sortText": "00000a45",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54175,7 +55100,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a1a",
+    "sortText": "00000a46",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54196,7 +55121,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a1b",
+    "sortText": "00000a47",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54217,7 +55142,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a1c",
+    "sortText": "00000a48",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54238,7 +55163,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a1e",
+    "sortText": "00000a4a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54259,7 +55184,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a1d",
+    "sortText": "00000a49",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54280,7 +55205,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a1f",
+    "sortText": "00000a4b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54301,7 +55226,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a20",
+    "sortText": "00000a4c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54322,7 +55247,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a21",
+    "sortText": "00000a4d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54343,7 +55268,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a22",
+    "sortText": "00000a4e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54364,7 +55289,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a23",
+    "sortText": "00000a4f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54385,7 +55310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a24",
+    "sortText": "00000a50",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54406,7 +55331,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a25",
+    "sortText": "00000a51",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54427,7 +55352,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a26",
+    "sortText": "00000a52",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54448,7 +55373,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a27",
+    "sortText": "00000a53",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54469,7 +55394,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a28",
+    "sortText": "00000a54",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54490,7 +55415,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a29",
+    "sortText": "00000a55",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54511,7 +55436,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a2a",
+    "sortText": "00000a56",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54532,7 +55457,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a2c",
+    "sortText": "00000a58",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54553,7 +55478,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a2b",
+    "sortText": "00000a57",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54574,7 +55499,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a2e",
+    "sortText": "00000a5a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54595,7 +55520,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a2d",
+    "sortText": "00000a59",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54616,7 +55541,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a2f",
+    "sortText": "00000a5b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54637,7 +55562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a33",
+    "sortText": "00000a5f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54658,7 +55583,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a30",
+    "sortText": "00000a5c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54679,7 +55604,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a31",
+    "sortText": "00000a5d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54700,7 +55625,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a32",
+    "sortText": "00000a5e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54721,7 +55646,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a34",
+    "sortText": "00000a60",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54742,7 +55667,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a35",
+    "sortText": "00000a61",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54763,7 +55688,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a36",
+    "sortText": "00000a62",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54784,7 +55709,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a37",
+    "sortText": "00000a63",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54805,7 +55730,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a38",
+    "sortText": "00000a64",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54826,7 +55751,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a39",
+    "sortText": "00000a65",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54847,7 +55772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a3a",
+    "sortText": "00000a66",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54868,7 +55793,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a3b",
+    "sortText": "00000a67",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54889,7 +55814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a3c",
+    "sortText": "00000a68",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54910,7 +55835,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a3d",
+    "sortText": "00000a69",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54931,7 +55856,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a3e",
+    "sortText": "00000a6a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54952,7 +55877,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a3f",
+    "sortText": "00000a6b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54973,7 +55898,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a40",
+    "sortText": "00000a6c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -54994,7 +55919,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a41",
+    "sortText": "00000a6d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55015,7 +55940,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a42",
+    "sortText": "00000a6e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55036,7 +55961,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a43",
+    "sortText": "00000a6f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55057,7 +55982,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a44",
+    "sortText": "00000a70",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55078,7 +56003,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a45",
+    "sortText": "00000a71",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55099,7 +56024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a46",
+    "sortText": "00000a72",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55120,7 +56045,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a47",
+    "sortText": "00000a73",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55141,7 +56066,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a48",
+    "sortText": "00000a74",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55162,7 +56087,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a49",
+    "sortText": "00000a75",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55183,7 +56108,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a4a",
+    "sortText": "00000a76",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55204,7 +56129,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a4b",
+    "sortText": "00000a77",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55225,7 +56150,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a4c",
+    "sortText": "00000a78",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55246,7 +56171,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a4d",
+    "sortText": "00000a79",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55267,7 +56192,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a4e",
+    "sortText": "00000a7a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55288,7 +56213,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a4f",
+    "sortText": "00000a7b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55309,7 +56234,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a50",
+    "sortText": "00000a7c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55330,7 +56255,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a51",
+    "sortText": "00000a7d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55351,7 +56276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a52",
+    "sortText": "00000a7e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55372,7 +56297,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a53",
+    "sortText": "00000a7f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55393,7 +56318,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a54",
+    "sortText": "00000a80",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55414,7 +56339,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a55",
+    "sortText": "00000a81",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55435,7 +56360,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a56",
+    "sortText": "00000a82",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55456,7 +56381,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a57",
+    "sortText": "00000a83",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55477,7 +56402,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a58",
+    "sortText": "00000a84",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55498,7 +56423,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a59",
+    "sortText": "00000a85",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55519,7 +56444,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a5a",
+    "sortText": "00000a86",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55540,7 +56465,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a5b",
+    "sortText": "00000a87",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55561,7 +56486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a5c",
+    "sortText": "00000a88",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55582,7 +56507,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a5d",
+    "sortText": "00000a89",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55603,7 +56528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a5e",
+    "sortText": "00000a8a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55624,7 +56549,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a5f",
+    "sortText": "00000a8b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55645,7 +56570,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a60",
+    "sortText": "00000a8c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55666,7 +56591,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a61",
+    "sortText": "00000a8d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55687,7 +56612,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a62",
+    "sortText": "00000a8e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55708,7 +56633,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a63",
+    "sortText": "00000a8f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55729,7 +56654,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a64",
+    "sortText": "00000a90",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55750,7 +56675,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a65",
+    "sortText": "00000a91",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55771,7 +56696,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a66",
+    "sortText": "00000a92",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55792,7 +56717,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a67",
+    "sortText": "00000a93",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55813,7 +56738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a68",
+    "sortText": "00000a94",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55834,7 +56759,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a69",
+    "sortText": "00000a95",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55855,7 +56780,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a6a",
+    "sortText": "00000a96",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55876,7 +56801,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a6b",
+    "sortText": "00000a97",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55897,7 +56822,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a6c",
+    "sortText": "00000a98",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55918,7 +56843,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a6d",
+    "sortText": "00000a99",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55939,7 +56864,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a70",
+    "sortText": "00000a9c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55960,7 +56885,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a6e",
+    "sortText": "00000a9a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -55981,7 +56906,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a6f",
+    "sortText": "00000a9b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56002,7 +56927,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a71",
+    "sortText": "00000a9d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56023,7 +56948,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a72",
+    "sortText": "00000a9e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56044,7 +56969,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a73",
+    "sortText": "00000a9f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56065,7 +56990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a74",
+    "sortText": "00000aa0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56086,7 +57011,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a75",
+    "sortText": "00000aa1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56107,7 +57032,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a76",
+    "sortText": "00000aa2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56128,7 +57053,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a77",
+    "sortText": "00000aa3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56149,7 +57074,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a78",
+    "sortText": "00000aa4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56170,7 +57095,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a79",
+    "sortText": "00000aa5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56191,7 +57116,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a7b",
+    "sortText": "00000aa7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56212,7 +57137,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a7a",
+    "sortText": "00000aa6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56233,7 +57158,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a7c",
+    "sortText": "00000aa8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56254,7 +57179,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a7d",
+    "sortText": "00000aa9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56275,7 +57200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a7e",
+    "sortText": "00000aaa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56296,7 +57221,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a7f",
+    "sortText": "00000aab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56317,7 +57242,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a80",
+    "sortText": "00000aac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56338,7 +57263,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a81",
+    "sortText": "00000aad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56359,7 +57284,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a82",
+    "sortText": "00000aae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56380,7 +57305,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a83",
+    "sortText": "00000aaf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56401,7 +57326,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a84",
+    "sortText": "00000ab0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56422,7 +57347,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a85",
+    "sortText": "00000ab1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56443,7 +57368,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a86",
+    "sortText": "00000ab2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56464,7 +57389,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a87",
+    "sortText": "00000ab3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56485,7 +57410,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a88",
+    "sortText": "00000ab4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56506,7 +57431,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a89",
+    "sortText": "00000ab5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56527,7 +57452,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a8a",
+    "sortText": "00000ab6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56548,7 +57473,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a8b",
+    "sortText": "00000ab7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56569,7 +57494,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a8c",
+    "sortText": "00000ab8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56590,7 +57515,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a8d",
+    "sortText": "00000ab9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56611,7 +57536,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a8e",
+    "sortText": "00000aba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56632,7 +57557,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a8f",
+    "sortText": "00000abb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56653,7 +57578,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a90",
+    "sortText": "00000abc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56674,7 +57599,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a91",
+    "sortText": "00000abd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56695,7 +57620,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a92",
+    "sortText": "00000abe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56716,7 +57641,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a93",
+    "sortText": "00000abf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56737,7 +57662,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a94",
+    "sortText": "00000ac0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56758,7 +57683,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a95",
+    "sortText": "00000ac1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56779,7 +57704,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a96",
+    "sortText": "00000ac2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56800,7 +57725,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a97",
+    "sortText": "00000ac3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56821,7 +57746,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a98",
+    "sortText": "00000ac4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56842,7 +57767,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a99",
+    "sortText": "00000ac5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56863,7 +57788,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a9a",
+    "sortText": "00000ac6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56884,7 +57809,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a9b",
+    "sortText": "00000ac7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56905,7 +57830,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a9c",
+    "sortText": "00000ac8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56926,7 +57851,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a9d",
+    "sortText": "00000ac9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56947,7 +57872,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a9e",
+    "sortText": "00000aca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56968,7 +57893,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000a9f",
+    "sortText": "00000acb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -56989,7 +57914,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa0",
+    "sortText": "00000acc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57010,7 +57935,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa1",
+    "sortText": "00000acd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57031,7 +57956,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa2",
+    "sortText": "00000ace",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57052,7 +57977,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa3",
+    "sortText": "00000acf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57073,7 +57998,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa4",
+    "sortText": "00000ad0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57094,7 +58019,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa5",
+    "sortText": "00000ad1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57115,7 +58040,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa6",
+    "sortText": "00000ad2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57136,7 +58061,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa7",
+    "sortText": "00000ad3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57157,7 +58082,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa8",
+    "sortText": "00000ad4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57178,7 +58103,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aa9",
+    "sortText": "00000ad5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57199,7 +58124,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aaa",
+    "sortText": "00000ad6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57220,7 +58145,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aab",
+    "sortText": "00000ad7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57241,7 +58166,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aae",
+    "sortText": "00000ada",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57262,7 +58187,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aaf",
+    "sortText": "00000adb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57283,7 +58208,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aac",
+    "sortText": "00000ad8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57304,7 +58229,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aad",
+    "sortText": "00000ad9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57325,7 +58250,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab0",
+    "sortText": "00000adc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57346,7 +58271,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab1",
+    "sortText": "00000add",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57367,7 +58292,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab4",
+    "sortText": "00000ae0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57388,7 +58313,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab5",
+    "sortText": "00000ae1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57409,7 +58334,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab2",
+    "sortText": "00000ade",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57430,7 +58355,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab3",
+    "sortText": "00000adf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57451,7 +58376,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab6",
+    "sortText": "00000ae2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57472,7 +58397,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab7",
+    "sortText": "00000ae3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57493,7 +58418,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab8",
+    "sortText": "00000ae4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57514,7 +58439,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ab9",
+    "sortText": "00000ae5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57535,7 +58460,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aba",
+    "sortText": "00000ae6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57556,7 +58481,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000abb",
+    "sortText": "00000ae7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57577,7 +58502,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000abc",
+    "sortText": "00000ae8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57598,7 +58523,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000abd",
+    "sortText": "00000ae9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57619,7 +58544,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000abe",
+    "sortText": "00000aea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57640,7 +58565,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000abf",
+    "sortText": "00000aeb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57661,7 +58586,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac0",
+    "sortText": "00000aec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57682,7 +58607,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac1",
+    "sortText": "00000aed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57703,7 +58628,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac2",
+    "sortText": "00000aee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57724,7 +58649,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac3",
+    "sortText": "00000aef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57745,7 +58670,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac4",
+    "sortText": "00000af0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57766,7 +58691,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac5",
+    "sortText": "00000af1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57787,7 +58712,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac6",
+    "sortText": "00000af2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57808,7 +58733,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac7",
+    "sortText": "00000af3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57829,7 +58754,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac8",
+    "sortText": "00000af4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57850,7 +58775,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ac9",
+    "sortText": "00000af5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57871,7 +58796,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aca",
+    "sortText": "00000af6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57892,7 +58817,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000acb",
+    "sortText": "00000af7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57913,7 +58838,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000acc",
+    "sortText": "00000af8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57934,7 +58859,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000acd",
+    "sortText": "00000af9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57955,7 +58880,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ace",
+    "sortText": "00000afa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57976,7 +58901,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000acf",
+    "sortText": "00000afb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -57997,12 +58922,33 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad0",
+    "sortText": "00000afc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.SignalRService/webPubSub/hubs@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'Microsoft.SignalRService/webPubSub/persistentStorages'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `Microsoft.SignalRService/webPubSub/persistentStorages`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000afd",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'Microsoft.SignalRService/webPubSub/persistentStorages@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -58018,7 +58964,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad1",
+    "sortText": "00000afe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58039,7 +58985,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad2",
+    "sortText": "00000aff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58060,7 +59006,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad3",
+    "sortText": "00000b00",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58081,7 +59027,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad4",
+    "sortText": "00000b01",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58102,7 +59048,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad5",
+    "sortText": "00000b02",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58123,7 +59069,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad6",
+    "sortText": "00000b03",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58144,7 +59090,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad7",
+    "sortText": "00000b04",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58165,7 +59111,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad8",
+    "sortText": "00000b05",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58186,7 +59132,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ad9",
+    "sortText": "00000b06",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58207,7 +59153,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ada",
+    "sortText": "00000b07",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58228,7 +59174,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000adb",
+    "sortText": "00000b08",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58249,7 +59195,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000adc",
+    "sortText": "00000b09",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58270,7 +59216,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000add",
+    "sortText": "00000b0a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58291,7 +59237,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ade",
+    "sortText": "00000b0b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58312,7 +59258,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000adf",
+    "sortText": "00000b0c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58333,7 +59279,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae0",
+    "sortText": "00000b0d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58354,7 +59300,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae1",
+    "sortText": "00000b0e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58375,7 +59321,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae2",
+    "sortText": "00000b0f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58396,7 +59342,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae3",
+    "sortText": "00000b10",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58417,7 +59363,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae4",
+    "sortText": "00000b11",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58438,7 +59384,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae5",
+    "sortText": "00000b12",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58459,7 +59405,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae6",
+    "sortText": "00000b13",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58480,7 +59426,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae7",
+    "sortText": "00000b14",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58501,7 +59447,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae8",
+    "sortText": "00000b15",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58522,7 +59468,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ae9",
+    "sortText": "00000b16",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58543,7 +59489,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aea",
+    "sortText": "00000b17",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58564,7 +59510,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aeb",
+    "sortText": "00000b18",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58585,7 +59531,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aec",
+    "sortText": "00000b19",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58606,7 +59552,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aed",
+    "sortText": "00000b1a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58627,7 +59573,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aee",
+    "sortText": "00000b1b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58648,7 +59594,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aef",
+    "sortText": "00000b1c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58669,7 +59615,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af0",
+    "sortText": "00000b1d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58690,7 +59636,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af1",
+    "sortText": "00000b1e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58711,7 +59657,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af2",
+    "sortText": "00000b1f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58732,7 +59678,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af3",
+    "sortText": "00000b20",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58753,7 +59699,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af4",
+    "sortText": "00000b21",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58774,7 +59720,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af5",
+    "sortText": "00000b22",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58795,7 +59741,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af6",
+    "sortText": "00000b23",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58816,7 +59762,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af7",
+    "sortText": "00000b24",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58837,7 +59783,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af8",
+    "sortText": "00000b25",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58858,7 +59804,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000af9",
+    "sortText": "00000b26",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58879,7 +59825,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000afa",
+    "sortText": "00000b27",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58900,7 +59846,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000afb",
+    "sortText": "00000b28",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58921,7 +59867,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000afc",
+    "sortText": "00000b29",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58942,7 +59888,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000afd",
+    "sortText": "00000b2a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58963,7 +59909,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000afe",
+    "sortText": "00000b2b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -58984,7 +59930,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000aff",
+    "sortText": "00000b2c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59005,7 +59951,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b00",
+    "sortText": "00000b2d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59026,7 +59972,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b01",
+    "sortText": "00000b2e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59047,7 +59993,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b02",
+    "sortText": "00000b2f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59068,7 +60014,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b03",
+    "sortText": "00000b30",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59089,7 +60035,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b04",
+    "sortText": "00000b31",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59110,7 +60056,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b05",
+    "sortText": "00000b32",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59131,7 +60077,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b06",
+    "sortText": "00000b33",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59152,7 +60098,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b07",
+    "sortText": "00000b34",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59173,7 +60119,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b08",
+    "sortText": "00000b35",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59194,7 +60140,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b09",
+    "sortText": "00000b36",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59215,7 +60161,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b0a",
+    "sortText": "00000b37",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59236,7 +60182,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b0b",
+    "sortText": "00000b38",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59257,7 +60203,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b0c",
+    "sortText": "00000b39",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59278,7 +60224,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b0d",
+    "sortText": "00000b3a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59299,7 +60245,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b0e",
+    "sortText": "00000b3b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59320,7 +60266,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b0f",
+    "sortText": "00000b3c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59341,7 +60287,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b10",
+    "sortText": "00000b3d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59362,7 +60308,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b11",
+    "sortText": "00000b3e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59383,7 +60329,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b12",
+    "sortText": "00000b3f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59404,7 +60350,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b13",
+    "sortText": "00000b40",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59425,7 +60371,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b14",
+    "sortText": "00000b41",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59446,7 +60392,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b15",
+    "sortText": "00000b42",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59467,7 +60413,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b16",
+    "sortText": "00000b43",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59488,7 +60434,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b17",
+    "sortText": "00000b44",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59509,7 +60455,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b18",
+    "sortText": "00000b45",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59530,7 +60476,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b19",
+    "sortText": "00000b46",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59551,7 +60497,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b1a",
+    "sortText": "00000b47",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59572,7 +60518,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b1b",
+    "sortText": "00000b48",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59593,7 +60539,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b1c",
+    "sortText": "00000b49",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59614,7 +60560,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b1d",
+    "sortText": "00000b4a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59635,7 +60581,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b1e",
+    "sortText": "00000b4b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59656,7 +60602,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b1f",
+    "sortText": "00000b4c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59677,7 +60623,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b20",
+    "sortText": "00000b4d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59698,7 +60644,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b21",
+    "sortText": "00000b4e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59719,7 +60665,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b22",
+    "sortText": "00000b4f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59740,7 +60686,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b23",
+    "sortText": "00000b50",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59761,7 +60707,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b24",
+    "sortText": "00000b51",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59782,7 +60728,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b25",
+    "sortText": "00000b52",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59803,7 +60749,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b26",
+    "sortText": "00000b53",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59824,7 +60770,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b27",
+    "sortText": "00000b54",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59845,7 +60791,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b28",
+    "sortText": "00000b55",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59866,7 +60812,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b29",
+    "sortText": "00000b56",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59887,7 +60833,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b2a",
+    "sortText": "00000b57",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59908,7 +60854,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b2b",
+    "sortText": "00000b58",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59929,7 +60875,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b2c",
+    "sortText": "00000b59",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59950,7 +60896,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b2d",
+    "sortText": "00000b5a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59971,7 +60917,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b2e",
+    "sortText": "00000b5b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -59992,7 +60938,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b2f",
+    "sortText": "00000b5c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60013,7 +60959,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b30",
+    "sortText": "00000b5d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60034,7 +60980,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b31",
+    "sortText": "00000b5e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60055,7 +61001,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b32",
+    "sortText": "00000b5f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60076,7 +61022,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b33",
+    "sortText": "00000b60",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60097,7 +61043,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b34",
+    "sortText": "00000b61",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60118,7 +61064,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b35",
+    "sortText": "00000b62",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60139,7 +61085,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b36",
+    "sortText": "00000b63",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60160,7 +61106,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b37",
+    "sortText": "00000b64",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60181,7 +61127,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b38",
+    "sortText": "00000b65",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60202,7 +61148,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b39",
+    "sortText": "00000b66",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60223,7 +61169,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b3a",
+    "sortText": "00000b67",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60244,7 +61190,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b3b",
+    "sortText": "00000b68",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60265,7 +61211,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b3c",
+    "sortText": "00000b69",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60286,7 +61232,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b3d",
+    "sortText": "00000b6a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60307,7 +61253,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b3e",
+    "sortText": "00000b6b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60328,7 +61274,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b3f",
+    "sortText": "00000b6c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60349,7 +61295,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b40",
+    "sortText": "00000b6d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60370,7 +61316,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b41",
+    "sortText": "00000b6e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60391,7 +61337,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b42",
+    "sortText": "00000b6f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60412,7 +61358,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b43",
+    "sortText": "00000b70",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60433,7 +61379,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b44",
+    "sortText": "00000b71",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60454,7 +61400,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b45",
+    "sortText": "00000b72",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60475,7 +61421,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b46",
+    "sortText": "00000b73",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60496,7 +61442,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b47",
+    "sortText": "00000b74",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60517,7 +61463,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b48",
+    "sortText": "00000b75",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60538,7 +61484,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b49",
+    "sortText": "00000b76",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60559,7 +61505,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b4a",
+    "sortText": "00000b77",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60580,7 +61526,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b4b",
+    "sortText": "00000b78",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60601,7 +61547,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b4c",
+    "sortText": "00000b79",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60622,7 +61568,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b4d",
+    "sortText": "00000b7a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60643,7 +61589,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b4e",
+    "sortText": "00000b7b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60664,7 +61610,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b4f",
+    "sortText": "00000b7c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60685,7 +61631,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b50",
+    "sortText": "00000b7d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60706,7 +61652,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b51",
+    "sortText": "00000b7e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60727,7 +61673,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b52",
+    "sortText": "00000b7f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60748,7 +61694,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b53",
+    "sortText": "00000b80",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60769,7 +61715,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b54",
+    "sortText": "00000b81",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60790,7 +61736,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b55",
+    "sortText": "00000b82",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60811,7 +61757,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b56",
+    "sortText": "00000b83",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60832,7 +61778,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b57",
+    "sortText": "00000b84",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60853,7 +61799,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b58",
+    "sortText": "00000b85",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60874,7 +61820,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b59",
+    "sortText": "00000b86",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60895,7 +61841,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b5a",
+    "sortText": "00000b87",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60916,7 +61862,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b5b",
+    "sortText": "00000b88",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60937,7 +61883,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b5c",
+    "sortText": "00000b89",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60958,7 +61904,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b5d",
+    "sortText": "00000b8a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -60979,7 +61925,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b5e",
+    "sortText": "00000b8b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61000,7 +61946,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b5f",
+    "sortText": "00000b8c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61021,7 +61967,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b60",
+    "sortText": "00000b8d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61042,7 +61988,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b61",
+    "sortText": "00000b8e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61063,7 +62009,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b62",
+    "sortText": "00000b8f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61084,7 +62030,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b63",
+    "sortText": "00000b90",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61105,7 +62051,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b64",
+    "sortText": "00000b91",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61126,7 +62072,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b65",
+    "sortText": "00000b92",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61147,7 +62093,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b66",
+    "sortText": "00000b93",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61168,7 +62114,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b67",
+    "sortText": "00000b94",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61189,7 +62135,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b68",
+    "sortText": "00000b95",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61210,7 +62156,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b69",
+    "sortText": "00000b96",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61231,7 +62177,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b6a",
+    "sortText": "00000b97",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61252,7 +62198,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b6b",
+    "sortText": "00000b98",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61273,7 +62219,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b6c",
+    "sortText": "00000b99",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61294,7 +62240,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b6d",
+    "sortText": "00000b9a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61315,7 +62261,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b6e",
+    "sortText": "00000b9b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61336,7 +62282,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b6f",
+    "sortText": "00000b9c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61357,7 +62303,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b70",
+    "sortText": "00000b9d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61378,7 +62324,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b71",
+    "sortText": "00000b9e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61399,7 +62345,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b72",
+    "sortText": "00000b9f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61420,7 +62366,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b73",
+    "sortText": "00000ba0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61441,7 +62387,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b74",
+    "sortText": "00000ba1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61462,7 +62408,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b75",
+    "sortText": "00000ba2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61483,7 +62429,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b76",
+    "sortText": "00000ba3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61504,7 +62450,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b77",
+    "sortText": "00000ba4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61525,7 +62471,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b78",
+    "sortText": "00000ba5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61546,7 +62492,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b79",
+    "sortText": "00000ba6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61567,7 +62513,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b7a",
+    "sortText": "00000ba7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61588,7 +62534,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b7b",
+    "sortText": "00000ba8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61609,7 +62555,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b7c",
+    "sortText": "00000ba9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61630,7 +62576,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b7d",
+    "sortText": "00000baa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61651,7 +62597,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b7e",
+    "sortText": "00000bab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61672,7 +62618,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b7f",
+    "sortText": "00000bac",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61693,7 +62639,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b80",
+    "sortText": "00000bad",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61714,7 +62660,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b81",
+    "sortText": "00000bae",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61735,7 +62681,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b82",
+    "sortText": "00000baf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61756,7 +62702,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b83",
+    "sortText": "00000bb0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61777,7 +62723,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b84",
+    "sortText": "00000bb1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61798,7 +62744,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b85",
+    "sortText": "00000bb2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61819,7 +62765,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b86",
+    "sortText": "00000bb3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61840,7 +62786,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b87",
+    "sortText": "00000bb4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61861,7 +62807,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b88",
+    "sortText": "00000bb5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61882,7 +62828,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b89",
+    "sortText": "00000bb6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61903,7 +62849,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b8a",
+    "sortText": "00000bb7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61924,7 +62870,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b8b",
+    "sortText": "00000bb8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61945,7 +62891,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b8c",
+    "sortText": "00000bb9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61966,7 +62912,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b8d",
+    "sortText": "00000bba",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -61987,7 +62933,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b8e",
+    "sortText": "00000bbb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62008,7 +62954,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b8f",
+    "sortText": "00000bbc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62029,7 +62975,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b90",
+    "sortText": "00000bbd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62050,7 +62996,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b91",
+    "sortText": "00000bbe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62071,7 +63017,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b92",
+    "sortText": "00000bbf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62092,7 +63038,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b93",
+    "sortText": "00000bc0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62113,7 +63059,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b94",
+    "sortText": "00000bc1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62134,7 +63080,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b95",
+    "sortText": "00000bc2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62155,7 +63101,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b96",
+    "sortText": "00000bc3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62176,7 +63122,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b97",
+    "sortText": "00000bc4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62197,7 +63143,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b98",
+    "sortText": "00000bc5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62218,7 +63164,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b99",
+    "sortText": "00000bc6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62239,7 +63185,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b9a",
+    "sortText": "00000bc7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62260,7 +63206,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b9b",
+    "sortText": "00000bc8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62281,7 +63227,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b9c",
+    "sortText": "00000bc9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62302,7 +63248,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b9d",
+    "sortText": "00000bca",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62323,7 +63269,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b9e",
+    "sortText": "00000bcb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62344,7 +63290,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000b9f",
+    "sortText": "00000bcc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62365,7 +63311,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba0",
+    "sortText": "00000bcd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62386,7 +63332,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba1",
+    "sortText": "00000bce",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62407,7 +63353,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba2",
+    "sortText": "00000bcf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62428,7 +63374,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba3",
+    "sortText": "00000bd0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62449,7 +63395,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba4",
+    "sortText": "00000bd1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62470,7 +63416,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba5",
+    "sortText": "00000bd2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62491,7 +63437,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba6",
+    "sortText": "00000bd3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62512,7 +63458,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba7",
+    "sortText": "00000bd4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62533,7 +63479,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba8",
+    "sortText": "00000bd5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62554,7 +63500,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ba9",
+    "sortText": "00000bd6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62575,7 +63521,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000baa",
+    "sortText": "00000bd7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62596,7 +63542,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bab",
+    "sortText": "00000bd8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62617,7 +63563,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bac",
+    "sortText": "00000bd9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62638,7 +63584,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bad",
+    "sortText": "00000bda",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62659,7 +63605,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bae",
+    "sortText": "00000bdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62680,7 +63626,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000baf",
+    "sortText": "00000bdc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62701,7 +63647,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb0",
+    "sortText": "00000bdd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62722,7 +63668,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb1",
+    "sortText": "00000bde",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62743,7 +63689,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb2",
+    "sortText": "00000bdf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62764,7 +63710,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb3",
+    "sortText": "00000be0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62785,7 +63731,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb4",
+    "sortText": "00000be1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62806,7 +63752,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb5",
+    "sortText": "00000be2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62827,7 +63773,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb6",
+    "sortText": "00000be3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62848,7 +63794,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb7",
+    "sortText": "00000be4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62869,7 +63815,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb8",
+    "sortText": "00000be5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62890,7 +63836,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bb9",
+    "sortText": "00000be6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62911,7 +63857,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bba",
+    "sortText": "00000be7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62932,7 +63878,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bbb",
+    "sortText": "00000be8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62953,7 +63899,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bbc",
+    "sortText": "00000be9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62974,7 +63920,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bbd",
+    "sortText": "00000bea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -62995,7 +63941,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bbe",
+    "sortText": "00000beb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63016,7 +63962,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bbf",
+    "sortText": "00000bec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63037,7 +63983,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc0",
+    "sortText": "00000bed",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63058,7 +64004,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc1",
+    "sortText": "00000bee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63079,7 +64025,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc2",
+    "sortText": "00000bef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63100,7 +64046,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc3",
+    "sortText": "00000bf0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63121,7 +64067,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc4",
+    "sortText": "00000bf1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63142,7 +64088,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc5",
+    "sortText": "00000bf2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63163,7 +64109,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc6",
+    "sortText": "00000bf3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63184,7 +64130,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc7",
+    "sortText": "00000bf4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63205,7 +64151,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc8",
+    "sortText": "00000bf5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63226,7 +64172,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bc9",
+    "sortText": "00000bf6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63247,7 +64193,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bca",
+    "sortText": "00000bf7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63268,7 +64214,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bcb",
+    "sortText": "00000bf8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63289,7 +64235,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bcc",
+    "sortText": "00000bf9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63310,7 +64256,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bcd",
+    "sortText": "00000bfa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63331,7 +64277,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bce",
+    "sortText": "00000bfb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63352,7 +64298,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bcf",
+    "sortText": "00000bfc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63373,7 +64319,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd0",
+    "sortText": "00000bfd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63394,7 +64340,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd1",
+    "sortText": "00000bfe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63415,7 +64361,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd2",
+    "sortText": "00000bff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63436,7 +64382,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd3",
+    "sortText": "00000c00",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63457,7 +64403,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd4",
+    "sortText": "00000c01",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63478,7 +64424,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd5",
+    "sortText": "00000c02",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63499,7 +64445,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd6",
+    "sortText": "00000c03",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63520,7 +64466,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd7",
+    "sortText": "00000c04",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63541,7 +64487,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd8",
+    "sortText": "00000c05",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63562,7 +64508,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bd9",
+    "sortText": "00000c06",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63583,7 +64529,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bda",
+    "sortText": "00000c07",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63604,7 +64550,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bdb",
+    "sortText": "00000c08",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63625,7 +64571,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bdc",
+    "sortText": "00000c09",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63646,7 +64592,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bdd",
+    "sortText": "00000c0a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63667,7 +64613,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bde",
+    "sortText": "00000c0b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63688,7 +64634,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bdf",
+    "sortText": "00000c0c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63709,7 +64655,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be0",
+    "sortText": "00000c0d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63730,7 +64676,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be1",
+    "sortText": "00000c0e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63751,7 +64697,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be2",
+    "sortText": "00000c0f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63772,7 +64718,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be3",
+    "sortText": "00000c10",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63793,7 +64739,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be4",
+    "sortText": "00000c11",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63814,7 +64760,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be5",
+    "sortText": "00000c12",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63835,7 +64781,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be6",
+    "sortText": "00000c13",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63856,7 +64802,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be7",
+    "sortText": "00000c14",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63877,7 +64823,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be8",
+    "sortText": "00000c15",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63898,7 +64844,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000be9",
+    "sortText": "00000c16",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63919,7 +64865,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bea",
+    "sortText": "00000c17",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63940,7 +64886,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000beb",
+    "sortText": "00000c18",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63961,7 +64907,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bec",
+    "sortText": "00000c19",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -63982,7 +64928,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bed",
+    "sortText": "00000c1a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64003,7 +64949,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bee",
+    "sortText": "00000c1b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64024,7 +64970,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bef",
+    "sortText": "00000c1c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64045,7 +64991,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf0",
+    "sortText": "00000c1d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64066,7 +65012,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf1",
+    "sortText": "00000c1e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64087,7 +65033,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf2",
+    "sortText": "00000c1f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64108,7 +65054,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf3",
+    "sortText": "00000c20",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64129,7 +65075,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf4",
+    "sortText": "00000c21",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64150,7 +65096,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf5",
+    "sortText": "00000c22",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64171,7 +65117,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf6",
+    "sortText": "00000c23",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64192,7 +65138,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf7",
+    "sortText": "00000c24",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64213,7 +65159,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf8",
+    "sortText": "00000c25",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64234,7 +65180,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bfa",
+    "sortText": "00000c27",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64255,7 +65201,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bf9",
+    "sortText": "00000c26",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64276,7 +65222,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bfb",
+    "sortText": "00000c28",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64297,7 +65243,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bfc",
+    "sortText": "00000c29",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64318,7 +65264,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bfd",
+    "sortText": "00000c2a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64339,7 +65285,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bfe",
+    "sortText": "00000c2b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64360,7 +65306,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000bff",
+    "sortText": "00000c2c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64381,7 +65327,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c00",
+    "sortText": "00000c2d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64402,7 +65348,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c01",
+    "sortText": "00000c2e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64423,7 +65369,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c02",
+    "sortText": "00000c2f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64444,7 +65390,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c03",
+    "sortText": "00000c30",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64465,7 +65411,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c04",
+    "sortText": "00000c31",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64486,7 +65432,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c05",
+    "sortText": "00000c32",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64507,7 +65453,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c06",
+    "sortText": "00000c33",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64528,7 +65474,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c07",
+    "sortText": "00000c34",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64549,7 +65495,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c08",
+    "sortText": "00000c35",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64570,7 +65516,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c09",
+    "sortText": "00000c36",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64591,7 +65537,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c0a",
+    "sortText": "00000c37",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64612,7 +65558,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c0b",
+    "sortText": "00000c38",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64633,7 +65579,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c0c",
+    "sortText": "00000c39",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64654,7 +65600,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c0d",
+    "sortText": "00000c3a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64675,7 +65621,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c0e",
+    "sortText": "00000c3b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64696,7 +65642,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c0f",
+    "sortText": "00000c3c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64717,7 +65663,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c10",
+    "sortText": "00000c3d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64738,7 +65684,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c11",
+    "sortText": "00000c3e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64759,7 +65705,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c12",
+    "sortText": "00000c3f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64780,7 +65726,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c13",
+    "sortText": "00000c40",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64801,7 +65747,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c1b",
+    "sortText": "00000c48",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64822,7 +65768,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c1c",
+    "sortText": "00000c49",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64843,7 +65789,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c1d",
+    "sortText": "00000c4a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64864,7 +65810,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c14",
+    "sortText": "00000c41",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64885,7 +65831,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c15",
+    "sortText": "00000c42",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64906,7 +65852,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c16",
+    "sortText": "00000c43",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64927,7 +65873,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c17",
+    "sortText": "00000c44",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64948,7 +65894,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c18",
+    "sortText": "00000c45",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64969,7 +65915,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c19",
+    "sortText": "00000c46",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -64990,75 +65936,12 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c1a",
+    "sortText": "00000c47",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'Microsoft.VirtualMachineImages/imageTemplates/triggers@$0'"
-    },
-    "command": {
-      "title": "resource type completion",
-      "command": "editor.action.triggerSuggest"
-    }
-  },
-  {
-    "label": "'Microsoft.VoiceServices/communicationsGateways'",
-    "kind": "class",
-    "documentation": {
-      "kind": "markdown",
-      "value": "Type: `Microsoft.VoiceServices/communicationsGateways`  \n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "00000c1e",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "'Microsoft.VoiceServices/communicationsGateways@$0'"
-    },
-    "command": {
-      "title": "resource type completion",
-      "command": "editor.action.triggerSuggest"
-    }
-  },
-  {
-    "label": "'Microsoft.VoiceServices/communicationsGateways/contacts'",
-    "kind": "class",
-    "documentation": {
-      "kind": "markdown",
-      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/contacts`  \n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "00000c1f",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "'Microsoft.VoiceServices/communicationsGateways/contacts@$0'"
-    },
-    "command": {
-      "title": "resource type completion",
-      "command": "editor.action.triggerSuggest"
-    }
-  },
-  {
-    "label": "'Microsoft.VoiceServices/communicationsGateways/testLines'",
-    "kind": "class",
-    "documentation": {
-      "kind": "markdown",
-      "value": "Type: `Microsoft.VoiceServices/communicationsGateways/testLines`  \n"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "00000c20",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "'Microsoft.VoiceServices/communicationsGateways/testLines@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -65074,7 +65957,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c21",
+    "sortText": "00000c4b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65095,7 +65978,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c22",
+    "sortText": "00000c4c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65116,7 +65999,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c23",
+    "sortText": "00000c4d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65137,7 +66020,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c24",
+    "sortText": "00000c4e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65158,7 +66041,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c25",
+    "sortText": "00000c4f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65179,7 +66062,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c26",
+    "sortText": "00000c50",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65200,7 +66083,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c27",
+    "sortText": "00000c51",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65221,7 +66104,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c28",
+    "sortText": "00000c52",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65242,7 +66125,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c29",
+    "sortText": "00000c53",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65263,7 +66146,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c2a",
+    "sortText": "00000c54",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65284,7 +66167,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c2b",
+    "sortText": "00000c55",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65305,7 +66188,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c2c",
+    "sortText": "00000c56",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65326,7 +66209,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c2d",
+    "sortText": "00000c57",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65347,7 +66230,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c2e",
+    "sortText": "00000c58",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65368,7 +66251,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c2f",
+    "sortText": "00000c59",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65389,7 +66272,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c30",
+    "sortText": "00000c5a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65410,7 +66293,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c31",
+    "sortText": "00000c5b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65431,7 +66314,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c32",
+    "sortText": "00000c5c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65452,7 +66335,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c33",
+    "sortText": "00000c5d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65473,7 +66356,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c34",
+    "sortText": "00000c5e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65494,7 +66377,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c35",
+    "sortText": "00000c5f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65515,7 +66398,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c36",
+    "sortText": "00000c60",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65536,7 +66419,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c37",
+    "sortText": "00000c61",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -65557,7 +66440,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c38",
+    "sortText": "00000c62",
     "filterText": "'Microsoft.Web/serverfarms asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65579,7 +66462,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c39",
+    "sortText": "00000c63",
     "filterText": "'Microsoft.Web/serverfarms/hybridConnectionNamespaces/relays asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65601,7 +66484,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c3a",
+    "sortText": "00000c64",
     "filterText": "'Microsoft.Web/serverfarms/hybridConnectionPlanLimits asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65623,7 +66506,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c3b",
+    "sortText": "00000c65",
     "filterText": "'Microsoft.Web/serverfarms/operationresults asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65645,7 +66528,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c3c",
+    "sortText": "00000c66",
     "filterText": "'Microsoft.Web/serverfarms/virtualNetworkConnections asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65667,7 +66550,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c3d",
+    "sortText": "00000c67",
     "filterText": "'Microsoft.Web/serverfarms/virtualNetworkConnections/gateways asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65689,7 +66572,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c3e",
+    "sortText": "00000c68",
     "filterText": "'Microsoft.Web/serverfarms/virtualNetworkConnections/routes asp appserviceplan hostingplan'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65711,7 +66594,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c3f",
+    "sortText": "00000c69",
     "filterText": "'Microsoft.Web/sites appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65733,7 +66616,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c40",
+    "sortText": "00000c6a",
     "filterText": "'Microsoft.Web/sites/backups appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65755,7 +66638,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c41",
+    "sortText": "00000c6b",
     "filterText": "'Microsoft.Web/sites/basicPublishingCredentialsPolicies appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65777,7 +66660,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c42",
+    "sortText": "00000c6c",
     "filterText": "'Microsoft.Web/sites/certificates appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65799,7 +66682,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c43",
+    "sortText": "00000c6d",
     "filterText": "'Microsoft.Web/sites/config appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65821,7 +66704,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c44",
+    "sortText": "00000c6e",
     "filterText": "'Microsoft.Web/sites/config/appsettings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65843,7 +66726,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c45",
+    "sortText": "00000c6f",
     "filterText": "'Microsoft.Web/sites/config/connectionstrings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65865,7 +66748,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c46",
+    "sortText": "00000c70",
     "filterText": "'Microsoft.Web/sites/config/snapshots appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65887,7 +66770,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c47",
+    "sortText": "00000c71",
     "filterText": "'Microsoft.Web/sites/continuouswebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65909,7 +66792,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c49",
+    "sortText": "00000c73",
     "filterText": "'Microsoft.Web/sites/deploymentStatus appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65931,7 +66814,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c48",
+    "sortText": "00000c72",
     "filterText": "'Microsoft.Web/sites/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65953,7 +66836,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c4a",
+    "sortText": "00000c74",
     "filterText": "'Microsoft.Web/sites/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65975,7 +66858,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c4b",
+    "sortText": "00000c75",
     "filterText": "'Microsoft.Web/sites/diagnostics appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -65997,7 +66880,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c4c",
+    "sortText": "00000c76",
     "filterText": "'Microsoft.Web/sites/diagnostics/analyses appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66019,7 +66902,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c4d",
+    "sortText": "00000c77",
     "filterText": "'Microsoft.Web/sites/diagnostics/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66041,7 +66924,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c4e",
+    "sortText": "00000c78",
     "filterText": "'Microsoft.Web/sites/domainOwnershipIdentifiers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66063,7 +66946,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c4f",
+    "sortText": "00000c79",
     "filterText": "'Microsoft.Web/sites/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66085,7 +66968,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c50",
+    "sortText": "00000c7a",
     "filterText": "'Microsoft.Web/sites/functions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66107,7 +66990,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c51",
+    "sortText": "00000c7b",
     "filterText": "'Microsoft.Web/sites/functions/keys appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66129,7 +67012,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c52",
+    "sortText": "00000c7c",
     "filterText": "'Microsoft.Web/sites/hostNameBindings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66151,7 +67034,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c53",
+    "sortText": "00000c7d",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66173,7 +67056,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c54",
+    "sortText": "00000c7e",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66195,7 +67078,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c55",
+    "sortText": "00000c7f",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66217,7 +67100,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c56",
+    "sortText": "00000c80",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/repetitions/requestHistories appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66239,7 +67122,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c57",
+    "sortText": "00000c81",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/runs/actions/scopeRepetitions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66261,7 +67144,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c58",
+    "sortText": "00000c82",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66283,7 +67166,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c59",
+    "sortText": "00000c83",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/triggers/histories appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66305,7 +67188,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c5a",
+    "sortText": "00000c84",
     "filterText": "'Microsoft.Web/sites/hostruntime/webhooks/api/workflows/versions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66327,7 +67210,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c5c",
+    "sortText": "00000c86",
     "filterText": "'Microsoft.Web/sites/hybridConnectionNamespaces/relays appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66349,7 +67232,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c5b",
+    "sortText": "00000c85",
     "filterText": "'Microsoft.Web/sites/hybridconnection appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66371,7 +67254,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c5d",
+    "sortText": "00000c87",
     "filterText": "'Microsoft.Web/sites/instances appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66393,7 +67276,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c5e",
+    "sortText": "00000c88",
     "filterText": "'Microsoft.Web/sites/instances/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66415,7 +67298,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c5f",
+    "sortText": "00000c89",
     "filterText": "'Microsoft.Web/sites/instances/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66437,7 +67320,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c60",
+    "sortText": "00000c8a",
     "filterText": "'Microsoft.Web/sites/instances/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66459,7 +67342,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c61",
+    "sortText": "00000c8b",
     "filterText": "'Microsoft.Web/sites/instances/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66481,7 +67364,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c62",
+    "sortText": "00000c8c",
     "filterText": "'Microsoft.Web/sites/instances/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66503,7 +67386,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c63",
+    "sortText": "00000c8d",
     "filterText": "'Microsoft.Web/sites/migratemysql appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66525,7 +67408,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c64",
+    "sortText": "00000c8e",
     "filterText": "'Microsoft.Web/sites/networkConfig appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66547,7 +67430,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c65",
+    "sortText": "00000c8f",
     "filterText": "'Microsoft.Web/sites/networkFeatures appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66569,7 +67452,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c66",
+    "sortText": "00000c90",
     "filterText": "'Microsoft.Web/sites/premieraddons appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66591,7 +67474,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c67",
+    "sortText": "00000c91",
     "filterText": "'Microsoft.Web/sites/privateAccess appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66613,7 +67496,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c68",
+    "sortText": "00000c92",
     "filterText": "'Microsoft.Web/sites/privateEndpointConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66635,7 +67518,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c69",
+    "sortText": "00000c93",
     "filterText": "'Microsoft.Web/sites/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66657,7 +67540,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c6a",
+    "sortText": "00000c94",
     "filterText": "'Microsoft.Web/sites/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66679,7 +67562,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c6b",
+    "sortText": "00000c95",
     "filterText": "'Microsoft.Web/sites/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66701,7 +67584,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c6c",
+    "sortText": "00000c96",
     "filterText": "'Microsoft.Web/sites/publicCertificates appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66723,7 +67606,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c6d",
+    "sortText": "00000c97",
     "filterText": "'Microsoft.Web/sites/recommendations appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66745,7 +67628,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c6e",
+    "sortText": "00000c98",
     "filterText": "'Microsoft.Web/sites/resourceHealthMetadata appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66767,7 +67650,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c6f",
+    "sortText": "00000c99",
     "filterText": "'Microsoft.Web/sites/sitecontainers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66789,7 +67672,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c70",
+    "sortText": "00000c9a",
     "filterText": "'Microsoft.Web/sites/siteextensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66811,7 +67694,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c71",
+    "sortText": "00000c9b",
     "filterText": "'Microsoft.Web/sites/slots appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66833,7 +67716,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c72",
+    "sortText": "00000c9c",
     "filterText": "'Microsoft.Web/sites/slots/backups appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66855,7 +67738,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c73",
+    "sortText": "00000c9d",
     "filterText": "'Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66877,7 +67760,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c74",
+    "sortText": "00000c9e",
     "filterText": "'Microsoft.Web/sites/slots/certificates appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66899,7 +67782,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c75",
+    "sortText": "00000c9f",
     "filterText": "'Microsoft.Web/sites/slots/config appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66921,7 +67804,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c76",
+    "sortText": "00000ca0",
     "filterText": "'Microsoft.Web/sites/slots/config/appsettings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66943,7 +67826,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c77",
+    "sortText": "00000ca1",
     "filterText": "'Microsoft.Web/sites/slots/config/connectionstrings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66965,7 +67848,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c78",
+    "sortText": "00000ca2",
     "filterText": "'Microsoft.Web/sites/slots/config/snapshots appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -66987,7 +67870,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c79",
+    "sortText": "00000ca3",
     "filterText": "'Microsoft.Web/sites/slots/continuouswebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67009,7 +67892,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c7b",
+    "sortText": "00000ca5",
     "filterText": "'Microsoft.Web/sites/slots/deploymentStatus appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67031,7 +67914,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c7a",
+    "sortText": "00000ca4",
     "filterText": "'Microsoft.Web/sites/slots/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67053,7 +67936,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c7c",
+    "sortText": "00000ca6",
     "filterText": "'Microsoft.Web/sites/slots/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67075,7 +67958,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c7d",
+    "sortText": "00000ca7",
     "filterText": "'Microsoft.Web/sites/slots/diagnostics appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67097,7 +67980,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c7e",
+    "sortText": "00000ca8",
     "filterText": "'Microsoft.Web/sites/slots/diagnostics/analyses appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67119,7 +68002,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c7f",
+    "sortText": "00000ca9",
     "filterText": "'Microsoft.Web/sites/slots/diagnostics/detectors appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67141,7 +68024,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c80",
+    "sortText": "00000caa",
     "filterText": "'Microsoft.Web/sites/slots/domainOwnershipIdentifiers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67163,7 +68046,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c81",
+    "sortText": "00000cab",
     "filterText": "'Microsoft.Web/sites/slots/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67185,7 +68068,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c82",
+    "sortText": "00000cac",
     "filterText": "'Microsoft.Web/sites/slots/functions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67207,7 +68090,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c83",
+    "sortText": "00000cad",
     "filterText": "'Microsoft.Web/sites/slots/functions/keys appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67229,7 +68112,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c84",
+    "sortText": "00000cae",
     "filterText": "'Microsoft.Web/sites/slots/hostNameBindings appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67251,7 +68134,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c86",
+    "sortText": "00000cb0",
     "filterText": "'Microsoft.Web/sites/slots/hybridConnectionNamespaces/relays appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67273,7 +68156,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c85",
+    "sortText": "00000caf",
     "filterText": "'Microsoft.Web/sites/slots/hybridconnection appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67295,7 +68178,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c87",
+    "sortText": "00000cb1",
     "filterText": "'Microsoft.Web/sites/slots/instances appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67317,7 +68200,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c88",
+    "sortText": "00000cb2",
     "filterText": "'Microsoft.Web/sites/slots/instances/deployments appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67339,7 +68222,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c89",
+    "sortText": "00000cb3",
     "filterText": "'Microsoft.Web/sites/slots/instances/extensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67361,7 +68244,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c8a",
+    "sortText": "00000cb4",
     "filterText": "'Microsoft.Web/sites/slots/instances/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67383,7 +68266,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c8b",
+    "sortText": "00000cb5",
     "filterText": "'Microsoft.Web/sites/slots/instances/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67405,7 +68288,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c8c",
+    "sortText": "00000cb6",
     "filterText": "'Microsoft.Web/sites/slots/instances/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67427,7 +68310,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c8d",
+    "sortText": "00000cb7",
     "filterText": "'Microsoft.Web/sites/slots/migratemysql appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67449,7 +68332,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c8e",
+    "sortText": "00000cb8",
     "filterText": "'Microsoft.Web/sites/slots/networkConfig appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67471,7 +68354,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c8f",
+    "sortText": "00000cb9",
     "filterText": "'Microsoft.Web/sites/slots/networkFeatures appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67493,7 +68376,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c90",
+    "sortText": "00000cba",
     "filterText": "'Microsoft.Web/sites/slots/premieraddons appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67515,7 +68398,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c91",
+    "sortText": "00000cbb",
     "filterText": "'Microsoft.Web/sites/slots/privateAccess appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67537,7 +68420,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c92",
+    "sortText": "00000cbc",
     "filterText": "'Microsoft.Web/sites/slots/privateEndpointConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67559,7 +68442,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c93",
+    "sortText": "00000cbd",
     "filterText": "'Microsoft.Web/sites/slots/processes appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67581,7 +68464,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c94",
+    "sortText": "00000cbe",
     "filterText": "'Microsoft.Web/sites/slots/processes/modules appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67603,7 +68486,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c95",
+    "sortText": "00000cbf",
     "filterText": "'Microsoft.Web/sites/slots/processes/threads appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67625,7 +68508,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c96",
+    "sortText": "00000cc0",
     "filterText": "'Microsoft.Web/sites/slots/publicCertificates appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67647,7 +68530,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c97",
+    "sortText": "00000cc1",
     "filterText": "'Microsoft.Web/sites/slots/resourceHealthMetadata appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67669,7 +68552,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c98",
+    "sortText": "00000cc2",
     "filterText": "'Microsoft.Web/sites/slots/sitecontainers appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67691,7 +68574,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c99",
+    "sortText": "00000cc3",
     "filterText": "'Microsoft.Web/sites/slots/siteextensions appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67713,7 +68596,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c9a",
+    "sortText": "00000cc4",
     "filterText": "'Microsoft.Web/sites/slots/sourcecontrols appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67735,7 +68618,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c9b",
+    "sortText": "00000cc5",
     "filterText": "'Microsoft.Web/sites/slots/triggeredwebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67757,7 +68640,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c9c",
+    "sortText": "00000cc6",
     "filterText": "'Microsoft.Web/sites/slots/triggeredwebjobs/history appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67779,7 +68662,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c9d",
+    "sortText": "00000cc7",
     "filterText": "'Microsoft.Web/sites/slots/virtualNetworkConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67801,7 +68684,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c9e",
+    "sortText": "00000cc8",
     "filterText": "'Microsoft.Web/sites/slots/virtualNetworkConnections/gateways appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67823,7 +68706,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000c9f",
+    "sortText": "00000cc9",
     "filterText": "'Microsoft.Web/sites/slots/webjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67845,7 +68728,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca0",
+    "sortText": "00000cca",
     "filterText": "'Microsoft.Web/sites/sourcecontrols appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67867,7 +68750,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca1",
+    "sortText": "00000ccb",
     "filterText": "'Microsoft.Web/sites/triggeredwebjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67889,7 +68772,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca2",
+    "sortText": "00000ccc",
     "filterText": "'Microsoft.Web/sites/triggeredwebjobs/history appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67911,7 +68794,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca3",
+    "sortText": "00000ccd",
     "filterText": "'Microsoft.Web/sites/virtualNetworkConnections appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67933,7 +68816,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca4",
+    "sortText": "00000cce",
     "filterText": "'Microsoft.Web/sites/virtualNetworkConnections/gateways appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67955,7 +68838,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca5",
+    "sortText": "00000ccf",
     "filterText": "'Microsoft.Web/sites/webjobs appservice webapp function'",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
@@ -67977,7 +68860,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca6",
+    "sortText": "00000cd0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -67998,7 +68881,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca7",
+    "sortText": "00000cd1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68019,7 +68902,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca8",
+    "sortText": "00000cd2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68040,7 +68923,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ca9",
+    "sortText": "00000cd3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68061,7 +68944,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000caa",
+    "sortText": "00000cd4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68082,7 +68965,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cab",
+    "sortText": "00000cd5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68103,7 +68986,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cac",
+    "sortText": "00000cd6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68124,7 +69007,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cad",
+    "sortText": "00000cd7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68145,7 +69028,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cae",
+    "sortText": "00000cd8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68166,7 +69049,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000caf",
+    "sortText": "00000cd9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68187,7 +69070,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb0",
+    "sortText": "00000cda",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68208,7 +69091,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb1",
+    "sortText": "00000cdb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68229,7 +69112,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb2",
+    "sortText": "00000cdc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68250,7 +69133,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb3",
+    "sortText": "00000cdd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68271,7 +69154,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb4",
+    "sortText": "00000cde",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68292,7 +69175,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb5",
+    "sortText": "00000cdf",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68313,7 +69196,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb6",
+    "sortText": "00000ce0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68334,7 +69217,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb7",
+    "sortText": "00000ce1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68355,7 +69238,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb8",
+    "sortText": "00000ce2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68376,7 +69259,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cb9",
+    "sortText": "00000ce3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68397,7 +69280,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cba",
+    "sortText": "00000ce4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68418,7 +69301,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cbb",
+    "sortText": "00000ce5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68439,7 +69322,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cbc",
+    "sortText": "00000ce6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68460,7 +69343,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cbd",
+    "sortText": "00000ce7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68481,7 +69364,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cbe",
+    "sortText": "00000ce8",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68502,7 +69385,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cbf",
+    "sortText": "00000ce9",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68523,7 +69406,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc1",
+    "sortText": "00000ceb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68544,7 +69427,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc0",
+    "sortText": "00000cea",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68565,7 +69448,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc2",
+    "sortText": "00000cec",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68586,7 +69469,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc3",
+    "sortText": "00000ced",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68607,7 +69490,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc4",
+    "sortText": "00000cee",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68628,7 +69511,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc5",
+    "sortText": "00000cef",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68649,7 +69532,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc6",
+    "sortText": "00000cf0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68670,7 +69553,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc7",
+    "sortText": "00000cf1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68691,7 +69574,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc8",
+    "sortText": "00000cf2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68712,7 +69595,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cc9",
+    "sortText": "00000cf3",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68733,7 +69616,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cca",
+    "sortText": "00000cf4",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68754,7 +69637,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ccb",
+    "sortText": "00000cf5",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68775,7 +69658,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ccc",
+    "sortText": "00000cf6",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68796,12 +69679,54 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ccd",
+    "sortText": "00000cf7",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
       "newText": "'MongoDB.Atlas/organizations@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'MongoDB.Atlas/organizations/projects'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `MongoDB.Atlas/organizations/projects`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000cf8",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'MongoDB.Atlas/organizations/projects@$0'"
+    },
+    "command": {
+      "title": "resource type completion",
+      "command": "editor.action.triggerSuggest"
+    }
+  },
+  {
+    "label": "'MongoDB.Atlas/organizations/projects/clusters'",
+    "kind": "class",
+    "documentation": {
+      "kind": "markdown",
+      "value": "Type: `MongoDB.Atlas/organizations/projects/clusters`  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "00000cf9",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "'MongoDB.Atlas/organizations/projects/clusters@$0'"
     },
     "command": {
       "title": "resource type completion",
@@ -68817,7 +69742,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cce",
+    "sortText": "00000cfa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68838,7 +69763,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ccf",
+    "sortText": "00000cfb",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68859,7 +69784,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd0",
+    "sortText": "00000cfc",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68880,7 +69805,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd1",
+    "sortText": "00000cfd",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68901,7 +69826,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd2",
+    "sortText": "00000cfe",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68922,7 +69847,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd3",
+    "sortText": "00000cff",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68943,7 +69868,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd4",
+    "sortText": "00000d00",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68964,7 +69889,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd5",
+    "sortText": "00000d01",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -68985,7 +69910,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd6",
+    "sortText": "00000d02",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69006,7 +69931,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd7",
+    "sortText": "00000d03",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69027,7 +69952,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd8",
+    "sortText": "00000d04",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69048,7 +69973,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cd9",
+    "sortText": "00000d05",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69069,7 +69994,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cda",
+    "sortText": "00000d06",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69090,7 +70015,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cdb",
+    "sortText": "00000d07",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69111,7 +70036,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cdc",
+    "sortText": "00000d08",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69132,7 +70057,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cdd",
+    "sortText": "00000d09",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69153,7 +70078,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cde",
+    "sortText": "00000d0a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69174,7 +70099,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cdf",
+    "sortText": "00000d0b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69195,7 +70120,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce0",
+    "sortText": "00000d0c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69216,7 +70141,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce1",
+    "sortText": "00000d0d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69237,7 +70162,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce2",
+    "sortText": "00000d0e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69258,7 +70183,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce3",
+    "sortText": "00000d0f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69279,7 +70204,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce4",
+    "sortText": "00000d10",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69300,7 +70225,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce5",
+    "sortText": "00000d11",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69321,7 +70246,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce6",
+    "sortText": "00000d12",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69342,7 +70267,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce7",
+    "sortText": "00000d13",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69363,7 +70288,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce8",
+    "sortText": "00000d14",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69384,7 +70309,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ce9",
+    "sortText": "00000d15",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69405,7 +70330,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cea",
+    "sortText": "00000d16",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69426,7 +70351,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ceb",
+    "sortText": "00000d17",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69447,7 +70372,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cec",
+    "sortText": "00000d18",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69468,7 +70393,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000ced",
+    "sortText": "00000d19",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69489,7 +70414,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cee",
+    "sortText": "00000d1a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69510,7 +70435,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cef",
+    "sortText": "00000d1b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69531,7 +70456,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf0",
+    "sortText": "00000d1c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69552,7 +70477,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf1",
+    "sortText": "00000d1d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69573,7 +70498,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf2",
+    "sortText": "00000d1e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69594,7 +70519,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf3",
+    "sortText": "00000d1f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69615,7 +70540,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf4",
+    "sortText": "00000d20",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69636,7 +70561,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf5",
+    "sortText": "00000d21",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69657,7 +70582,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf6",
+    "sortText": "00000d22",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69678,7 +70603,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf7",
+    "sortText": "00000d23",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69699,7 +70624,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf9",
+    "sortText": "00000d25",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69720,7 +70645,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cf8",
+    "sortText": "00000d24",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69741,7 +70666,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cfa",
+    "sortText": "00000d26",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69762,7 +70687,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cfb",
+    "sortText": "00000d27",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69783,7 +70708,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cfc",
+    "sortText": "00000d28",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69804,7 +70729,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cfd",
+    "sortText": "00000d29",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69825,7 +70750,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cfe",
+    "sortText": "00000d2a",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69846,7 +70771,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000cff",
+    "sortText": "00000d2b",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69867,7 +70792,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d00",
+    "sortText": "00000d2c",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69888,7 +70813,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d01",
+    "sortText": "00000d2d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69909,7 +70834,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d02",
+    "sortText": "00000d2e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69930,7 +70855,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d03",
+    "sortText": "00000d2f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69951,7 +70876,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d04",
+    "sortText": "00000d30",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69972,7 +70897,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d05",
+    "sortText": "00000d31",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -69993,7 +70918,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d06",
+    "sortText": "00000d32",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70014,7 +70939,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d07",
+    "sortText": "00000d33",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70035,7 +70960,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d08",
+    "sortText": "00000d34",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70056,7 +70981,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000d09",
+    "sortText": "00000d35",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70077,7 +71002,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000322",
+    "sortText": "00000333",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70098,7 +71023,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000323",
+    "sortText": "00000334",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70119,7 +71044,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034b",
+    "sortText": "0000035d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70140,7 +71065,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000034c",
+    "sortText": "0000035e",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70161,7 +71086,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000000d",
+    "sortText": "00000013",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70182,7 +71107,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000000e",
+    "sortText": "00000014",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70203,7 +71128,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000000f",
+    "sortText": "00000015",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70224,7 +71149,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000010",
+    "sortText": "00000016",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70245,7 +71170,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000011",
+    "sortText": "00000017",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70266,7 +71191,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000029",
+    "sortText": "0000002f",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70287,7 +71212,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000618",
+    "sortText": "00000639",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70308,7 +71233,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067c",
+    "sortText": "0000069d",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70329,7 +71254,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000067f",
+    "sortText": "000006a0",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70350,7 +71275,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000680",
+    "sortText": "000006a1",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70371,7 +71296,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000681",
+    "sortText": "000006a2",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70392,7 +71317,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "00000689",
+    "sortText": "000006aa",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {
@@ -70413,7 +71338,7 @@
     },
     "deprecated": false,
     "preselect": false,
-    "sortText": "0000068a",
+    "sortText": "000006ab",
     "insertTextFormat": "snippet",
     "insertTextMode": "adjustIndentation",
     "textEdit": {

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.json
@@ -10,7 +10,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "629611936207907589"
+      "templateHash": "17632740910680095755"
     }
   },
   "parameters": {
@@ -31,7 +31,7 @@
   "extensions": {
     "az": {
       "name": "AzureResourceManager",
-      "version": "0.2.871"
+      "version": "0.2.881"
     },
     "k8s": {
       "name": "Kubernetes",

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.sourcemap.bicep
@@ -32,7 +32,7 @@ var strParamVar1 = strParam1
 extension az
 //@    "az": {
 //@      "name": "AzureResourceManager",
-//@      "version": "0.2.871"
+//@      "version": "0.2.881"
 //@    },
 extension kubernetes as k8s
 //@    "k8s": {

--- a/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Extensions_CRLF/main.symbolicnames.json
@@ -10,7 +10,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "629611936207907589"
+      "templateHash": "17632740910680095755"
     }
   },
   "parameters": {
@@ -31,7 +31,7 @@
   "extensions": {
     "az": {
       "name": "AzureResourceManager",
-      "version": "0.2.871"
+      "version": "0.2.881"
     },
     "k8s": {
       "name": "Kubernetes",

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Bicep.Internal.RoslynAnalyzers" Version="0.1.60" />
     <PackageVersion Include="Azure.Bicep.Types" Version="0.6.50" />
-    <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.871" />
+    <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.881" />
     <PackageVersion Include="Azure.Bicep.Types.K8s" Version="0.1.644" />
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
     <PackageVersion Include="Azure.Deployments.Engine" Version="1.683.0" />


### PR DESCRIPTION
## Description

Update the Azure.Bicep.Types.Az package verion:
0.2.871 -> 0.2.881

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20027)