### PR TITLE
Fix force restore command to show picklist if active file is not a bicep file or no file is open

### DIFF
--- a/src/vscode-bicep/src/commands/forceModulesRestore.ts
+++ b/src/vscode-bicep/src/commands/forceModulesRestore.ts
@@ -4,6 +4,7 @@ import { IActionContext, parseError } from "@microsoft/vscode-azext-utils";
 import vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { OutputChannelManager } from "../utils/OutputChannelManager";
+import { findOrCreateActiveBicepFile } from "./findOrCreateActiveBicepFile";
 import { Command } from "./types";
 
 export class ForceModulesRestoreCommand implements Command {
@@ -13,12 +14,12 @@ export class ForceModulesRestoreCommand implements Command {
     private readonly outputChannelManager: OutputChannelManager,
   ) {}
 
-  public async execute(_context: IActionContext, documentUri?: vscode.Uri | undefined): Promise<void> {
-    documentUri ??= vscode.window.activeTextEditor?.document.uri;
-
-    if (!documentUri) {
-      return;
-    }
+  public async execute(context: IActionContext, documentUri?: vscode.Uri | undefined): Promise<void> {
+    documentUri = await findOrCreateActiveBicepFile(
+      context,
+      documentUri,
+      "Choose which Bicep file to restore modules for",
+    );
 
     if (documentUri.scheme === "output") {
       // The output panel in VS Code was implemented as a text editor by accident. Due to breaking change concerns,


### PR DESCRIPTION
## Description

For #10234.

## Example Usage

https://github.com/user-attachments/assets/c4b4bd49-f1b7-43c5-b0b1-8a5bbbd1f308


## Checklist

- [ ] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20029)