### PR TITLE
Fix Azure.Deployments.Templates rejects copy.count: 0; real ARM accepts as no-op  #19745

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ScenarioTests.cs
@@ -7892,4 +7892,51 @@ output locations array = flatten(map(databases, database => database.properties.
             ("BCP065", DiagnosticLevel.Error, """Function "utcNow" is not valid at this location. It can only be used as a parameter default value."""),
         ]);
     }
+
+    [TestMethod]
+    // https://github.com/azure/bicep/issues/19745
+    public void Test_Issue19745_EmptyArrayResourceLoopEvaluationShouldSucceed()
+    {
+        // Test that Bicep templates with empty array resource loops (copy.count = 0) can be evaluated successfully.
+        // Real Azure ARM accepts copy.count = 0 as a no-op (no resources deployed).
+        // This tests the workaround for the external Azure.Deployments.Templates package validation error.
+
+        var bicepTemplate = @"
+param items array = []
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = [for item in items: {
+  name: 'st${uniqueString(item)}'
+  location: resourceGroup().location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}]
+
+output deployedCount int = length(storage)
+";
+
+        var compilationResult = CompilationHelper.Compile(bicepTemplate);
+        compilationResult.Should().NotHaveAnyCompilationBlockingDiagnostics();
+        compilationResult.Template.Should().NotBeNull();
+
+        // Verify the compiled template has the copy block with length expression
+        var template = compilationResult.Template!;
+        template.Should().NotBeNull();
+
+        // Evaluate the template to ensure no validation error occurs
+        var armTemplate = template.ToJToken();
+        
+        // The TemplateEvaluator.Evaluate call should not throw an exception for copy.count = 0
+        var evaluatedTemplate = TemplateEvaluator.Evaluate(
+            armTemplate,
+            parametersJToken: null,
+            configBuilder: config => config,
+            features: null
+        );
+
+        evaluatedTemplate.Should().NotBeNull();
+        // Verify that resources with zero copy count were handled correctly
+        evaluatedTemplate.Resources.Should().HaveCount(0, because: "the storage resource has copy.count = 0 and should be excluded");
+    }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,10 +15,10 @@
     <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.871" />
     <PackageVersion Include="Azure.Bicep.Types.K8s" Version="0.1.644" />
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Deployments.Engine" Version="1.683.0" />
+    <PackageVersion Include="Azure.Deployments.Engine" Version="1.710.0" />
     <PackageVersion Include="Azure.Deployments.Extensibility.Core" Version="0.1.67" />
     <PackageVersion Include="Azure.Deployments.Internal.GenerateNotice" Version="0.1.60" />
-    <PackageVersion Include="Azure.Deployments.Templates" Version="1.683.0" />
+    <PackageVersion Include="Azure.Deployments.Templates" Version="1.710.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.ResourceManager.ResourceGraph" Version="1.1.1" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.11.2" />
@@ -59,7 +59,7 @@
     <PackageVersion Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.PowerPlatform.ResourceStack" Version="7.0.0.2080" />
+    <PackageVersion Include="Microsoft.PowerPlatform.ResourceStack" Version="7.0.0.2089" />
     <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.11.35222.181" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.12.18" />


### PR DESCRIPTION
Fixed https://github.com/Azure/bicep/issues/19745 


The external Azure.Deployments packages v1.710.0 now properly support copy.count = 0 (treating it as a no-op instead of an error). This is consistent with real Azure ARM behavior and aligns with API version 2019-05-10 and later.

Changes:
- Upgrade Azure.Deployments.Engine from 1.683.0 to 1.710.0
- Upgrade Azure.Deployments.Templates from 1.683.0 to 1.710.0
- Upgrade Microsoft.PowerPlatform.ResourceStack from 7.0.0.2080 to 7.0.0.2089
- Remove RemoveZeroCopyCounts workaround method from TemplateEvaluator
- Remove test workaround code that was skipping evaluation with zero-count resources
- Add regression test confirming empty array for-loops now compile successfully

Fixes: #19745

## Description

<!-- Provide a 1-2 sentence description of your change -->

## Example Usage

<!-- Provide example usage if you are making syntax or CLI changes. 
     Provide screenshots if you are making changes to editor user experience.
     Delete this section if it doesn't apply to your change. -->

## Checklist

- [ ] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20039)