### PR TITLE
Remove ISourceFile Uri

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ExtensibilityTests.cs
@@ -9,6 +9,7 @@ using Bicep.Core.UnitTests;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Extensions;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.TextFixtures.IO;
 using Bicep.TextFixtures.Mocks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -834,51 +835,55 @@ resource parent 'az:Microsoft.Storage/storageAccounts@2020-01-01' existing = {
             """{ "kubernetes": { "kubeConfig": "[if(equals(parameters('inputa'), 'a'), extensions('k8s').config.kubeConfig, createObject('value', 'b'))]", "namespace": "[if(equals(parameters('inputa'), 'a'), extensions('k8s').config.namespace, createObject('value', 'c'))]" } }""")]
         public async Task Modules_can_inherit_parent_module_extension_configs(string scenario, string moduleExtensionConfigsStr, string expectedExtConfigJson)
         {
-            var paramsUri = new Uri("file:///main.bicepparam");
-            var mainUri = new Uri("file:///main.bicep");
-            var moduleAUri = new Uri("file:///modulea.bicep");
+            var paramsFileContents =
+                """
+                using 'main.bicep'
 
-            var files = new Dictionary<Uri, string>
-            {
-                [paramsUri] =
-                    """
-                    using 'main.bicep'
+                param inputa = 'abc'
 
-                    param inputa = 'abc'
+                extensionConfig k8s with {
+                  kubeConfig: 'abc'
+                  namespace: 'other'
+                }
+                """;
 
-                    extensionConfig k8s with {
-                      kubeConfig: 'abc'
-                      namespace: 'other'
-                    }
-                    """,
-                [mainUri] =
-                    $$"""
-                      param inputa string
+            var mainFileContents =
+                $$"""
+                param inputa string
 
-                      extension kubernetes as k8s
+                extension kubernetes as k8s
 
-                      module modulea 'modulea.bicep' = {
-                        name: 'modulea'
-                        params: {
-                          inputa: inputa
-                        }
-                        {{moduleExtensionConfigsStr}}
-                      }
+                module modulea 'modulea.bicep' = {
+                  name: 'modulea'
+                  params: {
+                    inputa: inputa
+                  }
+                  {{moduleExtensionConfigsStr}}
+                }
 
-                      output outputa string = modulea.outputs.outputa
-                      """,
-                [moduleAUri] =
-                    """
-                    param inputa string
+                output outputa string = modulea.outputs.outputa
+                """;
 
-                    extension kubernetes
+            var moduleAFileContents =
+                """
+                param inputa string
 
-                    output outputa string = inputa
-                    """
-            };
+                extension kubernetes
+
+                output outputa string = inputa
+                """;
+
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicepparam", paramsFileContents),
+                ("main.bicep", mainFileContents),
+                ("modulea.bicep", moduleAFileContents));
+
+            var paramsUri = fileSet.GetUri("main.bicepparam");
+            var mainUri = fileSet.GetUri("main.bicep");
 
             var services = await CreateServiceBuilderWithMockMsGraph(moduleExtensionConfigsEnabled: true);
-            var compilation = services.BuildCompilation(files, paramsUri);
+            var compiler = services.WithFileExplorer(fileSet.FileExplorer).Build().GetCompiler();
+            var compilation = compiler.CreateCompilationWithoutRestore(paramsUri);
 
             compilation.Should().NotHaveAnyDiagnostics_WithAssertionScoping(d => d.IsError());
 

--- a/src/Bicep.Core.IntegrationTests/Scenarios/LocalJsonModuleTests.cs
+++ b/src/Bicep.Core.IntegrationTests/Scenarios/LocalJsonModuleTests.cs
@@ -6,6 +6,7 @@ using Bicep.Core.Diagnostics;
 using Bicep.Core.Semantics;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.IO.Abstraction;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -123,8 +124,7 @@ module mod 'module.json' = {
             }
         }
 
-        // TODO(file-io-abstraction): Need migration.
         private static ImmutableDictionary<string, ImmutableArray<IDiagnostic>> GetDiagnosticsByFileName(Compilation compilation) =>
-            compilation.GetAllDiagnosticsByBicepFile().ToImmutableDictionary(kvp => Path.GetFileName(kvp.Key.Uri.LocalPath), kvp => kvp.Value);
+            compilation.GetAllDiagnosticsByBicepFile().ToImmutableDictionary(kvp => kvp.Key.FileHandle.Uri.GetFileName(), kvp => kvp.Value);
     }
 }

--- a/src/Bicep.Core.UnitTests/Extensions/CompilationTestExtensions.cs
+++ b/src/Bicep.Core.UnitTests/Extensions/CompilationTestExtensions.cs
@@ -8,7 +8,7 @@ using Bicep.Core.Emit;
 using Bicep.Core.Semantics;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.UnitTests.Utils;
-using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.UnitTests.Extensions;
 
@@ -21,7 +21,7 @@ public static class CompilationTestExtensions
     /// <param name="compilation">The compilation.</param>
     /// <param name="bicepFileUri">(Optional) The Bicep file URI to compile an ARM template from.</param>
     /// <returns>ARM template JSON string.</returns>
-    public static string GetTestTemplate(this Compilation compilation, Uri? bicepFileUri = null)
+    public static string GetTestTemplate(this Compilation compilation, IOUri? bicepFileUri = null)
     {
         var stringBuilder = new StringBuilder();
         var stringWriter = new StringWriter(stringBuilder);
@@ -29,7 +29,7 @@ public static class CompilationTestExtensions
         SemanticModel? bicepFileModel;
         if (bicepFileUri is not null)
         {
-            var targetFile = compilation.SourceFileGrouping.SourceFiles.OfType<BicepFile>().Single(f => f.Uri == bicepFileUri);
+            var targetFile = compilation.SourceFileGrouping.SourceFiles.OfType<BicepFile>().Single(f => f.FileHandle.Uri == bicepFileUri);
             bicepFileModel = compilation.GetSemanticModel(targetFile);
         }
         else if (compilation.SourceFileGrouping.EntryPoint is BicepFile)
@@ -51,20 +51,19 @@ public static class CompilationTestExtensions
     /// Emits and returns the ARM template compiled from the params file compilation.
     /// </summary>
     /// <param name="result">The compilation.</param>
-    /// <param name="bicepFileUri">The Bicep file URI to generate the template from. If not provided, finding a "main.bicep" is attempted.</param>
+    /// <param name="bicepFileName">(Optional) The Bicep file name to compile an ARM template from. Defaults to 'main.bicep'.</param>
     /// <returns>ARM template JSON string.</returns>
-    public static string GetTestTemplate(this CompilationHelper.ParamsCompilationResult result, Uri? bicepFileUri = null)
+    public static string GetTestTemplate(this CompilationHelper.ParamsCompilationResult result, string bicepFileName = "main.bicep")
     {
-        bicepFileUri ??= result.Compilation.SourceFileGrouping.SourceFiles.First(f => f.Uri.AbsoluteUri.EndsWithInsensitively("/main.bicep")).Uri;
-
+        var bicepFileHandle = result.Compilation.SourceFileGrouping.SourceFiles.Single(f => f.FileHandle.Uri.GetFileName().Equals(bicepFileName, StringComparison.OrdinalIgnoreCase)).FileHandle;
         var stringBuilder = new StringBuilder();
         var stringWriter = new StringWriter(stringBuilder);
 
-        var model = result.Compilation.GetSemanticModel(result.Compilation.SourceFileGrouping.SourceFiles.Single(f => f.Uri == bicepFileUri));
+        var model = result.Compilation.GetSemanticModel(result.Compilation.SourceFileGrouping.SourceFiles.Single(f => f.FileHandle == bicepFileHandle));
 
         if (model is not SemanticModel bicepFileModel)
         {
-            throw new InvalidOperationException($"The file with URI '{bicepFileUri}' is not a '{nameof(BicepFile)}'. An ARM template cannot be emitted.");
+            throw new InvalidOperationException($"The file with URI '{bicepFileHandle}' is not a '{nameof(BicepFile)}'. An ARM template cannot be emitted.");
         }
 
         var emitter = new TemplateEmitter(bicepFileModel);

--- a/src/Bicep.Core/SourceGraph/ArmTemplateFile.cs
+++ b/src/Bicep.Core/SourceGraph/ArmTemplateFile.cs
@@ -17,14 +17,11 @@ namespace Bicep.Core.SourceGraph
                 throw new ArgumentException($"Expected {nameof(template)} and {nameof(templateObject)} to both be non-null or both be null.");
             }
 
-            this.Uri = fileHandle.Uri.ToUri();
             this.FileHandle = fileHandle;
             this.Text = text;
             this.Template = template;
             this.TemplateObject = templateObject;
         }
-
-        public Uri Uri { get; }
 
         public IFileHandle FileHandle { get; }
 

--- a/src/Bicep.Core/SourceGraph/BicepFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepFile.cs
@@ -23,7 +23,6 @@ namespace Bicep.Core.SourceGraph
             IDiagnosticLookup lexingErrorLookup,
             IDiagnosticLookup parsingErrorLookup)
             : base(
-                  fileHandle.Uri.ToUri(),
                   fileHandle,
                   lineStarts,
                   programSyntax,

--- a/src/Bicep.Core/SourceGraph/BicepParamFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepParamFile.cs
@@ -23,7 +23,6 @@ namespace Bicep.Core.SourceGraph
             IDiagnosticLookup lexingErrorLookup,
             IDiagnosticLookup parsingErrorLookup)
             : base(
-                  fileHandle.Uri.ToUri(),
                   fileHandle,
                   lineStarts,
                   programSyntax,

--- a/src/Bicep.Core/SourceGraph/BicepReplFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepReplFile.cs
@@ -23,7 +23,6 @@ public class BicepReplFile : BicepSourceFile
         IDiagnosticLookup lexingErrorLookup,
         IDiagnosticLookup parsingErrorLookup)
         : base(
-            fileHandle.Uri.ToUri(),
             fileHandle,
             lineStarts,
             programSyntax,

--- a/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
+++ b/src/Bicep.Core/SourceGraph/BicepSourceFile.cs
@@ -24,7 +24,6 @@ namespace Bicep.Core.SourceGraph
         private readonly ConcurrentBag<IOUri> referencedAuxiliaryFileUris;
 
         protected BicepSourceFile(
-            Uri fileUri,
             IFileHandle fileHandle,
             ImmutableArray<int> lineStarts,
             ProgramSyntax programSyntax,
@@ -34,7 +33,6 @@ namespace Bicep.Core.SourceGraph
             IDiagnosticLookup lexingErrorLookup,
             IDiagnosticLookup parsingErrorLookup)
         {
-            this.Uri = fileUri;
             this.FileHandle = fileHandle;
             this.LineStarts = lineStarts;
             this.ProgramSyntax = programSyntax;
@@ -50,7 +48,6 @@ namespace Bicep.Core.SourceGraph
 
         protected BicepSourceFile(BicepSourceFile original)
         {
-            this.Uri = original.Uri;
             this.FileHandle = original.FileHandle;
             this.LineStarts = original.LineStarts;
             this.ProgramSyntax = original.ProgramSyntax;
@@ -63,8 +60,6 @@ namespace Bicep.Core.SourceGraph
             this.ParsingErrorLookup = original.ParsingErrorLookup;
             this.DisabledDiagnosticsCache = original.DisabledDiagnosticsCache;
         }
-
-        public Uri Uri { get; }
 
         public IFileHandle FileHandle { get; }
 

--- a/src/Bicep.Core/SourceGraph/ISourceFile.cs
+++ b/src/Bicep.Core/SourceGraph/ISourceFile.cs
@@ -7,9 +7,6 @@ namespace Bicep.Core.SourceGraph
 {
     public interface ISourceFile
     {
-        // TODO(file-io-abstraction): This is now only referenced in tests. Remove after migration is done.
-        Uri Uri { get; }
-
         IFileHandle FileHandle { get; }
 
         string Text { get; }

--- a/src/Bicep.Core/SourceGraph/TemplateSpecFile.cs
+++ b/src/Bicep.Core/SourceGraph/TemplateSpecFile.cs
@@ -9,14 +9,11 @@ namespace Bicep.Core.SourceGraph
     {
         public TemplateSpecFile(IFileHandle fileHandle, string text, string? templateSpecId, ArmTemplateFile mainTemplateFile)
         {
-            this.Uri = fileHandle.Uri.ToUri();
             this.FileHandle = fileHandle;
             this.Text = text;
             this.TemplateSpecId = templateSpecId;
             this.MainTemplateFile = mainTemplateFile;
         }
-
-        public Uri Uri { get; }
 
         public IFileHandle FileHandle { get; }
 


### PR DESCRIPTION
Removes the obsolete `ISourceFile.Uri` property and migrates remaining test helpers/call sites to use `FileHandle.Uri` / `IOUri` instead.

Summary:
- Remove `Uri` from the `ISourceFile` contract and concrete source file classes.
- Update test template helpers to accept `IOUri`.
- Move remaining test usage from `sourceFile.Uri` to `sourceFile.FileHandle.Uri`.
- Update the extension config inheritance test to use `InMemoryTestFileSet`.

Validation:
- `dotnet build .\Bicep.sln /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20037)