### PR TITLE
Use CWD for building dummy file in publish-extension

### DIFF
--- a/src/Bicep.Cli/Commands/PublishExtensionCommand.cs
+++ b/src/Bicep.Cli/Commands/PublishExtensionCommand.cs
@@ -17,6 +17,7 @@ using Bicep.Core.Registry.Oci;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.TypeSystem;
 using Bicep.Core.TypeSystem.Providers.Az;
+using Bicep.Core.Utils;
 using Bicep.IO.Abstraction;
 using Bicep.IO.InMemory;
 using Bicep.Local.Deploy.Extensibility;
@@ -34,6 +35,7 @@ namespace Bicep.Cli.Commands
         IFileExplorer fileExplorer,
         InputOutputArgumentsResolver inputOutputArgumentsResolver,
         ILocalExtensionFactory localExtensionFactory,
+        IEnvironment environment,
         ILogger logger) : ICommand
     {
         public async Task<int> RunAsync(PublishExtensionArguments args, CancellationToken cancellationToken)
@@ -142,7 +144,7 @@ namespace Bicep.Cli.Commands
             }
             else
             {
-                dummyReferencingFileUri = new IOUri("file", "", "/dummy");
+                dummyReferencingFileUri = IOUri.FromFilePath(Path.Join(environment.CurrentDirectory, "dummy"));
             }
 
             var dummyReferencingFile = sourceFileFactory.CreateBicepFile(dummyReferencingFileUri, "");


### PR DESCRIPTION
The bicep config (bicepconfig.json) is resolved from the CWD of the .bicep file being compiled, and searching upwards in the file system, falling back to a default if one is not found.
 
With `publish-extension`, there isn't a .bicep file, yet the API to pick a config file requires one to run the above logic. So it looks like to work around this, the code just creates a dummy file to pass into this API. However, this is never going to be able to resolve an actual file.