### PR TITLE
Fix export of non-pure symbols

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ModuleContentDeduplicationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ModuleContentDeduplicationTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Bicep.Core.UnitTests;
+using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Features;
+using Bicep.Core.UnitTests.Utils;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.IntegrationTests
+{
+    [TestClass]
+    public class ModuleContentDeduplicationTests
+    {
+        [NotNull]
+        public TestContext? TestContext { get; set; }
+
+        private ServiceBuilder ServicesWithFeature
+            => new ServiceBuilder().WithFeatureOverrides(new FeatureProviderOverrides(TestContext, ModuleContentDeduplicationEnabled: true));
+
+        [TestMethod]
+        public void Enabled_emits_templateLink_contentId_and_deduplicates_identical_modules()
+        {
+            var result = CompilationHelper.Compile(
+                ServicesWithFeature,
+                ("main.bicep", """
+                    module mod1 'mod.bicep' = {
+                      name: 'mod1'
+                      params: { foo: 'a' }
+                    }
+
+                    module mod2 'mod.bicep' = {
+                      name: 'mod2'
+                      params: { foo: 'b' }
+                    }
+                    """),
+                ("mod.bicep", """
+                    param foo string
+                    output bar string = foo
+                    """));
+
+            result.Should().NotHaveAnyDiagnostics();
+            var template = result.Template!;
+
+            var contentId = template.SelectToken("$.resources['mod1'].properties.templateLink.contentId")?.ToString();
+            contentId.Should().NotBeNull();
+            contentId.Should().StartWith("sha256:");
+
+            using (new AssertionScope())
+            {
+                // The nested template is no longer inlined; both modules reference the shared content by id.
+                template.Should().NotHaveValueAtPath("$.resources['mod1'].properties.template");
+                template.Should().HaveValueAtPath("$.resources['mod1'].properties.templateLink", JToken.Parse($$"""
+                    { "contentId": "{{contentId}}" }
+                    """));
+
+                // Identical module bodies deduplicate to the same contentId.
+                template.Should().HaveValueAtPath("$.resources['mod2'].properties.templateLink", JToken.Parse($$"""
+                    { "contentId": "{{contentId}}" }
+                    """));
+
+                // The stored body is wrapped under "value".
+                template.Should().HaveValueAtPath($"$.content['{contentId}'].value.parameters", JToken.Parse("""
+                    {
+                      "foo": { "type": "string" }
+                    }
+                    """));
+                template.Should().HaveValueAtPath($"$.content['{contentId}'].value.outputs", JToken.Parse("""
+                    {
+                      "bar": { "type": "string", "value": "[parameters('foo')]" }
+                    }
+                    """));
+
+                // The shared store holds exactly one (deduplicated) entry.
+                ((JObject)template.SelectToken("$.content")!).Properties().Should().ContainSingle();
+            }
+        }
+
+        [TestMethod]
+        public void Enabled_deduplicates_nested_modules_into_single_top_level_store()
+        {
+            var result = CompilationHelper.Compile(
+                ServicesWithFeature,
+                ("main.bicep", """
+                    module parent 'parent.bicep' = {
+                      name: 'parent'
+                    }
+                    """),
+                ("parent.bicep", """
+                    module child1 'leaf.bicep' = {
+                      name: 'child1'
+                      params: { foo: 'a' }
+                    }
+                    module child2 'leaf.bicep' = {
+                      name: 'child2'
+                      params: { foo: 'b' }
+                    }
+                    """),
+                ("leaf.bicep", """
+                    param foo string
+                    output bar string = foo
+                    """));
+
+            result.Should().NotHaveAnyDiagnostics();
+            var template = result.Template!;
+
+            // The single top-level content store contains the parent and the (deduplicated) leaf.
+            var content = (JObject)template.SelectToken("$.content")!;
+            content.Properties().Should().HaveCount(2);
+
+            // Locate the parent's stored body (the entry whose value declares child modules).
+            var parentValue = content.Properties()
+                .Select(p => p.Value["value"]!)
+                .Single(v => v["resources"]?["child1"] is not null);
+
+            var child1Link = parentValue.SelectToken("resources.child1.properties.templateLink");
+
+            using (new AssertionScope())
+            {
+                // Nested module bodies also reference content by id rather than inlining templates.
+                parentValue.SelectToken("resources.child1.properties.template").Should().BeNull();
+                child1Link.Should().NotBeNull();
+
+                // Both children reference the same deduplicated leaf content.
+                parentValue.SelectToken("resources.child2.properties.templateLink").Should().DeepEqual(child1Link!);
+
+                // And the referenced leaf actually exists in the shared top-level store.
+                var leafContentId = child1Link!["contentId"]!.ToString();
+                content.Properties().Select(p => p.Name).Should().Contain(leafContentId);
+            }
+        }
+
+        [TestMethod]
+        public void Disabled_by_default_inlines_nested_templates_and_omits_content_store()
+        {
+            // Symbolic names are enabled purely so the emitted resources are an object map (stable JSONPath);
+            // the content-deduplication feature itself remains disabled.
+            var services = new ServiceBuilder().WithFeatureOverrides(new FeatureProviderOverrides(TestContext, SymbolicNameCodegenEnabled: true));
+            var result = CompilationHelper.Compile(
+                services,
+                ("main.bicep", """
+                    module mod 'mod.bicep' = {
+                      name: 'mod'
+                      params: { foo: 'a' }
+                    }
+                    """),
+                ("mod.bicep", """
+                    param foo string
+                    output bar string = foo
+                    """));
+
+            result.Should().NotHaveAnyDiagnostics();
+            var template = result.Template!;
+
+            using (new AssertionScope())
+            {
+                template.Should().HaveValueAtPath("$.resources['mod'].properties.template.$schema", "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#");
+                template.Should().NotHaveValueAtPath("$.resources['mod'].properties.templateLink");
+                template.Should().NotHaveValueAtPath("$.content");
+            }
+        }
+    }
+}

--- a/src/Bicep.Core.Samples/DataSets.cs
+++ b/src/Bicep.Core.Samples/DataSets.cs
@@ -98,9 +98,13 @@ namespace Bicep.Core.Samples
 
         public static DataSet Modules_CRLF => CreateDataSet();
 
+        public static DataSet ModulesContentManifest_CRLF => CreateDataSet();
+
         public static DataSet ModulesSubscription_LF => CreateDataSet();
 
         public static DataSet ModulesWithScopes_LF => CreateDataSet();
+
+        public static DataSet ModulesWithScopesContentManifest_LF => CreateDataSet();
 
         public static DataSet TestFramework_CRLF => CreateDataSet();
 

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+    "experimentalFeaturesEnabled": {
+        "moduleContentDeduplication": true
+    }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/folder with space/child with space.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/folder with space/child with space.bicep
@@ -1,0 +1,2 @@
+param location string = 'westus'
+output loc string = location

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/moduleb.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/moduleb.bicep
@@ -1,0 +1,8 @@
+param location string
+
+resource myResource 'Mock.Rp/mockResource@2020-01-01' = {
+  name: 'mockResource'
+  location: location
+}
+
+output myResourceId string = myResource.id

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/modulec.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/modulec.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string"
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "name": "myResource",
+      "type": "Mock.Rp/mockResource",
+      "apiVersion": "2020-01-01",
+      "location": "[parameters('location')]"
+    }
+  ],
+  "outputs": {
+    "myResourceId": {
+      "type": "string",
+      "value": "[resourceId('Mock.Rp/mockResource', 'myResource')]"
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/nullableOutputs.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/nullableOutputs.bicep
@@ -1,0 +1,12 @@
+output nullableString string? = 'foo'
+output nullableObj object? = {
+  deeply: {
+    nested: {
+      property: 'value'
+      array: [
+        'foo'
+        'bar'
+      ]
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/optionalParams.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/optionalParams.bicep
@@ -1,0 +1,17 @@
+param optionalString string = 'abc'
+param optionalInt int = 42
+param optionalObj object = {
+  a: 'b'
+}
+param optionalArray array = [
+  1
+  2
+  3
+]
+
+output outputObj object = {
+  optionalString: optionalString
+  optionalInt: optionalInt
+  optionalObj: optionalObj
+  optionalArray: optionalArray
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/secureParams.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/child/secureParams.bicep
@@ -1,0 +1,6 @@
+@secure()
+param secureStringParam1 string
+@secure()
+param secureStringParam2 string = ''
+
+output exposedSecureString string = secureStringParam1

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.bicep
@@ -1,0 +1,401 @@
+
+@sys.description('this is deployTimeSuffix param')
+param deployTimeSuffix string = newGuid()
+
+@sys.description('this module a')
+module modATest './modulea.bicep' = {
+  name: 'modATest'
+  params: {
+    stringParamB: 'hello!'
+    objParam: {
+      a: 'b'
+    }
+    arrayParam: [
+      {
+        a: 'b'
+      }
+      'abc'
+    ]
+  }
+}
+
+
+@sys.description('this module b')
+module modB './child/moduleb.bicep' = {
+  name: 'modB'
+  params: {
+    location: 'West US'
+  }
+}
+
+@sys.description('this is just module b with a condition')
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+  name: 'modBWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module modBWithCondition2 './child/moduleb.bicep' =
+// awkward comment
+if (1 + 1 == 2) {
+  name: 'modBWithCondition2'
+  params: {
+    location: 'East US'
+  }
+}
+
+module modC './child/modulec.json' = {
+  name: 'modC'
+  params: {
+    location: 'West US'
+  }
+}
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+  name: 'modCWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module optionalWithNoParams1 './child/optionalParams.bicep'= {
+  name: 'optionalWithNoParams1'
+}
+
+module optionalWithNoParams2 './child/optionalParams.bicep'= {
+  name: 'optionalWithNoParams2'
+  params: {
+  }
+}
+
+module optionalWithAllParams './child/optionalParams.bicep'= {
+  name: 'optionalWithNoParams3'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+  name: 'harry'
+  properties: {
+    modADep: modATest.outputs.stringOutputA
+    modBDep: modB.outputs.myResourceId
+    modCDep: modC.outputs.myResourceId
+  }
+}
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
+  name: 'optionalWithAllParamsAndManualDependency'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+  dependsOn: [
+    resWithDependencies
+    optionalWithAllParams
+  ]
+}
+
+module optionalWithImplicitDependency './child/optionalParams.bicep'= {
+  name: 'optionalWithImplicitDependency'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+module moduleWithCalculatedName './child/optionalParams.bicep'= {
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  properties: {
+    modADep: moduleWithCalculatedName.outputs.outputObj
+  }
+}
+
+output stringOutputA string = modATest.outputs.stringOutputA
+output stringOutputB string = modATest.outputs.stringOutputB
+output objOutput object = modATest.outputs.objOutput
+output arrayOutput array = modATest.outputs.arrayOutput
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+
+/*
+  valid loop cases
+*/
+
+@sys.description('this is myModules')
+var myModules = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+
+var emptyArray = []
+
+// simple module loop
+module storageResources 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+// simple indexed module loop
+module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules: {
+  name: module.name
+  params: {
+    arrayParam: [
+      i + 1
+    ]
+    objParam: module
+    stringParamB: module.location
+    stringParamA: concat('a', i)
+  }
+}]
+
+// nested module loop
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: [for i in range(0,3): concat('test-', i, '-', module.name)]
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+  name: 'hello-${duplicateAcrossScopes}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+var someDuplicate = true
+var otherDuplicate = false
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+  }
+}]
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+  name: 'propertyLoopInsideParameterValue'
+  params: {
+    objParam: {
+      a: [for i in range(0,10): i]
+      b: [for i in range(1,2): i]
+      c: {
+        d: [for j in range(2,3): j]
+      }
+      e: [for k in range(4,4): {
+        f: k
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j]
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+  params: {
+    objParam: {
+      a: [for (i, i2) in range(0,10): i + i2]
+      b: [for (i, i2) in range(1,2): i / i2]
+      c: {
+        d: [for (j, j2) in range(2,3): j * j2]
+      }
+      e: [for (k, k2) in range(4,4): {
+        f: k
+        g: k2
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j]
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
+  name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+  params: {
+    objParam: {
+      a: [for i in range(0,10): i + thing]
+      b: [for i in range(1,2): i * thing]
+      c: {
+        d: [for j in range(2,3): j]
+      }
+      e: [for k in range(4,4): {
+        f: k - thing
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j % (thing + 1)]
+      }
+    ]
+  }
+}]
+
+
+// BEGIN: Key Vault Secret Reference
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'testkeyvault'
+}
+
+module secureModule1 'child/secureParams.bicep' = {
+  name: 'secureModule1'
+  params: {
+    secureStringParam1: kv.getSecret('mySecret')
+    secureStringParam2: kv.getSecret('mySecret','secretVersion')
+  }
+}
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'testkeyvault'
+  scope: resourceGroup('otherGroup')
+}
+
+module secureModule2 'child/secureParams.bicep' = {
+  name: 'secureModule2'
+  params: {
+    secureStringParam1: scopedKv.getSecret('mySecret')
+    secureStringParam2: scopedKv.getSecret('mySecret','secretVersion')
+  }
+}
+
+//looped module with looped existing resource (Issue #2862)
+var vaults = [
+  {
+    vaultName: 'test-1-kv'
+    vaultRG: 'test-1-rg'
+    vaultSub: 'abcd-efgh'
+  }
+  {
+    vaultName: 'test-2-kv'
+    vaultRG: 'test-2-rg'
+    vaultSub: 'ijkl-1adg1'
+  }
+]
+var secrets = [
+  {
+    name: 'secret01'
+    version: 'versionA'
+  }
+  {
+    name: 'secret02'
+    version: 'versionB'
+  }
+]
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [for vault in vaults: {
+  name: vault.vaultName
+  scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+}]
+
+module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secrets: {
+  name: 'secureModuleLooped-${i}'
+  params: {
+    secureStringParam1: loopedKv[i].getSecret(secret.name)
+    secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+  }
+}]
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+  name: 'secureModuleCondition'
+  params: {
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret','secretVersion') : 'notTrue'
+  }
+}
+
+// END: Key Vault Secret Reference
+
+module withSpace 'module with space.bicep' = {
+  name: 'withSpace'
+}
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+  name: 'childWithSpace'
+}
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+
+module moduleWithNameof 'modulea.bicep' = {
+  name: 'nameofModule'
+  scope: resourceGroup(nameof(nameofModuleParam))
+  params:{
+    stringParamA: nameof(withSpace)
+    stringParamB: nameof(folderWithSpace)
+    objParam: {
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+    }
+    arrayParam: [
+      nameof(vaults)
+    ]
+  }
+}
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+  name: 'nullableOutputs'
+}
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.diagnostics.bicep
@@ -1,0 +1,417 @@
+
+@sys.description('this is deployTimeSuffix param')
+param deployTimeSuffix string = newGuid()
+
+@sys.description('this module a')
+module modATest './modulea.bicep' = {
+  name: 'modATest'
+  params: {
+    stringParamB: 'hello!'
+    objParam: {
+      a: 'b'
+    }
+    arrayParam: [
+      {
+        a: 'b'
+      }
+      'abc'
+    ]
+  }
+}
+
+
+@sys.description('this module b')
+module modB './child/moduleb.bicep' = {
+  name: 'modB'
+  params: {
+    location: 'West US'
+  }
+}
+
+@sys.description('this is just module b with a condition')
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+  name: 'modBWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module modBWithCondition2 './child/moduleb.bicep' =
+// awkward comment
+if (1 + 1 == 2) {
+  name: 'modBWithCondition2'
+  params: {
+    location: 'East US'
+  }
+}
+
+module modC './child/modulec.json' = {
+  name: 'modC'
+  params: {
+    location: 'West US'
+  }
+}
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+  name: 'modCWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module optionalWithNoParams1 './child/optionalParams.bicep'= {
+  name: 'optionalWithNoParams1'
+}
+
+module optionalWithNoParams2 './child/optionalParams.bicep'= {
+  name: 'optionalWithNoParams2'
+  params: {
+  }
+}
+
+module optionalWithAllParams './child/optionalParams.bicep'= {
+  name: 'optionalWithNoParams3'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[29:62) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (bicep https://aka.ms/bicep/core-diagnostics#BCP081) |'Mock.Rp/mockResource@2020-01-01'|
+  name: 'harry'
+  properties: {
+    modADep: modATest.outputs.stringOutputA
+    modBDep: modB.outputs.myResourceId
+    modCDep: modC.outputs.myResourceId
+  }
+}
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
+  name: 'optionalWithAllParamsAndManualDependency'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+  dependsOn: [
+    resWithDependencies
+    optionalWithAllParams
+  ]
+}
+
+module optionalWithImplicitDependency './child/optionalParams.bicep'= {
+  name: 'optionalWithImplicitDependency'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[20:97) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter-diagnostics#prefer-interpolation) |concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)|
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+module moduleWithCalculatedName './child/optionalParams.bicep'= {
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[20:97) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter-diagnostics#prefer-interpolation) |concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)|
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[43:76) [BCP081 (Warning)] Resource type "Mock.Rp/mockResource@2020-01-01" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed. (bicep https://aka.ms/bicep/core-diagnostics#BCP081) |'Mock.Rp/mockResource@2020-01-01'|
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@[08:77) [use-stable-resource-identifiers (Warning)] Resource identifiers should be reproducible outside of their initial deployment context. Resource resWithCalculatedNameDependencies's 'name' identifier is potentially nondeterministic due to its use of the 'newGuid' function (resWithCalculatedNameDependencies.name -> deployTimeSuffix (default value) -> newGuid()). (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-stable-resource-identifiers) |'${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'|
+  properties: {
+    modADep: moduleWithCalculatedName.outputs.outputObj
+  }
+}
+
+output stringOutputA string = modATest.outputs.stringOutputA
+output stringOutputB string = modATest.outputs.stringOutputB
+output objOutput object = modATest.outputs.objOutput
+//@[17:23) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-user-defined-types) |object|
+output arrayOutput array = modATest.outputs.arrayOutput
+//@[19:24) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-user-defined-types) |array|
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+//@[31:37) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-user-defined-types) |object|
+
+/*
+  valid loop cases
+*/
+
+@sys.description('this is myModules')
+var myModules = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+
+var emptyArray = []
+
+// simple module loop
+module storageResources 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+// simple indexed module loop
+module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules: {
+  name: module.name
+  params: {
+    arrayParam: [
+      i + 1
+    ]
+    objParam: module
+    stringParamB: module.location
+    stringParamA: concat('a', i)
+//@[18:32) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter-diagnostics#prefer-interpolation) |concat('a', i)|
+  }
+}]
+
+// nested module loop
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: [for i in range(0,3): concat('test-', i, '-', module.name)]
+//@[38:74) [prefer-interpolation (Warning)] Use string interpolation instead of the concat function. (bicep core linter https://aka.ms/bicep/linter-diagnostics#prefer-interpolation) |concat('test-', i, '-', module.name)|
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+//@[04:25) [no-unused-vars (Warning)] Variable "duplicateAcrossScopes" is declared but never used. (bicep core linter https://aka.ms/bicep/linter-diagnostics#no-unused-vars) |duplicateAcrossScopes|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+  name: 'hello-${duplicateAcrossScopes}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+  }
+}]
+
+var someDuplicate = true
+//@[04:17) [no-unused-vars (Warning)] Variable "someDuplicate" is declared but never used. (bicep core linter https://aka.ms/bicep/linter-diagnostics#no-unused-vars) |someDuplicate|
+var otherDuplicate = false
+//@[04:18) [no-unused-vars (Warning)] Variable "otherDuplicate" is declared but never used. (bicep core linter https://aka.ms/bicep/linter-diagnostics#no-unused-vars) |otherDuplicate|
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+  }
+}]
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+  name: 'propertyLoopInsideParameterValue'
+  params: {
+    objParam: {
+      a: [for i in range(0,10): i]
+      b: [for i in range(1,2): i]
+      c: {
+        d: [for j in range(2,3): j]
+      }
+      e: [for k in range(4,4): {
+        f: k
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j]
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+  params: {
+    objParam: {
+      a: [for (i, i2) in range(0,10): i + i2]
+      b: [for (i, i2) in range(1,2): i / i2]
+      c: {
+        d: [for (j, j2) in range(2,3): j * j2]
+      }
+      e: [for (k, k2) in range(4,4): {
+        f: k
+        g: k2
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j]
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
+//@[07:55) [BCP179 (Warning)] Unique resource or deployment name is required when looping. The loop item variable "thing" must be referenced in at least one of the value expressions of the following properties: "name", "scope" (bicep https://aka.ms/bicep/core-diagnostics#BCP179) |propertyLoopInsideParameterValueInsideModuleLoop|
+  name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+  params: {
+    objParam: {
+      a: [for i in range(0,10): i + thing]
+      b: [for i in range(1,2): i * thing]
+      c: {
+        d: [for j in range(2,3): j]
+      }
+      e: [for k in range(4,4): {
+        f: k - thing
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j % (thing + 1)]
+      }
+    ]
+  }
+}]
+
+
+// BEGIN: Key Vault Secret Reference
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'testkeyvault'
+}
+
+module secureModule1 'child/secureParams.bicep' = {
+  name: 'secureModule1'
+  params: {
+    secureStringParam1: kv.getSecret('mySecret')
+    secureStringParam2: kv.getSecret('mySecret','secretVersion')
+  }
+}
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'testkeyvault'
+  scope: resourceGroup('otherGroup')
+}
+
+module secureModule2 'child/secureParams.bicep' = {
+  name: 'secureModule2'
+  params: {
+    secureStringParam1: scopedKv.getSecret('mySecret')
+    secureStringParam2: scopedKv.getSecret('mySecret','secretVersion')
+  }
+}
+
+//looped module with looped existing resource (Issue #2862)
+var vaults = [
+  {
+    vaultName: 'test-1-kv'
+    vaultRG: 'test-1-rg'
+    vaultSub: 'abcd-efgh'
+  }
+  {
+    vaultName: 'test-2-kv'
+    vaultRG: 'test-2-rg'
+    vaultSub: 'ijkl-1adg1'
+  }
+]
+var secrets = [
+  {
+    name: 'secret01'
+    version: 'versionA'
+  }
+  {
+    name: 'secret02'
+    version: 'versionB'
+  }
+]
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [for vault in vaults: {
+  name: vault.vaultName
+  scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+}]
+
+module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secrets: {
+  name: 'secureModuleLooped-${i}'
+  params: {
+    secureStringParam1: loopedKv[i].getSecret(secret.name)
+    secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+  }
+}]
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+  name: 'secureModuleCondition'
+  params: {
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret','secretVersion') : 'notTrue'
+  }
+}
+
+// END: Key Vault Secret Reference
+
+module withSpace 'module with space.bicep' = {
+  name: 'withSpace'
+}
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+  name: 'childWithSpace'
+}
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+//@[04:16) [no-unused-vars (Warning)] Variable "nameofModule" is declared but never used. (bicep core linter https://aka.ms/bicep/linter-diagnostics#no-unused-vars) |nameofModule|
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+
+module moduleWithNameof 'modulea.bicep' = {
+  name: 'nameofModule'
+  scope: resourceGroup(nameof(nameofModuleParam))
+  params:{
+    stringParamA: nameof(withSpace)
+    stringParamB: nameof(folderWithSpace)
+    objParam: {
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+    }
+    arrayParam: [
+      nameof(vaults)
+    ]
+  }
+}
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+  name: 'nullableOutputs'
+}
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.formatted.bicep
@@ -1,0 +1,421 @@
+@sys.description('this is deployTimeSuffix param')
+param deployTimeSuffix string = newGuid()
+
+@sys.description('this module a')
+module modATest './modulea.bicep' = {
+  name: 'modATest'
+  params: {
+    stringParamB: 'hello!'
+    objParam: {
+      a: 'b'
+    }
+    arrayParam: [
+      {
+        a: 'b'
+      }
+      'abc'
+    ]
+  }
+}
+
+@sys.description('this module b')
+module modB './child/moduleb.bicep' = {
+  name: 'modB'
+  params: {
+    location: 'West US'
+  }
+}
+
+@sys.description('this is just module b with a condition')
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+  name: 'modBWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module modBWithCondition2 './child/moduleb.bicep' =
+  // awkward comment
+  if (1 + 1 == 2) {
+    name: 'modBWithCondition2'
+    params: {
+      location: 'East US'
+    }
+  }
+
+module modC './child/modulec.json' = {
+  name: 'modC'
+  params: {
+    location: 'West US'
+  }
+}
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+  name: 'modCWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module optionalWithNoParams1 './child/optionalParams.bicep' = {
+  name: 'optionalWithNoParams1'
+}
+
+module optionalWithNoParams2 './child/optionalParams.bicep' = {
+  name: 'optionalWithNoParams2'
+  params: {}
+}
+
+module optionalWithAllParams './child/optionalParams.bicep' = {
+  name: 'optionalWithNoParams3'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: {}
+    optionalArray: []
+  }
+}
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+  name: 'harry'
+  properties: {
+    modADep: modATest.outputs.stringOutputA
+    modBDep: modB.outputs.myResourceId
+    modCDep: modC.outputs.myResourceId
+  }
+}
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep' = {
+  name: 'optionalWithAllParamsAndManualDependency'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: {}
+    optionalArray: []
+  }
+  dependsOn: [
+    resWithDependencies
+    optionalWithAllParams
+  ]
+}
+
+module optionalWithImplicitDependency './child/optionalParams.bicep' = {
+  name: 'optionalWithImplicitDependency'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+    optionalInt: 42
+    optionalObj: {}
+    optionalArray: []
+  }
+}
+
+module moduleWithCalculatedName './child/optionalParams.bicep' = {
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+    optionalInt: 42
+    optionalObj: {}
+    optionalArray: []
+  }
+}
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  properties: {
+    modADep: moduleWithCalculatedName.outputs.outputObj
+  }
+}
+
+output stringOutputA string = modATest.outputs.stringOutputA
+output stringOutputB string = modATest.outputs.stringOutputB
+output objOutput object = modATest.outputs.objOutput
+output arrayOutput array = modATest.outputs.arrayOutput
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+
+/*
+  valid loop cases
+*/
+
+@sys.description('this is myModules')
+var myModules = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+
+var emptyArray = []
+
+// simple module loop
+module storageResources 'modulea.bicep' = [
+  for module in myModules: {
+    name: module.name
+    params: {
+      arrayParam: []
+      objParam: module
+      stringParamB: module.location
+    }
+  }
+]
+
+// simple indexed module loop
+module storageResourcesWithIndex 'modulea.bicep' = [
+  for (module, i) in myModules: {
+    name: module.name
+    params: {
+      arrayParam: [
+        i + 1
+      ]
+      objParam: module
+      stringParamB: module.location
+      stringParamA: concat('a', i)
+    }
+  }
+]
+
+// nested module loop
+module nestedModuleLoop 'modulea.bicep' = [
+  for module in myModules: {
+    name: module.name
+    params: {
+      arrayParam: [for i in range(0, 3): concat('test-', i, '-', module.name)]
+      objParam: module
+      stringParamB: module.location
+    }
+  }
+]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [
+  for x in emptyArray: {
+    name: 'hello-${x}'
+    params: {
+      objParam: {}
+      stringParamA: 'test'
+      stringParamB: 'test'
+      arrayParam: [for x in emptyArray: x]
+    }
+  }
+]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [
+  for duplicateAcrossScopes in []: {
+    name: 'hello-${duplicateAcrossScopes}'
+    params: {
+      objParam: {}
+      stringParamA: 'test'
+      stringParamB: 'test'
+      arrayParam: [for x in emptyArray: x]
+    }
+  }
+]
+
+var someDuplicate = true
+var otherDuplicate = false
+module duplicatesEverywhere 'modulea.bicep' = [
+  for someDuplicate in []: {
+    name: 'hello-${someDuplicate}'
+    params: {
+      objParam: {}
+      stringParamB: 'test'
+      arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+    }
+  }
+]
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+  name: 'propertyLoopInsideParameterValue'
+  params: {
+    objParam: {
+      a: [for i in range(0, 10): i]
+      b: [for i in range(1, 2): i]
+      c: {
+        d: [for j in range(2, 3): j]
+      }
+      e: [
+        for k in range(4, 4): {
+          f: k
+        }
+      ]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7, 7): j]
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+  params: {
+    objParam: {
+      a: [for (i, i2) in range(0, 10): i + i2]
+      b: [for (i, i2) in range(1, 2): i / i2]
+      c: {
+        d: [for (j, j2) in range(2, 3): j * j2]
+      }
+      e: [
+        for (k, k2) in range(4, 4): {
+          f: k
+          g: k2
+        }
+      ]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7, 7): j]
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [
+  for thing in range(0, 1): {
+    name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+    params: {
+      objParam: {
+        a: [for i in range(0, 10): i + thing]
+        b: [for i in range(1, 2): i * thing]
+        c: {
+          d: [for j in range(2, 3): j]
+        }
+        e: [
+          for k in range(4, 4): {
+            f: k - thing
+          }
+        ]
+      }
+      stringParamB: ''
+      arrayParam: [
+        {
+          e: [for j in range(7, 7): j % (thing + 1)]
+        }
+      ]
+    }
+  }
+]
+
+// BEGIN: Key Vault Secret Reference
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'testkeyvault'
+}
+
+module secureModule1 'child/secureParams.bicep' = {
+  name: 'secureModule1'
+  params: {
+    secureStringParam1: kv.getSecret('mySecret')
+    secureStringParam2: kv.getSecret('mySecret', 'secretVersion')
+  }
+}
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: 'testkeyvault'
+  scope: resourceGroup('otherGroup')
+}
+
+module secureModule2 'child/secureParams.bicep' = {
+  name: 'secureModule2'
+  params: {
+    secureStringParam1: scopedKv.getSecret('mySecret')
+    secureStringParam2: scopedKv.getSecret('mySecret', 'secretVersion')
+  }
+}
+
+//looped module with looped existing resource (Issue #2862)
+var vaults = [
+  {
+    vaultName: 'test-1-kv'
+    vaultRG: 'test-1-rg'
+    vaultSub: 'abcd-efgh'
+  }
+  {
+    vaultName: 'test-2-kv'
+    vaultRG: 'test-2-rg'
+    vaultSub: 'ijkl-1adg1'
+  }
+]
+var secrets = [
+  {
+    name: 'secret01'
+    version: 'versionA'
+  }
+  {
+    name: 'secret02'
+    version: 'versionB'
+  }
+]
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [
+  for vault in vaults: {
+    name: vault.vaultName
+    scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+  }
+]
+
+module secureModuleLooped 'child/secureParams.bicep' = [
+  for (secret, i) in secrets: {
+    name: 'secureModuleLooped-${i}'
+    params: {
+      secureStringParam1: loopedKv[i].getSecret(secret.name)
+      secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+    }
+  }
+]
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+  name: 'secureModuleCondition'
+  params: {
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret', 'secretVersion') : 'notTrue'
+  }
+}
+
+// END: Key Vault Secret Reference
+
+module withSpace 'module with space.bicep' = {
+  name: 'withSpace'
+}
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+  name: 'childWithSpace'
+}
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+
+module moduleWithNameof 'modulea.bicep' = {
+  name: 'nameofModule'
+  scope: resourceGroup(nameof(nameofModuleParam))
+  params: {
+    stringParamA: nameof(withSpace)
+    stringParamB: nameof(folderWithSpace)
+    objParam: {
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+    }
+    arrayParam: [
+      nameof(vaults)
+    ]
+  }
+}
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+  name: 'nullableOutputs'
+}
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.ir.bicep
@@ -1,0 +1,1372 @@
+
+//@[000:10080) ProgramExpression
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ResourceReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | ├─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) | | └─ModuleReferenceExpression [UNPARENTED]
+//@[000:00000) | └─ResourceDependencyExpression [UNPARENTED]
+//@[000:00000) |   └─ModuleReferenceExpression [UNPARENTED]
+@sys.description('this is deployTimeSuffix param')
+//@[000:00093) ├─DeclaredParameterExpression { Name = deployTimeSuffix }
+//@[017:00049) | ├─StringLiteralExpression { Value = this is deployTimeSuffix param }
+param deployTimeSuffix string = newGuid()
+//@[023:00029) | ├─AmbientTypeReferenceExpression { Name = string }
+//@[032:00041) | └─FunctionCallExpression { Name = newGuid }
+
+@sys.description('this module a')
+//@[000:00252) ├─DeclaredModuleExpression
+//@[017:00032) | ├─StringLiteralExpression { Value = this module a }
+module modATest './modulea.bicep' = {
+//@[036:00217) | ├─ObjectExpression
+  name: 'modATest'
+//@[002:00018) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00018) | |   └─StringLiteralExpression { Value = modATest }
+  params: {
+//@[010:00155) | └─ObjectExpression
+    stringParamB: 'hello!'
+//@[004:00026) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00026) |   | └─StringLiteralExpression { Value = hello! }
+    objParam: {
+//@[004:00036) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00036) |   | └─ObjectExpression
+      a: 'b'
+//@[006:00012) |   |   └─ObjectPropertyExpression
+//@[006:00007) |   |     ├─StringLiteralExpression { Value = a }
+//@[009:00012) |   |     └─StringLiteralExpression { Value = b }
+    }
+    arrayParam: [
+//@[004:00071) |   └─ObjectPropertyExpression
+//@[004:00014) |     ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00071) |     └─ArrayExpression
+      {
+//@[006:00032) |       ├─ObjectExpression
+        a: 'b'
+//@[008:00014) |       | └─ObjectPropertyExpression
+//@[008:00009) |       |   ├─StringLiteralExpression { Value = a }
+//@[011:00014) |       |   └─StringLiteralExpression { Value = b }
+      }
+      'abc'
+//@[006:00011) |       └─StringLiteralExpression { Value = abc }
+    ]
+  }
+}
+
+
+@sys.description('this module b')
+//@[000:00136) ├─DeclaredModuleExpression
+//@[017:00032) | ├─StringLiteralExpression { Value = this module b }
+module modB './child/moduleb.bicep' = {
+//@[038:00101) | ├─ObjectExpression
+  name: 'modB'
+//@[002:00014) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00014) | |   └─StringLiteralExpression { Value = modB }
+  params: {
+//@[010:00041) | └─ObjectExpression
+    location: 'West US'
+//@[004:00023) |   └─ObjectPropertyExpression
+//@[004:00012) |     ├─StringLiteralExpression { Value = location }
+//@[014:00023) |     └─StringLiteralExpression { Value = West US }
+  }
+}
+
+@sys.description('this is just module b with a condition')
+//@[000:00203) ├─DeclaredModuleExpression
+//@[017:00057) | ├─StringLiteralExpression { Value = this is just module b with a condition }
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+//@[055:00065) | ├─ConditionExpression
+//@[055:00065) | | ├─BinaryExpression { Operator = Equals }
+//@[055:00060) | | | ├─BinaryExpression { Operator = Add }
+//@[055:00056) | | | | ├─IntegerLiteralExpression { Value = 1 }
+//@[059:00060) | | | | └─IntegerLiteralExpression { Value = 1 }
+//@[064:00065) | | | └─IntegerLiteralExpression { Value = 2 }
+//@[067:00143) | | └─ObjectExpression
+  name: 'modBWithCondition'
+//@[002:00027) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00027) | |     └─StringLiteralExpression { Value = modBWithCondition }
+  params: {
+//@[010:00041) | └─ObjectExpression
+    location: 'East US'
+//@[004:00023) |   └─ObjectPropertyExpression
+//@[004:00012) |     ├─StringLiteralExpression { Value = location }
+//@[014:00023) |     └─StringLiteralExpression { Value = East US }
+  }
+}
+
+module modBWithCondition2 './child/moduleb.bicep' =
+//@[000:00166) ├─DeclaredModuleExpression
+// awkward comment
+if (1 + 1 == 2) {
+//@[004:00014) | ├─ConditionExpression
+//@[004:00014) | | ├─BinaryExpression { Operator = Equals }
+//@[004:00009) | | | ├─BinaryExpression { Operator = Add }
+//@[004:00005) | | | | ├─IntegerLiteralExpression { Value = 1 }
+//@[008:00009) | | | | └─IntegerLiteralExpression { Value = 1 }
+//@[013:00014) | | | └─IntegerLiteralExpression { Value = 2 }
+//@[016:00093) | | └─ObjectExpression
+  name: 'modBWithCondition2'
+//@[002:00028) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00028) | |     └─StringLiteralExpression { Value = modBWithCondition2 }
+  params: {
+//@[010:00041) | └─ObjectExpression
+    location: 'East US'
+//@[004:00023) |   └─ObjectPropertyExpression
+//@[004:00012) |     ├─StringLiteralExpression { Value = location }
+//@[014:00023) |     └─StringLiteralExpression { Value = East US }
+  }
+}
+
+module modC './child/modulec.json' = {
+//@[000:00100) ├─DeclaredModuleExpression
+//@[037:00100) | ├─ObjectExpression
+  name: 'modC'
+//@[002:00014) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00014) | |   └─StringLiteralExpression { Value = modC }
+  params: {
+//@[010:00041) | └─ObjectExpression
+    location: 'West US'
+//@[004:00023) |   └─ObjectPropertyExpression
+//@[004:00012) |     ├─StringLiteralExpression { Value = location }
+//@[014:00023) |     └─StringLiteralExpression { Value = West US }
+  }
+}
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+//@[000:00142) ├─DeclaredModuleExpression
+//@[054:00064) | ├─ConditionExpression
+//@[054:00064) | | ├─BinaryExpression { Operator = Equals }
+//@[054:00059) | | | ├─BinaryExpression { Operator = Subtract }
+//@[054:00055) | | | | ├─IntegerLiteralExpression { Value = 2 }
+//@[058:00059) | | | | └─IntegerLiteralExpression { Value = 1 }
+//@[063:00064) | | | └─IntegerLiteralExpression { Value = 1 }
+//@[066:00142) | | └─ObjectExpression
+  name: 'modCWithCondition'
+//@[002:00027) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00027) | |     └─StringLiteralExpression { Value = modCWithCondition }
+  params: {
+//@[010:00041) | └─ObjectExpression
+    location: 'East US'
+//@[004:00023) |   └─ObjectPropertyExpression
+//@[004:00012) |     ├─StringLiteralExpression { Value = location }
+//@[014:00023) |     └─StringLiteralExpression { Value = East US }
+  }
+}
+
+module optionalWithNoParams1 './child/optionalParams.bicep'= {
+//@[000:00098) ├─DeclaredModuleExpression
+//@[061:00098) | └─ObjectExpression
+  name: 'optionalWithNoParams1'
+//@[002:00031) |   └─ObjectPropertyExpression
+//@[002:00006) |     ├─StringLiteralExpression { Value = name }
+//@[008:00031) |     └─StringLiteralExpression { Value = optionalWithNoParams1 }
+}
+
+module optionalWithNoParams2 './child/optionalParams.bicep'= {
+//@[000:00116) ├─DeclaredModuleExpression
+//@[061:00116) | ├─ObjectExpression
+  name: 'optionalWithNoParams2'
+//@[002:00031) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00031) | |   └─StringLiteralExpression { Value = optionalWithNoParams2 }
+  params: {
+//@[010:00016) | └─ObjectExpression
+  }
+}
+
+module optionalWithAllParams './child/optionalParams.bicep'= {
+//@[000:00210) ├─DeclaredModuleExpression
+//@[061:00210) | ├─ObjectExpression
+  name: 'optionalWithNoParams3'
+//@[002:00031) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00031) | |   └─StringLiteralExpression { Value = optionalWithNoParams3 }
+  params: {
+//@[010:00110) | └─ObjectExpression
+    optionalString: 'abc'
+//@[004:00025) |   ├─ObjectPropertyExpression
+//@[004:00018) |   | ├─StringLiteralExpression { Value = optionalString }
+//@[020:00025) |   | └─StringLiteralExpression { Value = abc }
+    optionalInt: 42
+//@[004:00019) |   ├─ObjectPropertyExpression
+//@[004:00015) |   | ├─StringLiteralExpression { Value = optionalInt }
+//@[017:00019) |   | └─IntegerLiteralExpression { Value = 42 }
+    optionalObj: { }
+//@[004:00020) |   ├─ObjectPropertyExpression
+//@[004:00015) |   | ├─StringLiteralExpression { Value = optionalObj }
+//@[017:00020) |   | └─ObjectExpression
+    optionalArray: [ ]
+//@[004:00022) |   └─ObjectPropertyExpression
+//@[004:00017) |     ├─StringLiteralExpression { Value = optionalArray }
+//@[019:00022) |     └─ArrayExpression
+  }
+}
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:00233) ├─DeclaredResourceExpression
+//@[065:00233) | ├─ObjectExpression
+  name: 'harry'
+  properties: {
+//@[002:00145) | | └─ObjectPropertyExpression
+//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
+//@[014:00145) | |   └─ObjectExpression
+    modADep: modATest.outputs.stringOutputA
+//@[004:00043) | |     ├─ObjectPropertyExpression
+//@[004:00011) | |     | ├─StringLiteralExpression { Value = modADep }
+//@[013:00043) | |     | └─ModuleOutputPropertyAccessExpression { PropertyName = stringOutputA }
+//@[013:00029) | |     |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[013:00021) | |     |     └─ModuleReferenceExpression
+    modBDep: modB.outputs.myResourceId
+//@[004:00038) | |     ├─ObjectPropertyExpression
+//@[004:00011) | |     | ├─StringLiteralExpression { Value = modBDep }
+//@[013:00038) | |     | └─ModuleOutputPropertyAccessExpression { PropertyName = myResourceId }
+//@[013:00025) | |     |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[013:00017) | |     |     └─ModuleReferenceExpression
+    modCDep: modC.outputs.myResourceId
+//@[004:00038) | |     └─ObjectPropertyExpression
+//@[004:00011) | |       ├─StringLiteralExpression { Value = modCDep }
+//@[013:00038) | |       └─ModuleOutputPropertyAccessExpression { PropertyName = myResourceId }
+//@[013:00025) | |         └─PropertyAccessExpression { PropertyName = outputs }
+//@[013:00017) | |           └─ModuleReferenceExpression
+  }
+}
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
+//@[000:00321) ├─DeclaredModuleExpression
+//@[080:00321) | ├─ObjectExpression
+  name: 'optionalWithAllParamsAndManualDependency'
+//@[002:00050) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00050) | |   └─StringLiteralExpression { Value = optionalWithAllParamsAndManualDependency }
+  params: {
+//@[010:00110) | ├─ObjectExpression
+    optionalString: 'abc'
+//@[004:00025) | | ├─ObjectPropertyExpression
+//@[004:00018) | | | ├─StringLiteralExpression { Value = optionalString }
+//@[020:00025) | | | └─StringLiteralExpression { Value = abc }
+    optionalInt: 42
+//@[004:00019) | | ├─ObjectPropertyExpression
+//@[004:00015) | | | ├─StringLiteralExpression { Value = optionalInt }
+//@[017:00019) | | | └─IntegerLiteralExpression { Value = 42 }
+    optionalObj: { }
+//@[004:00020) | | ├─ObjectPropertyExpression
+//@[004:00015) | | | ├─StringLiteralExpression { Value = optionalObj }
+//@[017:00020) | | | └─ObjectExpression
+    optionalArray: [ ]
+//@[004:00022) | | └─ObjectPropertyExpression
+//@[004:00017) | |   ├─StringLiteralExpression { Value = optionalArray }
+//@[019:00022) | |   └─ArrayExpression
+  }
+  dependsOn: [
+    resWithDependencies
+    optionalWithAllParams
+  ]
+}
+
+module optionalWithImplicitDependency './child/optionalParams.bicep'= {
+//@[000:00300) ├─DeclaredModuleExpression
+//@[070:00300) | ├─ObjectExpression
+  name: 'optionalWithImplicitDependency'
+//@[002:00040) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00040) | |   └─StringLiteralExpression { Value = optionalWithImplicitDependency }
+  params: {
+//@[010:00182) | ├─ObjectExpression
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[004:00097) | | ├─ObjectPropertyExpression
+//@[004:00018) | | | ├─StringLiteralExpression { Value = optionalString }
+//@[020:00097) | | | └─FunctionCallExpression { Name = concat }
+//@[027:00049) | | |   ├─PropertyAccessExpression { PropertyName = id }
+//@[027:00046) | | |   | └─ResourceReferenceExpression
+//@[051:00096) | | |   └─PropertyAccessExpression { PropertyName = name }
+//@[051:00091) | | |     └─ModuleReferenceExpression
+    optionalInt: 42
+//@[004:00019) | | ├─ObjectPropertyExpression
+//@[004:00015) | | | ├─StringLiteralExpression { Value = optionalInt }
+//@[017:00019) | | | └─IntegerLiteralExpression { Value = 42 }
+    optionalObj: { }
+//@[004:00020) | | ├─ObjectPropertyExpression
+//@[004:00015) | | | ├─StringLiteralExpression { Value = optionalObj }
+//@[017:00020) | | | └─ObjectExpression
+    optionalArray: [ ]
+//@[004:00022) | | └─ObjectPropertyExpression
+//@[004:00017) | |   ├─StringLiteralExpression { Value = optionalArray }
+//@[019:00022) | |   └─ArrayExpression
+  }
+}
+
+module moduleWithCalculatedName './child/optionalParams.bicep'= {
+//@[000:00331) ├─DeclaredModuleExpression
+//@[064:00331) | ├─ObjectExpression
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@[002:00077) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00077) | |   └─InterpolatedStringExpression
+//@[011:00056) | |     ├─PropertyAccessExpression { PropertyName = name }
+//@[011:00051) | |     | └─ModuleReferenceExpression
+//@[059:00075) | |     └─ParametersReferenceExpression { Parameter = deployTimeSuffix }
+  params: {
+//@[010:00182) | ├─ObjectExpression
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[004:00097) | | ├─ObjectPropertyExpression
+//@[004:00018) | | | ├─StringLiteralExpression { Value = optionalString }
+//@[020:00097) | | | └─FunctionCallExpression { Name = concat }
+//@[027:00049) | | |   ├─PropertyAccessExpression { PropertyName = id }
+//@[027:00046) | | |   | └─ResourceReferenceExpression
+//@[051:00096) | | |   └─PropertyAccessExpression { PropertyName = name }
+//@[051:00091) | | |     └─ModuleReferenceExpression
+    optionalInt: 42
+//@[004:00019) | | ├─ObjectPropertyExpression
+//@[004:00015) | | | ├─StringLiteralExpression { Value = optionalInt }
+//@[017:00019) | | | └─IntegerLiteralExpression { Value = 42 }
+    optionalObj: { }
+//@[004:00020) | | ├─ObjectPropertyExpression
+//@[004:00015) | | | ├─StringLiteralExpression { Value = optionalObj }
+//@[017:00020) | | | └─ObjectExpression
+    optionalArray: [ ]
+//@[004:00022) | | └─ObjectPropertyExpression
+//@[004:00017) | |   ├─StringLiteralExpression { Value = optionalArray }
+//@[019:00022) | |   └─ArrayExpression
+  }
+}
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:00241) ├─DeclaredResourceExpression
+//@[079:00241) | ├─ObjectExpression
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  properties: {
+//@[002:00077) | | └─ObjectPropertyExpression
+//@[002:00012) | |   ├─StringLiteralExpression { Value = properties }
+//@[014:00077) | |   └─ObjectExpression
+    modADep: moduleWithCalculatedName.outputs.outputObj
+//@[004:00055) | |     └─ObjectPropertyExpression
+//@[004:00011) | |       ├─StringLiteralExpression { Value = modADep }
+//@[013:00055) | |       └─ModuleOutputPropertyAccessExpression { PropertyName = outputObj }
+//@[013:00045) | |         └─PropertyAccessExpression { PropertyName = outputs }
+//@[013:00037) | |           └─ModuleReferenceExpression
+  }
+}
+
+output stringOutputA string = modATest.outputs.stringOutputA
+//@[000:00060) ├─DeclaredOutputExpression { Name = stringOutputA }
+//@[021:00027) | ├─AmbientTypeReferenceExpression { Name = string }
+//@[030:00060) | └─ModuleOutputPropertyAccessExpression { PropertyName = stringOutputA }
+//@[030:00046) |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[030:00038) |     └─ModuleReferenceExpression
+output stringOutputB string = modATest.outputs.stringOutputB
+//@[000:00060) ├─DeclaredOutputExpression { Name = stringOutputB }
+//@[021:00027) | ├─AmbientTypeReferenceExpression { Name = string }
+//@[030:00060) | └─ModuleOutputPropertyAccessExpression { PropertyName = stringOutputB }
+//@[030:00046) |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[030:00038) |     └─ModuleReferenceExpression
+output objOutput object = modATest.outputs.objOutput
+//@[000:00052) ├─DeclaredOutputExpression { Name = objOutput }
+//@[017:00023) | ├─AmbientTypeReferenceExpression { Name = object }
+//@[026:00052) | └─ModuleOutputPropertyAccessExpression { PropertyName = objOutput }
+//@[026:00042) |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[026:00034) |     └─ModuleReferenceExpression
+output arrayOutput array = modATest.outputs.arrayOutput
+//@[000:00055) ├─DeclaredOutputExpression { Name = arrayOutput }
+//@[019:00024) | ├─AmbientTypeReferenceExpression { Name = array }
+//@[027:00055) | └─ModuleOutputPropertyAccessExpression { PropertyName = arrayOutput }
+//@[027:00043) |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[027:00035) |     └─ModuleReferenceExpression
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+//@[000:00082) ├─DeclaredOutputExpression { Name = modCalculatedNameOutput }
+//@[031:00037) | ├─AmbientTypeReferenceExpression { Name = object }
+//@[040:00082) | └─ModuleOutputPropertyAccessExpression { PropertyName = outputObj }
+//@[040:00072) |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[040:00064) |     └─ModuleReferenceExpression
+
+/*
+  valid loop cases
+*/
+
+@sys.description('this is myModules')
+//@[000:00162) ├─DeclaredVariableExpression { Name = myModules }
+//@[017:00036) | ├─StringLiteralExpression { Value = this is myModules }
+var myModules = [
+//@[016:00123) | └─ArrayExpression
+  {
+//@[002:00050) |   ├─ObjectExpression
+    name: 'one'
+//@[004:00015) |   | ├─ObjectPropertyExpression
+//@[004:00008) |   | | ├─StringLiteralExpression { Value = name }
+//@[010:00015) |   | | └─StringLiteralExpression { Value = one }
+    location: 'eastus2'
+//@[004:00023) |   | └─ObjectPropertyExpression
+//@[004:00012) |   |   ├─StringLiteralExpression { Value = location }
+//@[014:00023) |   |   └─StringLiteralExpression { Value = eastus2 }
+  }
+  {
+//@[002:00049) |   └─ObjectExpression
+    name: 'two'
+//@[004:00015) |     ├─ObjectPropertyExpression
+//@[004:00008) |     | ├─StringLiteralExpression { Value = name }
+//@[010:00015) |     | └─StringLiteralExpression { Value = two }
+    location: 'westus'
+//@[004:00022) |     └─ObjectPropertyExpression
+//@[004:00012) |       ├─StringLiteralExpression { Value = location }
+//@[014:00022) |       └─StringLiteralExpression { Value = westus }
+  }
+]
+
+var emptyArray = []
+//@[000:00019) ├─DeclaredVariableExpression { Name = emptyArray }
+//@[017:00019) | └─ArrayExpression
+
+// simple module loop
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[000:00189) ├─DeclaredModuleExpression
+//@[042:00189) | ├─ForLoopExpression
+//@[057:00066) | | ├─VariableReferenceExpression { Variable = myModules }
+//@[068:00188) | | └─ObjectExpression
+//@[057:00066) | |         └─VariableReferenceExpression { Variable = myModules }
+//@[057:00066) |   |   └─VariableReferenceExpression { Variable = myModules }
+//@[057:00066) |         └─VariableReferenceExpression { Variable = myModules }
+  name: module.name
+//@[002:00019) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00019) | |     └─PropertyAccessExpression { PropertyName = name }
+//@[008:00014) | |       └─ArrayAccessExpression
+//@[008:00014) | |         ├─CopyIndexExpression
+  params: {
+//@[010:00093) | └─ObjectExpression
+    arrayParam: []
+//@[004:00018) |   ├─ObjectPropertyExpression
+//@[004:00014) |   | ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00018) |   | └─ArrayExpression
+    objParam: module
+//@[004:00020) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00020) |   | └─ArrayAccessExpression
+//@[014:00020) |   |   ├─CopyIndexExpression
+    stringParamB: module.location
+//@[004:00033) |   └─ObjectPropertyExpression
+//@[004:00016) |     ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00033) |     └─PropertyAccessExpression { PropertyName = location }
+//@[018:00024) |       └─ArrayAccessExpression
+//@[018:00024) |         ├─CopyIndexExpression
+  }
+}]
+
+// simple indexed module loop
+module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules: {
+//@[000:00256) ├─DeclaredModuleExpression
+//@[051:00256) | ├─ForLoopExpression
+//@[071:00080) | | ├─VariableReferenceExpression { Variable = myModules }
+//@[082:00255) | | └─ObjectExpression
+//@[071:00080) | |         └─VariableReferenceExpression { Variable = myModules }
+//@[071:00080) |   |   └─VariableReferenceExpression { Variable = myModules }
+//@[071:00080) |   |     └─VariableReferenceExpression { Variable = myModules }
+  name: module.name
+//@[002:00019) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00019) | |     └─PropertyAccessExpression { PropertyName = name }
+//@[008:00014) | |       └─ArrayAccessExpression
+//@[008:00014) | |         ├─CopyIndexExpression
+  params: {
+//@[010:00146) | └─ObjectExpression
+    arrayParam: [
+//@[004:00037) |   ├─ObjectPropertyExpression
+//@[004:00014) |   | ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00037) |   | └─ArrayExpression
+      i + 1
+//@[006:00011) |   |   └─BinaryExpression { Operator = Add }
+//@[006:00007) |   |     ├─CopyIndexExpression
+//@[010:00011) |   |     └─IntegerLiteralExpression { Value = 1 }
+    ]
+    objParam: module
+//@[004:00020) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00020) |   | └─ArrayAccessExpression
+//@[014:00020) |   |   ├─CopyIndexExpression
+    stringParamB: module.location
+//@[004:00033) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00033) |   | └─PropertyAccessExpression { PropertyName = location }
+//@[018:00024) |   |   └─ArrayAccessExpression
+//@[018:00024) |   |     ├─CopyIndexExpression
+    stringParamA: concat('a', i)
+//@[004:00032) |   └─ObjectPropertyExpression
+//@[004:00016) |     ├─StringLiteralExpression { Value = stringParamA }
+//@[018:00032) |     └─FunctionCallExpression { Name = concat }
+//@[025:00028) |       ├─StringLiteralExpression { Value = a }
+//@[030:00031) |       └─CopyIndexExpression
+  }
+}]
+
+// nested module loop
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[000:00246) ├─DeclaredModuleExpression
+//@[042:00246) | ├─ForLoopExpression
+//@[057:00066) | | ├─VariableReferenceExpression { Variable = myModules }
+//@[068:00245) | | └─ObjectExpression
+//@[057:00066) | |         └─VariableReferenceExpression { Variable = myModules }
+//@[057:00066) |   |         └─VariableReferenceExpression { Variable = myModules }
+//@[057:00066) |   |   └─VariableReferenceExpression { Variable = myModules }
+//@[057:00066) |         └─VariableReferenceExpression { Variable = myModules }
+  name: module.name
+//@[002:00019) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00019) | |     └─PropertyAccessExpression { PropertyName = name }
+//@[008:00014) | |       └─ArrayAccessExpression
+//@[008:00014) | |         ├─CopyIndexExpression
+  params: {
+//@[010:00150) | └─ObjectExpression
+    arrayParam: [for i in range(0,3): concat('test-', i, '-', module.name)]
+//@[004:00075) |   ├─ObjectPropertyExpression
+//@[004:00014) |   | ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00075) |   | └─ForLoopExpression
+//@[026:00036) |   |   ├─FunctionCallExpression { Name = range }
+//@[032:00033) |   |   | ├─IntegerLiteralExpression { Value = 0 }
+//@[034:00035) |   |   | └─IntegerLiteralExpression { Value = 3 }
+//@[038:00074) |   |   └─FunctionCallExpression { Name = concat }
+//@[045:00052) |   |     ├─StringLiteralExpression { Value = test- }
+//@[054:00055) |   |     ├─ArrayAccessExpression
+//@[054:00055) |   |     | ├─CopyIndexExpression
+//@[026:00036) |   |     | └─FunctionCallExpression { Name = range }
+//@[032:00033) |   |     |   ├─IntegerLiteralExpression { Value = 0 }
+//@[034:00035) |   |     |   └─IntegerLiteralExpression { Value = 3 }
+//@[057:00060) |   |     ├─StringLiteralExpression { Value = - }
+//@[062:00073) |   |     └─PropertyAccessExpression { PropertyName = name }
+//@[062:00068) |   |       └─ArrayAccessExpression
+//@[062:00068) |   |         ├─CopyIndexExpression
+    objParam: module
+//@[004:00020) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00020) |   | └─ArrayAccessExpression
+//@[014:00020) |   |   ├─CopyIndexExpression
+    stringParamB: module.location
+//@[004:00033) |   └─ObjectPropertyExpression
+//@[004:00016) |     ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00033) |     └─PropertyAccessExpression { PropertyName = location }
+//@[018:00024) |       └─ArrayAccessExpression
+//@[018:00024) |         ├─CopyIndexExpression
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[000:00234) ├─DeclaredModuleExpression
+//@[056:00234) | ├─ForLoopExpression
+//@[066:00076) | | ├─VariableReferenceExpression { Variable = emptyArray }
+//@[077:00233) | | └─ObjectExpression
+//@[066:00076) | |         └─VariableReferenceExpression { Variable = emptyArray }
+  name: 'hello-${x}'
+//@[002:00020) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00020) | |     └─InterpolatedStringExpression
+//@[017:00018) | |       └─ArrayAccessExpression
+//@[017:00018) | |         ├─CopyIndexExpression
+  params: {
+//@[010:00128) | └─ObjectExpression
+    objParam: {}
+//@[004:00016) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00016) |   | └─ObjectExpression
+    stringParamA: 'test'
+//@[004:00024) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamA }
+//@[018:00024) |   | └─StringLiteralExpression { Value = test }
+    stringParamB: 'test'
+//@[004:00024) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00024) |   | └─StringLiteralExpression { Value = test }
+    arrayParam: [for x in emptyArray: x]
+//@[004:00040) |   └─ObjectPropertyExpression
+//@[004:00014) |     ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00040) |     └─ForLoopExpression
+//@[026:00036) |       ├─VariableReferenceExpression { Variable = emptyArray }
+//@[038:00039) |       └─ArrayAccessExpression
+//@[038:00039) |         ├─CopyIndexExpression
+//@[026:00036) |         └─VariableReferenceExpression { Variable = emptyArray }
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+//@[000:00035) ├─DeclaredVariableExpression { Name = duplicateAcrossScopes }
+//@[028:00035) | └─StringLiteralExpression { Value = hello }
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@[000:00264) ├─DeclaredModuleExpression
+//@[053:00264) | ├─ForLoopExpression
+//@[083:00085) | | ├─ArrayExpression
+//@[087:00263) | | └─ObjectExpression
+//@[083:00085) | |         └─ArrayExpression
+  name: 'hello-${duplicateAcrossScopes}'
+//@[002:00040) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00040) | |     └─InterpolatedStringExpression
+//@[017:00038) | |       └─ArrayAccessExpression
+//@[017:00038) | |         ├─CopyIndexExpression
+  params: {
+//@[010:00128) | └─ObjectExpression
+    objParam: {}
+//@[004:00016) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00016) |   | └─ObjectExpression
+    stringParamA: 'test'
+//@[004:00024) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamA }
+//@[018:00024) |   | └─StringLiteralExpression { Value = test }
+    stringParamB: 'test'
+//@[004:00024) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00024) |   | └─StringLiteralExpression { Value = test }
+    arrayParam: [for x in emptyArray: x]
+//@[004:00040) |   └─ObjectPropertyExpression
+//@[004:00014) |     ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00040) |     └─ForLoopExpression
+//@[026:00036) |       ├─VariableReferenceExpression { Variable = emptyArray }
+//@[038:00039) |       └─ArrayAccessExpression
+//@[038:00039) |         ├─CopyIndexExpression
+//@[026:00036) |         └─VariableReferenceExpression { Variable = emptyArray }
+  }
+}]
+
+var someDuplicate = true
+//@[000:00024) ├─DeclaredVariableExpression { Name = someDuplicate }
+//@[020:00024) | └─BooleanLiteralExpression { Value = True }
+var otherDuplicate = false
+//@[000:00026) ├─DeclaredVariableExpression { Name = otherDuplicate }
+//@[021:00026) | └─BooleanLiteralExpression { Value = False }
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[000:00263) ├─DeclaredModuleExpression
+//@[046:00263) | ├─ForLoopExpression
+//@[068:00070) | | ├─ArrayExpression
+//@[072:00262) | | └─ObjectExpression
+//@[068:00070) | |         └─ArrayExpression
+//@[068:00070) |         | └─ArrayExpression
+  name: 'hello-${someDuplicate}'
+//@[002:00032) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00032) | |     └─InterpolatedStringExpression
+//@[017:00030) | |       └─ArrayAccessExpression
+//@[017:00030) | |         ├─CopyIndexExpression
+  params: {
+//@[010:00150) | └─ObjectExpression
+    objParam: {}
+//@[004:00016) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00016) |   | └─ObjectExpression
+    stringParamB: 'test'
+//@[004:00024) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00024) |   | └─StringLiteralExpression { Value = test }
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[004:00088) |   └─ObjectPropertyExpression
+//@[004:00014) |     ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00088) |     └─ForLoopExpression
+//@[039:00049) |       ├─VariableReferenceExpression { Variable = emptyArray }
+//@[051:00087) |       └─InterpolatedStringExpression
+//@[054:00067) |         ├─ArrayAccessExpression
+//@[054:00067) |         | ├─CopyIndexExpression
+//@[071:00085) |         └─ArrayAccessExpression
+//@[071:00085) |           ├─CopyIndexExpression
+//@[039:00049) |           └─VariableReferenceExpression { Variable = emptyArray }
+  }
+}]
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+//@[000:00438) ├─DeclaredModuleExpression
+//@[058:00438) | ├─ObjectExpression
+  name: 'propertyLoopInsideParameterValue'
+//@[002:00042) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00042) | |   └─StringLiteralExpression { Value = propertyLoopInsideParameterValue }
+  params: {
+//@[010:00330) | └─ObjectExpression
+    objParam: {
+//@[004:00209) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00209) |   | └─ObjectExpression
+      a: [for i in range(0,10): i]
+//@[006:00034) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = a }
+//@[009:00034) |   |   | └─ForLoopExpression
+//@[019:00030) |   |   |   ├─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |   | ├─IntegerLiteralExpression { Value = 0 }
+//@[027:00029) |   |   |   | └─IntegerLiteralExpression { Value = 10 }
+//@[032:00033) |   |   |   └─ArrayAccessExpression
+//@[032:00033) |   |   |     ├─CopyIndexExpression
+//@[019:00030) |   |   |     └─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |       ├─IntegerLiteralExpression { Value = 0 }
+//@[027:00029) |   |   |       └─IntegerLiteralExpression { Value = 10 }
+      b: [for i in range(1,2): i]
+//@[006:00033) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = b }
+//@[009:00033) |   |   | └─ForLoopExpression
+//@[019:00029) |   |   |   ├─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |   | ├─IntegerLiteralExpression { Value = 1 }
+//@[027:00028) |   |   |   | └─IntegerLiteralExpression { Value = 2 }
+//@[031:00032) |   |   |   └─ArrayAccessExpression
+//@[031:00032) |   |   |     ├─CopyIndexExpression
+//@[019:00029) |   |   |     └─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |       ├─IntegerLiteralExpression { Value = 1 }
+//@[027:00028) |   |   |       └─IntegerLiteralExpression { Value = 2 }
+      c: {
+//@[006:00056) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = c }
+//@[009:00056) |   |   | └─ObjectExpression
+        d: [for j in range(2,3): j]
+//@[008:00035) |   |   |   └─ObjectPropertyExpression
+//@[008:00009) |   |   |     ├─StringLiteralExpression { Value = d }
+//@[011:00035) |   |   |     └─ForLoopExpression
+//@[021:00031) |   |   |       ├─FunctionCallExpression { Name = range }
+//@[027:00028) |   |   |       | ├─IntegerLiteralExpression { Value = 2 }
+//@[029:00030) |   |   |       | └─IntegerLiteralExpression { Value = 3 }
+//@[033:00034) |   |   |       └─ArrayAccessExpression
+//@[033:00034) |   |   |         ├─CopyIndexExpression
+//@[021:00031) |   |   |         └─FunctionCallExpression { Name = range }
+//@[027:00028) |   |   |           ├─IntegerLiteralExpression { Value = 2 }
+//@[029:00030) |   |   |           └─IntegerLiteralExpression { Value = 3 }
+      }
+      e: [for k in range(4,4): {
+//@[006:00056) |   |   └─ObjectPropertyExpression
+//@[006:00007) |   |     ├─StringLiteralExpression { Value = e }
+//@[009:00056) |   |     └─ForLoopExpression
+//@[019:00029) |   |       ├─FunctionCallExpression { Name = range }
+//@[025:00026) |   |       | ├─IntegerLiteralExpression { Value = 4 }
+//@[027:00028) |   |       | └─IntegerLiteralExpression { Value = 4 }
+//@[031:00055) |   |       └─ObjectExpression
+//@[019:00029) |   |             └─FunctionCallExpression { Name = range }
+//@[025:00026) |   |               ├─IntegerLiteralExpression { Value = 4 }
+//@[027:00028) |   |               └─IntegerLiteralExpression { Value = 4 }
+        f: k
+//@[008:00012) |   |         └─ObjectPropertyExpression
+//@[008:00009) |   |           ├─StringLiteralExpression { Value = f }
+//@[011:00012) |   |           └─ArrayAccessExpression
+//@[011:00012) |   |             ├─CopyIndexExpression
+      }]
+    }
+    stringParamB: ''
+//@[004:00020) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00020) |   | └─StringLiteralExpression { Value =  }
+    arrayParam: [
+//@[004:00079) |   └─ObjectPropertyExpression
+//@[004:00014) |     ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00079) |     └─ArrayExpression
+      {
+//@[006:00053) |       └─ObjectExpression
+        e: [for j in range(7,7): j]
+//@[008:00035) |         └─ObjectPropertyExpression
+//@[008:00009) |           ├─StringLiteralExpression { Value = e }
+//@[011:00035) |           └─ForLoopExpression
+//@[021:00031) |             ├─FunctionCallExpression { Name = range }
+//@[027:00028) |             | ├─IntegerLiteralExpression { Value = 7 }
+//@[029:00030) |             | └─IntegerLiteralExpression { Value = 7 }
+//@[033:00034) |             └─ArrayAccessExpression
+//@[033:00034) |               ├─CopyIndexExpression
+//@[021:00031) |               └─FunctionCallExpression { Name = range }
+//@[027:00028) |                 ├─IntegerLiteralExpression { Value = 7 }
+//@[029:00030) |                 └─IntegerLiteralExpression { Value = 7 }
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+//@[000:00514) ├─DeclaredModuleExpression
+//@[069:00514) | ├─ObjectExpression
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+//@[002:00053) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00053) | |   └─StringLiteralExpression { Value = propertyLoopInsideParameterValueWithIndexes }
+  params: {
+//@[010:00384) | └─ObjectExpression
+    objParam: {
+//@[004:00263) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00263) |   | └─ObjectExpression
+      a: [for (i, i2) in range(0,10): i + i2]
+//@[006:00045) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = a }
+//@[009:00045) |   |   | └─ForLoopExpression
+//@[025:00036) |   |   |   ├─FunctionCallExpression { Name = range }
+//@[031:00032) |   |   |   | ├─IntegerLiteralExpression { Value = 0 }
+//@[033:00035) |   |   |   | └─IntegerLiteralExpression { Value = 10 }
+//@[038:00044) |   |   |   └─BinaryExpression { Operator = Add }
+//@[038:00039) |   |   |     ├─ArrayAccessExpression
+//@[038:00039) |   |   |     | ├─CopyIndexExpression
+//@[025:00036) |   |   |     | └─FunctionCallExpression { Name = range }
+//@[031:00032) |   |   |     |   ├─IntegerLiteralExpression { Value = 0 }
+//@[033:00035) |   |   |     |   └─IntegerLiteralExpression { Value = 10 }
+//@[042:00044) |   |   |     └─CopyIndexExpression
+      b: [for (i, i2) in range(1,2): i / i2]
+//@[006:00044) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = b }
+//@[009:00044) |   |   | └─ForLoopExpression
+//@[025:00035) |   |   |   ├─FunctionCallExpression { Name = range }
+//@[031:00032) |   |   |   | ├─IntegerLiteralExpression { Value = 1 }
+//@[033:00034) |   |   |   | └─IntegerLiteralExpression { Value = 2 }
+//@[037:00043) |   |   |   └─BinaryExpression { Operator = Divide }
+//@[037:00038) |   |   |     ├─ArrayAccessExpression
+//@[037:00038) |   |   |     | ├─CopyIndexExpression
+//@[025:00035) |   |   |     | └─FunctionCallExpression { Name = range }
+//@[031:00032) |   |   |     |   ├─IntegerLiteralExpression { Value = 1 }
+//@[033:00034) |   |   |     |   └─IntegerLiteralExpression { Value = 2 }
+//@[041:00043) |   |   |     └─CopyIndexExpression
+      c: {
+//@[006:00067) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = c }
+//@[009:00067) |   |   | └─ObjectExpression
+        d: [for (j, j2) in range(2,3): j * j2]
+//@[008:00046) |   |   |   └─ObjectPropertyExpression
+//@[008:00009) |   |   |     ├─StringLiteralExpression { Value = d }
+//@[011:00046) |   |   |     └─ForLoopExpression
+//@[027:00037) |   |   |       ├─FunctionCallExpression { Name = range }
+//@[033:00034) |   |   |       | ├─IntegerLiteralExpression { Value = 2 }
+//@[035:00036) |   |   |       | └─IntegerLiteralExpression { Value = 3 }
+//@[039:00045) |   |   |       └─BinaryExpression { Operator = Multiply }
+//@[039:00040) |   |   |         ├─ArrayAccessExpression
+//@[039:00040) |   |   |         | ├─CopyIndexExpression
+//@[027:00037) |   |   |         | └─FunctionCallExpression { Name = range }
+//@[033:00034) |   |   |         |   ├─IntegerLiteralExpression { Value = 2 }
+//@[035:00036) |   |   |         |   └─IntegerLiteralExpression { Value = 3 }
+//@[043:00045) |   |   |         └─CopyIndexExpression
+      }
+      e: [for (k, k2) in range(4,4): {
+//@[006:00077) |   |   └─ObjectPropertyExpression
+//@[006:00007) |   |     ├─StringLiteralExpression { Value = e }
+//@[009:00077) |   |     └─ForLoopExpression
+//@[025:00035) |   |       ├─FunctionCallExpression { Name = range }
+//@[031:00032) |   |       | ├─IntegerLiteralExpression { Value = 4 }
+//@[033:00034) |   |       | └─IntegerLiteralExpression { Value = 4 }
+//@[037:00076) |   |       └─ObjectExpression
+//@[025:00035) |   |         |   └─FunctionCallExpression { Name = range }
+//@[031:00032) |   |         |     ├─IntegerLiteralExpression { Value = 4 }
+//@[033:00034) |   |         |     └─IntegerLiteralExpression { Value = 4 }
+        f: k
+//@[008:00012) |   |         ├─ObjectPropertyExpression
+//@[008:00009) |   |         | ├─StringLiteralExpression { Value = f }
+//@[011:00012) |   |         | └─ArrayAccessExpression
+//@[011:00012) |   |         |   ├─CopyIndexExpression
+        g: k2
+//@[008:00013) |   |         └─ObjectPropertyExpression
+//@[008:00009) |   |           ├─StringLiteralExpression { Value = g }
+//@[011:00013) |   |           └─CopyIndexExpression
+      }]
+    }
+    stringParamB: ''
+//@[004:00020) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00020) |   | └─StringLiteralExpression { Value =  }
+    arrayParam: [
+//@[004:00079) |   └─ObjectPropertyExpression
+//@[004:00014) |     ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00079) |     └─ArrayExpression
+      {
+//@[006:00053) |       └─ObjectExpression
+        e: [for j in range(7,7): j]
+//@[008:00035) |         └─ObjectPropertyExpression
+//@[008:00009) |           ├─StringLiteralExpression { Value = e }
+//@[011:00035) |           └─ForLoopExpression
+//@[021:00031) |             ├─FunctionCallExpression { Name = range }
+//@[027:00028) |             | ├─IntegerLiteralExpression { Value = 7 }
+//@[029:00030) |             | └─IntegerLiteralExpression { Value = 7 }
+//@[033:00034) |             └─ArrayAccessExpression
+//@[033:00034) |               ├─CopyIndexExpression
+//@[021:00031) |               └─FunctionCallExpression { Name = range }
+//@[027:00028) |                 ├─IntegerLiteralExpression { Value = 7 }
+//@[029:00030) |                 └─IntegerLiteralExpression { Value = 7 }
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
+//@[000:00535) ├─DeclaredModuleExpression
+//@[074:00535) | ├─ForLoopExpression
+//@[088:00098) | | ├─FunctionCallExpression { Name = range }
+//@[094:00095) | | | ├─IntegerLiteralExpression { Value = 0 }
+//@[096:00097) | | | └─IntegerLiteralExpression { Value = 1 }
+//@[100:00534) | | └─ObjectExpression
+//@[088:00098) |   |   |       └─FunctionCallExpression { Name = range }
+//@[094:00095) |   |   |         ├─IntegerLiteralExpression { Value = 0 }
+//@[096:00097) |   |   |         └─IntegerLiteralExpression { Value = 1 }
+//@[088:00098) |   |   |       └─FunctionCallExpression { Name = range }
+//@[094:00095) |   |   |         ├─IntegerLiteralExpression { Value = 0 }
+//@[096:00097) |   |   |         └─IntegerLiteralExpression { Value = 1 }
+//@[088:00098) |   |               └─FunctionCallExpression { Name = range }
+//@[094:00095) |   |                 ├─IntegerLiteralExpression { Value = 0 }
+//@[096:00097) |   |                 └─IntegerLiteralExpression { Value = 1 }
+//@[088:00098) |                 | └─FunctionCallExpression { Name = range }
+//@[094:00095) |                 |   ├─IntegerLiteralExpression { Value = 0 }
+//@[096:00097) |                 |   └─IntegerLiteralExpression { Value = 1 }
+  name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+//@[002:00058) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00058) | |     └─StringLiteralExpression { Value = propertyLoopInsideParameterValueInsideModuleLoop }
+  params: {
+//@[010:00368) | └─ObjectExpression
+    objParam: {
+//@[004:00233) |   ├─ObjectPropertyExpression
+//@[004:00012) |   | ├─StringLiteralExpression { Value = objParam }
+//@[014:00233) |   | └─ObjectExpression
+      a: [for i in range(0,10): i + thing]
+//@[006:00042) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = a }
+//@[009:00042) |   |   | └─ForLoopExpression
+//@[019:00030) |   |   |   ├─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |   | ├─IntegerLiteralExpression { Value = 0 }
+//@[027:00029) |   |   |   | └─IntegerLiteralExpression { Value = 10 }
+//@[032:00041) |   |   |   └─BinaryExpression { Operator = Add }
+//@[032:00033) |   |   |     ├─ArrayAccessExpression
+//@[032:00033) |   |   |     | ├─CopyIndexExpression
+//@[019:00030) |   |   |     | └─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |     |   ├─IntegerLiteralExpression { Value = 0 }
+//@[027:00029) |   |   |     |   └─IntegerLiteralExpression { Value = 10 }
+//@[036:00041) |   |   |     └─ArrayAccessExpression
+//@[036:00041) |   |   |       ├─CopyIndexExpression
+      b: [for i in range(1,2): i * thing]
+//@[006:00041) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = b }
+//@[009:00041) |   |   | └─ForLoopExpression
+//@[019:00029) |   |   |   ├─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |   | ├─IntegerLiteralExpression { Value = 1 }
+//@[027:00028) |   |   |   | └─IntegerLiteralExpression { Value = 2 }
+//@[031:00040) |   |   |   └─BinaryExpression { Operator = Multiply }
+//@[031:00032) |   |   |     ├─ArrayAccessExpression
+//@[031:00032) |   |   |     | ├─CopyIndexExpression
+//@[019:00029) |   |   |     | └─FunctionCallExpression { Name = range }
+//@[025:00026) |   |   |     |   ├─IntegerLiteralExpression { Value = 1 }
+//@[027:00028) |   |   |     |   └─IntegerLiteralExpression { Value = 2 }
+//@[035:00040) |   |   |     └─ArrayAccessExpression
+//@[035:00040) |   |   |       ├─CopyIndexExpression
+      c: {
+//@[006:00056) |   |   ├─ObjectPropertyExpression
+//@[006:00007) |   |   | ├─StringLiteralExpression { Value = c }
+//@[009:00056) |   |   | └─ObjectExpression
+        d: [for j in range(2,3): j]
+//@[008:00035) |   |   |   └─ObjectPropertyExpression
+//@[008:00009) |   |   |     ├─StringLiteralExpression { Value = d }
+//@[011:00035) |   |   |     └─ForLoopExpression
+//@[021:00031) |   |   |       ├─FunctionCallExpression { Name = range }
+//@[027:00028) |   |   |       | ├─IntegerLiteralExpression { Value = 2 }
+//@[029:00030) |   |   |       | └─IntegerLiteralExpression { Value = 3 }
+//@[033:00034) |   |   |       └─ArrayAccessExpression
+//@[033:00034) |   |   |         ├─CopyIndexExpression
+//@[021:00031) |   |   |         └─FunctionCallExpression { Name = range }
+//@[027:00028) |   |   |           ├─IntegerLiteralExpression { Value = 2 }
+//@[029:00030) |   |   |           └─IntegerLiteralExpression { Value = 3 }
+      }
+      e: [for k in range(4,4): {
+//@[006:00064) |   |   └─ObjectPropertyExpression
+//@[006:00007) |   |     ├─StringLiteralExpression { Value = e }
+//@[009:00064) |   |     └─ForLoopExpression
+//@[019:00029) |   |       ├─FunctionCallExpression { Name = range }
+//@[025:00026) |   |       | ├─IntegerLiteralExpression { Value = 4 }
+//@[027:00028) |   |       | └─IntegerLiteralExpression { Value = 4 }
+//@[031:00063) |   |       └─ObjectExpression
+//@[019:00029) |   |             | └─FunctionCallExpression { Name = range }
+//@[025:00026) |   |             |   ├─IntegerLiteralExpression { Value = 4 }
+//@[027:00028) |   |             |   └─IntegerLiteralExpression { Value = 4 }
+        f: k - thing
+//@[008:00020) |   |         └─ObjectPropertyExpression
+//@[008:00009) |   |           ├─StringLiteralExpression { Value = f }
+//@[011:00020) |   |           └─BinaryExpression { Operator = Subtract }
+//@[011:00012) |   |             ├─ArrayAccessExpression
+//@[011:00012) |   |             | ├─CopyIndexExpression
+//@[015:00020) |   |             └─ArrayAccessExpression
+//@[015:00020) |   |               ├─CopyIndexExpression
+      }]
+    }
+    stringParamB: ''
+//@[004:00020) |   ├─ObjectPropertyExpression
+//@[004:00016) |   | ├─StringLiteralExpression { Value = stringParamB }
+//@[018:00020) |   | └─StringLiteralExpression { Value =  }
+    arrayParam: [
+//@[004:00093) |   └─ObjectPropertyExpression
+//@[004:00014) |     ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00093) |     └─ArrayExpression
+      {
+//@[006:00067) |       └─ObjectExpression
+        e: [for j in range(7,7): j % (thing + 1)]
+//@[008:00049) |         └─ObjectPropertyExpression
+//@[008:00009) |           ├─StringLiteralExpression { Value = e }
+//@[011:00049) |           └─ForLoopExpression
+//@[021:00031) |             ├─FunctionCallExpression { Name = range }
+//@[027:00028) |             | ├─IntegerLiteralExpression { Value = 7 }
+//@[029:00030) |             | └─IntegerLiteralExpression { Value = 7 }
+//@[033:00048) |             └─BinaryExpression { Operator = Modulo }
+//@[033:00034) |               ├─ArrayAccessExpression
+//@[033:00034) |               | ├─CopyIndexExpression
+//@[021:00031) |               | └─FunctionCallExpression { Name = range }
+//@[027:00028) |               |   ├─IntegerLiteralExpression { Value = 7 }
+//@[029:00030) |               |   └─IntegerLiteralExpression { Value = 7 }
+//@[038:00047) |               └─BinaryExpression { Operator = Add }
+//@[038:00043) |                 ├─ArrayAccessExpression
+//@[038:00043) |                 | ├─CopyIndexExpression
+//@[046:00047) |                 └─IntegerLiteralExpression { Value = 1 }
+      }
+    ]
+  }
+}]
+
+
+// BEGIN: Key Vault Secret Reference
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[000:00090) ├─DeclaredResourceExpression
+//@[062:00090) | └─ObjectExpression
+  name: 'testkeyvault'
+}
+
+module secureModule1 'child/secureParams.bicep' = {
+//@[000:00213) ├─DeclaredModuleExpression
+//@[050:00213) | ├─ObjectExpression
+  name: 'secureModule1'
+//@[002:00023) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00023) | |   └─StringLiteralExpression { Value = secureModule1 }
+  params: {
+//@[010:00132) | └─ObjectExpression
+    secureStringParam1: kv.getSecret('mySecret')
+//@[004:00048) |   ├─ObjectPropertyExpression
+//@[004:00022) |   | ├─StringLiteralExpression { Value = secureStringParam1 }
+//@[024:00048) |   | └─ResourceFunctionCallExpression { Name = getSecret }
+//@[024:00026) |   |   ├─ResourceReferenceExpression
+//@[037:00047) |   |   └─StringLiteralExpression { Value = mySecret }
+    secureStringParam2: kv.getSecret('mySecret','secretVersion')
+//@[004:00064) |   └─ObjectPropertyExpression
+//@[004:00022) |     ├─StringLiteralExpression { Value = secureStringParam2 }
+//@[024:00064) |     └─ResourceFunctionCallExpression { Name = getSecret }
+//@[024:00026) |       ├─ResourceReferenceExpression
+//@[037:00047) |       ├─StringLiteralExpression { Value = mySecret }
+//@[048:00063) |       └─StringLiteralExpression { Value = secretVersion }
+  }
+}
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[000:00134) ├─DeclaredResourceExpression
+//@[068:00134) | └─ObjectExpression
+  name: 'testkeyvault'
+  scope: resourceGroup('otherGroup')
+}
+
+module secureModule2 'child/secureParams.bicep' = {
+//@[000:00225) ├─DeclaredModuleExpression
+//@[050:00225) | ├─ObjectExpression
+  name: 'secureModule2'
+//@[002:00023) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00023) | |   └─StringLiteralExpression { Value = secureModule2 }
+  params: {
+//@[010:00144) | └─ObjectExpression
+    secureStringParam1: scopedKv.getSecret('mySecret')
+//@[004:00054) |   ├─ObjectPropertyExpression
+//@[004:00022) |   | ├─StringLiteralExpression { Value = secureStringParam1 }
+//@[024:00054) |   | └─ResourceFunctionCallExpression { Name = getSecret }
+//@[024:00032) |   |   ├─ResourceReferenceExpression
+//@[043:00053) |   |   └─StringLiteralExpression { Value = mySecret }
+    secureStringParam2: scopedKv.getSecret('mySecret','secretVersion')
+//@[004:00070) |   └─ObjectPropertyExpression
+//@[004:00022) |     ├─StringLiteralExpression { Value = secureStringParam2 }
+//@[024:00070) |     └─ResourceFunctionCallExpression { Name = getSecret }
+//@[024:00032) |       ├─ResourceReferenceExpression
+//@[043:00053) |       ├─StringLiteralExpression { Value = mySecret }
+//@[054:00069) |       └─StringLiteralExpression { Value = secretVersion }
+  }
+}
+
+//looped module with looped existing resource (Issue #2862)
+var vaults = [
+//@[000:00200) ├─DeclaredVariableExpression { Name = vaults }
+//@[013:00200) | └─ArrayExpression
+  {
+//@[002:00089) |   ├─ObjectExpression
+    vaultName: 'test-1-kv'
+//@[004:00026) |   | ├─ObjectPropertyExpression
+//@[004:00013) |   | | ├─StringLiteralExpression { Value = vaultName }
+//@[015:00026) |   | | └─StringLiteralExpression { Value = test-1-kv }
+    vaultRG: 'test-1-rg'
+//@[004:00024) |   | ├─ObjectPropertyExpression
+//@[004:00011) |   | | ├─StringLiteralExpression { Value = vaultRG }
+//@[013:00024) |   | | └─StringLiteralExpression { Value = test-1-rg }
+    vaultSub: 'abcd-efgh'
+//@[004:00025) |   | └─ObjectPropertyExpression
+//@[004:00012) |   |   ├─StringLiteralExpression { Value = vaultSub }
+//@[014:00025) |   |   └─StringLiteralExpression { Value = abcd-efgh }
+  }
+  {
+//@[002:00090) |   └─ObjectExpression
+    vaultName: 'test-2-kv'
+//@[004:00026) |     ├─ObjectPropertyExpression
+//@[004:00013) |     | ├─StringLiteralExpression { Value = vaultName }
+//@[015:00026) |     | └─StringLiteralExpression { Value = test-2-kv }
+    vaultRG: 'test-2-rg'
+//@[004:00024) |     ├─ObjectPropertyExpression
+//@[004:00011) |     | ├─StringLiteralExpression { Value = vaultRG }
+//@[013:00024) |     | └─StringLiteralExpression { Value = test-2-rg }
+    vaultSub: 'ijkl-1adg1'
+//@[004:00026) |     └─ObjectPropertyExpression
+//@[004:00012) |       ├─StringLiteralExpression { Value = vaultSub }
+//@[014:00026) |       └─StringLiteralExpression { Value = ijkl-1adg1 }
+  }
+]
+var secrets = [
+//@[000:00132) ├─DeclaredVariableExpression { Name = secrets }
+//@[014:00132) | └─ArrayExpression
+  {
+//@[002:00055) |   ├─ObjectExpression
+    name: 'secret01'
+//@[004:00020) |   | ├─ObjectPropertyExpression
+//@[004:00008) |   | | ├─StringLiteralExpression { Value = name }
+//@[010:00020) |   | | └─StringLiteralExpression { Value = secret01 }
+    version: 'versionA'
+//@[004:00023) |   | └─ObjectPropertyExpression
+//@[004:00011) |   |   ├─StringLiteralExpression { Value = version }
+//@[013:00023) |   |   └─StringLiteralExpression { Value = versionA }
+  }
+  {
+//@[002:00055) |   └─ObjectExpression
+    name: 'secret02'
+//@[004:00020) |     ├─ObjectPropertyExpression
+//@[004:00008) |     | ├─StringLiteralExpression { Value = name }
+//@[010:00020) |     | └─StringLiteralExpression { Value = secret02 }
+    version: 'versionB'
+//@[004:00023) |     └─ObjectPropertyExpression
+//@[004:00011) |       ├─StringLiteralExpression { Value = version }
+//@[013:00023) |       └─StringLiteralExpression { Value = versionB }
+  }
+]
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [for vault in vaults: {
+//@[000:00175) ├─DeclaredResourceExpression
+//@[068:00175) | └─ForLoopExpression
+//@[082:00088) |   ├─VariableReferenceExpression { Variable = vaults }
+//@[090:00174) |   └─ObjectExpression
+  name: vault.vaultName
+  scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+}]
+
+module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secrets: {
+//@[000:00278) ├─DeclaredModuleExpression
+//@[055:00278) | ├─ForLoopExpression
+//@[075:00082) | | ├─VariableReferenceExpression { Variable = secrets }
+//@[084:00277) | | └─ObjectExpression
+//@[075:00082) |   |       └─VariableReferenceExpression { Variable = secrets }
+//@[075:00082) |       |   └─VariableReferenceExpression { Variable = secrets }
+//@[075:00082) |           └─VariableReferenceExpression { Variable = secrets }
+  name: 'secureModuleLooped-${i}'
+//@[002:00033) | |   └─ObjectPropertyExpression
+//@[002:00006) | |     ├─StringLiteralExpression { Value = name }
+//@[008:00033) | |     └─InterpolatedStringExpression
+//@[030:00031) | |       └─CopyIndexExpression
+  params: {
+//@[010:00152) | └─ObjectExpression
+    secureStringParam1: loopedKv[i].getSecret(secret.name)
+//@[004:00058) |   ├─ObjectPropertyExpression
+//@[004:00022) |   | ├─StringLiteralExpression { Value = secureStringParam1 }
+//@[024:00058) |   | └─ResourceFunctionCallExpression { Name = getSecret }
+//@[024:00035) |   |   ├─ResourceReferenceExpression
+//@[046:00057) |   |   └─PropertyAccessExpression { PropertyName = name }
+//@[046:00052) |   |     └─ArrayAccessExpression
+//@[046:00052) |   |       ├─CopyIndexExpression
+    secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+//@[004:00074) |   └─ObjectPropertyExpression
+//@[004:00022) |     ├─StringLiteralExpression { Value = secureStringParam2 }
+//@[024:00074) |     └─ResourceFunctionCallExpression { Name = getSecret }
+//@[024:00035) |       ├─ResourceReferenceExpression
+//@[046:00057) |       ├─PropertyAccessExpression { PropertyName = name }
+//@[046:00052) |       | └─ArrayAccessExpression
+//@[046:00052) |       |   ├─CopyIndexExpression
+//@[059:00073) |       └─PropertyAccessExpression { PropertyName = version }
+//@[059:00065) |         └─ArrayAccessExpression
+//@[059:00065) |           ├─CopyIndexExpression
+  }
+}]
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+//@[000:00285) ├─DeclaredModuleExpression
+//@[058:00285) | ├─ObjectExpression
+  name: 'secureModuleCondition'
+//@[002:00031) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00031) | |   └─StringLiteralExpression { Value = secureModuleCondition }
+  params: {
+//@[010:00188) | └─ObjectExpression
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+//@[004:00067) |   ├─ObjectPropertyExpression
+//@[004:00022) |   | ├─StringLiteralExpression { Value = secureStringParam1 }
+//@[024:00067) |   | └─TernaryExpression
+//@[024:00028) |   |   ├─BooleanLiteralExpression { Value = True }
+//@[031:00055) |   |   ├─ResourceFunctionCallExpression { Name = getSecret }
+//@[031:00033) |   |   | ├─ResourceReferenceExpression
+//@[044:00054) |   |   | └─StringLiteralExpression { Value = mySecret }
+//@[058:00067) |   |   └─StringLiteralExpression { Value = notTrue }
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret','secretVersion') : 'notTrue'
+//@[004:00101) |   └─ObjectPropertyExpression
+//@[004:00022) |     ├─StringLiteralExpression { Value = secureStringParam2 }
+//@[024:00101) |     └─TernaryExpression
+//@[024:00028) |       ├─BooleanLiteralExpression { Value = True }
+//@[031:00089) |       ├─TernaryExpression
+//@[031:00036) |       | ├─BooleanLiteralExpression { Value = False }
+//@[039:00046) |       | ├─StringLiteralExpression { Value = false }
+//@[049:00089) |       | └─ResourceFunctionCallExpression { Name = getSecret }
+//@[049:00051) |       |   ├─ResourceReferenceExpression
+//@[062:00072) |       |   ├─StringLiteralExpression { Value = mySecret }
+//@[073:00088) |       |   └─StringLiteralExpression { Value = secretVersion }
+//@[092:00101) |       └─StringLiteralExpression { Value = notTrue }
+  }
+}
+
+// END: Key Vault Secret Reference
+
+module withSpace 'module with space.bicep' = {
+//@[000:00070) ├─DeclaredModuleExpression
+//@[045:00070) | └─ObjectExpression
+  name: 'withSpace'
+//@[002:00019) |   └─ObjectPropertyExpression
+//@[002:00006) |     ├─StringLiteralExpression { Value = name }
+//@[008:00019) |     └─StringLiteralExpression { Value = withSpace }
+}
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+//@[000:00104) ├─DeclaredModuleExpression
+//@[074:00104) | └─ObjectExpression
+  name: 'childWithSpace'
+//@[002:00024) |   └─ObjectPropertyExpression
+//@[002:00006) |     ├─StringLiteralExpression { Value = name }
+//@[008:00024) |     └─StringLiteralExpression { Value = childWithSpace }
+}
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+//@[000:00042) ├─DeclaredVariableExpression { Name = nameofModule }
+//@[026:00041) | └─StringLiteralExpression { Value = folderWithSpace }
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+//@[000:00081) ├─DeclaredVariableExpression { Name = nameofModuleParam }
+//@[031:00080) | └─StringLiteralExpression { Value = exposedSecureString }
+
+module moduleWithNameof 'modulea.bicep' = {
+//@[000:00358) ├─DeclaredModuleExpression
+//@[042:00358) | ├─ObjectExpression
+  name: 'nameofModule'
+//@[002:00022) | | └─ObjectPropertyExpression
+//@[002:00006) | |   ├─StringLiteralExpression { Value = name }
+//@[008:00022) | |   └─StringLiteralExpression { Value = nameofModule }
+  scope: resourceGroup(nameof(nameofModuleParam))
+  params:{
+//@[009:00235) | ├─ObjectExpression
+    stringParamA: nameof(withSpace)
+//@[004:00035) | | ├─ObjectPropertyExpression
+//@[004:00016) | | | ├─StringLiteralExpression { Value = stringParamA }
+//@[025:00034) | | | └─StringLiteralExpression { Value = withSpace }
+    stringParamB: nameof(folderWithSpace)
+//@[004:00041) | | ├─ObjectPropertyExpression
+//@[004:00016) | | | ├─StringLiteralExpression { Value = stringParamB }
+//@[025:00040) | | | └─StringLiteralExpression { Value = folderWithSpace }
+    objParam: {
+//@[004:00090) | | ├─ObjectPropertyExpression
+//@[004:00012) | | | ├─StringLiteralExpression { Value = objParam }
+//@[014:00090) | | | └─ObjectExpression
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+//@[006:00066) | | |   └─ObjectPropertyExpression
+//@[006:00007) | | |     ├─StringLiteralExpression { Value = a }
+//@[016:00065) | | |     └─StringLiteralExpression { Value = exposedSecureString }
+    }
+    arrayParam: [
+//@[004:00046) | | └─ObjectPropertyExpression
+//@[004:00014) | |   ├─StringLiteralExpression { Value = arrayParam }
+//@[016:00046) | |   └─ArrayExpression
+      nameof(vaults)
+//@[013:00019) | |     └─StringLiteralExpression { Value = vaults }
+    ]
+  }
+}
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+//@[000:00096) ├─DeclaredModuleExpression
+//@[065:00096) | └─ObjectExpression
+  name: 'nullableOutputs'
+//@[002:00025) |   └─ObjectPropertyExpression
+//@[002:00006) |     ├─StringLiteralExpression { Value = name }
+//@[008:00025) |     └─StringLiteralExpression { Value = nullableOutputs }
+}
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+//@[000:00081) ├─DeclaredOutputExpression { Name = nullableString }
+//@[022:00029) | ├─NullableTypeExpression { Name = null | string }
+//@[022:00028) | | └─AmbientTypeReferenceExpression { Name = string }
+//@[032:00081) | └─ModuleOutputPropertyAccessExpression { PropertyName = nullableString }
+//@[032:00065) |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[032:00057) |     └─ModuleReferenceExpression
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+//@[000:00107) ├─DeclaredOutputExpression { Name = deeplyNestedProperty }
+//@[028:00035) | ├─NullableTypeExpression { Name = null | string }
+//@[028:00034) | | └─AmbientTypeReferenceExpression { Name = string }
+//@[038:00107) | └─PropertyAccessExpression { PropertyName = property }
+//@[038:00098) |   └─PropertyAccessExpression { PropertyName = nested }
+//@[038:00091) |     └─PropertyAccessExpression { PropertyName = deeply }
+//@[038:00084) |       └─ModuleOutputPropertyAccessExpression { PropertyName = nullableObj }
+//@[038:00071) |         └─PropertyAccessExpression { PropertyName = outputs }
+//@[038:00063) |           └─ModuleReferenceExpression
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+//@[000:00108) ├─DeclaredOutputExpression { Name = deeplyNestedArrayItem }
+//@[029:00036) | ├─NullableTypeExpression { Name = null | string }
+//@[029:00035) | | └─AmbientTypeReferenceExpression { Name = string }
+//@[039:00108) | └─ArrayAccessExpression
+//@[106:00107) |   ├─IntegerLiteralExpression { Value = 0 }
+//@[039:00105) |   └─PropertyAccessExpression { PropertyName = array }
+//@[039:00099) |     └─PropertyAccessExpression { PropertyName = nested }
+//@[039:00092) |       └─PropertyAccessExpression { PropertyName = deeply }
+//@[039:00085) |         └─ModuleOutputPropertyAccessExpression { PropertyName = nullableObj }
+//@[039:00072) |           └─PropertyAccessExpression { PropertyName = outputs }
+//@[039:00064) |             └─ModuleReferenceExpression
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+//@[000:00116) ├─DeclaredOutputExpression { Name = deeplyNestedArrayItemFromEnd }
+//@[036:00043) | ├─NullableTypeExpression { Name = null | string }
+//@[036:00042) | | └─AmbientTypeReferenceExpression { Name = string }
+//@[046:00116) | └─ArrayAccessExpression
+//@[114:00115) |   ├─IntegerLiteralExpression { Value = 1 }
+//@[046:00112) |   └─PropertyAccessExpression { PropertyName = array }
+//@[046:00106) |     └─PropertyAccessExpression { PropertyName = nested }
+//@[046:00099) |       └─PropertyAccessExpression { PropertyName = deeply }
+//@[046:00092) |         └─ModuleOutputPropertyAccessExpression { PropertyName = nullableObj }
+//@[046:00079) |           └─PropertyAccessExpression { PropertyName = outputs }
+//@[046:00071) |             └─ModuleReferenceExpression
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]
+//@[000:00124) └─DeclaredOutputExpression { Name = deeplyNestedArrayItemFromEndAttempt }
+//@[043:00050)   ├─NullableTypeExpression { Name = null | string }
+//@[043:00049)   | └─AmbientTypeReferenceExpression { Name = string }
+//@[053:00124)   └─ArrayAccessExpression
+//@[122:00123)     ├─IntegerLiteralExpression { Value = 1 }
+//@[053:00119)     └─PropertyAccessExpression { PropertyName = array }
+//@[053:00113)       └─PropertyAccessExpression { PropertyName = nested }
+//@[053:00106)         └─PropertyAccessExpression { PropertyName = deeply }
+//@[053:00099)           └─ModuleOutputPropertyAccessExpression { PropertyName = nullableObj }
+//@[053:00086)             └─PropertyAccessExpression { PropertyName = outputs }
+//@[053:00078)               └─ModuleReferenceExpression
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.json
@@ -1,0 +1,1358 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Enable content-addressed deduplication of nested module templates"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "499660557410836361"
+    }
+  },
+  "parameters": {
+    "deployTimeSuffix": {
+      "type": "string",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "this is deployTimeSuffix param"
+      }
+    }
+  },
+  "variables": {
+    "myModules": [
+      {
+        "name": "one",
+        "location": "eastus2"
+      },
+      {
+        "name": "two",
+        "location": "westus"
+      }
+    ],
+    "emptyArray": [],
+    "duplicateAcrossScopes": "hello",
+    "someDuplicate": true,
+    "otherDuplicate": false,
+    "vaults": [
+      {
+        "vaultName": "test-1-kv",
+        "vaultRG": "test-1-rg",
+        "vaultSub": "abcd-efgh"
+      },
+      {
+        "vaultName": "test-2-kv",
+        "vaultRG": "test-2-rg",
+        "vaultSub": "ijkl-1adg1"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "secret01",
+        "version": "versionA"
+      },
+      {
+        "name": "secret02",
+        "version": "versionB"
+      }
+    ],
+    "nameofModule": "folderWithSpace",
+    "nameofModuleParam": "exposedSecureString"
+  },
+  "resources": {
+    "resWithDependencies": {
+      "type": "Mock.Rp/mockResource",
+      "apiVersion": "2020-01-01",
+      "name": "harry",
+      "properties": {
+        "modADep": "[reference('modATest').outputs.stringOutputA.value]",
+        "modBDep": "[reference('modB').outputs.myResourceId.value]",
+        "modCDep": "[reference('modC').outputs.myResourceId.value]"
+      },
+      "dependsOn": [
+        "modATest",
+        "modB",
+        "modC"
+      ]
+    },
+    "resWithCalculatedNameDependencies": {
+      "type": "Mock.Rp/mockResource",
+      "apiVersion": "2020-01-01",
+      "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
+      "properties": {
+        "modADep": "[reference('moduleWithCalculatedName').outputs.outputObj.value]"
+      },
+      "dependsOn": [
+        "moduleWithCalculatedName",
+        "optionalWithAllParamsAndManualDependency"
+      ]
+    },
+    "kv": {
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "testkeyvault"
+    },
+    "scopedKv": {
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "resourceGroup": "otherGroup",
+      "name": "testkeyvault"
+    },
+    "loopedKv": {
+      "copy": {
+        "name": "loopedKv",
+        "count": "[length(variables('vaults'))]"
+      },
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "subscriptionId": "[variables('vaults')[copyIndex()].vaultSub]",
+      "resourceGroup": "[variables('vaults')[copyIndex()].vaultRG]",
+      "name": "[variables('vaults')[copyIndex()].vaultName]"
+    },
+    "modATest": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modATest",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "stringParamB": {
+            "value": "hello!"
+          },
+          "objParam": {
+            "value": {
+              "a": "b"
+            }
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "a": "b"
+              },
+              "abc"
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      },
+      "metadata": {
+        "description": "this module a"
+      }
+    },
+    "modB": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modB",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "West US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+        }
+      },
+      "metadata": {
+        "description": "this module b"
+      }
+    },
+    "modBWithCondition": {
+      "condition": "[equals(add(1, 1), 2)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modBWithCondition",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "East US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+        }
+      },
+      "metadata": {
+        "description": "this is just module b with a condition"
+      }
+    },
+    "modBWithCondition2": {
+      "condition": "[equals(add(1, 1), 2)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modBWithCondition2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "East US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+        }
+      }
+    },
+    "modC": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modC",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "West US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff"
+        }
+      }
+    },
+    "modCWithCondition": {
+      "condition": "[equals(sub(2, 1), 1)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modCWithCondition",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "East US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff"
+        }
+      }
+    },
+    "optionalWithNoParams1": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithNoParams1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      }
+    },
+    "optionalWithNoParams2": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithNoParams2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      }
+    },
+    "optionalWithAllParams": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithNoParams3",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "abc"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      }
+    },
+    "optionalWithAllParamsAndManualDependency": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithAllParamsAndManualDependency",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "abc"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      },
+      "dependsOn": [
+        "optionalWithAllParams",
+        "resWithDependencies"
+      ]
+    },
+    "optionalWithImplicitDependency": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithImplicitDependency",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      },
+      "dependsOn": [
+        "optionalWithAllParamsAndManualDependency",
+        "resWithDependencies"
+      ]
+    },
+    "moduleWithCalculatedName": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      },
+      "dependsOn": [
+        "optionalWithAllParamsAndManualDependency",
+        "resWithDependencies"
+      ]
+    },
+    "storageResources": {
+      "copy": {
+        "name": "storageResources",
+        "count": "[length(variables('myModules'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[variables('myModules')[copyIndex()].name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "arrayParam": {
+            "value": []
+          },
+          "objParam": {
+            "value": "[variables('myModules')[copyIndex()]]"
+          },
+          "stringParamB": {
+            "value": "[variables('myModules')[copyIndex()].location]"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "storageResourcesWithIndex": {
+      "copy": {
+        "name": "storageResourcesWithIndex",
+        "count": "[length(variables('myModules'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[variables('myModules')[copyIndex()].name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "arrayParam": {
+            "value": [
+              "[add(copyIndex(), 1)]"
+            ]
+          },
+          "objParam": {
+            "value": "[variables('myModules')[copyIndex()]]"
+          },
+          "stringParamB": {
+            "value": "[variables('myModules')[copyIndex()].location]"
+          },
+          "stringParamA": {
+            "value": "[concat('a', copyIndex())]"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "nestedModuleLoop": {
+      "copy": {
+        "name": "nestedModuleLoop",
+        "count": "[length(variables('myModules'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[variables('myModules')[copyIndex()].name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(range(0, 3))]",
+                "input": "[concat('test-', range(0, 3)[copyIndex('value')], '-', variables('myModules')[copyIndex()].name)]"
+              }
+            ]
+          },
+          "objParam": {
+            "value": "[variables('myModules')[copyIndex()]]"
+          },
+          "stringParamB": {
+            "value": "[variables('myModules')[copyIndex()].location]"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "duplicateIdentifiersWithinLoop": {
+      "copy": {
+        "name": "duplicateIdentifiersWithinLoop",
+        "count": "[length(variables('emptyArray'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('hello-{0}', variables('emptyArray')[copyIndex()])]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {}
+          },
+          "stringParamA": {
+            "value": "test"
+          },
+          "stringParamB": {
+            "value": "test"
+          },
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('emptyArray'))]",
+                "input": "[variables('emptyArray')[copyIndex('value')]]"
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "duplicateInGlobalAndOneLoop": {
+      "copy": {
+        "name": "duplicateInGlobalAndOneLoop",
+        "count": "[length(createArray())]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('hello-{0}', createArray()[copyIndex()])]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {}
+          },
+          "stringParamA": {
+            "value": "test"
+          },
+          "stringParamB": {
+            "value": "test"
+          },
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('emptyArray'))]",
+                "input": "[variables('emptyArray')[copyIndex('value')]]"
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "duplicatesEverywhere": {
+      "copy": {
+        "name": "duplicatesEverywhere",
+        "count": "[length(createArray())]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('hello-{0}', createArray()[copyIndex()])]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {}
+          },
+          "stringParamB": {
+            "value": "test"
+          },
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('emptyArray'))]",
+                "input": "[format('{0}-{1}', createArray()[copyIndex()], variables('emptyArray')[copyIndex('value')])]"
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "propertyLoopInsideParameterValue": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "propertyLoopInsideParameterValue",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {
+              "copy": [
+                {
+                  "name": "a",
+                  "count": "[length(range(0, 10))]",
+                  "input": "[range(0, 10)[copyIndex('a')]]"
+                },
+                {
+                  "name": "b",
+                  "count": "[length(range(1, 2))]",
+                  "input": "[range(1, 2)[copyIndex('b')]]"
+                },
+                {
+                  "name": "e",
+                  "count": "[length(range(4, 4))]",
+                  "input": {
+                    "f": "[range(4, 4)[copyIndex('e')]]"
+                  }
+                }
+              ],
+              "c": {
+                "copy": [
+                  {
+                    "name": "d",
+                    "count": "[length(range(2, 3))]",
+                    "input": "[range(2, 3)[copyIndex('d')]]"
+                  }
+                ]
+              }
+            }
+          },
+          "stringParamB": {
+            "value": ""
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "copy": [
+                  {
+                    "name": "e",
+                    "count": "[length(range(7, 7))]",
+                    "input": "[range(7, 7)[copyIndex('e')]]"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "propertyLoopInsideParameterValueWithIndexes": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "propertyLoopInsideParameterValueWithIndexes",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {
+              "copy": [
+                {
+                  "name": "a",
+                  "count": "[length(range(0, 10))]",
+                  "input": "[add(range(0, 10)[copyIndex('a')], copyIndex('a'))]"
+                },
+                {
+                  "name": "b",
+                  "count": "[length(range(1, 2))]",
+                  "input": "[div(range(1, 2)[copyIndex('b')], copyIndex('b'))]"
+                },
+                {
+                  "name": "e",
+                  "count": "[length(range(4, 4))]",
+                  "input": {
+                    "f": "[range(4, 4)[copyIndex('e')]]",
+                    "g": "[copyIndex('e')]"
+                  }
+                }
+              ],
+              "c": {
+                "copy": [
+                  {
+                    "name": "d",
+                    "count": "[length(range(2, 3))]",
+                    "input": "[mul(range(2, 3)[copyIndex('d')], copyIndex('d'))]"
+                  }
+                ]
+              }
+            }
+          },
+          "stringParamB": {
+            "value": ""
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "copy": [
+                  {
+                    "name": "e",
+                    "count": "[length(range(7, 7))]",
+                    "input": "[range(7, 7)[copyIndex('e')]]"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "propertyLoopInsideParameterValueInsideModuleLoop": {
+      "copy": {
+        "name": "propertyLoopInsideParameterValueInsideModuleLoop",
+        "count": "[length(range(0, 1))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "propertyLoopInsideParameterValueInsideModuleLoop",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {
+              "copy": [
+                {
+                  "name": "a",
+                  "count": "[length(range(0, 10))]",
+                  "input": "[add(range(0, 10)[copyIndex('a')], range(0, 1)[copyIndex()])]"
+                },
+                {
+                  "name": "b",
+                  "count": "[length(range(1, 2))]",
+                  "input": "[mul(range(1, 2)[copyIndex('b')], range(0, 1)[copyIndex()])]"
+                },
+                {
+                  "name": "e",
+                  "count": "[length(range(4, 4))]",
+                  "input": {
+                    "f": "[sub(range(4, 4)[copyIndex('e')], range(0, 1)[copyIndex()])]"
+                  }
+                }
+              ],
+              "c": {
+                "copy": [
+                  {
+                    "name": "d",
+                    "count": "[length(range(2, 3))]",
+                    "input": "[range(2, 3)[copyIndex('d')]]"
+                  }
+                ]
+              }
+            }
+          },
+          "stringParamB": {
+            "value": ""
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "copy": [
+                  {
+                    "name": "e",
+                    "count": "[length(range(7, 7))]",
+                    "input": "[mod(range(7, 7)[copyIndex('e')], add(range(0, 1)[copyIndex()], 1))]"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "secureModule1": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "secureModule1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret"
+            }
+          },
+          "secureStringParam2": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret",
+              "secretVersion": "secretVersion"
+            }
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "secureModule2": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "secureModule2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'otherGroup'), 'Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret"
+            }
+          },
+          "secureStringParam2": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'otherGroup'), 'Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret",
+              "secretVersion": "secretVersion"
+            }
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "secureModuleLooped": {
+      "copy": {
+        "name": "secureModuleLooped",
+        "count": "[length(variables('secrets'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('secureModuleLooped-{0}', copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('vaults')[copyIndex()].vaultSub, variables('vaults')[copyIndex()].vaultRG), 'Microsoft.KeyVault/vaults', variables('vaults')[copyIndex()].vaultName)]"
+              },
+              "secretName": "[variables('secrets')[copyIndex()].name]"
+            }
+          },
+          "secureStringParam2": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('vaults')[copyIndex()].vaultSub, variables('vaults')[copyIndex()].vaultRG), 'Microsoft.KeyVault/vaults', variables('vaults')[copyIndex()].vaultName)]"
+              },
+              "secretName": "[variables('secrets')[copyIndex()].name]",
+              "secretVersion": "[variables('secrets')[copyIndex()].version]"
+            }
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "secureModuleCondition": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "secureModuleCondition",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": "[if(true(), createObject('reference', createObject('keyVault', createObject('id', resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')), 'secretName', 'mySecret')), createObject('value', 'notTrue'))]",
+          "secureStringParam2": "[if(true(), if(false(), createObject('value', 'false'), createObject('reference', createObject('keyVault', createObject('id', resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')), 'secretName', 'mySecret', 'secretVersion', 'secretVersion'))), createObject('value', 'notTrue'))]"
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "withSpace": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "withSpace",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232"
+        }
+      }
+    },
+    "folderWithSpace": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "childWithSpace",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232"
+        }
+      }
+    },
+    "moduleWithNameof": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "nameofModule",
+      "resourceGroup": "nameofModuleParam",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "stringParamA": {
+            "value": "withSpace"
+          },
+          "stringParamB": {
+            "value": "folderWithSpace"
+          },
+          "objParam": {
+            "value": {
+              "a": "exposedSecureString"
+            }
+          },
+          "arrayParam": {
+            "value": [
+              "vaults"
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      },
+      "dependsOn": [
+        "folderWithSpace",
+        "secureModuleCondition",
+        "withSpace"
+      ]
+    },
+    "moduleWithNullableOutputs": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "nullableOutputs",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:102b87ceac71f62e683d20752641b5488b8deb56efb533795fc4f9dcdd0caebe"
+        }
+      }
+    }
+  },
+  "outputs": {
+    "stringOutputA": {
+      "type": "string",
+      "value": "[reference('modATest').outputs.stringOutputA.value]"
+    },
+    "stringOutputB": {
+      "type": "string",
+      "value": "[reference('modATest').outputs.stringOutputB.value]"
+    },
+    "objOutput": {
+      "type": "object",
+      "value": "[reference('modATest').outputs.objOutput.value]"
+    },
+    "arrayOutput": {
+      "type": "array",
+      "value": "[reference('modATest').outputs.arrayOutput.value]"
+    },
+    "modCalculatedNameOutput": {
+      "type": "object",
+      "value": "[reference('moduleWithCalculatedName').outputs.outputObj.value]"
+    },
+    "nullableString": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableString'), 'value')]"
+    },
+    "deeplyNestedProperty": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'property')]"
+    },
+    "deeplyNestedArrayItem": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array', 0)]"
+    },
+    "deeplyNestedArrayItemFromEnd": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array', createObject('value', 1, 'fromEnd', true()))]"
+    },
+    "deeplyNestedArrayItemFromEndAttempt": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryIndexFromEnd(tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array'), 1)]"
+    }
+  },
+  "content": {
+    "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+        "parameters": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "variables": {},
+        "resources": [
+          {
+            "name": "myResource",
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "location": "[parameters('location')]"
+          }
+        ],
+        "outputs": {
+          "myResourceId": {
+            "type": "string",
+            "value": "[resourceId('Mock.Rp/mockResource', 'myResource')]"
+          }
+        }
+      }
+    },
+    "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "2734319700446247652"
+          }
+        },
+        "parameters": {
+          "secureStringParam1": {
+            "type": "securestring"
+          },
+          "secureStringParam2": {
+            "type": "securestring",
+            "defaultValue": ""
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "exposedSecureString": {
+            "type": "string",
+            "value": "[parameters('secureStringParam1')]"
+          }
+        }
+      }
+    },
+    "sha256:102b87ceac71f62e683d20752641b5488b8deb56efb533795fc4f9dcdd0caebe": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "12443670995828892617"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "nullableString": {
+            "type": "string",
+            "nullable": true,
+            "value": "foo"
+          },
+          "nullableObj": {
+            "type": "object",
+            "nullable": true,
+            "value": {
+              "deeply": {
+                "nested": {
+                  "property": "value",
+                  "array": [
+                    "foo",
+                    "bar"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "6810048809782302279"
+          }
+        },
+        "parameters": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "myResource": {
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "name": "mockResource",
+            "location": "[parameters('location')]"
+          }
+        },
+        "outputs": {
+          "myResourceId": {
+            "type": "string",
+            "value": "[resourceId('Mock.Rp/mockResource', 'mockResource')]"
+          }
+        }
+      }
+    },
+    "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "13815270916276102317"
+          }
+        },
+        "parameters": {
+          "stringParamA": {
+            "type": "string",
+            "defaultValue": "test"
+          },
+          "stringParamB": {
+            "type": "string"
+          },
+          "objParam": {
+            "type": "object"
+          },
+          "arrayParam": {
+            "type": "array"
+          }
+        },
+        "resources": {
+          "basicStorage": {
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "name": "basicblobs",
+            "location": "[parameters('stringParamA')]"
+          },
+          "dnsZone": {
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "name": "myZone",
+            "location": "[parameters('stringParamB')]"
+          }
+        },
+        "outputs": {
+          "stringOutputA": {
+            "type": "string",
+            "value": "[parameters('stringParamA')]"
+          },
+          "stringOutputB": {
+            "type": "string",
+            "value": "[parameters('stringParamB')]"
+          },
+          "objOutput": {
+            "type": "object",
+            "value": "[reference('basicStorage')]"
+          },
+          "arrayOutput": {
+            "type": "array",
+            "value": [
+              "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+              "[resourceId('Mock.Rp/mockResource', 'myZone')]"
+            ]
+          }
+        }
+      }
+    },
+    "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "2225368239751975239"
+          }
+        },
+        "parameters": {
+          "optionalString": {
+            "type": "string",
+            "defaultValue": "abc"
+          },
+          "optionalInt": {
+            "type": "int",
+            "defaultValue": 42
+          },
+          "optionalObj": {
+            "type": "object",
+            "defaultValue": {
+              "a": "b"
+            }
+          },
+          "optionalArray": {
+            "type": "array",
+            "defaultValue": [
+              1,
+              2,
+              3
+            ]
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "outputObj": {
+            "type": "object",
+            "value": {
+              "optionalString": "[parameters('optionalString')]",
+              "optionalInt": "[parameters('optionalInt')]",
+              "optionalObj": "[parameters('optionalObj')]",
+              "optionalArray": "[parameters('optionalArray')]"
+            }
+          }
+        }
+      }
+    },
+    "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "11836443688215930685"
+          }
+        },
+        "parameters": {
+          "location": {
+            "type": "string",
+            "defaultValue": "westus"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "loc": {
+            "type": "string",
+            "value": "[parameters('location')]"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.json
@@ -1062,7 +1062,7 @@
       "value": "[tryIndexFromEnd(tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array'), 1)]"
     }
   },
-  "content": {
+  "contentManifest": {
     "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff": {
       "value": {
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.sourcemap.bicep
@@ -1,0 +1,1443 @@
+
+@sys.description('this is deployTimeSuffix param')
+//@      "metadata": {
+//@        "description": "this is deployTimeSuffix param"
+//@      }
+param deployTimeSuffix string = newGuid()
+//@    "deployTimeSuffix": {
+//@      "type": "string",
+//@      "defaultValue": "[newGuid()]",
+//@    }
+
+@sys.description('this module a')
+//@        "description": "this module a"
+module modATest './modulea.bicep' = {
+//@    "modATest": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      },
+//@      "metadata": {
+//@      }
+//@    },
+  name: 'modATest'
+//@      "name": "modATest",
+  params: {
+//@        "parameters": {
+//@        },
+    stringParamB: 'hello!'
+//@          "stringParamB": {
+//@            "value": "hello!"
+//@          },
+    objParam: {
+//@          "objParam": {
+//@            "value": {
+//@            }
+//@          },
+      a: 'b'
+//@              "a": "b"
+    }
+    arrayParam: [
+//@          "arrayParam": {
+//@            "value": [
+//@            ]
+//@          }
+      {
+//@              {
+//@              },
+        a: 'b'
+//@                "a": "b"
+      }
+      'abc'
+//@              "abc"
+    ]
+  }
+}
+
+
+@sys.description('this module b')
+//@        "description": "this module b"
+module modB './child/moduleb.bicep' = {
+//@    "modB": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+//@        }
+//@      },
+//@      "metadata": {
+//@      }
+//@    },
+  name: 'modB'
+//@      "name": "modB",
+  params: {
+//@        "parameters": {
+//@        },
+    location: 'West US'
+//@          "location": {
+//@            "value": "West US"
+//@          }
+  }
+}
+
+@sys.description('this is just module b with a condition')
+//@        "description": "this is just module b with a condition"
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+//@    "modBWithCondition": {
+//@      "condition": "[equals(add(1, 1), 2)]",
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+//@        }
+//@      },
+//@      "metadata": {
+//@      }
+//@    },
+  name: 'modBWithCondition'
+//@      "name": "modBWithCondition",
+  params: {
+//@        "parameters": {
+//@        },
+    location: 'East US'
+//@          "location": {
+//@            "value": "East US"
+//@          }
+  }
+}
+
+module modBWithCondition2 './child/moduleb.bicep' =
+//@    "modBWithCondition2": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+//@        }
+//@      }
+//@    },
+// awkward comment
+if (1 + 1 == 2) {
+//@      "condition": "[equals(add(1, 1), 2)]",
+  name: 'modBWithCondition2'
+//@      "name": "modBWithCondition2",
+  params: {
+//@        "parameters": {
+//@        },
+    location: 'East US'
+//@          "location": {
+//@            "value": "East US"
+//@          }
+  }
+}
+
+module modC './child/modulec.json' = {
+//@    "modC": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff"
+//@        }
+//@      }
+//@    },
+  name: 'modC'
+//@      "name": "modC",
+  params: {
+//@        "parameters": {
+//@        },
+    location: 'West US'
+//@          "location": {
+//@            "value": "West US"
+//@          }
+  }
+}
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+//@    "modCWithCondition": {
+//@      "condition": "[equals(sub(2, 1), 1)]",
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff"
+//@        }
+//@      }
+//@    },
+  name: 'modCWithCondition'
+//@      "name": "modCWithCondition",
+  params: {
+//@        "parameters": {
+//@        },
+    location: 'East US'
+//@          "location": {
+//@            "value": "East US"
+//@          }
+  }
+}
+
+module optionalWithNoParams1 './child/optionalParams.bicep'= {
+//@    "optionalWithNoParams1": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+//@        }
+//@      }
+//@    },
+  name: 'optionalWithNoParams1'
+//@      "name": "optionalWithNoParams1",
+}
+
+module optionalWithNoParams2 './child/optionalParams.bicep'= {
+//@    "optionalWithNoParams2": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+//@        }
+//@      }
+//@    },
+  name: 'optionalWithNoParams2'
+//@      "name": "optionalWithNoParams2",
+  params: {
+//@        "parameters": {},
+  }
+}
+
+module optionalWithAllParams './child/optionalParams.bicep'= {
+//@    "optionalWithAllParams": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+//@        }
+//@      }
+//@    },
+  name: 'optionalWithNoParams3'
+//@      "name": "optionalWithNoParams3",
+  params: {
+//@        "parameters": {
+//@        },
+    optionalString: 'abc'
+//@          "optionalString": {
+//@            "value": "abc"
+//@          },
+    optionalInt: 42
+//@          "optionalInt": {
+//@            "value": 42
+//@          },
+    optionalObj: { }
+//@          "optionalObj": {
+//@            "value": {}
+//@          },
+    optionalArray: [ ]
+//@          "optionalArray": {
+//@            "value": []
+//@          }
+  }
+}
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@    "resWithDependencies": {
+//@      "type": "Mock.Rp/mockResource",
+//@      "apiVersion": "2020-01-01",
+//@      "name": "harry",
+//@      "dependsOn": [
+//@        "modATest",
+//@        "modB",
+//@        "modC"
+//@      ]
+//@    },
+  name: 'harry'
+  properties: {
+//@      "properties": {
+//@      },
+    modADep: modATest.outputs.stringOutputA
+//@        "modADep": "[reference('modATest').outputs.stringOutputA.value]",
+    modBDep: modB.outputs.myResourceId
+//@        "modBDep": "[reference('modB').outputs.myResourceId.value]",
+    modCDep: modC.outputs.myResourceId
+//@        "modCDep": "[reference('modC').outputs.myResourceId.value]"
+  }
+}
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
+//@    "optionalWithAllParamsAndManualDependency": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+//@        }
+//@      },
+//@      "dependsOn": [
+//@        "optionalWithAllParams",
+//@        "resWithDependencies"
+//@      ]
+//@    },
+  name: 'optionalWithAllParamsAndManualDependency'
+//@      "name": "optionalWithAllParamsAndManualDependency",
+  params: {
+//@        "parameters": {
+//@        },
+    optionalString: 'abc'
+//@          "optionalString": {
+//@            "value": "abc"
+//@          },
+    optionalInt: 42
+//@          "optionalInt": {
+//@            "value": 42
+//@          },
+    optionalObj: { }
+//@          "optionalObj": {
+//@            "value": {}
+//@          },
+    optionalArray: [ ]
+//@          "optionalArray": {
+//@            "value": []
+//@          }
+  }
+  dependsOn: [
+    resWithDependencies
+    optionalWithAllParams
+  ]
+}
+
+module optionalWithImplicitDependency './child/optionalParams.bicep'= {
+//@    "optionalWithImplicitDependency": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+//@        }
+//@      },
+//@      "dependsOn": [
+//@        "optionalWithAllParamsAndManualDependency",
+//@        "resWithDependencies"
+//@      ]
+//@    },
+  name: 'optionalWithImplicitDependency'
+//@      "name": "optionalWithImplicitDependency",
+  params: {
+//@        "parameters": {
+//@        },
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@          "optionalString": {
+//@            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
+//@          },
+    optionalInt: 42
+//@          "optionalInt": {
+//@            "value": 42
+//@          },
+    optionalObj: { }
+//@          "optionalObj": {
+//@            "value": {}
+//@          },
+    optionalArray: [ ]
+//@          "optionalArray": {
+//@            "value": []
+//@          }
+  }
+}
+
+module moduleWithCalculatedName './child/optionalParams.bicep'= {
+//@    "moduleWithCalculatedName": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+//@        }
+//@      },
+//@      "dependsOn": [
+//@        "optionalWithAllParamsAndManualDependency",
+//@        "resWithDependencies"
+//@      ]
+//@    },
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@      "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
+  params: {
+//@        "parameters": {
+//@        },
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@          "optionalString": {
+//@            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
+//@          },
+    optionalInt: 42
+//@          "optionalInt": {
+//@            "value": 42
+//@          },
+    optionalObj: { }
+//@          "optionalObj": {
+//@            "value": {}
+//@          },
+    optionalArray: [ ]
+//@          "optionalArray": {
+//@            "value": []
+//@          }
+  }
+}
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@    "resWithCalculatedNameDependencies": {
+//@      "type": "Mock.Rp/mockResource",
+//@      "apiVersion": "2020-01-01",
+//@      "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
+//@      "dependsOn": [
+//@        "moduleWithCalculatedName",
+//@        "optionalWithAllParamsAndManualDependency"
+//@      ]
+//@    },
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  properties: {
+//@      "properties": {
+//@      },
+    modADep: moduleWithCalculatedName.outputs.outputObj
+//@        "modADep": "[reference('moduleWithCalculatedName').outputs.outputObj.value]"
+  }
+}
+
+output stringOutputA string = modATest.outputs.stringOutputA
+//@    "stringOutputA": {
+//@      "type": "string",
+//@      "value": "[reference('modATest').outputs.stringOutputA.value]"
+//@    },
+output stringOutputB string = modATest.outputs.stringOutputB
+//@    "stringOutputB": {
+//@      "type": "string",
+//@      "value": "[reference('modATest').outputs.stringOutputB.value]"
+//@    },
+output objOutput object = modATest.outputs.objOutput
+//@    "objOutput": {
+//@      "type": "object",
+//@      "value": "[reference('modATest').outputs.objOutput.value]"
+//@    },
+output arrayOutput array = modATest.outputs.arrayOutput
+//@    "arrayOutput": {
+//@      "type": "array",
+//@      "value": "[reference('modATest').outputs.arrayOutput.value]"
+//@    },
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+//@    "modCalculatedNameOutput": {
+//@      "type": "object",
+//@      "value": "[reference('moduleWithCalculatedName').outputs.outputObj.value]"
+//@    },
+
+/*
+  valid loop cases
+*/
+
+@sys.description('this is myModules')
+var myModules = [
+//@    "myModules": [
+//@    ],
+  {
+//@      {
+//@      },
+    name: 'one'
+//@        "name": "one",
+    location: 'eastus2'
+//@        "location": "eastus2"
+  }
+  {
+//@      {
+//@      }
+    name: 'two'
+//@        "name": "two",
+    location: 'westus'
+//@        "location": "westus"
+  }
+]
+
+var emptyArray = []
+//@    "emptyArray": [],
+
+// simple module loop
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@    "storageResources": {
+//@      "copy": {
+//@        "name": "storageResources",
+//@        "count": "[length(variables('myModules'))]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: module.name
+//@      "name": "[variables('myModules')[copyIndex()].name]",
+  params: {
+//@        "parameters": {
+//@        },
+    arrayParam: []
+//@          "arrayParam": {
+//@            "value": []
+//@          },
+    objParam: module
+//@          "objParam": {
+//@            "value": "[variables('myModules')[copyIndex()]]"
+//@          },
+    stringParamB: module.location
+//@          "stringParamB": {
+//@            "value": "[variables('myModules')[copyIndex()].location]"
+//@          }
+  }
+}]
+
+// simple indexed module loop
+module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules: {
+//@    "storageResourcesWithIndex": {
+//@      "copy": {
+//@        "name": "storageResourcesWithIndex",
+//@        "count": "[length(variables('myModules'))]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: module.name
+//@      "name": "[variables('myModules')[copyIndex()].name]",
+  params: {
+//@        "parameters": {
+//@        },
+    arrayParam: [
+//@          "arrayParam": {
+//@            "value": [
+//@            ]
+//@          },
+      i + 1
+//@              "[add(copyIndex(), 1)]"
+    ]
+    objParam: module
+//@          "objParam": {
+//@            "value": "[variables('myModules')[copyIndex()]]"
+//@          },
+    stringParamB: module.location
+//@          "stringParamB": {
+//@            "value": "[variables('myModules')[copyIndex()].location]"
+//@          },
+    stringParamA: concat('a', i)
+//@          "stringParamA": {
+//@            "value": "[concat('a', copyIndex())]"
+//@          }
+  }
+}]
+
+// nested module loop
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@    "nestedModuleLoop": {
+//@      "copy": {
+//@        "name": "nestedModuleLoop",
+//@        "count": "[length(variables('myModules'))]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: module.name
+//@      "name": "[variables('myModules')[copyIndex()].name]",
+  params: {
+//@        "parameters": {
+//@          "arrayParam": {
+//@          },
+//@        },
+    arrayParam: [for i in range(0,3): concat('test-', i, '-', module.name)]
+//@            "copy": [
+//@              {
+//@                "name": "value",
+//@                "count": "[length(range(0, 3))]",
+//@                "input": "[concat('test-', range(0, 3)[copyIndex('value')], '-', variables('myModules')[copyIndex()].name)]"
+//@              }
+//@            ]
+    objParam: module
+//@          "objParam": {
+//@            "value": "[variables('myModules')[copyIndex()]]"
+//@          },
+    stringParamB: module.location
+//@          "stringParamB": {
+//@            "value": "[variables('myModules')[copyIndex()].location]"
+//@          }
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@    "duplicateIdentifiersWithinLoop": {
+//@      "copy": {
+//@        "name": "duplicateIdentifiersWithinLoop",
+//@        "count": "[length(variables('emptyArray'))]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: 'hello-${x}'
+//@      "name": "[format('hello-{0}', variables('emptyArray')[copyIndex()])]",
+  params: {
+//@        "parameters": {
+//@          "arrayParam": {
+//@          }
+//@        },
+    objParam: {}
+//@          "objParam": {
+//@            "value": {}
+//@          },
+    stringParamA: 'test'
+//@          "stringParamA": {
+//@            "value": "test"
+//@          },
+    stringParamB: 'test'
+//@          "stringParamB": {
+//@            "value": "test"
+//@          },
+    arrayParam: [for x in emptyArray: x]
+//@            "copy": [
+//@              {
+//@                "name": "value",
+//@                "count": "[length(variables('emptyArray'))]",
+//@                "input": "[variables('emptyArray')[copyIndex('value')]]"
+//@              }
+//@            ]
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+//@    "duplicateAcrossScopes": "hello",
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@    "duplicateInGlobalAndOneLoop": {
+//@      "copy": {
+//@        "name": "duplicateInGlobalAndOneLoop",
+//@        "count": "[length(createArray())]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: 'hello-${duplicateAcrossScopes}'
+//@      "name": "[format('hello-{0}', createArray()[copyIndex()])]",
+  params: {
+//@        "parameters": {
+//@          "arrayParam": {
+//@          }
+//@        },
+    objParam: {}
+//@          "objParam": {
+//@            "value": {}
+//@          },
+    stringParamA: 'test'
+//@          "stringParamA": {
+//@            "value": "test"
+//@          },
+    stringParamB: 'test'
+//@          "stringParamB": {
+//@            "value": "test"
+//@          },
+    arrayParam: [for x in emptyArray: x]
+//@            "copy": [
+//@              {
+//@                "name": "value",
+//@                "count": "[length(variables('emptyArray'))]",
+//@                "input": "[variables('emptyArray')[copyIndex('value')]]"
+//@              }
+//@            ]
+  }
+}]
+
+var someDuplicate = true
+//@    "someDuplicate": true,
+var otherDuplicate = false
+//@    "otherDuplicate": false,
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@    "duplicatesEverywhere": {
+//@      "copy": {
+//@        "name": "duplicatesEverywhere",
+//@        "count": "[length(createArray())]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: 'hello-${someDuplicate}'
+//@      "name": "[format('hello-{0}', createArray()[copyIndex()])]",
+  params: {
+//@        "parameters": {
+//@          "arrayParam": {
+//@          }
+//@        },
+    objParam: {}
+//@          "objParam": {
+//@            "value": {}
+//@          },
+    stringParamB: 'test'
+//@          "stringParamB": {
+//@            "value": "test"
+//@          },
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@            "copy": [
+//@              {
+//@                "name": "value",
+//@                "count": "[length(variables('emptyArray'))]",
+//@                "input": "[format('{0}-{1}', createArray()[copyIndex()], variables('emptyArray')[copyIndex('value')])]"
+//@              }
+//@            ]
+  }
+}]
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+//@    "propertyLoopInsideParameterValue": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: 'propertyLoopInsideParameterValue'
+//@      "name": "propertyLoopInsideParameterValue",
+  params: {
+//@        "parameters": {
+//@        },
+    objParam: {
+//@          "objParam": {
+//@            "value": {
+//@              "copy": [
+//@              ],
+//@            }
+//@          },
+      a: [for i in range(0,10): i]
+//@                {
+//@                  "name": "a",
+//@                  "count": "[length(range(0, 10))]",
+//@                  "input": "[range(0, 10)[copyIndex('a')]]"
+//@                },
+      b: [for i in range(1,2): i]
+//@                {
+//@                  "name": "b",
+//@                  "count": "[length(range(1, 2))]",
+//@                  "input": "[range(1, 2)[copyIndex('b')]]"
+//@                },
+      c: {
+//@              "c": {
+//@                "copy": [
+//@                ]
+//@              }
+        d: [for j in range(2,3): j]
+//@                  {
+//@                    "name": "d",
+//@                    "count": "[length(range(2, 3))]",
+//@                    "input": "[range(2, 3)[copyIndex('d')]]"
+//@                  }
+      }
+      e: [for k in range(4,4): {
+//@                {
+//@                  "name": "e",
+//@                  "count": "[length(range(4, 4))]",
+//@                  "input": {
+//@                  }
+//@                }
+        f: k
+//@                    "f": "[range(4, 4)[copyIndex('e')]]"
+      }]
+    }
+    stringParamB: ''
+//@          "stringParamB": {
+//@            "value": ""
+//@          },
+    arrayParam: [
+//@          "arrayParam": {
+//@            "value": [
+//@            ]
+//@          }
+      {
+//@              {
+//@                "copy": [
+//@                ]
+//@              }
+        e: [for j in range(7,7): j]
+//@                  {
+//@                    "name": "e",
+//@                    "count": "[length(range(7, 7))]",
+//@                    "input": "[range(7, 7)[copyIndex('e')]]"
+//@                  }
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+//@    "propertyLoopInsideParameterValueWithIndexes": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+//@      "name": "propertyLoopInsideParameterValueWithIndexes",
+  params: {
+//@        "parameters": {
+//@        },
+    objParam: {
+//@          "objParam": {
+//@            "value": {
+//@              "copy": [
+//@              ],
+//@            }
+//@          },
+      a: [for (i, i2) in range(0,10): i + i2]
+//@                {
+//@                  "name": "a",
+//@                  "count": "[length(range(0, 10))]",
+//@                  "input": "[add(range(0, 10)[copyIndex('a')], copyIndex('a'))]"
+//@                },
+      b: [for (i, i2) in range(1,2): i / i2]
+//@                {
+//@                  "name": "b",
+//@                  "count": "[length(range(1, 2))]",
+//@                  "input": "[div(range(1, 2)[copyIndex('b')], copyIndex('b'))]"
+//@                },
+      c: {
+//@              "c": {
+//@                "copy": [
+//@                ]
+//@              }
+        d: [for (j, j2) in range(2,3): j * j2]
+//@                  {
+//@                    "name": "d",
+//@                    "count": "[length(range(2, 3))]",
+//@                    "input": "[mul(range(2, 3)[copyIndex('d')], copyIndex('d'))]"
+//@                  }
+      }
+      e: [for (k, k2) in range(4,4): {
+//@                {
+//@                  "name": "e",
+//@                  "count": "[length(range(4, 4))]",
+//@                  "input": {
+//@                  }
+//@                }
+        f: k
+//@                    "f": "[range(4, 4)[copyIndex('e')]]",
+        g: k2
+//@                    "g": "[copyIndex('e')]"
+      }]
+    }
+    stringParamB: ''
+//@          "stringParamB": {
+//@            "value": ""
+//@          },
+    arrayParam: [
+//@          "arrayParam": {
+//@            "value": [
+//@            ]
+//@          }
+      {
+//@              {
+//@                "copy": [
+//@                ]
+//@              }
+        e: [for j in range(7,7): j]
+//@                  {
+//@                    "name": "e",
+//@                    "count": "[length(range(7, 7))]",
+//@                    "input": "[range(7, 7)[copyIndex('e')]]"
+//@                  }
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
+//@    "propertyLoopInsideParameterValueInsideModuleLoop": {
+//@      "copy": {
+//@        "name": "propertyLoopInsideParameterValueInsideModuleLoop",
+//@        "count": "[length(range(0, 1))]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      }
+//@    },
+  name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+//@      "name": "propertyLoopInsideParameterValueInsideModuleLoop",
+  params: {
+//@        "parameters": {
+//@        },
+    objParam: {
+//@          "objParam": {
+//@            "value": {
+//@              "copy": [
+//@              ],
+//@            }
+//@          },
+      a: [for i in range(0,10): i + thing]
+//@                {
+//@                  "name": "a",
+//@                  "count": "[length(range(0, 10))]",
+//@                  "input": "[add(range(0, 10)[copyIndex('a')], range(0, 1)[copyIndex()])]"
+//@                },
+      b: [for i in range(1,2): i * thing]
+//@                {
+//@                  "name": "b",
+//@                  "count": "[length(range(1, 2))]",
+//@                  "input": "[mul(range(1, 2)[copyIndex('b')], range(0, 1)[copyIndex()])]"
+//@                },
+      c: {
+//@              "c": {
+//@                "copy": [
+//@                ]
+//@              }
+        d: [for j in range(2,3): j]
+//@                  {
+//@                    "name": "d",
+//@                    "count": "[length(range(2, 3))]",
+//@                    "input": "[range(2, 3)[copyIndex('d')]]"
+//@                  }
+      }
+      e: [for k in range(4,4): {
+//@                {
+//@                  "name": "e",
+//@                  "count": "[length(range(4, 4))]",
+//@                  "input": {
+//@                  }
+//@                }
+        f: k - thing
+//@                    "f": "[sub(range(4, 4)[copyIndex('e')], range(0, 1)[copyIndex()])]"
+      }]
+    }
+    stringParamB: ''
+//@          "stringParamB": {
+//@            "value": ""
+//@          },
+    arrayParam: [
+//@          "arrayParam": {
+//@            "value": [
+//@            ]
+//@          }
+      {
+//@              {
+//@                "copy": [
+//@                ]
+//@              }
+        e: [for j in range(7,7): j % (thing + 1)]
+//@                  {
+//@                    "name": "e",
+//@                    "count": "[length(range(7, 7))]",
+//@                    "input": "[mod(range(7, 7)[copyIndex('e')], add(range(0, 1)[copyIndex()], 1))]"
+//@                  }
+      }
+    ]
+  }
+}]
+
+
+// BEGIN: Key Vault Secret Reference
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@    "kv": {
+//@      "existing": true,
+//@      "type": "Microsoft.KeyVault/vaults",
+//@      "apiVersion": "2019-09-01",
+//@      "name": "testkeyvault"
+//@    },
+  name: 'testkeyvault'
+}
+
+module secureModule1 'child/secureParams.bicep' = {
+//@    "secureModule1": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+//@        }
+//@      }
+//@    },
+  name: 'secureModule1'
+//@      "name": "secureModule1",
+  params: {
+//@        "parameters": {
+//@        },
+    secureStringParam1: kv.getSecret('mySecret')
+//@          "secureStringParam1": {
+//@            "reference": {
+//@              "keyVault": {
+//@                "id": "[resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')]"
+//@              },
+//@              "secretName": "mySecret"
+//@            }
+//@          },
+    secureStringParam2: kv.getSecret('mySecret','secretVersion')
+//@          "secureStringParam2": {
+//@            "reference": {
+//@              "keyVault": {
+//@                "id": "[resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')]"
+//@              },
+//@              "secretName": "mySecret",
+//@              "secretVersion": "secretVersion"
+//@            }
+//@          }
+  }
+}
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@    "scopedKv": {
+//@      "existing": true,
+//@      "type": "Microsoft.KeyVault/vaults",
+//@      "apiVersion": "2019-09-01",
+//@      "resourceGroup": "otherGroup",
+//@      "name": "testkeyvault"
+//@    },
+  name: 'testkeyvault'
+  scope: resourceGroup('otherGroup')
+}
+
+module secureModule2 'child/secureParams.bicep' = {
+//@    "secureModule2": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+//@        }
+//@      }
+//@    },
+  name: 'secureModule2'
+//@      "name": "secureModule2",
+  params: {
+//@        "parameters": {
+//@        },
+    secureStringParam1: scopedKv.getSecret('mySecret')
+//@          "secureStringParam1": {
+//@            "reference": {
+//@              "keyVault": {
+//@                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'otherGroup'), 'Microsoft.KeyVault/vaults', 'testkeyvault')]"
+//@              },
+//@              "secretName": "mySecret"
+//@            }
+//@          },
+    secureStringParam2: scopedKv.getSecret('mySecret','secretVersion')
+//@          "secureStringParam2": {
+//@            "reference": {
+//@              "keyVault": {
+//@                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'otherGroup'), 'Microsoft.KeyVault/vaults', 'testkeyvault')]"
+//@              },
+//@              "secretName": "mySecret",
+//@              "secretVersion": "secretVersion"
+//@            }
+//@          }
+  }
+}
+
+//looped module with looped existing resource (Issue #2862)
+var vaults = [
+//@    "vaults": [
+//@    ],
+  {
+//@      {
+//@      },
+    vaultName: 'test-1-kv'
+//@        "vaultName": "test-1-kv",
+    vaultRG: 'test-1-rg'
+//@        "vaultRG": "test-1-rg",
+    vaultSub: 'abcd-efgh'
+//@        "vaultSub": "abcd-efgh"
+  }
+  {
+//@      {
+//@      }
+    vaultName: 'test-2-kv'
+//@        "vaultName": "test-2-kv",
+    vaultRG: 'test-2-rg'
+//@        "vaultRG": "test-2-rg",
+    vaultSub: 'ijkl-1adg1'
+//@        "vaultSub": "ijkl-1adg1"
+  }
+]
+var secrets = [
+//@    "secrets": [
+//@    ],
+  {
+//@      {
+//@      },
+    name: 'secret01'
+//@        "name": "secret01",
+    version: 'versionA'
+//@        "version": "versionA"
+  }
+  {
+//@      {
+//@      }
+    name: 'secret02'
+//@        "name": "secret02",
+    version: 'versionB'
+//@        "version": "versionB"
+  }
+]
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [for vault in vaults: {
+//@    "loopedKv": {
+//@      "copy": {
+//@        "name": "loopedKv",
+//@        "count": "[length(variables('vaults'))]"
+//@      },
+//@      "existing": true,
+//@      "type": "Microsoft.KeyVault/vaults",
+//@      "apiVersion": "2019-09-01",
+//@      "subscriptionId": "[variables('vaults')[copyIndex()].vaultSub]",
+//@      "resourceGroup": "[variables('vaults')[copyIndex()].vaultRG]",
+//@      "name": "[variables('vaults')[copyIndex()].vaultName]"
+//@    },
+  name: vault.vaultName
+  scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+}]
+
+module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secrets: {
+//@    "secureModuleLooped": {
+//@      "copy": {
+//@        "name": "secureModuleLooped",
+//@        "count": "[length(variables('secrets'))]"
+//@      },
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+//@        }
+//@      }
+//@    },
+  name: 'secureModuleLooped-${i}'
+//@      "name": "[format('secureModuleLooped-{0}', copyIndex())]",
+  params: {
+//@        "parameters": {
+//@        },
+    secureStringParam1: loopedKv[i].getSecret(secret.name)
+//@          "secureStringParam1": {
+//@            "reference": {
+//@              "keyVault": {
+//@                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('vaults')[copyIndex()].vaultSub, variables('vaults')[copyIndex()].vaultRG), 'Microsoft.KeyVault/vaults', variables('vaults')[copyIndex()].vaultName)]"
+//@              },
+//@              "secretName": "[variables('secrets')[copyIndex()].name]"
+//@            }
+//@          },
+    secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+//@          "secureStringParam2": {
+//@            "reference": {
+//@              "keyVault": {
+//@                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('vaults')[copyIndex()].vaultSub, variables('vaults')[copyIndex()].vaultRG), 'Microsoft.KeyVault/vaults', variables('vaults')[copyIndex()].vaultName)]"
+//@              },
+//@              "secretName": "[variables('secrets')[copyIndex()].name]",
+//@              "secretVersion": "[variables('secrets')[copyIndex()].version]"
+//@            }
+//@          }
+  }
+}]
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+//@    "secureModuleCondition": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+//@        }
+//@      }
+//@    },
+  name: 'secureModuleCondition'
+//@      "name": "secureModuleCondition",
+  params: {
+//@        "parameters": {
+//@        },
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+//@          "secureStringParam1": "[if(true(), createObject('reference', createObject('keyVault', createObject('id', resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')), 'secretName', 'mySecret')), createObject('value', 'notTrue'))]",
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret','secretVersion') : 'notTrue'
+//@          "secureStringParam2": "[if(true(), if(false(), createObject('value', 'false'), createObject('reference', createObject('keyVault', createObject('id', resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')), 'secretName', 'mySecret', 'secretVersion', 'secretVersion'))), createObject('value', 'notTrue'))]"
+  }
+}
+
+// END: Key Vault Secret Reference
+
+module withSpace 'module with space.bicep' = {
+//@    "withSpace": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232"
+//@        }
+//@      }
+//@    },
+  name: 'withSpace'
+//@      "name": "withSpace",
+}
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+//@    "folderWithSpace": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232"
+//@        }
+//@      }
+//@    },
+  name: 'childWithSpace'
+//@      "name": "childWithSpace",
+}
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+//@    "nameofModule": "folderWithSpace",
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+//@    "nameofModuleParam": "exposedSecureString"
+
+module moduleWithNameof 'modulea.bicep' = {
+//@    "moduleWithNameof": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "resourceGroup": "nameofModuleParam",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+//@        }
+//@      },
+//@      "dependsOn": [
+//@        "folderWithSpace",
+//@        "secureModuleCondition",
+//@        "withSpace"
+//@      ]
+//@    },
+  name: 'nameofModule'
+//@      "name": "nameofModule",
+  scope: resourceGroup(nameof(nameofModuleParam))
+  params:{
+//@        "parameters": {
+//@        },
+    stringParamA: nameof(withSpace)
+//@          "stringParamA": {
+//@            "value": "withSpace"
+//@          },
+    stringParamB: nameof(folderWithSpace)
+//@          "stringParamB": {
+//@            "value": "folderWithSpace"
+//@          },
+    objParam: {
+//@          "objParam": {
+//@            "value": {
+//@            }
+//@          },
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+//@              "a": "exposedSecureString"
+    }
+    arrayParam: [
+//@          "arrayParam": {
+//@            "value": [
+//@            ]
+//@          }
+      nameof(vaults)
+//@              "vaults"
+    ]
+  }
+}
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+//@    "moduleWithNullableOutputs": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:102b87ceac71f62e683d20752641b5488b8deb56efb533795fc4f9dcdd0caebe"
+//@        }
+//@      }
+//@    }
+  name: 'nullableOutputs'
+//@      "name": "nullableOutputs",
+}
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+//@    "nullableString": {
+//@      "type": "string",
+//@      "nullable": true,
+//@      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableString'), 'value')]"
+//@    },
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+//@    "deeplyNestedProperty": {
+//@      "type": "string",
+//@      "nullable": true,
+//@      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'property')]"
+//@    },
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+//@    "deeplyNestedArrayItem": {
+//@      "type": "string",
+//@      "nullable": true,
+//@      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array', 0)]"
+//@    },
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+//@    "deeplyNestedArrayItemFromEnd": {
+//@      "type": "string",
+//@      "nullable": true,
+//@      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array', createObject('value', 1, 'fromEnd', true()))]"
+//@    },
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]
+//@    "deeplyNestedArrayItemFromEndAttempt": {
+//@      "type": "string",
+//@      "nullable": true,
+//@      "value": "[tryIndexFromEnd(tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array'), 1)]"
+//@    }
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.symbolicnames.json
@@ -1,0 +1,1358 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Enable content-addressed deduplication of nested module templates"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "499660557410836361"
+    }
+  },
+  "parameters": {
+    "deployTimeSuffix": {
+      "type": "string",
+      "defaultValue": "[newGuid()]",
+      "metadata": {
+        "description": "this is deployTimeSuffix param"
+      }
+    }
+  },
+  "variables": {
+    "myModules": [
+      {
+        "name": "one",
+        "location": "eastus2"
+      },
+      {
+        "name": "two",
+        "location": "westus"
+      }
+    ],
+    "emptyArray": [],
+    "duplicateAcrossScopes": "hello",
+    "someDuplicate": true,
+    "otherDuplicate": false,
+    "vaults": [
+      {
+        "vaultName": "test-1-kv",
+        "vaultRG": "test-1-rg",
+        "vaultSub": "abcd-efgh"
+      },
+      {
+        "vaultName": "test-2-kv",
+        "vaultRG": "test-2-rg",
+        "vaultSub": "ijkl-1adg1"
+      }
+    ],
+    "secrets": [
+      {
+        "name": "secret01",
+        "version": "versionA"
+      },
+      {
+        "name": "secret02",
+        "version": "versionB"
+      }
+    ],
+    "nameofModule": "folderWithSpace",
+    "nameofModuleParam": "exposedSecureString"
+  },
+  "resources": {
+    "resWithDependencies": {
+      "type": "Mock.Rp/mockResource",
+      "apiVersion": "2020-01-01",
+      "name": "harry",
+      "properties": {
+        "modADep": "[reference('modATest').outputs.stringOutputA.value]",
+        "modBDep": "[reference('modB').outputs.myResourceId.value]",
+        "modCDep": "[reference('modC').outputs.myResourceId.value]"
+      },
+      "dependsOn": [
+        "modATest",
+        "modB",
+        "modC"
+      ]
+    },
+    "resWithCalculatedNameDependencies": {
+      "type": "Mock.Rp/mockResource",
+      "apiVersion": "2020-01-01",
+      "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
+      "properties": {
+        "modADep": "[reference('moduleWithCalculatedName').outputs.outputObj.value]"
+      },
+      "dependsOn": [
+        "moduleWithCalculatedName",
+        "optionalWithAllParamsAndManualDependency"
+      ]
+    },
+    "kv": {
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "name": "testkeyvault"
+    },
+    "scopedKv": {
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "resourceGroup": "otherGroup",
+      "name": "testkeyvault"
+    },
+    "loopedKv": {
+      "copy": {
+        "name": "loopedKv",
+        "count": "[length(variables('vaults'))]"
+      },
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2019-09-01",
+      "subscriptionId": "[variables('vaults')[copyIndex()].vaultSub]",
+      "resourceGroup": "[variables('vaults')[copyIndex()].vaultRG]",
+      "name": "[variables('vaults')[copyIndex()].vaultName]"
+    },
+    "modATest": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modATest",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "stringParamB": {
+            "value": "hello!"
+          },
+          "objParam": {
+            "value": {
+              "a": "b"
+            }
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "a": "b"
+              },
+              "abc"
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      },
+      "metadata": {
+        "description": "this module a"
+      }
+    },
+    "modB": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modB",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "West US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+        }
+      },
+      "metadata": {
+        "description": "this module b"
+      }
+    },
+    "modBWithCondition": {
+      "condition": "[equals(add(1, 1), 2)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modBWithCondition",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "East US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+        }
+      },
+      "metadata": {
+        "description": "this is just module b with a condition"
+      }
+    },
+    "modBWithCondition2": {
+      "condition": "[equals(add(1, 1), 2)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modBWithCondition2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "East US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635"
+        }
+      }
+    },
+    "modC": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modC",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "West US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff"
+        }
+      }
+    },
+    "modCWithCondition": {
+      "condition": "[equals(sub(2, 1), 1)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "modCWithCondition",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "East US"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff"
+        }
+      }
+    },
+    "optionalWithNoParams1": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithNoParams1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      }
+    },
+    "optionalWithNoParams2": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithNoParams2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {},
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      }
+    },
+    "optionalWithAllParams": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithNoParams3",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "abc"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      }
+    },
+    "optionalWithAllParamsAndManualDependency": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithAllParamsAndManualDependency",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "abc"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      },
+      "dependsOn": [
+        "optionalWithAllParams",
+        "resWithDependencies"
+      ]
+    },
+    "optionalWithImplicitDependency": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "optionalWithImplicitDependency",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      },
+      "dependsOn": [
+        "optionalWithAllParamsAndManualDependency",
+        "resWithDependencies"
+      ]
+    },
+    "moduleWithCalculatedName": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('{0}{1}', 'optionalWithAllParamsAndManualDependency', parameters('deployTimeSuffix'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "optionalString": {
+            "value": "[concat(resourceId('Mock.Rp/mockResource', 'harry'), 'optionalWithAllParamsAndManualDependency')]"
+          },
+          "optionalInt": {
+            "value": 42
+          },
+          "optionalObj": {
+            "value": {}
+          },
+          "optionalArray": {
+            "value": []
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37"
+        }
+      },
+      "dependsOn": [
+        "optionalWithAllParamsAndManualDependency",
+        "resWithDependencies"
+      ]
+    },
+    "storageResources": {
+      "copy": {
+        "name": "storageResources",
+        "count": "[length(variables('myModules'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[variables('myModules')[copyIndex()].name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "arrayParam": {
+            "value": []
+          },
+          "objParam": {
+            "value": "[variables('myModules')[copyIndex()]]"
+          },
+          "stringParamB": {
+            "value": "[variables('myModules')[copyIndex()].location]"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "storageResourcesWithIndex": {
+      "copy": {
+        "name": "storageResourcesWithIndex",
+        "count": "[length(variables('myModules'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[variables('myModules')[copyIndex()].name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "arrayParam": {
+            "value": [
+              "[add(copyIndex(), 1)]"
+            ]
+          },
+          "objParam": {
+            "value": "[variables('myModules')[copyIndex()]]"
+          },
+          "stringParamB": {
+            "value": "[variables('myModules')[copyIndex()].location]"
+          },
+          "stringParamA": {
+            "value": "[concat('a', copyIndex())]"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "nestedModuleLoop": {
+      "copy": {
+        "name": "nestedModuleLoop",
+        "count": "[length(variables('myModules'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[variables('myModules')[copyIndex()].name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(range(0, 3))]",
+                "input": "[concat('test-', range(0, 3)[copyIndex('value')], '-', variables('myModules')[copyIndex()].name)]"
+              }
+            ]
+          },
+          "objParam": {
+            "value": "[variables('myModules')[copyIndex()]]"
+          },
+          "stringParamB": {
+            "value": "[variables('myModules')[copyIndex()].location]"
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "duplicateIdentifiersWithinLoop": {
+      "copy": {
+        "name": "duplicateIdentifiersWithinLoop",
+        "count": "[length(variables('emptyArray'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('hello-{0}', variables('emptyArray')[copyIndex()])]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {}
+          },
+          "stringParamA": {
+            "value": "test"
+          },
+          "stringParamB": {
+            "value": "test"
+          },
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('emptyArray'))]",
+                "input": "[variables('emptyArray')[copyIndex('value')]]"
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "duplicateInGlobalAndOneLoop": {
+      "copy": {
+        "name": "duplicateInGlobalAndOneLoop",
+        "count": "[length(createArray())]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('hello-{0}', createArray()[copyIndex()])]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {}
+          },
+          "stringParamA": {
+            "value": "test"
+          },
+          "stringParamB": {
+            "value": "test"
+          },
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('emptyArray'))]",
+                "input": "[variables('emptyArray')[copyIndex('value')]]"
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "duplicatesEverywhere": {
+      "copy": {
+        "name": "duplicatesEverywhere",
+        "count": "[length(createArray())]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('hello-{0}', createArray()[copyIndex()])]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {}
+          },
+          "stringParamB": {
+            "value": "test"
+          },
+          "arrayParam": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('emptyArray'))]",
+                "input": "[format('{0}-{1}', createArray()[copyIndex()], variables('emptyArray')[copyIndex('value')])]"
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "propertyLoopInsideParameterValue": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "propertyLoopInsideParameterValue",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {
+              "copy": [
+                {
+                  "name": "a",
+                  "count": "[length(range(0, 10))]",
+                  "input": "[range(0, 10)[copyIndex('a')]]"
+                },
+                {
+                  "name": "b",
+                  "count": "[length(range(1, 2))]",
+                  "input": "[range(1, 2)[copyIndex('b')]]"
+                },
+                {
+                  "name": "e",
+                  "count": "[length(range(4, 4))]",
+                  "input": {
+                    "f": "[range(4, 4)[copyIndex('e')]]"
+                  }
+                }
+              ],
+              "c": {
+                "copy": [
+                  {
+                    "name": "d",
+                    "count": "[length(range(2, 3))]",
+                    "input": "[range(2, 3)[copyIndex('d')]]"
+                  }
+                ]
+              }
+            }
+          },
+          "stringParamB": {
+            "value": ""
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "copy": [
+                  {
+                    "name": "e",
+                    "count": "[length(range(7, 7))]",
+                    "input": "[range(7, 7)[copyIndex('e')]]"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "propertyLoopInsideParameterValueWithIndexes": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "propertyLoopInsideParameterValueWithIndexes",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {
+              "copy": [
+                {
+                  "name": "a",
+                  "count": "[length(range(0, 10))]",
+                  "input": "[add(range(0, 10)[copyIndex('a')], copyIndex('a'))]"
+                },
+                {
+                  "name": "b",
+                  "count": "[length(range(1, 2))]",
+                  "input": "[div(range(1, 2)[copyIndex('b')], copyIndex('b'))]"
+                },
+                {
+                  "name": "e",
+                  "count": "[length(range(4, 4))]",
+                  "input": {
+                    "f": "[range(4, 4)[copyIndex('e')]]",
+                    "g": "[copyIndex('e')]"
+                  }
+                }
+              ],
+              "c": {
+                "copy": [
+                  {
+                    "name": "d",
+                    "count": "[length(range(2, 3))]",
+                    "input": "[mul(range(2, 3)[copyIndex('d')], copyIndex('d'))]"
+                  }
+                ]
+              }
+            }
+          },
+          "stringParamB": {
+            "value": ""
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "copy": [
+                  {
+                    "name": "e",
+                    "count": "[length(range(7, 7))]",
+                    "input": "[range(7, 7)[copyIndex('e')]]"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "propertyLoopInsideParameterValueInsideModuleLoop": {
+      "copy": {
+        "name": "propertyLoopInsideParameterValueInsideModuleLoop",
+        "count": "[length(range(0, 1))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "propertyLoopInsideParameterValueInsideModuleLoop",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "objParam": {
+            "value": {
+              "copy": [
+                {
+                  "name": "a",
+                  "count": "[length(range(0, 10))]",
+                  "input": "[add(range(0, 10)[copyIndex('a')], range(0, 1)[copyIndex()])]"
+                },
+                {
+                  "name": "b",
+                  "count": "[length(range(1, 2))]",
+                  "input": "[mul(range(1, 2)[copyIndex('b')], range(0, 1)[copyIndex()])]"
+                },
+                {
+                  "name": "e",
+                  "count": "[length(range(4, 4))]",
+                  "input": {
+                    "f": "[sub(range(4, 4)[copyIndex('e')], range(0, 1)[copyIndex()])]"
+                  }
+                }
+              ],
+              "c": {
+                "copy": [
+                  {
+                    "name": "d",
+                    "count": "[length(range(2, 3))]",
+                    "input": "[range(2, 3)[copyIndex('d')]]"
+                  }
+                ]
+              }
+            }
+          },
+          "stringParamB": {
+            "value": ""
+          },
+          "arrayParam": {
+            "value": [
+              {
+                "copy": [
+                  {
+                    "name": "e",
+                    "count": "[length(range(7, 7))]",
+                    "input": "[mod(range(7, 7)[copyIndex('e')], add(range(0, 1)[copyIndex()], 1))]"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      }
+    },
+    "secureModule1": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "secureModule1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret"
+            }
+          },
+          "secureStringParam2": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret",
+              "secretVersion": "secretVersion"
+            }
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "secureModule2": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "secureModule2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'otherGroup'), 'Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret"
+            }
+          },
+          "secureStringParam2": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, 'otherGroup'), 'Microsoft.KeyVault/vaults', 'testkeyvault')]"
+              },
+              "secretName": "mySecret",
+              "secretVersion": "secretVersion"
+            }
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "secureModuleLooped": {
+      "copy": {
+        "name": "secureModuleLooped",
+        "count": "[length(variables('secrets'))]"
+      },
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('secureModuleLooped-{0}', copyIndex())]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('vaults')[copyIndex()].vaultSub, variables('vaults')[copyIndex()].vaultRG), 'Microsoft.KeyVault/vaults', variables('vaults')[copyIndex()].vaultName)]"
+              },
+              "secretName": "[variables('secrets')[copyIndex()].name]"
+            }
+          },
+          "secureStringParam2": {
+            "reference": {
+              "keyVault": {
+                "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('vaults')[copyIndex()].vaultSub, variables('vaults')[copyIndex()].vaultRG), 'Microsoft.KeyVault/vaults', variables('vaults')[copyIndex()].vaultName)]"
+              },
+              "secretName": "[variables('secrets')[copyIndex()].name]",
+              "secretVersion": "[variables('secrets')[copyIndex()].version]"
+            }
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "secureModuleCondition": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "secureModuleCondition",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "secureStringParam1": "[if(true(), createObject('reference', createObject('keyVault', createObject('id', resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')), 'secretName', 'mySecret')), createObject('value', 'notTrue'))]",
+          "secureStringParam2": "[if(true(), if(false(), createObject('value', 'false'), createObject('reference', createObject('keyVault', createObject('id', resourceId('Microsoft.KeyVault/vaults', 'testkeyvault')), 'secretName', 'mySecret', 'secretVersion', 'secretVersion'))), createObject('value', 'notTrue'))]"
+        },
+        "templateLink": {
+          "contentId": "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307"
+        }
+      }
+    },
+    "withSpace": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "withSpace",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232"
+        }
+      }
+    },
+    "folderWithSpace": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "childWithSpace",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232"
+        }
+      }
+    },
+    "moduleWithNameof": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "nameofModule",
+      "resourceGroup": "nameofModuleParam",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "stringParamA": {
+            "value": "withSpace"
+          },
+          "stringParamB": {
+            "value": "folderWithSpace"
+          },
+          "objParam": {
+            "value": {
+              "a": "exposedSecureString"
+            }
+          },
+          "arrayParam": {
+            "value": [
+              "vaults"
+            ]
+          }
+        },
+        "templateLink": {
+          "contentId": "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8"
+        }
+      },
+      "dependsOn": [
+        "folderWithSpace",
+        "secureModuleCondition",
+        "withSpace"
+      ]
+    },
+    "moduleWithNullableOutputs": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "nullableOutputs",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:102b87ceac71f62e683d20752641b5488b8deb56efb533795fc4f9dcdd0caebe"
+        }
+      }
+    }
+  },
+  "outputs": {
+    "stringOutputA": {
+      "type": "string",
+      "value": "[reference('modATest').outputs.stringOutputA.value]"
+    },
+    "stringOutputB": {
+      "type": "string",
+      "value": "[reference('modATest').outputs.stringOutputB.value]"
+    },
+    "objOutput": {
+      "type": "object",
+      "value": "[reference('modATest').outputs.objOutput.value]"
+    },
+    "arrayOutput": {
+      "type": "array",
+      "value": "[reference('modATest').outputs.arrayOutput.value]"
+    },
+    "modCalculatedNameOutput": {
+      "type": "object",
+      "value": "[reference('moduleWithCalculatedName').outputs.outputObj.value]"
+    },
+    "nullableString": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableString'), 'value')]"
+    },
+    "deeplyNestedProperty": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'property')]"
+    },
+    "deeplyNestedArrayItem": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array', 0)]"
+    },
+    "deeplyNestedArrayItemFromEnd": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array', createObject('value', 1, 'fromEnd', true()))]"
+    },
+    "deeplyNestedArrayItemFromEndAttempt": {
+      "type": "string",
+      "nullable": true,
+      "value": "[tryIndexFromEnd(tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array'), 1)]"
+    }
+  },
+  "content": {
+    "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "contentVersion": "1.0.0.0",
+        "parameters": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "variables": {},
+        "resources": [
+          {
+            "name": "myResource",
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "location": "[parameters('location')]"
+          }
+        ],
+        "outputs": {
+          "myResourceId": {
+            "type": "string",
+            "value": "[resourceId('Mock.Rp/mockResource', 'myResource')]"
+          }
+        }
+      }
+    },
+    "sha256:0f50c83850e68f2b1400fcc9dfdf687abf802a9c6c00006ab440f199adf77307": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "2734319700446247652"
+          }
+        },
+        "parameters": {
+          "secureStringParam1": {
+            "type": "securestring"
+          },
+          "secureStringParam2": {
+            "type": "securestring",
+            "defaultValue": ""
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "exposedSecureString": {
+            "type": "string",
+            "value": "[parameters('secureStringParam1')]"
+          }
+        }
+      }
+    },
+    "sha256:102b87ceac71f62e683d20752641b5488b8deb56efb533795fc4f9dcdd0caebe": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "12443670995828892617"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "nullableString": {
+            "type": "string",
+            "nullable": true,
+            "value": "foo"
+          },
+          "nullableObj": {
+            "type": "object",
+            "nullable": true,
+            "value": {
+              "deeply": {
+                "nested": {
+                  "property": "value",
+                  "array": [
+                    "foo",
+                    "bar"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "sha256:46c4f4978f9dfa961077a6987e6cb391fa193368e6d62e7d26a2b621eb4e4635": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "6810048809782302279"
+          }
+        },
+        "parameters": {
+          "location": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "myResource": {
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "name": "mockResource",
+            "location": "[parameters('location')]"
+          }
+        },
+        "outputs": {
+          "myResourceId": {
+            "type": "string",
+            "value": "[resourceId('Mock.Rp/mockResource', 'mockResource')]"
+          }
+        }
+      }
+    },
+    "sha256:736592f4cbb4a67b7591bd618b4cb31b2c75c5c7523cb9743808170ac2af08d8": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "13815270916276102317"
+          }
+        },
+        "parameters": {
+          "stringParamA": {
+            "type": "string",
+            "defaultValue": "test"
+          },
+          "stringParamB": {
+            "type": "string"
+          },
+          "objParam": {
+            "type": "object"
+          },
+          "arrayParam": {
+            "type": "array"
+          }
+        },
+        "resources": {
+          "basicStorage": {
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "name": "basicblobs",
+            "location": "[parameters('stringParamA')]"
+          },
+          "dnsZone": {
+            "type": "Mock.Rp/mockResource",
+            "apiVersion": "2020-01-01",
+            "name": "myZone",
+            "location": "[parameters('stringParamB')]"
+          }
+        },
+        "outputs": {
+          "stringOutputA": {
+            "type": "string",
+            "value": "[parameters('stringParamA')]"
+          },
+          "stringOutputB": {
+            "type": "string",
+            "value": "[parameters('stringParamB')]"
+          },
+          "objOutput": {
+            "type": "object",
+            "value": "[reference('basicStorage')]"
+          },
+          "arrayOutput": {
+            "type": "array",
+            "value": [
+              "[resourceId('Mock.Rp/mockResource', 'basicblobs')]",
+              "[resourceId('Mock.Rp/mockResource', 'myZone')]"
+            ]
+          }
+        }
+      }
+    },
+    "sha256:bdec2bfbd4230566b89b2daa0ce806d8502f6ce60ae9159bfe63d4e8210bcf37": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "2225368239751975239"
+          }
+        },
+        "parameters": {
+          "optionalString": {
+            "type": "string",
+            "defaultValue": "abc"
+          },
+          "optionalInt": {
+            "type": "int",
+            "defaultValue": 42
+          },
+          "optionalObj": {
+            "type": "object",
+            "defaultValue": {
+              "a": "b"
+            }
+          },
+          "optionalArray": {
+            "type": "array",
+            "defaultValue": [
+              1,
+              2,
+              3
+            ]
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "outputObj": {
+            "type": "object",
+            "value": {
+              "optionalString": "[parameters('optionalString')]",
+              "optionalInt": "[parameters('optionalInt')]",
+              "optionalObj": "[parameters('optionalObj')]",
+              "optionalArray": "[parameters('optionalArray')]"
+            }
+          }
+        }
+      }
+    },
+    "sha256:c0d1c4818d330e7eed569f74a2ca7caee290ee7b0b6ba17f7b3d32fa9e4cf232": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "11836443688215930685"
+          }
+        },
+        "parameters": {
+          "location": {
+            "type": "string",
+            "defaultValue": "westus"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "loc": {
+            "type": "string",
+            "value": "[parameters('location')]"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.symbolicnames.json
@@ -1062,7 +1062,7 @@
       "value": "[tryIndexFromEnd(tryGet(tryGet(reference('moduleWithNullableOutputs').outputs, 'nullableObj'), 'value', 'deeply', 'nested', 'array'), 1)]"
     }
   },
-  "content": {
+  "contentManifest": {
     "sha256:0dca82bb0b680be5308885b844217493b57c438f9c26322e541ffe1c9bf164ff": {
       "value": {
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.symbols.bicep
@@ -1,0 +1,492 @@
+
+@sys.description('this is deployTimeSuffix param')
+param deployTimeSuffix string = newGuid()
+//@[06:22) Parameter deployTimeSuffix. Type: string. Declaration start char: 0, length: 93
+
+@sys.description('this module a')
+module modATest './modulea.bicep' = {
+//@[07:15) Module modATest. Type: module. Declaration start char: 0, length: 252
+  name: 'modATest'
+  params: {
+    stringParamB: 'hello!'
+    objParam: {
+      a: 'b'
+    }
+    arrayParam: [
+      {
+        a: 'b'
+      }
+      'abc'
+    ]
+  }
+}
+
+
+@sys.description('this module b')
+module modB './child/moduleb.bicep' = {
+//@[07:11) Module modB. Type: module. Declaration start char: 0, length: 136
+  name: 'modB'
+  params: {
+    location: 'West US'
+  }
+}
+
+@sys.description('this is just module b with a condition')
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+//@[07:24) Module modBWithCondition. Type: module. Declaration start char: 0, length: 203
+  name: 'modBWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module modBWithCondition2 './child/moduleb.bicep' =
+//@[07:25) Module modBWithCondition2. Type: module. Declaration start char: 0, length: 166
+// awkward comment
+if (1 + 1 == 2) {
+  name: 'modBWithCondition2'
+  params: {
+    location: 'East US'
+  }
+}
+
+module modC './child/modulec.json' = {
+//@[07:11) Module modC. Type: module. Declaration start char: 0, length: 100
+  name: 'modC'
+  params: {
+    location: 'West US'
+  }
+}
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+//@[07:24) Module modCWithCondition. Type: module. Declaration start char: 0, length: 142
+  name: 'modCWithCondition'
+  params: {
+    location: 'East US'
+  }
+}
+
+module optionalWithNoParams1 './child/optionalParams.bicep'= {
+//@[07:28) Module optionalWithNoParams1. Type: module. Declaration start char: 0, length: 98
+  name: 'optionalWithNoParams1'
+}
+
+module optionalWithNoParams2 './child/optionalParams.bicep'= {
+//@[07:28) Module optionalWithNoParams2. Type: module. Declaration start char: 0, length: 116
+  name: 'optionalWithNoParams2'
+  params: {
+  }
+}
+
+module optionalWithAllParams './child/optionalParams.bicep'= {
+//@[07:28) Module optionalWithAllParams. Type: module. Declaration start char: 0, length: 210
+  name: 'optionalWithNoParams3'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 65, length: 168
+//@[09:28) Resource resWithDependencies. Type: Mock.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 233
+  name: 'harry'
+  properties: {
+    modADep: modATest.outputs.stringOutputA
+    modBDep: modB.outputs.myResourceId
+    modCDep: modC.outputs.myResourceId
+  }
+}
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
+//@[07:47) Module optionalWithAllParamsAndManualDependency. Type: module. Declaration start char: 0, length: 321
+  name: 'optionalWithAllParamsAndManualDependency'
+  params: {
+    optionalString: 'abc'
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+  dependsOn: [
+    resWithDependencies
+    optionalWithAllParams
+  ]
+}
+
+module optionalWithImplicitDependency './child/optionalParams.bicep'= {
+//@[07:37) Module optionalWithImplicitDependency. Type: module. Declaration start char: 0, length: 300
+  name: 'optionalWithImplicitDependency'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+module moduleWithCalculatedName './child/optionalParams.bicep'= {
+//@[07:31) Module moduleWithCalculatedName. Type: module. Declaration start char: 0, length: 331
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  params: {
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+    optionalInt: 42
+    optionalObj: { }
+    optionalArray: [ ]
+  }
+}
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[00:08) Local this. Type: object. Declaration start char: 79, length: 162
+//@[09:42) Resource resWithCalculatedNameDependencies. Type: Mock.Rp/mockResource@2020-01-01. Declaration start char: 0, length: 241
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+  properties: {
+    modADep: moduleWithCalculatedName.outputs.outputObj
+  }
+}
+
+output stringOutputA string = modATest.outputs.stringOutputA
+//@[07:20) Output stringOutputA. Type: string. Declaration start char: 0, length: 60
+output stringOutputB string = modATest.outputs.stringOutputB
+//@[07:20) Output stringOutputB. Type: string. Declaration start char: 0, length: 60
+output objOutput object = modATest.outputs.objOutput
+//@[07:16) Output objOutput. Type: object. Declaration start char: 0, length: 52
+output arrayOutput array = modATest.outputs.arrayOutput
+//@[07:18) Output arrayOutput. Type: array. Declaration start char: 0, length: 55
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+//@[07:30) Output modCalculatedNameOutput. Type: object. Declaration start char: 0, length: 82
+
+/*
+  valid loop cases
+*/
+
+@sys.description('this is myModules')
+var myModules = [
+//@[04:13) Variable myModules. Type: [object, object]. Declaration start char: 0, length: 162
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+
+var emptyArray = []
+//@[04:14) Variable emptyArray. Type: <empty array>. Declaration start char: 0, length: 19
+
+// simple module loop
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[47:53) Local module. Type: object | object. Declaration start char: 47, length: 6
+//@[07:23) Module storageResources. Type: module[]. Declaration start char: 0, length: 189
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+// simple indexed module loop
+module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules: {
+//@[57:63) Local module. Type: object | object. Declaration start char: 57, length: 6
+//@[65:66) Local i. Type: int. Declaration start char: 65, length: 1
+//@[07:32) Module storageResourcesWithIndex. Type: module[]. Declaration start char: 0, length: 256
+  name: module.name
+  params: {
+    arrayParam: [
+      i + 1
+    ]
+    objParam: module
+    stringParamB: module.location
+    stringParamA: concat('a', i)
+  }
+}]
+
+// nested module loop
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[47:53) Local module. Type: object | object. Declaration start char: 47, length: 6
+//@[07:23) Module nestedModuleLoop. Type: module[]. Declaration start char: 0, length: 246
+  name: module.name
+  params: {
+    arrayParam: [for i in range(0,3): concat('test-', i, '-', module.name)]
+//@[21:22) Local i. Type: int. Declaration start char: 21, length: 1
+    objParam: module
+    stringParamB: module.location
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[61:62) Local x. Type: never. Declaration start char: 61, length: 1
+//@[07:37) Module duplicateIdentifiersWithinLoop. Type: module[]. Declaration start char: 0, length: 234
+  name: 'hello-${x}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+//@[21:22) Local x. Type: never. Declaration start char: 21, length: 1
+  }
+}]
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+var duplicateAcrossScopes = 'hello'
+//@[04:25) Variable duplicateAcrossScopes. Type: 'hello'. Declaration start char: 0, length: 35
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@[58:79) Local duplicateAcrossScopes. Type: never. Declaration start char: 58, length: 21
+//@[07:34) Module duplicateInGlobalAndOneLoop. Type: module[]. Declaration start char: 0, length: 264
+  name: 'hello-${duplicateAcrossScopes}'
+  params: {
+    objParam: {}
+    stringParamA: 'test'
+    stringParamB: 'test'
+    arrayParam: [for x in emptyArray: x]
+//@[21:22) Local x. Type: never. Declaration start char: 21, length: 1
+  }
+}]
+
+var someDuplicate = true
+//@[04:17) Variable someDuplicate. Type: true. Declaration start char: 0, length: 24
+var otherDuplicate = false
+//@[04:18) Variable otherDuplicate. Type: false. Declaration start char: 0, length: 26
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[51:64) Local someDuplicate. Type: never. Declaration start char: 51, length: 13
+//@[07:27) Module duplicatesEverywhere. Type: module[]. Declaration start char: 0, length: 263
+  name: 'hello-${someDuplicate}'
+  params: {
+    objParam: {}
+    stringParamB: 'test'
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[21:35) Local otherDuplicate. Type: never. Declaration start char: 21, length: 14
+  }
+}]
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+//@[07:39) Module propertyLoopInsideParameterValue. Type: module. Declaration start char: 0, length: 438
+  name: 'propertyLoopInsideParameterValue'
+  params: {
+    objParam: {
+      a: [for i in range(0,10): i]
+//@[14:15) Local i. Type: int. Declaration start char: 14, length: 1
+      b: [for i in range(1,2): i]
+//@[14:15) Local i. Type: int. Declaration start char: 14, length: 1
+      c: {
+        d: [for j in range(2,3): j]
+//@[16:17) Local j. Type: int. Declaration start char: 16, length: 1
+      }
+      e: [for k in range(4,4): {
+//@[14:15) Local k. Type: int. Declaration start char: 14, length: 1
+        f: k
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j]
+//@[16:17) Local j. Type: int. Declaration start char: 16, length: 1
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+//@[07:50) Module propertyLoopInsideParameterValueWithIndexes. Type: module. Declaration start char: 0, length: 514
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+  params: {
+    objParam: {
+      a: [for (i, i2) in range(0,10): i + i2]
+//@[15:16) Local i. Type: int. Declaration start char: 15, length: 1
+//@[18:20) Local i2. Type: int. Declaration start char: 18, length: 2
+      b: [for (i, i2) in range(1,2): i / i2]
+//@[15:16) Local i. Type: int. Declaration start char: 15, length: 1
+//@[18:20) Local i2. Type: int. Declaration start char: 18, length: 2
+      c: {
+        d: [for (j, j2) in range(2,3): j * j2]
+//@[17:18) Local j. Type: int. Declaration start char: 17, length: 1
+//@[20:22) Local j2. Type: int. Declaration start char: 20, length: 2
+      }
+      e: [for (k, k2) in range(4,4): {
+//@[15:16) Local k. Type: int. Declaration start char: 15, length: 1
+//@[18:20) Local k2. Type: int. Declaration start char: 18, length: 2
+        f: k
+        g: k2
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j]
+//@[16:17) Local j. Type: int. Declaration start char: 16, length: 1
+      }
+    ]
+  }
+}
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
+//@[79:84) Local thing. Type: 0. Declaration start char: 79, length: 5
+//@[07:55) Module propertyLoopInsideParameterValueInsideModuleLoop. Type: module[]. Declaration start char: 0, length: 535
+  name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+  params: {
+    objParam: {
+      a: [for i in range(0,10): i + thing]
+//@[14:15) Local i. Type: int. Declaration start char: 14, length: 1
+      b: [for i in range(1,2): i * thing]
+//@[14:15) Local i. Type: int. Declaration start char: 14, length: 1
+      c: {
+        d: [for j in range(2,3): j]
+//@[16:17) Local j. Type: int. Declaration start char: 16, length: 1
+      }
+      e: [for k in range(4,4): {
+//@[14:15) Local k. Type: int. Declaration start char: 14, length: 1
+        f: k - thing
+      }]
+    }
+    stringParamB: ''
+    arrayParam: [
+      {
+        e: [for j in range(7,7): j % (thing + 1)]
+//@[16:17) Local j. Type: int. Declaration start char: 16, length: 1
+      }
+    ]
+  }
+}]
+
+
+// BEGIN: Key Vault Secret Reference
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[09:11) Resource kv. Type: Microsoft.KeyVault/vaults@2019-09-01. Declaration start char: 0, length: 90
+  name: 'testkeyvault'
+}
+
+module secureModule1 'child/secureParams.bicep' = {
+//@[07:20) Module secureModule1. Type: module. Declaration start char: 0, length: 213
+  name: 'secureModule1'
+  params: {
+    secureStringParam1: kv.getSecret('mySecret')
+    secureStringParam2: kv.getSecret('mySecret','secretVersion')
+  }
+}
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[09:17) Resource scopedKv. Type: Microsoft.KeyVault/vaults@2019-09-01. Declaration start char: 0, length: 134
+  name: 'testkeyvault'
+  scope: resourceGroup('otherGroup')
+}
+
+module secureModule2 'child/secureParams.bicep' = {
+//@[07:20) Module secureModule2. Type: module. Declaration start char: 0, length: 225
+  name: 'secureModule2'
+  params: {
+    secureStringParam1: scopedKv.getSecret('mySecret')
+    secureStringParam2: scopedKv.getSecret('mySecret','secretVersion')
+  }
+}
+
+//looped module with looped existing resource (Issue #2862)
+var vaults = [
+//@[04:10) Variable vaults. Type: [object, object]. Declaration start char: 0, length: 200
+  {
+    vaultName: 'test-1-kv'
+    vaultRG: 'test-1-rg'
+    vaultSub: 'abcd-efgh'
+  }
+  {
+    vaultName: 'test-2-kv'
+    vaultRG: 'test-2-rg'
+    vaultSub: 'ijkl-1adg1'
+  }
+]
+var secrets = [
+//@[04:11) Variable secrets. Type: [object, object]. Declaration start char: 0, length: 132
+  {
+    name: 'secret01'
+    version: 'versionA'
+  }
+  {
+    name: 'secret02'
+    version: 'versionB'
+  }
+]
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [for vault in vaults: {
+//@[73:78) Local vault. Type: object | object. Declaration start char: 73, length: 5
+//@[09:17) Resource loopedKv. Type: Microsoft.KeyVault/vaults@2019-09-01[]. Declaration start char: 0, length: 175
+  name: vault.vaultName
+  scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+}]
+
+module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secrets: {
+//@[61:67) Local secret. Type: object | object. Declaration start char: 61, length: 6
+//@[69:70) Local i. Type: int. Declaration start char: 69, length: 1
+//@[07:25) Module secureModuleLooped. Type: module[]. Declaration start char: 0, length: 278
+  name: 'secureModuleLooped-${i}'
+  params: {
+    secureStringParam1: loopedKv[i].getSecret(secret.name)
+    secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+  }
+}]
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+//@[07:28) Module secureModuleCondition. Type: module. Declaration start char: 0, length: 285
+  name: 'secureModuleCondition'
+  params: {
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret','secretVersion') : 'notTrue'
+  }
+}
+
+// END: Key Vault Secret Reference
+
+module withSpace 'module with space.bicep' = {
+//@[07:16) Module withSpace. Type: module. Declaration start char: 0, length: 70
+  name: 'withSpace'
+}
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+//@[07:22) Module folderWithSpace. Type: module. Declaration start char: 0, length: 104
+  name: 'childWithSpace'
+}
+
+// nameof
+
+var nameofModule = nameof(folderWithSpace)
+//@[04:16) Variable nameofModule. Type: 'folderWithSpace'. Declaration start char: 0, length: 42
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+//@[04:21) Variable nameofModuleParam. Type: 'exposedSecureString'. Declaration start char: 0, length: 81
+
+module moduleWithNameof 'modulea.bicep' = {
+//@[07:23) Module moduleWithNameof. Type: module. Declaration start char: 0, length: 358
+  name: 'nameofModule'
+  scope: resourceGroup(nameof(nameofModuleParam))
+  params:{
+    stringParamA: nameof(withSpace)
+    stringParamB: nameof(folderWithSpace)
+    objParam: {
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+    }
+    arrayParam: [
+      nameof(vaults)
+    ]
+  }
+}
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+//@[07:32) Module moduleWithNullableOutputs. Type: module. Declaration start char: 0, length: 96
+  name: 'nullableOutputs'
+}
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+//@[07:21) Output nullableString. Type: null | string. Declaration start char: 0, length: 81
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+//@[07:27) Output deeplyNestedProperty. Type: null | string. Declaration start char: 0, length: 107
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+//@[07:28) Output deeplyNestedArrayItem. Type: null | string. Declaration start char: 0, length: 108
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+//@[07:35) Output deeplyNestedArrayItemFromEnd. Type: null | string. Declaration start char: 0, length: 116
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]
+//@[07:42) Output deeplyNestedArrayItemFromEndAttempt. Type: null | string. Declaration start char: 0, length: 124
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.syntax.bicep
@@ -1,0 +1,3759 @@
+
+//@[000:10080) ProgramSyntax
+//@[000:00002) ├─Token(NewLine) |\r\n|
+@sys.description('this is deployTimeSuffix param')
+//@[000:00093) ├─ParameterDeclarationSyntax
+//@[000:00050) | ├─DecoratorSyntax
+//@[000:00001) | | ├─Token(At) |@|
+//@[001:00050) | | └─InstanceFunctionCallSyntax
+//@[001:00004) | |   ├─VariableAccessSyntax
+//@[001:00004) | |   | └─IdentifierSyntax
+//@[001:00004) | |   |   └─Token(Identifier) |sys|
+//@[004:00005) | |   ├─Token(Dot) |.|
+//@[005:00016) | |   ├─IdentifierSyntax
+//@[005:00016) | |   | └─Token(Identifier) |description|
+//@[016:00017) | |   ├─Token(LeftParen) |(|
+//@[017:00049) | |   ├─FunctionArgumentSyntax
+//@[017:00049) | |   | └─StringSyntax
+//@[017:00049) | |   |   └─Token(StringComplete) |'this is deployTimeSuffix param'|
+//@[049:00050) | |   └─Token(RightParen) |)|
+//@[050:00052) | ├─Token(NewLine) |\r\n|
+param deployTimeSuffix string = newGuid()
+//@[000:00005) | ├─Token(Identifier) |param|
+//@[006:00022) | ├─IdentifierSyntax
+//@[006:00022) | | └─Token(Identifier) |deployTimeSuffix|
+//@[023:00029) | ├─TypeVariableAccessSyntax
+//@[023:00029) | | └─IdentifierSyntax
+//@[023:00029) | |   └─Token(Identifier) |string|
+//@[030:00041) | └─ParameterDefaultValueSyntax
+//@[030:00031) |   ├─Token(Assignment) |=|
+//@[032:00041) |   └─FunctionCallSyntax
+//@[032:00039) |     ├─IdentifierSyntax
+//@[032:00039) |     | └─Token(Identifier) |newGuid|
+//@[039:00040) |     ├─Token(LeftParen) |(|
+//@[040:00041) |     └─Token(RightParen) |)|
+//@[041:00045) ├─Token(NewLine) |\r\n\r\n|
+
+@sys.description('this module a')
+//@[000:00252) ├─ModuleDeclarationSyntax
+//@[000:00033) | ├─DecoratorSyntax
+//@[000:00001) | | ├─Token(At) |@|
+//@[001:00033) | | └─InstanceFunctionCallSyntax
+//@[001:00004) | |   ├─VariableAccessSyntax
+//@[001:00004) | |   | └─IdentifierSyntax
+//@[001:00004) | |   |   └─Token(Identifier) |sys|
+//@[004:00005) | |   ├─Token(Dot) |.|
+//@[005:00016) | |   ├─IdentifierSyntax
+//@[005:00016) | |   | └─Token(Identifier) |description|
+//@[016:00017) | |   ├─Token(LeftParen) |(|
+//@[017:00032) | |   ├─FunctionArgumentSyntax
+//@[017:00032) | |   | └─StringSyntax
+//@[017:00032) | |   |   └─Token(StringComplete) |'this module a'|
+//@[032:00033) | |   └─Token(RightParen) |)|
+//@[033:00035) | ├─Token(NewLine) |\r\n|
+module modATest './modulea.bicep' = {
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00015) | ├─IdentifierSyntax
+//@[007:00015) | | └─Token(Identifier) |modATest|
+//@[016:00033) | ├─StringSyntax
+//@[016:00033) | | └─Token(StringComplete) |'./modulea.bicep'|
+//@[034:00035) | ├─Token(Assignment) |=|
+//@[036:00217) | └─ObjectSyntax
+//@[036:00037) |   ├─Token(LeftBrace) |{|
+//@[037:00039) |   ├─Token(NewLine) |\r\n|
+  name: 'modATest'
+//@[002:00018) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00018) |   | └─StringSyntax
+//@[008:00018) |   |   └─Token(StringComplete) |'modATest'|
+//@[018:00020) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00155) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00155) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    stringParamB: 'hello!'
+//@[004:00026) |   |   ├─ObjectPropertySyntax
+//@[004:00016) |   |   | ├─IdentifierSyntax
+//@[004:00016) |   |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   |   | ├─Token(Colon) |:|
+//@[018:00026) |   |   | └─StringSyntax
+//@[018:00026) |   |   |   └─Token(StringComplete) |'hello!'|
+//@[026:00028) |   |   ├─Token(NewLine) |\r\n|
+    objParam: {
+//@[004:00036) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00036) |   |   | └─ObjectSyntax
+//@[014:00015) |   |   |   ├─Token(LeftBrace) |{|
+//@[015:00017) |   |   |   ├─Token(NewLine) |\r\n|
+      a: 'b'
+//@[006:00012) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |a|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00012) |   |   |   | └─StringSyntax
+//@[009:00012) |   |   |   |   └─Token(StringComplete) |'b'|
+//@[012:00014) |   |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[004:00005) |   |   |   └─Token(RightBrace) |}|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+    arrayParam: [
+//@[004:00071) |   |   ├─ObjectPropertySyntax
+//@[004:00014) |   |   | ├─IdentifierSyntax
+//@[004:00014) |   |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   |   | ├─Token(Colon) |:|
+//@[016:00071) |   |   | └─ArraySyntax
+//@[016:00017) |   |   |   ├─Token(LeftSquare) |[|
+//@[017:00019) |   |   |   ├─Token(NewLine) |\r\n|
+      {
+//@[006:00032) |   |   |   ├─ArrayItemSyntax
+//@[006:00032) |   |   |   | └─ObjectSyntax
+//@[006:00007) |   |   |   |   ├─Token(LeftBrace) |{|
+//@[007:00009) |   |   |   |   ├─Token(NewLine) |\r\n|
+        a: 'b'
+//@[008:00014) |   |   |   |   ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | └─Token(Identifier) |a|
+//@[009:00010) |   |   |   |   | ├─Token(Colon) |:|
+//@[011:00014) |   |   |   |   | └─StringSyntax
+//@[011:00014) |   |   |   |   |   └─Token(StringComplete) |'b'|
+//@[014:00016) |   |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
+      'abc'
+//@[006:00011) |   |   |   ├─ArrayItemSyntax
+//@[006:00011) |   |   |   | └─StringSyntax
+//@[006:00011) |   |   |   |   └─Token(StringComplete) |'abc'|
+//@[011:00013) |   |   |   ├─Token(NewLine) |\r\n|
+    ]
+//@[004:00005) |   |   |   └─Token(RightSquare) |]|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00007) ├─Token(NewLine) |\r\n\r\n\r\n|
+
+
+@sys.description('this module b')
+//@[000:00136) ├─ModuleDeclarationSyntax
+//@[000:00033) | ├─DecoratorSyntax
+//@[000:00001) | | ├─Token(At) |@|
+//@[001:00033) | | └─InstanceFunctionCallSyntax
+//@[001:00004) | |   ├─VariableAccessSyntax
+//@[001:00004) | |   | └─IdentifierSyntax
+//@[001:00004) | |   |   └─Token(Identifier) |sys|
+//@[004:00005) | |   ├─Token(Dot) |.|
+//@[005:00016) | |   ├─IdentifierSyntax
+//@[005:00016) | |   | └─Token(Identifier) |description|
+//@[016:00017) | |   ├─Token(LeftParen) |(|
+//@[017:00032) | |   ├─FunctionArgumentSyntax
+//@[017:00032) | |   | └─StringSyntax
+//@[017:00032) | |   |   └─Token(StringComplete) |'this module b'|
+//@[032:00033) | |   └─Token(RightParen) |)|
+//@[033:00035) | ├─Token(NewLine) |\r\n|
+module modB './child/moduleb.bicep' = {
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00011) | ├─IdentifierSyntax
+//@[007:00011) | | └─Token(Identifier) |modB|
+//@[012:00035) | ├─StringSyntax
+//@[012:00035) | | └─Token(StringComplete) |'./child/moduleb.bicep'|
+//@[036:00037) | ├─Token(Assignment) |=|
+//@[038:00101) | └─ObjectSyntax
+//@[038:00039) |   ├─Token(LeftBrace) |{|
+//@[039:00041) |   ├─Token(NewLine) |\r\n|
+  name: 'modB'
+//@[002:00014) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00014) |   | └─StringSyntax
+//@[008:00014) |   |   └─Token(StringComplete) |'modB'|
+//@[014:00016) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00041) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00041) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    location: 'West US'
+//@[004:00023) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |location|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00023) |   |   | └─StringSyntax
+//@[014:00023) |   |   |   └─Token(StringComplete) |'West US'|
+//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+@sys.description('this is just module b with a condition')
+//@[000:00203) ├─ModuleDeclarationSyntax
+//@[000:00058) | ├─DecoratorSyntax
+//@[000:00001) | | ├─Token(At) |@|
+//@[001:00058) | | └─InstanceFunctionCallSyntax
+//@[001:00004) | |   ├─VariableAccessSyntax
+//@[001:00004) | |   | └─IdentifierSyntax
+//@[001:00004) | |   |   └─Token(Identifier) |sys|
+//@[004:00005) | |   ├─Token(Dot) |.|
+//@[005:00016) | |   ├─IdentifierSyntax
+//@[005:00016) | |   | └─Token(Identifier) |description|
+//@[016:00017) | |   ├─Token(LeftParen) |(|
+//@[017:00057) | |   ├─FunctionArgumentSyntax
+//@[017:00057) | |   | └─StringSyntax
+//@[017:00057) | |   |   └─Token(StringComplete) |'this is just module b with a condition'|
+//@[057:00058) | |   └─Token(RightParen) |)|
+//@[058:00060) | ├─Token(NewLine) |\r\n|
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00024) | ├─IdentifierSyntax
+//@[007:00024) | | └─Token(Identifier) |modBWithCondition|
+//@[025:00048) | ├─StringSyntax
+//@[025:00048) | | └─Token(StringComplete) |'./child/moduleb.bicep'|
+//@[049:00050) | ├─Token(Assignment) |=|
+//@[051:00143) | └─IfConditionSyntax
+//@[051:00053) |   ├─Token(Identifier) |if|
+//@[054:00066) |   ├─ParenthesizedExpressionSyntax
+//@[054:00055) |   | ├─Token(LeftParen) |(|
+//@[055:00065) |   | ├─BinaryOperationSyntax
+//@[055:00060) |   | | ├─BinaryOperationSyntax
+//@[055:00056) |   | | | ├─IntegerLiteralSyntax
+//@[055:00056) |   | | | | └─Token(Integer) |1|
+//@[057:00058) |   | | | ├─Token(Plus) |+|
+//@[059:00060) |   | | | └─IntegerLiteralSyntax
+//@[059:00060) |   | | |   └─Token(Integer) |1|
+//@[061:00063) |   | | ├─Token(Equals) |==|
+//@[064:00065) |   | | └─IntegerLiteralSyntax
+//@[064:00065) |   | |   └─Token(Integer) |2|
+//@[065:00066) |   | └─Token(RightParen) |)|
+//@[067:00143) |   └─ObjectSyntax
+//@[067:00068) |     ├─Token(LeftBrace) |{|
+//@[068:00070) |     ├─Token(NewLine) |\r\n|
+  name: 'modBWithCondition'
+//@[002:00027) |     ├─ObjectPropertySyntax
+//@[002:00006) |     | ├─IdentifierSyntax
+//@[002:00006) |     | | └─Token(Identifier) |name|
+//@[006:00007) |     | ├─Token(Colon) |:|
+//@[008:00027) |     | └─StringSyntax
+//@[008:00027) |     |   └─Token(StringComplete) |'modBWithCondition'|
+//@[027:00029) |     ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00041) |     ├─ObjectPropertySyntax
+//@[002:00008) |     | ├─IdentifierSyntax
+//@[002:00008) |     | | └─Token(Identifier) |params|
+//@[008:00009) |     | ├─Token(Colon) |:|
+//@[010:00041) |     | └─ObjectSyntax
+//@[010:00011) |     |   ├─Token(LeftBrace) |{|
+//@[011:00013) |     |   ├─Token(NewLine) |\r\n|
+    location: 'East US'
+//@[004:00023) |     |   ├─ObjectPropertySyntax
+//@[004:00012) |     |   | ├─IdentifierSyntax
+//@[004:00012) |     |   | | └─Token(Identifier) |location|
+//@[012:00013) |     |   | ├─Token(Colon) |:|
+//@[014:00023) |     |   | └─StringSyntax
+//@[014:00023) |     |   |   └─Token(StringComplete) |'East US'|
+//@[023:00025) |     |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |     |   └─Token(RightBrace) |}|
+//@[003:00005) |     ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |     └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module modBWithCondition2 './child/moduleb.bicep' =
+//@[000:00166) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00025) | ├─IdentifierSyntax
+//@[007:00025) | | └─Token(Identifier) |modBWithCondition2|
+//@[026:00049) | ├─StringSyntax
+//@[026:00049) | | └─Token(StringComplete) |'./child/moduleb.bicep'|
+//@[050:00051) | ├─Token(Assignment) |=|
+//@[051:00053) | ├─Token(NewLine) |\r\n|
+// awkward comment
+//@[018:00020) | ├─Token(NewLine) |\r\n|
+if (1 + 1 == 2) {
+//@[000:00093) | └─IfConditionSyntax
+//@[000:00002) |   ├─Token(Identifier) |if|
+//@[003:00015) |   ├─ParenthesizedExpressionSyntax
+//@[003:00004) |   | ├─Token(LeftParen) |(|
+//@[004:00014) |   | ├─BinaryOperationSyntax
+//@[004:00009) |   | | ├─BinaryOperationSyntax
+//@[004:00005) |   | | | ├─IntegerLiteralSyntax
+//@[004:00005) |   | | | | └─Token(Integer) |1|
+//@[006:00007) |   | | | ├─Token(Plus) |+|
+//@[008:00009) |   | | | └─IntegerLiteralSyntax
+//@[008:00009) |   | | |   └─Token(Integer) |1|
+//@[010:00012) |   | | ├─Token(Equals) |==|
+//@[013:00014) |   | | └─IntegerLiteralSyntax
+//@[013:00014) |   | |   └─Token(Integer) |2|
+//@[014:00015) |   | └─Token(RightParen) |)|
+//@[016:00093) |   └─ObjectSyntax
+//@[016:00017) |     ├─Token(LeftBrace) |{|
+//@[017:00019) |     ├─Token(NewLine) |\r\n|
+  name: 'modBWithCondition2'
+//@[002:00028) |     ├─ObjectPropertySyntax
+//@[002:00006) |     | ├─IdentifierSyntax
+//@[002:00006) |     | | └─Token(Identifier) |name|
+//@[006:00007) |     | ├─Token(Colon) |:|
+//@[008:00028) |     | └─StringSyntax
+//@[008:00028) |     |   └─Token(StringComplete) |'modBWithCondition2'|
+//@[028:00030) |     ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00041) |     ├─ObjectPropertySyntax
+//@[002:00008) |     | ├─IdentifierSyntax
+//@[002:00008) |     | | └─Token(Identifier) |params|
+//@[008:00009) |     | ├─Token(Colon) |:|
+//@[010:00041) |     | └─ObjectSyntax
+//@[010:00011) |     |   ├─Token(LeftBrace) |{|
+//@[011:00013) |     |   ├─Token(NewLine) |\r\n|
+    location: 'East US'
+//@[004:00023) |     |   ├─ObjectPropertySyntax
+//@[004:00012) |     |   | ├─IdentifierSyntax
+//@[004:00012) |     |   | | └─Token(Identifier) |location|
+//@[012:00013) |     |   | ├─Token(Colon) |:|
+//@[014:00023) |     |   | └─StringSyntax
+//@[014:00023) |     |   |   └─Token(StringComplete) |'East US'|
+//@[023:00025) |     |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |     |   └─Token(RightBrace) |}|
+//@[003:00005) |     ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |     └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module modC './child/modulec.json' = {
+//@[000:00100) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00011) | ├─IdentifierSyntax
+//@[007:00011) | | └─Token(Identifier) |modC|
+//@[012:00034) | ├─StringSyntax
+//@[012:00034) | | └─Token(StringComplete) |'./child/modulec.json'|
+//@[035:00036) | ├─Token(Assignment) |=|
+//@[037:00100) | └─ObjectSyntax
+//@[037:00038) |   ├─Token(LeftBrace) |{|
+//@[038:00040) |   ├─Token(NewLine) |\r\n|
+  name: 'modC'
+//@[002:00014) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00014) |   | └─StringSyntax
+//@[008:00014) |   |   └─Token(StringComplete) |'modC'|
+//@[014:00016) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00041) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00041) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    location: 'West US'
+//@[004:00023) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |location|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00023) |   |   | └─StringSyntax
+//@[014:00023) |   |   |   └─Token(StringComplete) |'West US'|
+//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+//@[000:00142) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00024) | ├─IdentifierSyntax
+//@[007:00024) | | └─Token(Identifier) |modCWithCondition|
+//@[025:00047) | ├─StringSyntax
+//@[025:00047) | | └─Token(StringComplete) |'./child/modulec.json'|
+//@[048:00049) | ├─Token(Assignment) |=|
+//@[050:00142) | └─IfConditionSyntax
+//@[050:00052) |   ├─Token(Identifier) |if|
+//@[053:00065) |   ├─ParenthesizedExpressionSyntax
+//@[053:00054) |   | ├─Token(LeftParen) |(|
+//@[054:00064) |   | ├─BinaryOperationSyntax
+//@[054:00059) |   | | ├─BinaryOperationSyntax
+//@[054:00055) |   | | | ├─IntegerLiteralSyntax
+//@[054:00055) |   | | | | └─Token(Integer) |2|
+//@[056:00057) |   | | | ├─Token(Minus) |-|
+//@[058:00059) |   | | | └─IntegerLiteralSyntax
+//@[058:00059) |   | | |   └─Token(Integer) |1|
+//@[060:00062) |   | | ├─Token(Equals) |==|
+//@[063:00064) |   | | └─IntegerLiteralSyntax
+//@[063:00064) |   | |   └─Token(Integer) |1|
+//@[064:00065) |   | └─Token(RightParen) |)|
+//@[066:00142) |   └─ObjectSyntax
+//@[066:00067) |     ├─Token(LeftBrace) |{|
+//@[067:00069) |     ├─Token(NewLine) |\r\n|
+  name: 'modCWithCondition'
+//@[002:00027) |     ├─ObjectPropertySyntax
+//@[002:00006) |     | ├─IdentifierSyntax
+//@[002:00006) |     | | └─Token(Identifier) |name|
+//@[006:00007) |     | ├─Token(Colon) |:|
+//@[008:00027) |     | └─StringSyntax
+//@[008:00027) |     |   └─Token(StringComplete) |'modCWithCondition'|
+//@[027:00029) |     ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00041) |     ├─ObjectPropertySyntax
+//@[002:00008) |     | ├─IdentifierSyntax
+//@[002:00008) |     | | └─Token(Identifier) |params|
+//@[008:00009) |     | ├─Token(Colon) |:|
+//@[010:00041) |     | └─ObjectSyntax
+//@[010:00011) |     |   ├─Token(LeftBrace) |{|
+//@[011:00013) |     |   ├─Token(NewLine) |\r\n|
+    location: 'East US'
+//@[004:00023) |     |   ├─ObjectPropertySyntax
+//@[004:00012) |     |   | ├─IdentifierSyntax
+//@[004:00012) |     |   | | └─Token(Identifier) |location|
+//@[012:00013) |     |   | ├─Token(Colon) |:|
+//@[014:00023) |     |   | └─StringSyntax
+//@[014:00023) |     |   |   └─Token(StringComplete) |'East US'|
+//@[023:00025) |     |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |     |   └─Token(RightBrace) |}|
+//@[003:00005) |     ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |     └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module optionalWithNoParams1 './child/optionalParams.bicep'= {
+//@[000:00098) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00028) | ├─IdentifierSyntax
+//@[007:00028) | | └─Token(Identifier) |optionalWithNoParams1|
+//@[029:00059) | ├─StringSyntax
+//@[029:00059) | | └─Token(StringComplete) |'./child/optionalParams.bicep'|
+//@[059:00060) | ├─Token(Assignment) |=|
+//@[061:00098) | └─ObjectSyntax
+//@[061:00062) |   ├─Token(LeftBrace) |{|
+//@[062:00064) |   ├─Token(NewLine) |\r\n|
+  name: 'optionalWithNoParams1'
+//@[002:00031) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00031) |   | └─StringSyntax
+//@[008:00031) |   |   └─Token(StringComplete) |'optionalWithNoParams1'|
+//@[031:00033) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module optionalWithNoParams2 './child/optionalParams.bicep'= {
+//@[000:00116) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00028) | ├─IdentifierSyntax
+//@[007:00028) | | └─Token(Identifier) |optionalWithNoParams2|
+//@[029:00059) | ├─StringSyntax
+//@[029:00059) | | └─Token(StringComplete) |'./child/optionalParams.bicep'|
+//@[059:00060) | ├─Token(Assignment) |=|
+//@[061:00116) | └─ObjectSyntax
+//@[061:00062) |   ├─Token(LeftBrace) |{|
+//@[062:00064) |   ├─Token(NewLine) |\r\n|
+  name: 'optionalWithNoParams2'
+//@[002:00031) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00031) |   | └─StringSyntax
+//@[008:00031) |   |   └─Token(StringComplete) |'optionalWithNoParams2'|
+//@[031:00033) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00016) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00016) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module optionalWithAllParams './child/optionalParams.bicep'= {
+//@[000:00210) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00028) | ├─IdentifierSyntax
+//@[007:00028) | | └─Token(Identifier) |optionalWithAllParams|
+//@[029:00059) | ├─StringSyntax
+//@[029:00059) | | └─Token(StringComplete) |'./child/optionalParams.bicep'|
+//@[059:00060) | ├─Token(Assignment) |=|
+//@[061:00210) | └─ObjectSyntax
+//@[061:00062) |   ├─Token(LeftBrace) |{|
+//@[062:00064) |   ├─Token(NewLine) |\r\n|
+  name: 'optionalWithNoParams3'
+//@[002:00031) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00031) |   | └─StringSyntax
+//@[008:00031) |   |   └─Token(StringComplete) |'optionalWithNoParams3'|
+//@[031:00033) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00110) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00110) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    optionalString: 'abc'
+//@[004:00025) |   |   ├─ObjectPropertySyntax
+//@[004:00018) |   |   | ├─IdentifierSyntax
+//@[004:00018) |   |   | | └─Token(Identifier) |optionalString|
+//@[018:00019) |   |   | ├─Token(Colon) |:|
+//@[020:00025) |   |   | └─StringSyntax
+//@[020:00025) |   |   |   └─Token(StringComplete) |'abc'|
+//@[025:00027) |   |   ├─Token(NewLine) |\r\n|
+    optionalInt: 42
+//@[004:00019) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalInt|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00019) |   |   | └─IntegerLiteralSyntax
+//@[017:00019) |   |   |   └─Token(Integer) |42|
+//@[019:00021) |   |   ├─Token(NewLine) |\r\n|
+    optionalObj: { }
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalObj|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00020) |   |   | └─ObjectSyntax
+//@[017:00018) |   |   |   ├─Token(LeftBrace) |{|
+//@[019:00020) |   |   |   └─Token(RightBrace) |}|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    optionalArray: [ ]
+//@[004:00022) |   |   ├─ObjectPropertySyntax
+//@[004:00017) |   |   | ├─IdentifierSyntax
+//@[004:00017) |   |   | | └─Token(Identifier) |optionalArray|
+//@[017:00018) |   |   | ├─Token(Colon) |:|
+//@[019:00022) |   |   | └─ArraySyntax
+//@[019:00020) |   |   |   ├─Token(LeftSquare) |[|
+//@[021:00022) |   |   |   └─Token(RightSquare) |]|
+//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:00233) ├─ResourceDeclarationSyntax
+//@[000:00008) | ├─Token(Identifier) |resource|
+//@[009:00028) | ├─IdentifierSyntax
+//@[009:00028) | | └─Token(Identifier) |resWithDependencies|
+//@[029:00062) | ├─StringSyntax
+//@[029:00062) | | └─Token(StringComplete) |'Mock.Rp/mockResource@2020-01-01'|
+//@[063:00064) | ├─Token(Assignment) |=|
+//@[065:00233) | └─ObjectSyntax
+//@[065:00066) |   ├─Token(LeftBrace) |{|
+//@[066:00068) |   ├─Token(NewLine) |\r\n|
+  name: 'harry'
+//@[002:00015) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00015) |   | └─StringSyntax
+//@[008:00015) |   |   └─Token(StringComplete) |'harry'|
+//@[015:00017) |   ├─Token(NewLine) |\r\n|
+  properties: {
+//@[002:00145) |   ├─ObjectPropertySyntax
+//@[002:00012) |   | ├─IdentifierSyntax
+//@[002:00012) |   | | └─Token(Identifier) |properties|
+//@[012:00013) |   | ├─Token(Colon) |:|
+//@[014:00145) |   | └─ObjectSyntax
+//@[014:00015) |   |   ├─Token(LeftBrace) |{|
+//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
+    modADep: modATest.outputs.stringOutputA
+//@[004:00043) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |modADep|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00043) |   |   | └─PropertyAccessSyntax
+//@[013:00029) |   |   |   ├─PropertyAccessSyntax
+//@[013:00021) |   |   |   | ├─VariableAccessSyntax
+//@[013:00021) |   |   |   | | └─IdentifierSyntax
+//@[013:00021) |   |   |   | |   └─Token(Identifier) |modATest|
+//@[021:00022) |   |   |   | ├─Token(Dot) |.|
+//@[022:00029) |   |   |   | └─IdentifierSyntax
+//@[022:00029) |   |   |   |   └─Token(Identifier) |outputs|
+//@[029:00030) |   |   |   ├─Token(Dot) |.|
+//@[030:00043) |   |   |   └─IdentifierSyntax
+//@[030:00043) |   |   |     └─Token(Identifier) |stringOutputA|
+//@[043:00045) |   |   ├─Token(NewLine) |\r\n|
+    modBDep: modB.outputs.myResourceId
+//@[004:00038) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |modBDep|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00038) |   |   | └─PropertyAccessSyntax
+//@[013:00025) |   |   |   ├─PropertyAccessSyntax
+//@[013:00017) |   |   |   | ├─VariableAccessSyntax
+//@[013:00017) |   |   |   | | └─IdentifierSyntax
+//@[013:00017) |   |   |   | |   └─Token(Identifier) |modB|
+//@[017:00018) |   |   |   | ├─Token(Dot) |.|
+//@[018:00025) |   |   |   | └─IdentifierSyntax
+//@[018:00025) |   |   |   |   └─Token(Identifier) |outputs|
+//@[025:00026) |   |   |   ├─Token(Dot) |.|
+//@[026:00038) |   |   |   └─IdentifierSyntax
+//@[026:00038) |   |   |     └─Token(Identifier) |myResourceId|
+//@[038:00040) |   |   ├─Token(NewLine) |\r\n|
+    modCDep: modC.outputs.myResourceId
+//@[004:00038) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |modCDep|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00038) |   |   | └─PropertyAccessSyntax
+//@[013:00025) |   |   |   ├─PropertyAccessSyntax
+//@[013:00017) |   |   |   | ├─VariableAccessSyntax
+//@[013:00017) |   |   |   | | └─IdentifierSyntax
+//@[013:00017) |   |   |   | |   └─Token(Identifier) |modC|
+//@[017:00018) |   |   |   | ├─Token(Dot) |.|
+//@[018:00025) |   |   |   | └─IdentifierSyntax
+//@[018:00025) |   |   |   |   └─Token(Identifier) |outputs|
+//@[025:00026) |   |   |   ├─Token(Dot) |.|
+//@[026:00038) |   |   |   └─IdentifierSyntax
+//@[026:00038) |   |   |     └─Token(Identifier) |myResourceId|
+//@[038:00040) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
+//@[000:00321) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00047) | ├─IdentifierSyntax
+//@[007:00047) | | └─Token(Identifier) |optionalWithAllParamsAndManualDependency|
+//@[048:00078) | ├─StringSyntax
+//@[048:00078) | | └─Token(StringComplete) |'./child/optionalParams.bicep'|
+//@[078:00079) | ├─Token(Assignment) |=|
+//@[080:00321) | └─ObjectSyntax
+//@[080:00081) |   ├─Token(LeftBrace) |{|
+//@[081:00083) |   ├─Token(NewLine) |\r\n|
+  name: 'optionalWithAllParamsAndManualDependency'
+//@[002:00050) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00050) |   | └─StringSyntax
+//@[008:00050) |   |   └─Token(StringComplete) |'optionalWithAllParamsAndManualDependency'|
+//@[050:00052) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00110) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00110) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    optionalString: 'abc'
+//@[004:00025) |   |   ├─ObjectPropertySyntax
+//@[004:00018) |   |   | ├─IdentifierSyntax
+//@[004:00018) |   |   | | └─Token(Identifier) |optionalString|
+//@[018:00019) |   |   | ├─Token(Colon) |:|
+//@[020:00025) |   |   | └─StringSyntax
+//@[020:00025) |   |   |   └─Token(StringComplete) |'abc'|
+//@[025:00027) |   |   ├─Token(NewLine) |\r\n|
+    optionalInt: 42
+//@[004:00019) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalInt|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00019) |   |   | └─IntegerLiteralSyntax
+//@[017:00019) |   |   |   └─Token(Integer) |42|
+//@[019:00021) |   |   ├─Token(NewLine) |\r\n|
+    optionalObj: { }
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalObj|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00020) |   |   | └─ObjectSyntax
+//@[017:00018) |   |   |   ├─Token(LeftBrace) |{|
+//@[019:00020) |   |   |   └─Token(RightBrace) |}|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    optionalArray: [ ]
+//@[004:00022) |   |   ├─ObjectPropertySyntax
+//@[004:00017) |   |   | ├─IdentifierSyntax
+//@[004:00017) |   |   | | └─Token(Identifier) |optionalArray|
+//@[017:00018) |   |   | ├─Token(Colon) |:|
+//@[019:00022) |   |   | └─ArraySyntax
+//@[019:00020) |   |   |   ├─Token(LeftSquare) |[|
+//@[021:00022) |   |   |   └─Token(RightSquare) |]|
+//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+  dependsOn: [
+//@[002:00071) |   ├─ObjectPropertySyntax
+//@[002:00011) |   | ├─IdentifierSyntax
+//@[002:00011) |   | | └─Token(Identifier) |dependsOn|
+//@[011:00012) |   | ├─Token(Colon) |:|
+//@[013:00071) |   | └─ArraySyntax
+//@[013:00014) |   |   ├─Token(LeftSquare) |[|
+//@[014:00016) |   |   ├─Token(NewLine) |\r\n|
+    resWithDependencies
+//@[004:00023) |   |   ├─ArrayItemSyntax
+//@[004:00023) |   |   | └─VariableAccessSyntax
+//@[004:00023) |   |   |   └─IdentifierSyntax
+//@[004:00023) |   |   |     └─Token(Identifier) |resWithDependencies|
+//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
+    optionalWithAllParams
+//@[004:00025) |   |   ├─ArrayItemSyntax
+//@[004:00025) |   |   | └─VariableAccessSyntax
+//@[004:00025) |   |   |   └─IdentifierSyntax
+//@[004:00025) |   |   |     └─Token(Identifier) |optionalWithAllParams|
+//@[025:00027) |   |   ├─Token(NewLine) |\r\n|
+  ]
+//@[002:00003) |   |   └─Token(RightSquare) |]|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module optionalWithImplicitDependency './child/optionalParams.bicep'= {
+//@[000:00300) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00037) | ├─IdentifierSyntax
+//@[007:00037) | | └─Token(Identifier) |optionalWithImplicitDependency|
+//@[038:00068) | ├─StringSyntax
+//@[038:00068) | | └─Token(StringComplete) |'./child/optionalParams.bicep'|
+//@[068:00069) | ├─Token(Assignment) |=|
+//@[070:00300) | └─ObjectSyntax
+//@[070:00071) |   ├─Token(LeftBrace) |{|
+//@[071:00073) |   ├─Token(NewLine) |\r\n|
+  name: 'optionalWithImplicitDependency'
+//@[002:00040) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00040) |   | └─StringSyntax
+//@[008:00040) |   |   └─Token(StringComplete) |'optionalWithImplicitDependency'|
+//@[040:00042) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00182) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00182) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[004:00097) |   |   ├─ObjectPropertySyntax
+//@[004:00018) |   |   | ├─IdentifierSyntax
+//@[004:00018) |   |   | | └─Token(Identifier) |optionalString|
+//@[018:00019) |   |   | ├─Token(Colon) |:|
+//@[020:00097) |   |   | └─FunctionCallSyntax
+//@[020:00026) |   |   |   ├─IdentifierSyntax
+//@[020:00026) |   |   |   | └─Token(Identifier) |concat|
+//@[026:00027) |   |   |   ├─Token(LeftParen) |(|
+//@[027:00049) |   |   |   ├─FunctionArgumentSyntax
+//@[027:00049) |   |   |   | └─PropertyAccessSyntax
+//@[027:00046) |   |   |   |   ├─VariableAccessSyntax
+//@[027:00046) |   |   |   |   | └─IdentifierSyntax
+//@[027:00046) |   |   |   |   |   └─Token(Identifier) |resWithDependencies|
+//@[046:00047) |   |   |   |   ├─Token(Dot) |.|
+//@[047:00049) |   |   |   |   └─IdentifierSyntax
+//@[047:00049) |   |   |   |     └─Token(Identifier) |id|
+//@[049:00050) |   |   |   ├─Token(Comma) |,|
+//@[051:00096) |   |   |   ├─FunctionArgumentSyntax
+//@[051:00096) |   |   |   | └─PropertyAccessSyntax
+//@[051:00091) |   |   |   |   ├─VariableAccessSyntax
+//@[051:00091) |   |   |   |   | └─IdentifierSyntax
+//@[051:00091) |   |   |   |   |   └─Token(Identifier) |optionalWithAllParamsAndManualDependency|
+//@[091:00092) |   |   |   |   ├─Token(Dot) |.|
+//@[092:00096) |   |   |   |   └─IdentifierSyntax
+//@[092:00096) |   |   |   |     └─Token(Identifier) |name|
+//@[096:00097) |   |   |   └─Token(RightParen) |)|
+//@[097:00099) |   |   ├─Token(NewLine) |\r\n|
+    optionalInt: 42
+//@[004:00019) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalInt|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00019) |   |   | └─IntegerLiteralSyntax
+//@[017:00019) |   |   |   └─Token(Integer) |42|
+//@[019:00021) |   |   ├─Token(NewLine) |\r\n|
+    optionalObj: { }
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalObj|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00020) |   |   | └─ObjectSyntax
+//@[017:00018) |   |   |   ├─Token(LeftBrace) |{|
+//@[019:00020) |   |   |   └─Token(RightBrace) |}|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    optionalArray: [ ]
+//@[004:00022) |   |   ├─ObjectPropertySyntax
+//@[004:00017) |   |   | ├─IdentifierSyntax
+//@[004:00017) |   |   | | └─Token(Identifier) |optionalArray|
+//@[017:00018) |   |   | ├─Token(Colon) |:|
+//@[019:00022) |   |   | └─ArraySyntax
+//@[019:00020) |   |   |   ├─Token(LeftSquare) |[|
+//@[021:00022) |   |   |   └─Token(RightSquare) |]|
+//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module moduleWithCalculatedName './child/optionalParams.bicep'= {
+//@[000:00331) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00031) | ├─IdentifierSyntax
+//@[007:00031) | | └─Token(Identifier) |moduleWithCalculatedName|
+//@[032:00062) | ├─StringSyntax
+//@[032:00062) | | └─Token(StringComplete) |'./child/optionalParams.bicep'|
+//@[062:00063) | ├─Token(Assignment) |=|
+//@[064:00331) | └─ObjectSyntax
+//@[064:00065) |   ├─Token(LeftBrace) |{|
+//@[065:00067) |   ├─Token(NewLine) |\r\n|
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@[002:00077) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00077) |   | └─StringSyntax
+//@[008:00011) |   |   ├─Token(StringLeftPiece) |'${|
+//@[011:00056) |   |   ├─PropertyAccessSyntax
+//@[011:00051) |   |   | ├─VariableAccessSyntax
+//@[011:00051) |   |   | | └─IdentifierSyntax
+//@[011:00051) |   |   | |   └─Token(Identifier) |optionalWithAllParamsAndManualDependency|
+//@[051:00052) |   |   | ├─Token(Dot) |.|
+//@[052:00056) |   |   | └─IdentifierSyntax
+//@[052:00056) |   |   |   └─Token(Identifier) |name|
+//@[056:00059) |   |   ├─Token(StringMiddlePiece) |}${|
+//@[059:00075) |   |   ├─VariableAccessSyntax
+//@[059:00075) |   |   | └─IdentifierSyntax
+//@[059:00075) |   |   |   └─Token(Identifier) |deployTimeSuffix|
+//@[075:00077) |   |   └─Token(StringRightPiece) |}'|
+//@[077:00079) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00182) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00182) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[004:00097) |   |   ├─ObjectPropertySyntax
+//@[004:00018) |   |   | ├─IdentifierSyntax
+//@[004:00018) |   |   | | └─Token(Identifier) |optionalString|
+//@[018:00019) |   |   | ├─Token(Colon) |:|
+//@[020:00097) |   |   | └─FunctionCallSyntax
+//@[020:00026) |   |   |   ├─IdentifierSyntax
+//@[020:00026) |   |   |   | └─Token(Identifier) |concat|
+//@[026:00027) |   |   |   ├─Token(LeftParen) |(|
+//@[027:00049) |   |   |   ├─FunctionArgumentSyntax
+//@[027:00049) |   |   |   | └─PropertyAccessSyntax
+//@[027:00046) |   |   |   |   ├─VariableAccessSyntax
+//@[027:00046) |   |   |   |   | └─IdentifierSyntax
+//@[027:00046) |   |   |   |   |   └─Token(Identifier) |resWithDependencies|
+//@[046:00047) |   |   |   |   ├─Token(Dot) |.|
+//@[047:00049) |   |   |   |   └─IdentifierSyntax
+//@[047:00049) |   |   |   |     └─Token(Identifier) |id|
+//@[049:00050) |   |   |   ├─Token(Comma) |,|
+//@[051:00096) |   |   |   ├─FunctionArgumentSyntax
+//@[051:00096) |   |   |   | └─PropertyAccessSyntax
+//@[051:00091) |   |   |   |   ├─VariableAccessSyntax
+//@[051:00091) |   |   |   |   | └─IdentifierSyntax
+//@[051:00091) |   |   |   |   |   └─Token(Identifier) |optionalWithAllParamsAndManualDependency|
+//@[091:00092) |   |   |   |   ├─Token(Dot) |.|
+//@[092:00096) |   |   |   |   └─IdentifierSyntax
+//@[092:00096) |   |   |   |     └─Token(Identifier) |name|
+//@[096:00097) |   |   |   └─Token(RightParen) |)|
+//@[097:00099) |   |   ├─Token(NewLine) |\r\n|
+    optionalInt: 42
+//@[004:00019) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalInt|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00019) |   |   | └─IntegerLiteralSyntax
+//@[017:00019) |   |   |   └─Token(Integer) |42|
+//@[019:00021) |   |   ├─Token(NewLine) |\r\n|
+    optionalObj: { }
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00015) |   |   | ├─IdentifierSyntax
+//@[004:00015) |   |   | | └─Token(Identifier) |optionalObj|
+//@[015:00016) |   |   | ├─Token(Colon) |:|
+//@[017:00020) |   |   | └─ObjectSyntax
+//@[017:00018) |   |   |   ├─Token(LeftBrace) |{|
+//@[019:00020) |   |   |   └─Token(RightBrace) |}|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    optionalArray: [ ]
+//@[004:00022) |   |   ├─ObjectPropertySyntax
+//@[004:00017) |   |   | ├─IdentifierSyntax
+//@[004:00017) |   |   | | └─Token(Identifier) |optionalArray|
+//@[017:00018) |   |   | ├─Token(Colon) |:|
+//@[019:00022) |   |   | └─ArraySyntax
+//@[019:00020) |   |   |   ├─Token(LeftSquare) |[|
+//@[021:00022) |   |   |   └─Token(RightSquare) |]|
+//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:00241) ├─ResourceDeclarationSyntax
+//@[000:00008) | ├─Token(Identifier) |resource|
+//@[009:00042) | ├─IdentifierSyntax
+//@[009:00042) | | └─Token(Identifier) |resWithCalculatedNameDependencies|
+//@[043:00076) | ├─StringSyntax
+//@[043:00076) | | └─Token(StringComplete) |'Mock.Rp/mockResource@2020-01-01'|
+//@[077:00078) | ├─Token(Assignment) |=|
+//@[079:00241) | └─ObjectSyntax
+//@[079:00080) |   ├─Token(LeftBrace) |{|
+//@[080:00082) |   ├─Token(NewLine) |\r\n|
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@[002:00077) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00077) |   | └─StringSyntax
+//@[008:00011) |   |   ├─Token(StringLeftPiece) |'${|
+//@[011:00056) |   |   ├─PropertyAccessSyntax
+//@[011:00051) |   |   | ├─VariableAccessSyntax
+//@[011:00051) |   |   | | └─IdentifierSyntax
+//@[011:00051) |   |   | |   └─Token(Identifier) |optionalWithAllParamsAndManualDependency|
+//@[051:00052) |   |   | ├─Token(Dot) |.|
+//@[052:00056) |   |   | └─IdentifierSyntax
+//@[052:00056) |   |   |   └─Token(Identifier) |name|
+//@[056:00059) |   |   ├─Token(StringMiddlePiece) |}${|
+//@[059:00075) |   |   ├─VariableAccessSyntax
+//@[059:00075) |   |   | └─IdentifierSyntax
+//@[059:00075) |   |   |   └─Token(Identifier) |deployTimeSuffix|
+//@[075:00077) |   |   └─Token(StringRightPiece) |}'|
+//@[077:00079) |   ├─Token(NewLine) |\r\n|
+  properties: {
+//@[002:00077) |   ├─ObjectPropertySyntax
+//@[002:00012) |   | ├─IdentifierSyntax
+//@[002:00012) |   | | └─Token(Identifier) |properties|
+//@[012:00013) |   | ├─Token(Colon) |:|
+//@[014:00077) |   | └─ObjectSyntax
+//@[014:00015) |   |   ├─Token(LeftBrace) |{|
+//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
+    modADep: moduleWithCalculatedName.outputs.outputObj
+//@[004:00055) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |modADep|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00055) |   |   | └─PropertyAccessSyntax
+//@[013:00045) |   |   |   ├─PropertyAccessSyntax
+//@[013:00037) |   |   |   | ├─VariableAccessSyntax
+//@[013:00037) |   |   |   | | └─IdentifierSyntax
+//@[013:00037) |   |   |   | |   └─Token(Identifier) |moduleWithCalculatedName|
+//@[037:00038) |   |   |   | ├─Token(Dot) |.|
+//@[038:00045) |   |   |   | └─IdentifierSyntax
+//@[038:00045) |   |   |   |   └─Token(Identifier) |outputs|
+//@[045:00046) |   |   |   ├─Token(Dot) |.|
+//@[046:00055) |   |   |   └─IdentifierSyntax
+//@[046:00055) |   |   |     └─Token(Identifier) |outputObj|
+//@[055:00057) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+output stringOutputA string = modATest.outputs.stringOutputA
+//@[000:00060) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00020) | ├─IdentifierSyntax
+//@[007:00020) | | └─Token(Identifier) |stringOutputA|
+//@[021:00027) | ├─TypeVariableAccessSyntax
+//@[021:00027) | | └─IdentifierSyntax
+//@[021:00027) | |   └─Token(Identifier) |string|
+//@[028:00029) | ├─Token(Assignment) |=|
+//@[030:00060) | └─PropertyAccessSyntax
+//@[030:00046) |   ├─PropertyAccessSyntax
+//@[030:00038) |   | ├─VariableAccessSyntax
+//@[030:00038) |   | | └─IdentifierSyntax
+//@[030:00038) |   | |   └─Token(Identifier) |modATest|
+//@[038:00039) |   | ├─Token(Dot) |.|
+//@[039:00046) |   | └─IdentifierSyntax
+//@[039:00046) |   |   └─Token(Identifier) |outputs|
+//@[046:00047) |   ├─Token(Dot) |.|
+//@[047:00060) |   └─IdentifierSyntax
+//@[047:00060) |     └─Token(Identifier) |stringOutputA|
+//@[060:00062) ├─Token(NewLine) |\r\n|
+output stringOutputB string = modATest.outputs.stringOutputB
+//@[000:00060) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00020) | ├─IdentifierSyntax
+//@[007:00020) | | └─Token(Identifier) |stringOutputB|
+//@[021:00027) | ├─TypeVariableAccessSyntax
+//@[021:00027) | | └─IdentifierSyntax
+//@[021:00027) | |   └─Token(Identifier) |string|
+//@[028:00029) | ├─Token(Assignment) |=|
+//@[030:00060) | └─PropertyAccessSyntax
+//@[030:00046) |   ├─PropertyAccessSyntax
+//@[030:00038) |   | ├─VariableAccessSyntax
+//@[030:00038) |   | | └─IdentifierSyntax
+//@[030:00038) |   | |   └─Token(Identifier) |modATest|
+//@[038:00039) |   | ├─Token(Dot) |.|
+//@[039:00046) |   | └─IdentifierSyntax
+//@[039:00046) |   |   └─Token(Identifier) |outputs|
+//@[046:00047) |   ├─Token(Dot) |.|
+//@[047:00060) |   └─IdentifierSyntax
+//@[047:00060) |     └─Token(Identifier) |stringOutputB|
+//@[060:00062) ├─Token(NewLine) |\r\n|
+output objOutput object = modATest.outputs.objOutput
+//@[000:00052) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00016) | ├─IdentifierSyntax
+//@[007:00016) | | └─Token(Identifier) |objOutput|
+//@[017:00023) | ├─TypeVariableAccessSyntax
+//@[017:00023) | | └─IdentifierSyntax
+//@[017:00023) | |   └─Token(Identifier) |object|
+//@[024:00025) | ├─Token(Assignment) |=|
+//@[026:00052) | └─PropertyAccessSyntax
+//@[026:00042) |   ├─PropertyAccessSyntax
+//@[026:00034) |   | ├─VariableAccessSyntax
+//@[026:00034) |   | | └─IdentifierSyntax
+//@[026:00034) |   | |   └─Token(Identifier) |modATest|
+//@[034:00035) |   | ├─Token(Dot) |.|
+//@[035:00042) |   | └─IdentifierSyntax
+//@[035:00042) |   |   └─Token(Identifier) |outputs|
+//@[042:00043) |   ├─Token(Dot) |.|
+//@[043:00052) |   └─IdentifierSyntax
+//@[043:00052) |     └─Token(Identifier) |objOutput|
+//@[052:00054) ├─Token(NewLine) |\r\n|
+output arrayOutput array = modATest.outputs.arrayOutput
+//@[000:00055) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00018) | ├─IdentifierSyntax
+//@[007:00018) | | └─Token(Identifier) |arrayOutput|
+//@[019:00024) | ├─TypeVariableAccessSyntax
+//@[019:00024) | | └─IdentifierSyntax
+//@[019:00024) | |   └─Token(Identifier) |array|
+//@[025:00026) | ├─Token(Assignment) |=|
+//@[027:00055) | └─PropertyAccessSyntax
+//@[027:00043) |   ├─PropertyAccessSyntax
+//@[027:00035) |   | ├─VariableAccessSyntax
+//@[027:00035) |   | | └─IdentifierSyntax
+//@[027:00035) |   | |   └─Token(Identifier) |modATest|
+//@[035:00036) |   | ├─Token(Dot) |.|
+//@[036:00043) |   | └─IdentifierSyntax
+//@[036:00043) |   |   └─Token(Identifier) |outputs|
+//@[043:00044) |   ├─Token(Dot) |.|
+//@[044:00055) |   └─IdentifierSyntax
+//@[044:00055) |     └─Token(Identifier) |arrayOutput|
+//@[055:00057) ├─Token(NewLine) |\r\n|
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+//@[000:00082) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00030) | ├─IdentifierSyntax
+//@[007:00030) | | └─Token(Identifier) |modCalculatedNameOutput|
+//@[031:00037) | ├─TypeVariableAccessSyntax
+//@[031:00037) | | └─IdentifierSyntax
+//@[031:00037) | |   └─Token(Identifier) |object|
+//@[038:00039) | ├─Token(Assignment) |=|
+//@[040:00082) | └─PropertyAccessSyntax
+//@[040:00072) |   ├─PropertyAccessSyntax
+//@[040:00064) |   | ├─VariableAccessSyntax
+//@[040:00064) |   | | └─IdentifierSyntax
+//@[040:00064) |   | |   └─Token(Identifier) |moduleWithCalculatedName|
+//@[064:00065) |   | ├─Token(Dot) |.|
+//@[065:00072) |   | └─IdentifierSyntax
+//@[065:00072) |   |   └─Token(Identifier) |outputs|
+//@[072:00073) |   ├─Token(Dot) |.|
+//@[073:00082) |   └─IdentifierSyntax
+//@[073:00082) |     └─Token(Identifier) |outputObj|
+//@[082:00086) ├─Token(NewLine) |\r\n\r\n|
+
+/*
+  valid loop cases
+*/
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+@sys.description('this is myModules')
+//@[000:00162) ├─VariableDeclarationSyntax
+//@[000:00037) | ├─DecoratorSyntax
+//@[000:00001) | | ├─Token(At) |@|
+//@[001:00037) | | └─InstanceFunctionCallSyntax
+//@[001:00004) | |   ├─VariableAccessSyntax
+//@[001:00004) | |   | └─IdentifierSyntax
+//@[001:00004) | |   |   └─Token(Identifier) |sys|
+//@[004:00005) | |   ├─Token(Dot) |.|
+//@[005:00016) | |   ├─IdentifierSyntax
+//@[005:00016) | |   | └─Token(Identifier) |description|
+//@[016:00017) | |   ├─Token(LeftParen) |(|
+//@[017:00036) | |   ├─FunctionArgumentSyntax
+//@[017:00036) | |   | └─StringSyntax
+//@[017:00036) | |   |   └─Token(StringComplete) |'this is myModules'|
+//@[036:00037) | |   └─Token(RightParen) |)|
+//@[037:00039) | ├─Token(NewLine) |\r\n|
+var myModules = [
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00013) | ├─IdentifierSyntax
+//@[004:00013) | | └─Token(Identifier) |myModules|
+//@[014:00015) | ├─Token(Assignment) |=|
+//@[016:00123) | └─ArraySyntax
+//@[016:00017) |   ├─Token(LeftSquare) |[|
+//@[017:00019) |   ├─Token(NewLine) |\r\n|
+  {
+//@[002:00050) |   ├─ArrayItemSyntax
+//@[002:00050) |   | └─ObjectSyntax
+//@[002:00003) |   |   ├─Token(LeftBrace) |{|
+//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
+    name: 'one'
+//@[004:00015) |   |   ├─ObjectPropertySyntax
+//@[004:00008) |   |   | ├─IdentifierSyntax
+//@[004:00008) |   |   | | └─Token(Identifier) |name|
+//@[008:00009) |   |   | ├─Token(Colon) |:|
+//@[010:00015) |   |   | └─StringSyntax
+//@[010:00015) |   |   |   └─Token(StringComplete) |'one'|
+//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
+    location: 'eastus2'
+//@[004:00023) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |location|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00023) |   |   | └─StringSyntax
+//@[014:00023) |   |   |   └─Token(StringComplete) |'eastus2'|
+//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+  {
+//@[002:00049) |   ├─ArrayItemSyntax
+//@[002:00049) |   | └─ObjectSyntax
+//@[002:00003) |   |   ├─Token(LeftBrace) |{|
+//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
+    name: 'two'
+//@[004:00015) |   |   ├─ObjectPropertySyntax
+//@[004:00008) |   |   | ├─IdentifierSyntax
+//@[004:00008) |   |   | | └─Token(Identifier) |name|
+//@[008:00009) |   |   | ├─Token(Colon) |:|
+//@[010:00015) |   |   | └─StringSyntax
+//@[010:00015) |   |   |   └─Token(StringComplete) |'two'|
+//@[015:00017) |   |   ├─Token(NewLine) |\r\n|
+    location: 'westus'
+//@[004:00022) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |location|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00022) |   |   | └─StringSyntax
+//@[014:00022) |   |   |   └─Token(StringComplete) |'westus'|
+//@[022:00024) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+]
+//@[000:00001) |   └─Token(RightSquare) |]|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+var emptyArray = []
+//@[000:00019) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00014) | ├─IdentifierSyntax
+//@[004:00014) | | └─Token(Identifier) |emptyArray|
+//@[015:00016) | ├─Token(Assignment) |=|
+//@[017:00019) | └─ArraySyntax
+//@[017:00018) |   ├─Token(LeftSquare) |[|
+//@[018:00019) |   └─Token(RightSquare) |]|
+//@[019:00023) ├─Token(NewLine) |\r\n\r\n|
+
+// simple module loop
+//@[021:00023) ├─Token(NewLine) |\r\n|
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[000:00189) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00023) | ├─IdentifierSyntax
+//@[007:00023) | | └─Token(Identifier) |storageResources|
+//@[024:00039) | ├─StringSyntax
+//@[024:00039) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[040:00041) | ├─Token(Assignment) |=|
+//@[042:00189) | └─ForSyntax
+//@[042:00043) |   ├─Token(LeftSquare) |[|
+//@[043:00046) |   ├─Token(Identifier) |for|
+//@[047:00053) |   ├─LocalVariableSyntax
+//@[047:00053) |   | └─IdentifierSyntax
+//@[047:00053) |   |   └─Token(Identifier) |module|
+//@[054:00056) |   ├─Token(Identifier) |in|
+//@[057:00066) |   ├─VariableAccessSyntax
+//@[057:00066) |   | └─IdentifierSyntax
+//@[057:00066) |   |   └─Token(Identifier) |myModules|
+//@[066:00067) |   ├─Token(Colon) |:|
+//@[068:00188) |   ├─ObjectSyntax
+//@[068:00069) |   | ├─Token(LeftBrace) |{|
+//@[069:00071) |   | ├─Token(NewLine) |\r\n|
+  name: module.name
+//@[002:00019) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00019) |   | | └─PropertyAccessSyntax
+//@[008:00014) |   | |   ├─VariableAccessSyntax
+//@[008:00014) |   | |   | └─IdentifierSyntax
+//@[008:00014) |   | |   |   └─Token(Identifier) |module|
+//@[014:00015) |   | |   ├─Token(Dot) |.|
+//@[015:00019) |   | |   └─IdentifierSyntax
+//@[015:00019) |   | |     └─Token(Identifier) |name|
+//@[019:00021) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00093) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00093) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    arrayParam: []
+//@[004:00018) |   | |   ├─ObjectPropertySyntax
+//@[004:00014) |   | |   | ├─IdentifierSyntax
+//@[004:00014) |   | |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   | |   | ├─Token(Colon) |:|
+//@[016:00018) |   | |   | └─ArraySyntax
+//@[016:00017) |   | |   |   ├─Token(LeftSquare) |[|
+//@[017:00018) |   | |   |   └─Token(RightSquare) |]|
+//@[018:00020) |   | |   ├─Token(NewLine) |\r\n|
+    objParam: module
+//@[004:00020) |   | |   ├─ObjectPropertySyntax
+//@[004:00012) |   | |   | ├─IdentifierSyntax
+//@[004:00012) |   | |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   | |   | ├─Token(Colon) |:|
+//@[014:00020) |   | |   | └─VariableAccessSyntax
+//@[014:00020) |   | |   |   └─IdentifierSyntax
+//@[014:00020) |   | |   |     └─Token(Identifier) |module|
+//@[020:00022) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamB: module.location
+//@[004:00033) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00033) |   | |   | └─PropertyAccessSyntax
+//@[018:00024) |   | |   |   ├─VariableAccessSyntax
+//@[018:00024) |   | |   |   | └─IdentifierSyntax
+//@[018:00024) |   | |   |   |   └─Token(Identifier) |module|
+//@[024:00025) |   | |   |   ├─Token(Dot) |.|
+//@[025:00033) |   | |   |   └─IdentifierSyntax
+//@[025:00033) |   | |   |     └─Token(Identifier) |location|
+//@[033:00035) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+// simple indexed module loop
+//@[029:00031) ├─Token(NewLine) |\r\n|
+module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules: {
+//@[000:00256) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00032) | ├─IdentifierSyntax
+//@[007:00032) | | └─Token(Identifier) |storageResourcesWithIndex|
+//@[033:00048) | ├─StringSyntax
+//@[033:00048) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[049:00050) | ├─Token(Assignment) |=|
+//@[051:00256) | └─ForSyntax
+//@[051:00052) |   ├─Token(LeftSquare) |[|
+//@[052:00055) |   ├─Token(Identifier) |for|
+//@[056:00067) |   ├─VariableBlockSyntax
+//@[056:00057) |   | ├─Token(LeftParen) |(|
+//@[057:00063) |   | ├─LocalVariableSyntax
+//@[057:00063) |   | | └─IdentifierSyntax
+//@[057:00063) |   | |   └─Token(Identifier) |module|
+//@[063:00064) |   | ├─Token(Comma) |,|
+//@[065:00066) |   | ├─LocalVariableSyntax
+//@[065:00066) |   | | └─IdentifierSyntax
+//@[065:00066) |   | |   └─Token(Identifier) |i|
+//@[066:00067) |   | └─Token(RightParen) |)|
+//@[068:00070) |   ├─Token(Identifier) |in|
+//@[071:00080) |   ├─VariableAccessSyntax
+//@[071:00080) |   | └─IdentifierSyntax
+//@[071:00080) |   |   └─Token(Identifier) |myModules|
+//@[080:00081) |   ├─Token(Colon) |:|
+//@[082:00255) |   ├─ObjectSyntax
+//@[082:00083) |   | ├─Token(LeftBrace) |{|
+//@[083:00085) |   | ├─Token(NewLine) |\r\n|
+  name: module.name
+//@[002:00019) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00019) |   | | └─PropertyAccessSyntax
+//@[008:00014) |   | |   ├─VariableAccessSyntax
+//@[008:00014) |   | |   | └─IdentifierSyntax
+//@[008:00014) |   | |   |   └─Token(Identifier) |module|
+//@[014:00015) |   | |   ├─Token(Dot) |.|
+//@[015:00019) |   | |   └─IdentifierSyntax
+//@[015:00019) |   | |     └─Token(Identifier) |name|
+//@[019:00021) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00146) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00146) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    arrayParam: [
+//@[004:00037) |   | |   ├─ObjectPropertySyntax
+//@[004:00014) |   | |   | ├─IdentifierSyntax
+//@[004:00014) |   | |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   | |   | ├─Token(Colon) |:|
+//@[016:00037) |   | |   | └─ArraySyntax
+//@[016:00017) |   | |   |   ├─Token(LeftSquare) |[|
+//@[017:00019) |   | |   |   ├─Token(NewLine) |\r\n|
+      i + 1
+//@[006:00011) |   | |   |   ├─ArrayItemSyntax
+//@[006:00011) |   | |   |   | └─BinaryOperationSyntax
+//@[006:00007) |   | |   |   |   ├─VariableAccessSyntax
+//@[006:00007) |   | |   |   |   | └─IdentifierSyntax
+//@[006:00007) |   | |   |   |   |   └─Token(Identifier) |i|
+//@[008:00009) |   | |   |   |   ├─Token(Plus) |+|
+//@[010:00011) |   | |   |   |   └─IntegerLiteralSyntax
+//@[010:00011) |   | |   |   |     └─Token(Integer) |1|
+//@[011:00013) |   | |   |   ├─Token(NewLine) |\r\n|
+    ]
+//@[004:00005) |   | |   |   └─Token(RightSquare) |]|
+//@[005:00007) |   | |   ├─Token(NewLine) |\r\n|
+    objParam: module
+//@[004:00020) |   | |   ├─ObjectPropertySyntax
+//@[004:00012) |   | |   | ├─IdentifierSyntax
+//@[004:00012) |   | |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   | |   | ├─Token(Colon) |:|
+//@[014:00020) |   | |   | └─VariableAccessSyntax
+//@[014:00020) |   | |   |   └─IdentifierSyntax
+//@[014:00020) |   | |   |     └─Token(Identifier) |module|
+//@[020:00022) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamB: module.location
+//@[004:00033) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00033) |   | |   | └─PropertyAccessSyntax
+//@[018:00024) |   | |   |   ├─VariableAccessSyntax
+//@[018:00024) |   | |   |   | └─IdentifierSyntax
+//@[018:00024) |   | |   |   |   └─Token(Identifier) |module|
+//@[024:00025) |   | |   |   ├─Token(Dot) |.|
+//@[025:00033) |   | |   |   └─IdentifierSyntax
+//@[025:00033) |   | |   |     └─Token(Identifier) |location|
+//@[033:00035) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamA: concat('a', i)
+//@[004:00032) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamA|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00032) |   | |   | └─FunctionCallSyntax
+//@[018:00024) |   | |   |   ├─IdentifierSyntax
+//@[018:00024) |   | |   |   | └─Token(Identifier) |concat|
+//@[024:00025) |   | |   |   ├─Token(LeftParen) |(|
+//@[025:00028) |   | |   |   ├─FunctionArgumentSyntax
+//@[025:00028) |   | |   |   | └─StringSyntax
+//@[025:00028) |   | |   |   |   └─Token(StringComplete) |'a'|
+//@[028:00029) |   | |   |   ├─Token(Comma) |,|
+//@[030:00031) |   | |   |   ├─FunctionArgumentSyntax
+//@[030:00031) |   | |   |   | └─VariableAccessSyntax
+//@[030:00031) |   | |   |   |   └─IdentifierSyntax
+//@[030:00031) |   | |   |   |     └─Token(Identifier) |i|
+//@[031:00032) |   | |   |   └─Token(RightParen) |)|
+//@[032:00034) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+// nested module loop
+//@[021:00023) ├─Token(NewLine) |\r\n|
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[000:00246) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00023) | ├─IdentifierSyntax
+//@[007:00023) | | └─Token(Identifier) |nestedModuleLoop|
+//@[024:00039) | ├─StringSyntax
+//@[024:00039) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[040:00041) | ├─Token(Assignment) |=|
+//@[042:00246) | └─ForSyntax
+//@[042:00043) |   ├─Token(LeftSquare) |[|
+//@[043:00046) |   ├─Token(Identifier) |for|
+//@[047:00053) |   ├─LocalVariableSyntax
+//@[047:00053) |   | └─IdentifierSyntax
+//@[047:00053) |   |   └─Token(Identifier) |module|
+//@[054:00056) |   ├─Token(Identifier) |in|
+//@[057:00066) |   ├─VariableAccessSyntax
+//@[057:00066) |   | └─IdentifierSyntax
+//@[057:00066) |   |   └─Token(Identifier) |myModules|
+//@[066:00067) |   ├─Token(Colon) |:|
+//@[068:00245) |   ├─ObjectSyntax
+//@[068:00069) |   | ├─Token(LeftBrace) |{|
+//@[069:00071) |   | ├─Token(NewLine) |\r\n|
+  name: module.name
+//@[002:00019) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00019) |   | | └─PropertyAccessSyntax
+//@[008:00014) |   | |   ├─VariableAccessSyntax
+//@[008:00014) |   | |   | └─IdentifierSyntax
+//@[008:00014) |   | |   |   └─Token(Identifier) |module|
+//@[014:00015) |   | |   ├─Token(Dot) |.|
+//@[015:00019) |   | |   └─IdentifierSyntax
+//@[015:00019) |   | |     └─Token(Identifier) |name|
+//@[019:00021) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00150) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00150) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    arrayParam: [for i in range(0,3): concat('test-', i, '-', module.name)]
+//@[004:00075) |   | |   ├─ObjectPropertySyntax
+//@[004:00014) |   | |   | ├─IdentifierSyntax
+//@[004:00014) |   | |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   | |   | ├─Token(Colon) |:|
+//@[016:00075) |   | |   | └─ForSyntax
+//@[016:00017) |   | |   |   ├─Token(LeftSquare) |[|
+//@[017:00020) |   | |   |   ├─Token(Identifier) |for|
+//@[021:00022) |   | |   |   ├─LocalVariableSyntax
+//@[021:00022) |   | |   |   | └─IdentifierSyntax
+//@[021:00022) |   | |   |   |   └─Token(Identifier) |i|
+//@[023:00025) |   | |   |   ├─Token(Identifier) |in|
+//@[026:00036) |   | |   |   ├─FunctionCallSyntax
+//@[026:00031) |   | |   |   | ├─IdentifierSyntax
+//@[026:00031) |   | |   |   | | └─Token(Identifier) |range|
+//@[031:00032) |   | |   |   | ├─Token(LeftParen) |(|
+//@[032:00033) |   | |   |   | ├─FunctionArgumentSyntax
+//@[032:00033) |   | |   |   | | └─IntegerLiteralSyntax
+//@[032:00033) |   | |   |   | |   └─Token(Integer) |0|
+//@[033:00034) |   | |   |   | ├─Token(Comma) |,|
+//@[034:00035) |   | |   |   | ├─FunctionArgumentSyntax
+//@[034:00035) |   | |   |   | | └─IntegerLiteralSyntax
+//@[034:00035) |   | |   |   | |   └─Token(Integer) |3|
+//@[035:00036) |   | |   |   | └─Token(RightParen) |)|
+//@[036:00037) |   | |   |   ├─Token(Colon) |:|
+//@[038:00074) |   | |   |   ├─FunctionCallSyntax
+//@[038:00044) |   | |   |   | ├─IdentifierSyntax
+//@[038:00044) |   | |   |   | | └─Token(Identifier) |concat|
+//@[044:00045) |   | |   |   | ├─Token(LeftParen) |(|
+//@[045:00052) |   | |   |   | ├─FunctionArgumentSyntax
+//@[045:00052) |   | |   |   | | └─StringSyntax
+//@[045:00052) |   | |   |   | |   └─Token(StringComplete) |'test-'|
+//@[052:00053) |   | |   |   | ├─Token(Comma) |,|
+//@[054:00055) |   | |   |   | ├─FunctionArgumentSyntax
+//@[054:00055) |   | |   |   | | └─VariableAccessSyntax
+//@[054:00055) |   | |   |   | |   └─IdentifierSyntax
+//@[054:00055) |   | |   |   | |     └─Token(Identifier) |i|
+//@[055:00056) |   | |   |   | ├─Token(Comma) |,|
+//@[057:00060) |   | |   |   | ├─FunctionArgumentSyntax
+//@[057:00060) |   | |   |   | | └─StringSyntax
+//@[057:00060) |   | |   |   | |   └─Token(StringComplete) |'-'|
+//@[060:00061) |   | |   |   | ├─Token(Comma) |,|
+//@[062:00073) |   | |   |   | ├─FunctionArgumentSyntax
+//@[062:00073) |   | |   |   | | └─PropertyAccessSyntax
+//@[062:00068) |   | |   |   | |   ├─VariableAccessSyntax
+//@[062:00068) |   | |   |   | |   | └─IdentifierSyntax
+//@[062:00068) |   | |   |   | |   |   └─Token(Identifier) |module|
+//@[068:00069) |   | |   |   | |   ├─Token(Dot) |.|
+//@[069:00073) |   | |   |   | |   └─IdentifierSyntax
+//@[069:00073) |   | |   |   | |     └─Token(Identifier) |name|
+//@[073:00074) |   | |   |   | └─Token(RightParen) |)|
+//@[074:00075) |   | |   |   └─Token(RightSquare) |]|
+//@[075:00077) |   | |   ├─Token(NewLine) |\r\n|
+    objParam: module
+//@[004:00020) |   | |   ├─ObjectPropertySyntax
+//@[004:00012) |   | |   | ├─IdentifierSyntax
+//@[004:00012) |   | |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   | |   | ├─Token(Colon) |:|
+//@[014:00020) |   | |   | └─VariableAccessSyntax
+//@[014:00020) |   | |   |   └─IdentifierSyntax
+//@[014:00020) |   | |   |     └─Token(Identifier) |module|
+//@[020:00022) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamB: module.location
+//@[004:00033) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00033) |   | |   | └─PropertyAccessSyntax
+//@[018:00024) |   | |   |   ├─VariableAccessSyntax
+//@[018:00024) |   | |   |   | └─IdentifierSyntax
+//@[018:00024) |   | |   |   |   └─Token(Identifier) |module|
+//@[024:00025) |   | |   |   ├─Token(Dot) |.|
+//@[025:00033) |   | |   |   └─IdentifierSyntax
+//@[025:00033) |   | |   |     └─Token(Identifier) |location|
+//@[033:00035) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[074:00076) ├─Token(NewLine) |\r\n|
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[000:00234) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00037) | ├─IdentifierSyntax
+//@[007:00037) | | └─Token(Identifier) |duplicateIdentifiersWithinLoop|
+//@[038:00053) | ├─StringSyntax
+//@[038:00053) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[054:00055) | ├─Token(Assignment) |=|
+//@[056:00234) | └─ForSyntax
+//@[056:00057) |   ├─Token(LeftSquare) |[|
+//@[057:00060) |   ├─Token(Identifier) |for|
+//@[061:00062) |   ├─LocalVariableSyntax
+//@[061:00062) |   | └─IdentifierSyntax
+//@[061:00062) |   |   └─Token(Identifier) |x|
+//@[063:00065) |   ├─Token(Identifier) |in|
+//@[066:00076) |   ├─VariableAccessSyntax
+//@[066:00076) |   | └─IdentifierSyntax
+//@[066:00076) |   |   └─Token(Identifier) |emptyArray|
+//@[076:00077) |   ├─Token(Colon) |:|
+//@[077:00233) |   ├─ObjectSyntax
+//@[077:00078) |   | ├─Token(LeftBrace) |{|
+//@[078:00080) |   | ├─Token(NewLine) |\r\n|
+  name: 'hello-${x}'
+//@[002:00020) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00020) |   | | └─StringSyntax
+//@[008:00017) |   | |   ├─Token(StringLeftPiece) |'hello-${|
+//@[017:00018) |   | |   ├─VariableAccessSyntax
+//@[017:00018) |   | |   | └─IdentifierSyntax
+//@[017:00018) |   | |   |   └─Token(Identifier) |x|
+//@[018:00020) |   | |   └─Token(StringRightPiece) |}'|
+//@[020:00022) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00128) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00128) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    objParam: {}
+//@[004:00016) |   | |   ├─ObjectPropertySyntax
+//@[004:00012) |   | |   | ├─IdentifierSyntax
+//@[004:00012) |   | |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   | |   | ├─Token(Colon) |:|
+//@[014:00016) |   | |   | └─ObjectSyntax
+//@[014:00015) |   | |   |   ├─Token(LeftBrace) |{|
+//@[015:00016) |   | |   |   └─Token(RightBrace) |}|
+//@[016:00018) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamA: 'test'
+//@[004:00024) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamA|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00024) |   | |   | └─StringSyntax
+//@[018:00024) |   | |   |   └─Token(StringComplete) |'test'|
+//@[024:00026) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamB: 'test'
+//@[004:00024) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00024) |   | |   | └─StringSyntax
+//@[018:00024) |   | |   |   └─Token(StringComplete) |'test'|
+//@[024:00026) |   | |   ├─Token(NewLine) |\r\n|
+    arrayParam: [for x in emptyArray: x]
+//@[004:00040) |   | |   ├─ObjectPropertySyntax
+//@[004:00014) |   | |   | ├─IdentifierSyntax
+//@[004:00014) |   | |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   | |   | ├─Token(Colon) |:|
+//@[016:00040) |   | |   | └─ForSyntax
+//@[016:00017) |   | |   |   ├─Token(LeftSquare) |[|
+//@[017:00020) |   | |   |   ├─Token(Identifier) |for|
+//@[021:00022) |   | |   |   ├─LocalVariableSyntax
+//@[021:00022) |   | |   |   | └─IdentifierSyntax
+//@[021:00022) |   | |   |   |   └─Token(Identifier) |x|
+//@[023:00025) |   | |   |   ├─Token(Identifier) |in|
+//@[026:00036) |   | |   |   ├─VariableAccessSyntax
+//@[026:00036) |   | |   |   | └─IdentifierSyntax
+//@[026:00036) |   | |   |   |   └─Token(Identifier) |emptyArray|
+//@[036:00037) |   | |   |   ├─Token(Colon) |:|
+//@[038:00039) |   | |   |   ├─VariableAccessSyntax
+//@[038:00039) |   | |   |   | └─IdentifierSyntax
+//@[038:00039) |   | |   |   |   └─Token(Identifier) |x|
+//@[039:00040) |   | |   |   └─Token(RightSquare) |]|
+//@[040:00042) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[074:00076) ├─Token(NewLine) |\r\n|
+var duplicateAcrossScopes = 'hello'
+//@[000:00035) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00025) | ├─IdentifierSyntax
+//@[004:00025) | | └─Token(Identifier) |duplicateAcrossScopes|
+//@[026:00027) | ├─Token(Assignment) |=|
+//@[028:00035) | └─StringSyntax
+//@[028:00035) |   └─Token(StringComplete) |'hello'|
+//@[035:00037) ├─Token(NewLine) |\r\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@[000:00264) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00034) | ├─IdentifierSyntax
+//@[007:00034) | | └─Token(Identifier) |duplicateInGlobalAndOneLoop|
+//@[035:00050) | ├─StringSyntax
+//@[035:00050) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[051:00052) | ├─Token(Assignment) |=|
+//@[053:00264) | └─ForSyntax
+//@[053:00054) |   ├─Token(LeftSquare) |[|
+//@[054:00057) |   ├─Token(Identifier) |for|
+//@[058:00079) |   ├─LocalVariableSyntax
+//@[058:00079) |   | └─IdentifierSyntax
+//@[058:00079) |   |   └─Token(Identifier) |duplicateAcrossScopes|
+//@[080:00082) |   ├─Token(Identifier) |in|
+//@[083:00085) |   ├─ArraySyntax
+//@[083:00084) |   | ├─Token(LeftSquare) |[|
+//@[084:00085) |   | └─Token(RightSquare) |]|
+//@[085:00086) |   ├─Token(Colon) |:|
+//@[087:00263) |   ├─ObjectSyntax
+//@[087:00088) |   | ├─Token(LeftBrace) |{|
+//@[088:00090) |   | ├─Token(NewLine) |\r\n|
+  name: 'hello-${duplicateAcrossScopes}'
+//@[002:00040) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00040) |   | | └─StringSyntax
+//@[008:00017) |   | |   ├─Token(StringLeftPiece) |'hello-${|
+//@[017:00038) |   | |   ├─VariableAccessSyntax
+//@[017:00038) |   | |   | └─IdentifierSyntax
+//@[017:00038) |   | |   |   └─Token(Identifier) |duplicateAcrossScopes|
+//@[038:00040) |   | |   └─Token(StringRightPiece) |}'|
+//@[040:00042) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00128) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00128) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    objParam: {}
+//@[004:00016) |   | |   ├─ObjectPropertySyntax
+//@[004:00012) |   | |   | ├─IdentifierSyntax
+//@[004:00012) |   | |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   | |   | ├─Token(Colon) |:|
+//@[014:00016) |   | |   | └─ObjectSyntax
+//@[014:00015) |   | |   |   ├─Token(LeftBrace) |{|
+//@[015:00016) |   | |   |   └─Token(RightBrace) |}|
+//@[016:00018) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamA: 'test'
+//@[004:00024) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamA|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00024) |   | |   | └─StringSyntax
+//@[018:00024) |   | |   |   └─Token(StringComplete) |'test'|
+//@[024:00026) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamB: 'test'
+//@[004:00024) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00024) |   | |   | └─StringSyntax
+//@[018:00024) |   | |   |   └─Token(StringComplete) |'test'|
+//@[024:00026) |   | |   ├─Token(NewLine) |\r\n|
+    arrayParam: [for x in emptyArray: x]
+//@[004:00040) |   | |   ├─ObjectPropertySyntax
+//@[004:00014) |   | |   | ├─IdentifierSyntax
+//@[004:00014) |   | |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   | |   | ├─Token(Colon) |:|
+//@[016:00040) |   | |   | └─ForSyntax
+//@[016:00017) |   | |   |   ├─Token(LeftSquare) |[|
+//@[017:00020) |   | |   |   ├─Token(Identifier) |for|
+//@[021:00022) |   | |   |   ├─LocalVariableSyntax
+//@[021:00022) |   | |   |   | └─IdentifierSyntax
+//@[021:00022) |   | |   |   |   └─Token(Identifier) |x|
+//@[023:00025) |   | |   |   ├─Token(Identifier) |in|
+//@[026:00036) |   | |   |   ├─VariableAccessSyntax
+//@[026:00036) |   | |   |   | └─IdentifierSyntax
+//@[026:00036) |   | |   |   |   └─Token(Identifier) |emptyArray|
+//@[036:00037) |   | |   |   ├─Token(Colon) |:|
+//@[038:00039) |   | |   |   ├─VariableAccessSyntax
+//@[038:00039) |   | |   |   | └─IdentifierSyntax
+//@[038:00039) |   | |   |   |   └─Token(Identifier) |x|
+//@[039:00040) |   | |   |   └─Token(RightSquare) |]|
+//@[040:00042) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+var someDuplicate = true
+//@[000:00024) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00017) | ├─IdentifierSyntax
+//@[004:00017) | | └─Token(Identifier) |someDuplicate|
+//@[018:00019) | ├─Token(Assignment) |=|
+//@[020:00024) | └─BooleanLiteralSyntax
+//@[020:00024) |   └─Token(TrueKeyword) |true|
+//@[024:00026) ├─Token(NewLine) |\r\n|
+var otherDuplicate = false
+//@[000:00026) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00018) | ├─IdentifierSyntax
+//@[004:00018) | | └─Token(Identifier) |otherDuplicate|
+//@[019:00020) | ├─Token(Assignment) |=|
+//@[021:00026) | └─BooleanLiteralSyntax
+//@[021:00026) |   └─Token(FalseKeyword) |false|
+//@[026:00028) ├─Token(NewLine) |\r\n|
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[000:00263) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00027) | ├─IdentifierSyntax
+//@[007:00027) | | └─Token(Identifier) |duplicatesEverywhere|
+//@[028:00043) | ├─StringSyntax
+//@[028:00043) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[044:00045) | ├─Token(Assignment) |=|
+//@[046:00263) | └─ForSyntax
+//@[046:00047) |   ├─Token(LeftSquare) |[|
+//@[047:00050) |   ├─Token(Identifier) |for|
+//@[051:00064) |   ├─LocalVariableSyntax
+//@[051:00064) |   | └─IdentifierSyntax
+//@[051:00064) |   |   └─Token(Identifier) |someDuplicate|
+//@[065:00067) |   ├─Token(Identifier) |in|
+//@[068:00070) |   ├─ArraySyntax
+//@[068:00069) |   | ├─Token(LeftSquare) |[|
+//@[069:00070) |   | └─Token(RightSquare) |]|
+//@[070:00071) |   ├─Token(Colon) |:|
+//@[072:00262) |   ├─ObjectSyntax
+//@[072:00073) |   | ├─Token(LeftBrace) |{|
+//@[073:00075) |   | ├─Token(NewLine) |\r\n|
+  name: 'hello-${someDuplicate}'
+//@[002:00032) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00032) |   | | └─StringSyntax
+//@[008:00017) |   | |   ├─Token(StringLeftPiece) |'hello-${|
+//@[017:00030) |   | |   ├─VariableAccessSyntax
+//@[017:00030) |   | |   | └─IdentifierSyntax
+//@[017:00030) |   | |   |   └─Token(Identifier) |someDuplicate|
+//@[030:00032) |   | |   └─Token(StringRightPiece) |}'|
+//@[032:00034) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00150) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00150) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    objParam: {}
+//@[004:00016) |   | |   ├─ObjectPropertySyntax
+//@[004:00012) |   | |   | ├─IdentifierSyntax
+//@[004:00012) |   | |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   | |   | ├─Token(Colon) |:|
+//@[014:00016) |   | |   | └─ObjectSyntax
+//@[014:00015) |   | |   |   ├─Token(LeftBrace) |{|
+//@[015:00016) |   | |   |   └─Token(RightBrace) |}|
+//@[016:00018) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamB: 'test'
+//@[004:00024) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00024) |   | |   | └─StringSyntax
+//@[018:00024) |   | |   |   └─Token(StringComplete) |'test'|
+//@[024:00026) |   | |   ├─Token(NewLine) |\r\n|
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[004:00088) |   | |   ├─ObjectPropertySyntax
+//@[004:00014) |   | |   | ├─IdentifierSyntax
+//@[004:00014) |   | |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   | |   | ├─Token(Colon) |:|
+//@[016:00088) |   | |   | └─ForSyntax
+//@[016:00017) |   | |   |   ├─Token(LeftSquare) |[|
+//@[017:00020) |   | |   |   ├─Token(Identifier) |for|
+//@[021:00035) |   | |   |   ├─LocalVariableSyntax
+//@[021:00035) |   | |   |   | └─IdentifierSyntax
+//@[021:00035) |   | |   |   |   └─Token(Identifier) |otherDuplicate|
+//@[036:00038) |   | |   |   ├─Token(Identifier) |in|
+//@[039:00049) |   | |   |   ├─VariableAccessSyntax
+//@[039:00049) |   | |   |   | └─IdentifierSyntax
+//@[039:00049) |   | |   |   |   └─Token(Identifier) |emptyArray|
+//@[049:00050) |   | |   |   ├─Token(Colon) |:|
+//@[051:00087) |   | |   |   ├─StringSyntax
+//@[051:00054) |   | |   |   | ├─Token(StringLeftPiece) |'${|
+//@[054:00067) |   | |   |   | ├─VariableAccessSyntax
+//@[054:00067) |   | |   |   | | └─IdentifierSyntax
+//@[054:00067) |   | |   |   | |   └─Token(Identifier) |someDuplicate|
+//@[067:00071) |   | |   |   | ├─Token(StringMiddlePiece) |}-${|
+//@[071:00085) |   | |   |   | ├─VariableAccessSyntax
+//@[071:00085) |   | |   |   | | └─IdentifierSyntax
+//@[071:00085) |   | |   |   | |   └─Token(Identifier) |otherDuplicate|
+//@[085:00087) |   | |   |   | └─Token(StringRightPiece) |}'|
+//@[087:00088) |   | |   |   └─Token(RightSquare) |]|
+//@[088:00090) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+//@[000:00438) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00039) | ├─IdentifierSyntax
+//@[007:00039) | | └─Token(Identifier) |propertyLoopInsideParameterValue|
+//@[040:00055) | ├─StringSyntax
+//@[040:00055) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[056:00057) | ├─Token(Assignment) |=|
+//@[058:00438) | └─ObjectSyntax
+//@[058:00059) |   ├─Token(LeftBrace) |{|
+//@[059:00061) |   ├─Token(NewLine) |\r\n|
+  name: 'propertyLoopInsideParameterValue'
+//@[002:00042) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00042) |   | └─StringSyntax
+//@[008:00042) |   |   └─Token(StringComplete) |'propertyLoopInsideParameterValue'|
+//@[042:00044) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00330) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00330) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    objParam: {
+//@[004:00209) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00209) |   |   | └─ObjectSyntax
+//@[014:00015) |   |   |   ├─Token(LeftBrace) |{|
+//@[015:00017) |   |   |   ├─Token(NewLine) |\r\n|
+      a: [for i in range(0,10): i]
+//@[006:00034) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |a|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00034) |   |   |   | └─ForSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   |   |   |   ├─Token(Identifier) |for|
+//@[014:00015) |   |   |   |   ├─LocalVariableSyntax
+//@[014:00015) |   |   |   |   | └─IdentifierSyntax
+//@[014:00015) |   |   |   |   |   └─Token(Identifier) |i|
+//@[016:00018) |   |   |   |   ├─Token(Identifier) |in|
+//@[019:00030) |   |   |   |   ├─FunctionCallSyntax
+//@[019:00024) |   |   |   |   | ├─IdentifierSyntax
+//@[019:00024) |   |   |   |   | | └─Token(Identifier) |range|
+//@[024:00025) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[025:00026) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[025:00026) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[025:00026) |   |   |   |   | |   └─Token(Integer) |0|
+//@[026:00027) |   |   |   |   | ├─Token(Comma) |,|
+//@[027:00029) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00029) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00029) |   |   |   |   | |   └─Token(Integer) |10|
+//@[029:00030) |   |   |   |   | └─Token(RightParen) |)|
+//@[030:00031) |   |   |   |   ├─Token(Colon) |:|
+//@[032:00033) |   |   |   |   ├─VariableAccessSyntax
+//@[032:00033) |   |   |   |   | └─IdentifierSyntax
+//@[032:00033) |   |   |   |   |   └─Token(Identifier) |i|
+//@[033:00034) |   |   |   |   └─Token(RightSquare) |]|
+//@[034:00036) |   |   |   ├─Token(NewLine) |\r\n|
+      b: [for i in range(1,2): i]
+//@[006:00033) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |b|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00033) |   |   |   | └─ForSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   |   |   |   ├─Token(Identifier) |for|
+//@[014:00015) |   |   |   |   ├─LocalVariableSyntax
+//@[014:00015) |   |   |   |   | └─IdentifierSyntax
+//@[014:00015) |   |   |   |   |   └─Token(Identifier) |i|
+//@[016:00018) |   |   |   |   ├─Token(Identifier) |in|
+//@[019:00029) |   |   |   |   ├─FunctionCallSyntax
+//@[019:00024) |   |   |   |   | ├─IdentifierSyntax
+//@[019:00024) |   |   |   |   | | └─Token(Identifier) |range|
+//@[024:00025) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[025:00026) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[025:00026) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[025:00026) |   |   |   |   | |   └─Token(Integer) |1|
+//@[026:00027) |   |   |   |   | ├─Token(Comma) |,|
+//@[027:00028) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   |   |   |   | |   └─Token(Integer) |2|
+//@[028:00029) |   |   |   |   | └─Token(RightParen) |)|
+//@[029:00030) |   |   |   |   ├─Token(Colon) |:|
+//@[031:00032) |   |   |   |   ├─VariableAccessSyntax
+//@[031:00032) |   |   |   |   | └─IdentifierSyntax
+//@[031:00032) |   |   |   |   |   └─Token(Identifier) |i|
+//@[032:00033) |   |   |   |   └─Token(RightSquare) |]|
+//@[033:00035) |   |   |   ├─Token(NewLine) |\r\n|
+      c: {
+//@[006:00056) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |c|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00056) |   |   |   | └─ObjectSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftBrace) |{|
+//@[010:00012) |   |   |   |   ├─Token(NewLine) |\r\n|
+        d: [for j in range(2,3): j]
+//@[008:00035) |   |   |   |   ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | └─Token(Identifier) |d|
+//@[009:00010) |   |   |   |   | ├─Token(Colon) |:|
+//@[011:00035) |   |   |   |   | └─ForSyntax
+//@[011:00012) |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[012:00015) |   |   |   |   |   ├─Token(Identifier) |for|
+//@[016:00017) |   |   |   |   |   ├─LocalVariableSyntax
+//@[016:00017) |   |   |   |   |   | └─IdentifierSyntax
+//@[016:00017) |   |   |   |   |   |   └─Token(Identifier) |j|
+//@[018:00020) |   |   |   |   |   ├─Token(Identifier) |in|
+//@[021:00031) |   |   |   |   |   ├─FunctionCallSyntax
+//@[021:00026) |   |   |   |   |   | ├─IdentifierSyntax
+//@[021:00026) |   |   |   |   |   | | └─Token(Identifier) |range|
+//@[026:00027) |   |   |   |   |   | ├─Token(LeftParen) |(|
+//@[027:00028) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   |   |   |   |   | |   └─Token(Integer) |2|
+//@[028:00029) |   |   |   |   |   | ├─Token(Comma) |,|
+//@[029:00030) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[029:00030) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[029:00030) |   |   |   |   |   | |   └─Token(Integer) |3|
+//@[030:00031) |   |   |   |   |   | └─Token(RightParen) |)|
+//@[031:00032) |   |   |   |   |   ├─Token(Colon) |:|
+//@[033:00034) |   |   |   |   |   ├─VariableAccessSyntax
+//@[033:00034) |   |   |   |   |   | └─IdentifierSyntax
+//@[033:00034) |   |   |   |   |   |   └─Token(Identifier) |j|
+//@[034:00035) |   |   |   |   |   └─Token(RightSquare) |]|
+//@[035:00037) |   |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
+      e: [for k in range(4,4): {
+//@[006:00056) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |e|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00056) |   |   |   | └─ForSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   |   |   |   ├─Token(Identifier) |for|
+//@[014:00015) |   |   |   |   ├─LocalVariableSyntax
+//@[014:00015) |   |   |   |   | └─IdentifierSyntax
+//@[014:00015) |   |   |   |   |   └─Token(Identifier) |k|
+//@[016:00018) |   |   |   |   ├─Token(Identifier) |in|
+//@[019:00029) |   |   |   |   ├─FunctionCallSyntax
+//@[019:00024) |   |   |   |   | ├─IdentifierSyntax
+//@[019:00024) |   |   |   |   | | └─Token(Identifier) |range|
+//@[024:00025) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[025:00026) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[025:00026) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[025:00026) |   |   |   |   | |   └─Token(Integer) |4|
+//@[026:00027) |   |   |   |   | ├─Token(Comma) |,|
+//@[027:00028) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   |   |   |   | |   └─Token(Integer) |4|
+//@[028:00029) |   |   |   |   | └─Token(RightParen) |)|
+//@[029:00030) |   |   |   |   ├─Token(Colon) |:|
+//@[031:00055) |   |   |   |   ├─ObjectSyntax
+//@[031:00032) |   |   |   |   | ├─Token(LeftBrace) |{|
+//@[032:00034) |   |   |   |   | ├─Token(NewLine) |\r\n|
+        f: k
+//@[008:00012) |   |   |   |   | ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | | └─Token(Identifier) |f|
+//@[009:00010) |   |   |   |   | | ├─Token(Colon) |:|
+//@[011:00012) |   |   |   |   | | └─VariableAccessSyntax
+//@[011:00012) |   |   |   |   | |   └─IdentifierSyntax
+//@[011:00012) |   |   |   |   | |     └─Token(Identifier) |k|
+//@[012:00014) |   |   |   |   | ├─Token(NewLine) |\r\n|
+      }]
+//@[006:00007) |   |   |   |   | └─Token(RightBrace) |}|
+//@[007:00008) |   |   |   |   └─Token(RightSquare) |]|
+//@[008:00010) |   |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[004:00005) |   |   |   └─Token(RightBrace) |}|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+    stringParamB: ''
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00016) |   |   | ├─IdentifierSyntax
+//@[004:00016) |   |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   |   | ├─Token(Colon) |:|
+//@[018:00020) |   |   | └─StringSyntax
+//@[018:00020) |   |   |   └─Token(StringComplete) |''|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    arrayParam: [
+//@[004:00079) |   |   ├─ObjectPropertySyntax
+//@[004:00014) |   |   | ├─IdentifierSyntax
+//@[004:00014) |   |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   |   | ├─Token(Colon) |:|
+//@[016:00079) |   |   | └─ArraySyntax
+//@[016:00017) |   |   |   ├─Token(LeftSquare) |[|
+//@[017:00019) |   |   |   ├─Token(NewLine) |\r\n|
+      {
+//@[006:00053) |   |   |   ├─ArrayItemSyntax
+//@[006:00053) |   |   |   | └─ObjectSyntax
+//@[006:00007) |   |   |   |   ├─Token(LeftBrace) |{|
+//@[007:00009) |   |   |   |   ├─Token(NewLine) |\r\n|
+        e: [for j in range(7,7): j]
+//@[008:00035) |   |   |   |   ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | └─Token(Identifier) |e|
+//@[009:00010) |   |   |   |   | ├─Token(Colon) |:|
+//@[011:00035) |   |   |   |   | └─ForSyntax
+//@[011:00012) |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[012:00015) |   |   |   |   |   ├─Token(Identifier) |for|
+//@[016:00017) |   |   |   |   |   ├─LocalVariableSyntax
+//@[016:00017) |   |   |   |   |   | └─IdentifierSyntax
+//@[016:00017) |   |   |   |   |   |   └─Token(Identifier) |j|
+//@[018:00020) |   |   |   |   |   ├─Token(Identifier) |in|
+//@[021:00031) |   |   |   |   |   ├─FunctionCallSyntax
+//@[021:00026) |   |   |   |   |   | ├─IdentifierSyntax
+//@[021:00026) |   |   |   |   |   | | └─Token(Identifier) |range|
+//@[026:00027) |   |   |   |   |   | ├─Token(LeftParen) |(|
+//@[027:00028) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   |   |   |   |   | |   └─Token(Integer) |7|
+//@[028:00029) |   |   |   |   |   | ├─Token(Comma) |,|
+//@[029:00030) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[029:00030) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[029:00030) |   |   |   |   |   | |   └─Token(Integer) |7|
+//@[030:00031) |   |   |   |   |   | └─Token(RightParen) |)|
+//@[031:00032) |   |   |   |   |   ├─Token(Colon) |:|
+//@[033:00034) |   |   |   |   |   ├─VariableAccessSyntax
+//@[033:00034) |   |   |   |   |   | └─IdentifierSyntax
+//@[033:00034) |   |   |   |   |   |   └─Token(Identifier) |j|
+//@[034:00035) |   |   |   |   |   └─Token(RightSquare) |]|
+//@[035:00037) |   |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
+    ]
+//@[004:00005) |   |   |   └─Token(RightSquare) |]|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+//@[000:00514) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00050) | ├─IdentifierSyntax
+//@[007:00050) | | └─Token(Identifier) |propertyLoopInsideParameterValueWithIndexes|
+//@[051:00066) | ├─StringSyntax
+//@[051:00066) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[067:00068) | ├─Token(Assignment) |=|
+//@[069:00514) | └─ObjectSyntax
+//@[069:00070) |   ├─Token(LeftBrace) |{|
+//@[070:00072) |   ├─Token(NewLine) |\r\n|
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+//@[002:00053) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00053) |   | └─StringSyntax
+//@[008:00053) |   |   └─Token(StringComplete) |'propertyLoopInsideParameterValueWithIndexes'|
+//@[053:00055) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00384) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00384) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    objParam: {
+//@[004:00263) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00263) |   |   | └─ObjectSyntax
+//@[014:00015) |   |   |   ├─Token(LeftBrace) |{|
+//@[015:00017) |   |   |   ├─Token(NewLine) |\r\n|
+      a: [for (i, i2) in range(0,10): i + i2]
+//@[006:00045) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |a|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00045) |   |   |   | └─ForSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   |   |   |   ├─Token(Identifier) |for|
+//@[014:00021) |   |   |   |   ├─VariableBlockSyntax
+//@[014:00015) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[015:00016) |   |   |   |   | ├─LocalVariableSyntax
+//@[015:00016) |   |   |   |   | | └─IdentifierSyntax
+//@[015:00016) |   |   |   |   | |   └─Token(Identifier) |i|
+//@[016:00017) |   |   |   |   | ├─Token(Comma) |,|
+//@[018:00020) |   |   |   |   | ├─LocalVariableSyntax
+//@[018:00020) |   |   |   |   | | └─IdentifierSyntax
+//@[018:00020) |   |   |   |   | |   └─Token(Identifier) |i2|
+//@[020:00021) |   |   |   |   | └─Token(RightParen) |)|
+//@[022:00024) |   |   |   |   ├─Token(Identifier) |in|
+//@[025:00036) |   |   |   |   ├─FunctionCallSyntax
+//@[025:00030) |   |   |   |   | ├─IdentifierSyntax
+//@[025:00030) |   |   |   |   | | └─Token(Identifier) |range|
+//@[030:00031) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[031:00032) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[031:00032) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[031:00032) |   |   |   |   | |   └─Token(Integer) |0|
+//@[032:00033) |   |   |   |   | ├─Token(Comma) |,|
+//@[033:00035) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[033:00035) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[033:00035) |   |   |   |   | |   └─Token(Integer) |10|
+//@[035:00036) |   |   |   |   | └─Token(RightParen) |)|
+//@[036:00037) |   |   |   |   ├─Token(Colon) |:|
+//@[038:00044) |   |   |   |   ├─BinaryOperationSyntax
+//@[038:00039) |   |   |   |   | ├─VariableAccessSyntax
+//@[038:00039) |   |   |   |   | | └─IdentifierSyntax
+//@[038:00039) |   |   |   |   | |   └─Token(Identifier) |i|
+//@[040:00041) |   |   |   |   | ├─Token(Plus) |+|
+//@[042:00044) |   |   |   |   | └─VariableAccessSyntax
+//@[042:00044) |   |   |   |   |   └─IdentifierSyntax
+//@[042:00044) |   |   |   |   |     └─Token(Identifier) |i2|
+//@[044:00045) |   |   |   |   └─Token(RightSquare) |]|
+//@[045:00047) |   |   |   ├─Token(NewLine) |\r\n|
+      b: [for (i, i2) in range(1,2): i / i2]
+//@[006:00044) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |b|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00044) |   |   |   | └─ForSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   |   |   |   ├─Token(Identifier) |for|
+//@[014:00021) |   |   |   |   ├─VariableBlockSyntax
+//@[014:00015) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[015:00016) |   |   |   |   | ├─LocalVariableSyntax
+//@[015:00016) |   |   |   |   | | └─IdentifierSyntax
+//@[015:00016) |   |   |   |   | |   └─Token(Identifier) |i|
+//@[016:00017) |   |   |   |   | ├─Token(Comma) |,|
+//@[018:00020) |   |   |   |   | ├─LocalVariableSyntax
+//@[018:00020) |   |   |   |   | | └─IdentifierSyntax
+//@[018:00020) |   |   |   |   | |   └─Token(Identifier) |i2|
+//@[020:00021) |   |   |   |   | └─Token(RightParen) |)|
+//@[022:00024) |   |   |   |   ├─Token(Identifier) |in|
+//@[025:00035) |   |   |   |   ├─FunctionCallSyntax
+//@[025:00030) |   |   |   |   | ├─IdentifierSyntax
+//@[025:00030) |   |   |   |   | | └─Token(Identifier) |range|
+//@[030:00031) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[031:00032) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[031:00032) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[031:00032) |   |   |   |   | |   └─Token(Integer) |1|
+//@[032:00033) |   |   |   |   | ├─Token(Comma) |,|
+//@[033:00034) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[033:00034) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[033:00034) |   |   |   |   | |   └─Token(Integer) |2|
+//@[034:00035) |   |   |   |   | └─Token(RightParen) |)|
+//@[035:00036) |   |   |   |   ├─Token(Colon) |:|
+//@[037:00043) |   |   |   |   ├─BinaryOperationSyntax
+//@[037:00038) |   |   |   |   | ├─VariableAccessSyntax
+//@[037:00038) |   |   |   |   | | └─IdentifierSyntax
+//@[037:00038) |   |   |   |   | |   └─Token(Identifier) |i|
+//@[039:00040) |   |   |   |   | ├─Token(Slash) |/|
+//@[041:00043) |   |   |   |   | └─VariableAccessSyntax
+//@[041:00043) |   |   |   |   |   └─IdentifierSyntax
+//@[041:00043) |   |   |   |   |     └─Token(Identifier) |i2|
+//@[043:00044) |   |   |   |   └─Token(RightSquare) |]|
+//@[044:00046) |   |   |   ├─Token(NewLine) |\r\n|
+      c: {
+//@[006:00067) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |c|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00067) |   |   |   | └─ObjectSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftBrace) |{|
+//@[010:00012) |   |   |   |   ├─Token(NewLine) |\r\n|
+        d: [for (j, j2) in range(2,3): j * j2]
+//@[008:00046) |   |   |   |   ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | └─Token(Identifier) |d|
+//@[009:00010) |   |   |   |   | ├─Token(Colon) |:|
+//@[011:00046) |   |   |   |   | └─ForSyntax
+//@[011:00012) |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[012:00015) |   |   |   |   |   ├─Token(Identifier) |for|
+//@[016:00023) |   |   |   |   |   ├─VariableBlockSyntax
+//@[016:00017) |   |   |   |   |   | ├─Token(LeftParen) |(|
+//@[017:00018) |   |   |   |   |   | ├─LocalVariableSyntax
+//@[017:00018) |   |   |   |   |   | | └─IdentifierSyntax
+//@[017:00018) |   |   |   |   |   | |   └─Token(Identifier) |j|
+//@[018:00019) |   |   |   |   |   | ├─Token(Comma) |,|
+//@[020:00022) |   |   |   |   |   | ├─LocalVariableSyntax
+//@[020:00022) |   |   |   |   |   | | └─IdentifierSyntax
+//@[020:00022) |   |   |   |   |   | |   └─Token(Identifier) |j2|
+//@[022:00023) |   |   |   |   |   | └─Token(RightParen) |)|
+//@[024:00026) |   |   |   |   |   ├─Token(Identifier) |in|
+//@[027:00037) |   |   |   |   |   ├─FunctionCallSyntax
+//@[027:00032) |   |   |   |   |   | ├─IdentifierSyntax
+//@[027:00032) |   |   |   |   |   | | └─Token(Identifier) |range|
+//@[032:00033) |   |   |   |   |   | ├─Token(LeftParen) |(|
+//@[033:00034) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[033:00034) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[033:00034) |   |   |   |   |   | |   └─Token(Integer) |2|
+//@[034:00035) |   |   |   |   |   | ├─Token(Comma) |,|
+//@[035:00036) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[035:00036) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[035:00036) |   |   |   |   |   | |   └─Token(Integer) |3|
+//@[036:00037) |   |   |   |   |   | └─Token(RightParen) |)|
+//@[037:00038) |   |   |   |   |   ├─Token(Colon) |:|
+//@[039:00045) |   |   |   |   |   ├─BinaryOperationSyntax
+//@[039:00040) |   |   |   |   |   | ├─VariableAccessSyntax
+//@[039:00040) |   |   |   |   |   | | └─IdentifierSyntax
+//@[039:00040) |   |   |   |   |   | |   └─Token(Identifier) |j|
+//@[041:00042) |   |   |   |   |   | ├─Token(Asterisk) |*|
+//@[043:00045) |   |   |   |   |   | └─VariableAccessSyntax
+//@[043:00045) |   |   |   |   |   |   └─IdentifierSyntax
+//@[043:00045) |   |   |   |   |   |     └─Token(Identifier) |j2|
+//@[045:00046) |   |   |   |   |   └─Token(RightSquare) |]|
+//@[046:00048) |   |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
+      e: [for (k, k2) in range(4,4): {
+//@[006:00077) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |e|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00077) |   |   |   | └─ForSyntax
+//@[009:00010) |   |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   |   |   |   ├─Token(Identifier) |for|
+//@[014:00021) |   |   |   |   ├─VariableBlockSyntax
+//@[014:00015) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[015:00016) |   |   |   |   | ├─LocalVariableSyntax
+//@[015:00016) |   |   |   |   | | └─IdentifierSyntax
+//@[015:00016) |   |   |   |   | |   └─Token(Identifier) |k|
+//@[016:00017) |   |   |   |   | ├─Token(Comma) |,|
+//@[018:00020) |   |   |   |   | ├─LocalVariableSyntax
+//@[018:00020) |   |   |   |   | | └─IdentifierSyntax
+//@[018:00020) |   |   |   |   | |   └─Token(Identifier) |k2|
+//@[020:00021) |   |   |   |   | └─Token(RightParen) |)|
+//@[022:00024) |   |   |   |   ├─Token(Identifier) |in|
+//@[025:00035) |   |   |   |   ├─FunctionCallSyntax
+//@[025:00030) |   |   |   |   | ├─IdentifierSyntax
+//@[025:00030) |   |   |   |   | | └─Token(Identifier) |range|
+//@[030:00031) |   |   |   |   | ├─Token(LeftParen) |(|
+//@[031:00032) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[031:00032) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[031:00032) |   |   |   |   | |   └─Token(Integer) |4|
+//@[032:00033) |   |   |   |   | ├─Token(Comma) |,|
+//@[033:00034) |   |   |   |   | ├─FunctionArgumentSyntax
+//@[033:00034) |   |   |   |   | | └─IntegerLiteralSyntax
+//@[033:00034) |   |   |   |   | |   └─Token(Integer) |4|
+//@[034:00035) |   |   |   |   | └─Token(RightParen) |)|
+//@[035:00036) |   |   |   |   ├─Token(Colon) |:|
+//@[037:00076) |   |   |   |   ├─ObjectSyntax
+//@[037:00038) |   |   |   |   | ├─Token(LeftBrace) |{|
+//@[038:00040) |   |   |   |   | ├─Token(NewLine) |\r\n|
+        f: k
+//@[008:00012) |   |   |   |   | ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | | └─Token(Identifier) |f|
+//@[009:00010) |   |   |   |   | | ├─Token(Colon) |:|
+//@[011:00012) |   |   |   |   | | └─VariableAccessSyntax
+//@[011:00012) |   |   |   |   | |   └─IdentifierSyntax
+//@[011:00012) |   |   |   |   | |     └─Token(Identifier) |k|
+//@[012:00014) |   |   |   |   | ├─Token(NewLine) |\r\n|
+        g: k2
+//@[008:00013) |   |   |   |   | ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | | └─Token(Identifier) |g|
+//@[009:00010) |   |   |   |   | | ├─Token(Colon) |:|
+//@[011:00013) |   |   |   |   | | └─VariableAccessSyntax
+//@[011:00013) |   |   |   |   | |   └─IdentifierSyntax
+//@[011:00013) |   |   |   |   | |     └─Token(Identifier) |k2|
+//@[013:00015) |   |   |   |   | ├─Token(NewLine) |\r\n|
+      }]
+//@[006:00007) |   |   |   |   | └─Token(RightBrace) |}|
+//@[007:00008) |   |   |   |   └─Token(RightSquare) |]|
+//@[008:00010) |   |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[004:00005) |   |   |   └─Token(RightBrace) |}|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+    stringParamB: ''
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00016) |   |   | ├─IdentifierSyntax
+//@[004:00016) |   |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   |   | ├─Token(Colon) |:|
+//@[018:00020) |   |   | └─StringSyntax
+//@[018:00020) |   |   |   └─Token(StringComplete) |''|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    arrayParam: [
+//@[004:00079) |   |   ├─ObjectPropertySyntax
+//@[004:00014) |   |   | ├─IdentifierSyntax
+//@[004:00014) |   |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   |   | ├─Token(Colon) |:|
+//@[016:00079) |   |   | └─ArraySyntax
+//@[016:00017) |   |   |   ├─Token(LeftSquare) |[|
+//@[017:00019) |   |   |   ├─Token(NewLine) |\r\n|
+      {
+//@[006:00053) |   |   |   ├─ArrayItemSyntax
+//@[006:00053) |   |   |   | └─ObjectSyntax
+//@[006:00007) |   |   |   |   ├─Token(LeftBrace) |{|
+//@[007:00009) |   |   |   |   ├─Token(NewLine) |\r\n|
+        e: [for j in range(7,7): j]
+//@[008:00035) |   |   |   |   ├─ObjectPropertySyntax
+//@[008:00009) |   |   |   |   | ├─IdentifierSyntax
+//@[008:00009) |   |   |   |   | | └─Token(Identifier) |e|
+//@[009:00010) |   |   |   |   | ├─Token(Colon) |:|
+//@[011:00035) |   |   |   |   | └─ForSyntax
+//@[011:00012) |   |   |   |   |   ├─Token(LeftSquare) |[|
+//@[012:00015) |   |   |   |   |   ├─Token(Identifier) |for|
+//@[016:00017) |   |   |   |   |   ├─LocalVariableSyntax
+//@[016:00017) |   |   |   |   |   | └─IdentifierSyntax
+//@[016:00017) |   |   |   |   |   |   └─Token(Identifier) |j|
+//@[018:00020) |   |   |   |   |   ├─Token(Identifier) |in|
+//@[021:00031) |   |   |   |   |   ├─FunctionCallSyntax
+//@[021:00026) |   |   |   |   |   | ├─IdentifierSyntax
+//@[021:00026) |   |   |   |   |   | | └─Token(Identifier) |range|
+//@[026:00027) |   |   |   |   |   | ├─Token(LeftParen) |(|
+//@[027:00028) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   |   |   |   |   | |   └─Token(Integer) |7|
+//@[028:00029) |   |   |   |   |   | ├─Token(Comma) |,|
+//@[029:00030) |   |   |   |   |   | ├─FunctionArgumentSyntax
+//@[029:00030) |   |   |   |   |   | | └─IntegerLiteralSyntax
+//@[029:00030) |   |   |   |   |   | |   └─Token(Integer) |7|
+//@[030:00031) |   |   |   |   |   | └─Token(RightParen) |)|
+//@[031:00032) |   |   |   |   |   ├─Token(Colon) |:|
+//@[033:00034) |   |   |   |   |   ├─VariableAccessSyntax
+//@[033:00034) |   |   |   |   |   | └─IdentifierSyntax
+//@[033:00034) |   |   |   |   |   |   └─Token(Identifier) |j|
+//@[034:00035) |   |   |   |   |   └─Token(RightSquare) |]|
+//@[035:00037) |   |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00007) |   |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   |   |   ├─Token(NewLine) |\r\n|
+    ]
+//@[004:00005) |   |   |   └─Token(RightSquare) |]|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
+//@[000:00535) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00055) | ├─IdentifierSyntax
+//@[007:00055) | | └─Token(Identifier) |propertyLoopInsideParameterValueInsideModuleLoop|
+//@[056:00071) | ├─StringSyntax
+//@[056:00071) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[072:00073) | ├─Token(Assignment) |=|
+//@[074:00535) | └─ForSyntax
+//@[074:00075) |   ├─Token(LeftSquare) |[|
+//@[075:00078) |   ├─Token(Identifier) |for|
+//@[079:00084) |   ├─LocalVariableSyntax
+//@[079:00084) |   | └─IdentifierSyntax
+//@[079:00084) |   |   └─Token(Identifier) |thing|
+//@[085:00087) |   ├─Token(Identifier) |in|
+//@[088:00098) |   ├─FunctionCallSyntax
+//@[088:00093) |   | ├─IdentifierSyntax
+//@[088:00093) |   | | └─Token(Identifier) |range|
+//@[093:00094) |   | ├─Token(LeftParen) |(|
+//@[094:00095) |   | ├─FunctionArgumentSyntax
+//@[094:00095) |   | | └─IntegerLiteralSyntax
+//@[094:00095) |   | |   └─Token(Integer) |0|
+//@[095:00096) |   | ├─Token(Comma) |,|
+//@[096:00097) |   | ├─FunctionArgumentSyntax
+//@[096:00097) |   | | └─IntegerLiteralSyntax
+//@[096:00097) |   | |   └─Token(Integer) |1|
+//@[097:00098) |   | └─Token(RightParen) |)|
+//@[098:00099) |   ├─Token(Colon) |:|
+//@[100:00534) |   ├─ObjectSyntax
+//@[100:00101) |   | ├─Token(LeftBrace) |{|
+//@[101:00103) |   | ├─Token(NewLine) |\r\n|
+  name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+//@[002:00058) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00058) |   | | └─StringSyntax
+//@[008:00058) |   | |   └─Token(StringComplete) |'propertyLoopInsideParameterValueInsideModuleLoop'|
+//@[058:00060) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00368) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00368) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    objParam: {
+//@[004:00233) |   | |   ├─ObjectPropertySyntax
+//@[004:00012) |   | |   | ├─IdentifierSyntax
+//@[004:00012) |   | |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   | |   | ├─Token(Colon) |:|
+//@[014:00233) |   | |   | └─ObjectSyntax
+//@[014:00015) |   | |   |   ├─Token(LeftBrace) |{|
+//@[015:00017) |   | |   |   ├─Token(NewLine) |\r\n|
+      a: [for i in range(0,10): i + thing]
+//@[006:00042) |   | |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   | |   |   | ├─IdentifierSyntax
+//@[006:00007) |   | |   |   | | └─Token(Identifier) |a|
+//@[007:00008) |   | |   |   | ├─Token(Colon) |:|
+//@[009:00042) |   | |   |   | └─ForSyntax
+//@[009:00010) |   | |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   | |   |   |   ├─Token(Identifier) |for|
+//@[014:00015) |   | |   |   |   ├─LocalVariableSyntax
+//@[014:00015) |   | |   |   |   | └─IdentifierSyntax
+//@[014:00015) |   | |   |   |   |   └─Token(Identifier) |i|
+//@[016:00018) |   | |   |   |   ├─Token(Identifier) |in|
+//@[019:00030) |   | |   |   |   ├─FunctionCallSyntax
+//@[019:00024) |   | |   |   |   | ├─IdentifierSyntax
+//@[019:00024) |   | |   |   |   | | └─Token(Identifier) |range|
+//@[024:00025) |   | |   |   |   | ├─Token(LeftParen) |(|
+//@[025:00026) |   | |   |   |   | ├─FunctionArgumentSyntax
+//@[025:00026) |   | |   |   |   | | └─IntegerLiteralSyntax
+//@[025:00026) |   | |   |   |   | |   └─Token(Integer) |0|
+//@[026:00027) |   | |   |   |   | ├─Token(Comma) |,|
+//@[027:00029) |   | |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00029) |   | |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00029) |   | |   |   |   | |   └─Token(Integer) |10|
+//@[029:00030) |   | |   |   |   | └─Token(RightParen) |)|
+//@[030:00031) |   | |   |   |   ├─Token(Colon) |:|
+//@[032:00041) |   | |   |   |   ├─BinaryOperationSyntax
+//@[032:00033) |   | |   |   |   | ├─VariableAccessSyntax
+//@[032:00033) |   | |   |   |   | | └─IdentifierSyntax
+//@[032:00033) |   | |   |   |   | |   └─Token(Identifier) |i|
+//@[034:00035) |   | |   |   |   | ├─Token(Plus) |+|
+//@[036:00041) |   | |   |   |   | └─VariableAccessSyntax
+//@[036:00041) |   | |   |   |   |   └─IdentifierSyntax
+//@[036:00041) |   | |   |   |   |     └─Token(Identifier) |thing|
+//@[041:00042) |   | |   |   |   └─Token(RightSquare) |]|
+//@[042:00044) |   | |   |   ├─Token(NewLine) |\r\n|
+      b: [for i in range(1,2): i * thing]
+//@[006:00041) |   | |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   | |   |   | ├─IdentifierSyntax
+//@[006:00007) |   | |   |   | | └─Token(Identifier) |b|
+//@[007:00008) |   | |   |   | ├─Token(Colon) |:|
+//@[009:00041) |   | |   |   | └─ForSyntax
+//@[009:00010) |   | |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   | |   |   |   ├─Token(Identifier) |for|
+//@[014:00015) |   | |   |   |   ├─LocalVariableSyntax
+//@[014:00015) |   | |   |   |   | └─IdentifierSyntax
+//@[014:00015) |   | |   |   |   |   └─Token(Identifier) |i|
+//@[016:00018) |   | |   |   |   ├─Token(Identifier) |in|
+//@[019:00029) |   | |   |   |   ├─FunctionCallSyntax
+//@[019:00024) |   | |   |   |   | ├─IdentifierSyntax
+//@[019:00024) |   | |   |   |   | | └─Token(Identifier) |range|
+//@[024:00025) |   | |   |   |   | ├─Token(LeftParen) |(|
+//@[025:00026) |   | |   |   |   | ├─FunctionArgumentSyntax
+//@[025:00026) |   | |   |   |   | | └─IntegerLiteralSyntax
+//@[025:00026) |   | |   |   |   | |   └─Token(Integer) |1|
+//@[026:00027) |   | |   |   |   | ├─Token(Comma) |,|
+//@[027:00028) |   | |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   | |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   | |   |   |   | |   └─Token(Integer) |2|
+//@[028:00029) |   | |   |   |   | └─Token(RightParen) |)|
+//@[029:00030) |   | |   |   |   ├─Token(Colon) |:|
+//@[031:00040) |   | |   |   |   ├─BinaryOperationSyntax
+//@[031:00032) |   | |   |   |   | ├─VariableAccessSyntax
+//@[031:00032) |   | |   |   |   | | └─IdentifierSyntax
+//@[031:00032) |   | |   |   |   | |   └─Token(Identifier) |i|
+//@[033:00034) |   | |   |   |   | ├─Token(Asterisk) |*|
+//@[035:00040) |   | |   |   |   | └─VariableAccessSyntax
+//@[035:00040) |   | |   |   |   |   └─IdentifierSyntax
+//@[035:00040) |   | |   |   |   |     └─Token(Identifier) |thing|
+//@[040:00041) |   | |   |   |   └─Token(RightSquare) |]|
+//@[041:00043) |   | |   |   ├─Token(NewLine) |\r\n|
+      c: {
+//@[006:00056) |   | |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   | |   |   | ├─IdentifierSyntax
+//@[006:00007) |   | |   |   | | └─Token(Identifier) |c|
+//@[007:00008) |   | |   |   | ├─Token(Colon) |:|
+//@[009:00056) |   | |   |   | └─ObjectSyntax
+//@[009:00010) |   | |   |   |   ├─Token(LeftBrace) |{|
+//@[010:00012) |   | |   |   |   ├─Token(NewLine) |\r\n|
+        d: [for j in range(2,3): j]
+//@[008:00035) |   | |   |   |   ├─ObjectPropertySyntax
+//@[008:00009) |   | |   |   |   | ├─IdentifierSyntax
+//@[008:00009) |   | |   |   |   | | └─Token(Identifier) |d|
+//@[009:00010) |   | |   |   |   | ├─Token(Colon) |:|
+//@[011:00035) |   | |   |   |   | └─ForSyntax
+//@[011:00012) |   | |   |   |   |   ├─Token(LeftSquare) |[|
+//@[012:00015) |   | |   |   |   |   ├─Token(Identifier) |for|
+//@[016:00017) |   | |   |   |   |   ├─LocalVariableSyntax
+//@[016:00017) |   | |   |   |   |   | └─IdentifierSyntax
+//@[016:00017) |   | |   |   |   |   |   └─Token(Identifier) |j|
+//@[018:00020) |   | |   |   |   |   ├─Token(Identifier) |in|
+//@[021:00031) |   | |   |   |   |   ├─FunctionCallSyntax
+//@[021:00026) |   | |   |   |   |   | ├─IdentifierSyntax
+//@[021:00026) |   | |   |   |   |   | | └─Token(Identifier) |range|
+//@[026:00027) |   | |   |   |   |   | ├─Token(LeftParen) |(|
+//@[027:00028) |   | |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   | |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   | |   |   |   |   | |   └─Token(Integer) |2|
+//@[028:00029) |   | |   |   |   |   | ├─Token(Comma) |,|
+//@[029:00030) |   | |   |   |   |   | ├─FunctionArgumentSyntax
+//@[029:00030) |   | |   |   |   |   | | └─IntegerLiteralSyntax
+//@[029:00030) |   | |   |   |   |   | |   └─Token(Integer) |3|
+//@[030:00031) |   | |   |   |   |   | └─Token(RightParen) |)|
+//@[031:00032) |   | |   |   |   |   ├─Token(Colon) |:|
+//@[033:00034) |   | |   |   |   |   ├─VariableAccessSyntax
+//@[033:00034) |   | |   |   |   |   | └─IdentifierSyntax
+//@[033:00034) |   | |   |   |   |   |   └─Token(Identifier) |j|
+//@[034:00035) |   | |   |   |   |   └─Token(RightSquare) |]|
+//@[035:00037) |   | |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00007) |   | |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   | |   |   ├─Token(NewLine) |\r\n|
+      e: [for k in range(4,4): {
+//@[006:00064) |   | |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   | |   |   | ├─IdentifierSyntax
+//@[006:00007) |   | |   |   | | └─Token(Identifier) |e|
+//@[007:00008) |   | |   |   | ├─Token(Colon) |:|
+//@[009:00064) |   | |   |   | └─ForSyntax
+//@[009:00010) |   | |   |   |   ├─Token(LeftSquare) |[|
+//@[010:00013) |   | |   |   |   ├─Token(Identifier) |for|
+//@[014:00015) |   | |   |   |   ├─LocalVariableSyntax
+//@[014:00015) |   | |   |   |   | └─IdentifierSyntax
+//@[014:00015) |   | |   |   |   |   └─Token(Identifier) |k|
+//@[016:00018) |   | |   |   |   ├─Token(Identifier) |in|
+//@[019:00029) |   | |   |   |   ├─FunctionCallSyntax
+//@[019:00024) |   | |   |   |   | ├─IdentifierSyntax
+//@[019:00024) |   | |   |   |   | | └─Token(Identifier) |range|
+//@[024:00025) |   | |   |   |   | ├─Token(LeftParen) |(|
+//@[025:00026) |   | |   |   |   | ├─FunctionArgumentSyntax
+//@[025:00026) |   | |   |   |   | | └─IntegerLiteralSyntax
+//@[025:00026) |   | |   |   |   | |   └─Token(Integer) |4|
+//@[026:00027) |   | |   |   |   | ├─Token(Comma) |,|
+//@[027:00028) |   | |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   | |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   | |   |   |   | |   └─Token(Integer) |4|
+//@[028:00029) |   | |   |   |   | └─Token(RightParen) |)|
+//@[029:00030) |   | |   |   |   ├─Token(Colon) |:|
+//@[031:00063) |   | |   |   |   ├─ObjectSyntax
+//@[031:00032) |   | |   |   |   | ├─Token(LeftBrace) |{|
+//@[032:00034) |   | |   |   |   | ├─Token(NewLine) |\r\n|
+        f: k - thing
+//@[008:00020) |   | |   |   |   | ├─ObjectPropertySyntax
+//@[008:00009) |   | |   |   |   | | ├─IdentifierSyntax
+//@[008:00009) |   | |   |   |   | | | └─Token(Identifier) |f|
+//@[009:00010) |   | |   |   |   | | ├─Token(Colon) |:|
+//@[011:00020) |   | |   |   |   | | └─BinaryOperationSyntax
+//@[011:00012) |   | |   |   |   | |   ├─VariableAccessSyntax
+//@[011:00012) |   | |   |   |   | |   | └─IdentifierSyntax
+//@[011:00012) |   | |   |   |   | |   |   └─Token(Identifier) |k|
+//@[013:00014) |   | |   |   |   | |   ├─Token(Minus) |-|
+//@[015:00020) |   | |   |   |   | |   └─VariableAccessSyntax
+//@[015:00020) |   | |   |   |   | |     └─IdentifierSyntax
+//@[015:00020) |   | |   |   |   | |       └─Token(Identifier) |thing|
+//@[020:00022) |   | |   |   |   | ├─Token(NewLine) |\r\n|
+      }]
+//@[006:00007) |   | |   |   |   | └─Token(RightBrace) |}|
+//@[007:00008) |   | |   |   |   └─Token(RightSquare) |]|
+//@[008:00010) |   | |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[004:00005) |   | |   |   └─Token(RightBrace) |}|
+//@[005:00007) |   | |   ├─Token(NewLine) |\r\n|
+    stringParamB: ''
+//@[004:00020) |   | |   ├─ObjectPropertySyntax
+//@[004:00016) |   | |   | ├─IdentifierSyntax
+//@[004:00016) |   | |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   | |   | ├─Token(Colon) |:|
+//@[018:00020) |   | |   | └─StringSyntax
+//@[018:00020) |   | |   |   └─Token(StringComplete) |''|
+//@[020:00022) |   | |   ├─Token(NewLine) |\r\n|
+    arrayParam: [
+//@[004:00093) |   | |   ├─ObjectPropertySyntax
+//@[004:00014) |   | |   | ├─IdentifierSyntax
+//@[004:00014) |   | |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   | |   | ├─Token(Colon) |:|
+//@[016:00093) |   | |   | └─ArraySyntax
+//@[016:00017) |   | |   |   ├─Token(LeftSquare) |[|
+//@[017:00019) |   | |   |   ├─Token(NewLine) |\r\n|
+      {
+//@[006:00067) |   | |   |   ├─ArrayItemSyntax
+//@[006:00067) |   | |   |   | └─ObjectSyntax
+//@[006:00007) |   | |   |   |   ├─Token(LeftBrace) |{|
+//@[007:00009) |   | |   |   |   ├─Token(NewLine) |\r\n|
+        e: [for j in range(7,7): j % (thing + 1)]
+//@[008:00049) |   | |   |   |   ├─ObjectPropertySyntax
+//@[008:00009) |   | |   |   |   | ├─IdentifierSyntax
+//@[008:00009) |   | |   |   |   | | └─Token(Identifier) |e|
+//@[009:00010) |   | |   |   |   | ├─Token(Colon) |:|
+//@[011:00049) |   | |   |   |   | └─ForSyntax
+//@[011:00012) |   | |   |   |   |   ├─Token(LeftSquare) |[|
+//@[012:00015) |   | |   |   |   |   ├─Token(Identifier) |for|
+//@[016:00017) |   | |   |   |   |   ├─LocalVariableSyntax
+//@[016:00017) |   | |   |   |   |   | └─IdentifierSyntax
+//@[016:00017) |   | |   |   |   |   |   └─Token(Identifier) |j|
+//@[018:00020) |   | |   |   |   |   ├─Token(Identifier) |in|
+//@[021:00031) |   | |   |   |   |   ├─FunctionCallSyntax
+//@[021:00026) |   | |   |   |   |   | ├─IdentifierSyntax
+//@[021:00026) |   | |   |   |   |   | | └─Token(Identifier) |range|
+//@[026:00027) |   | |   |   |   |   | ├─Token(LeftParen) |(|
+//@[027:00028) |   | |   |   |   |   | ├─FunctionArgumentSyntax
+//@[027:00028) |   | |   |   |   |   | | └─IntegerLiteralSyntax
+//@[027:00028) |   | |   |   |   |   | |   └─Token(Integer) |7|
+//@[028:00029) |   | |   |   |   |   | ├─Token(Comma) |,|
+//@[029:00030) |   | |   |   |   |   | ├─FunctionArgumentSyntax
+//@[029:00030) |   | |   |   |   |   | | └─IntegerLiteralSyntax
+//@[029:00030) |   | |   |   |   |   | |   └─Token(Integer) |7|
+//@[030:00031) |   | |   |   |   |   | └─Token(RightParen) |)|
+//@[031:00032) |   | |   |   |   |   ├─Token(Colon) |:|
+//@[033:00048) |   | |   |   |   |   ├─BinaryOperationSyntax
+//@[033:00034) |   | |   |   |   |   | ├─VariableAccessSyntax
+//@[033:00034) |   | |   |   |   |   | | └─IdentifierSyntax
+//@[033:00034) |   | |   |   |   |   | |   └─Token(Identifier) |j|
+//@[035:00036) |   | |   |   |   |   | ├─Token(Modulo) |%|
+//@[037:00048) |   | |   |   |   |   | └─ParenthesizedExpressionSyntax
+//@[037:00038) |   | |   |   |   |   |   ├─Token(LeftParen) |(|
+//@[038:00047) |   | |   |   |   |   |   ├─BinaryOperationSyntax
+//@[038:00043) |   | |   |   |   |   |   | ├─VariableAccessSyntax
+//@[038:00043) |   | |   |   |   |   |   | | └─IdentifierSyntax
+//@[038:00043) |   | |   |   |   |   |   | |   └─Token(Identifier) |thing|
+//@[044:00045) |   | |   |   |   |   |   | ├─Token(Plus) |+|
+//@[046:00047) |   | |   |   |   |   |   | └─IntegerLiteralSyntax
+//@[046:00047) |   | |   |   |   |   |   |   └─Token(Integer) |1|
+//@[047:00048) |   | |   |   |   |   |   └─Token(RightParen) |)|
+//@[048:00049) |   | |   |   |   |   └─Token(RightSquare) |]|
+//@[049:00051) |   | |   |   |   ├─Token(NewLine) |\r\n|
+      }
+//@[006:00007) |   | |   |   |   └─Token(RightBrace) |}|
+//@[007:00009) |   | |   |   ├─Token(NewLine) |\r\n|
+    ]
+//@[004:00005) |   | |   |   └─Token(RightSquare) |]|
+//@[005:00007) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00008) ├─Token(NewLine) |\r\n\r\n\r\n|
+
+
+// BEGIN: Key Vault Secret Reference
+//@[036:00040) ├─Token(NewLine) |\r\n\r\n|
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[000:00090) ├─ResourceDeclarationSyntax
+//@[000:00008) | ├─Token(Identifier) |resource|
+//@[009:00011) | ├─IdentifierSyntax
+//@[009:00011) | | └─Token(Identifier) |kv|
+//@[012:00050) | ├─StringSyntax
+//@[012:00050) | | └─Token(StringComplete) |'Microsoft.KeyVault/vaults@2019-09-01'|
+//@[051:00059) | ├─Token(Identifier) |existing|
+//@[060:00061) | ├─Token(Assignment) |=|
+//@[062:00090) | └─ObjectSyntax
+//@[062:00063) |   ├─Token(LeftBrace) |{|
+//@[063:00065) |   ├─Token(NewLine) |\r\n|
+  name: 'testkeyvault'
+//@[002:00022) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00022) |   | └─StringSyntax
+//@[008:00022) |   |   └─Token(StringComplete) |'testkeyvault'|
+//@[022:00024) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module secureModule1 'child/secureParams.bicep' = {
+//@[000:00213) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00020) | ├─IdentifierSyntax
+//@[007:00020) | | └─Token(Identifier) |secureModule1|
+//@[021:00047) | ├─StringSyntax
+//@[021:00047) | | └─Token(StringComplete) |'child/secureParams.bicep'|
+//@[048:00049) | ├─Token(Assignment) |=|
+//@[050:00213) | └─ObjectSyntax
+//@[050:00051) |   ├─Token(LeftBrace) |{|
+//@[051:00053) |   ├─Token(NewLine) |\r\n|
+  name: 'secureModule1'
+//@[002:00023) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00023) |   | └─StringSyntax
+//@[008:00023) |   |   └─Token(StringComplete) |'secureModule1'|
+//@[023:00025) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00132) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00132) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    secureStringParam1: kv.getSecret('mySecret')
+//@[004:00048) |   |   ├─ObjectPropertySyntax
+//@[004:00022) |   |   | ├─IdentifierSyntax
+//@[004:00022) |   |   | | └─Token(Identifier) |secureStringParam1|
+//@[022:00023) |   |   | ├─Token(Colon) |:|
+//@[024:00048) |   |   | └─InstanceFunctionCallSyntax
+//@[024:00026) |   |   |   ├─VariableAccessSyntax
+//@[024:00026) |   |   |   | └─IdentifierSyntax
+//@[024:00026) |   |   |   |   └─Token(Identifier) |kv|
+//@[026:00027) |   |   |   ├─Token(Dot) |.|
+//@[027:00036) |   |   |   ├─IdentifierSyntax
+//@[027:00036) |   |   |   | └─Token(Identifier) |getSecret|
+//@[036:00037) |   |   |   ├─Token(LeftParen) |(|
+//@[037:00047) |   |   |   ├─FunctionArgumentSyntax
+//@[037:00047) |   |   |   | └─StringSyntax
+//@[037:00047) |   |   |   |   └─Token(StringComplete) |'mySecret'|
+//@[047:00048) |   |   |   └─Token(RightParen) |)|
+//@[048:00050) |   |   ├─Token(NewLine) |\r\n|
+    secureStringParam2: kv.getSecret('mySecret','secretVersion')
+//@[004:00064) |   |   ├─ObjectPropertySyntax
+//@[004:00022) |   |   | ├─IdentifierSyntax
+//@[004:00022) |   |   | | └─Token(Identifier) |secureStringParam2|
+//@[022:00023) |   |   | ├─Token(Colon) |:|
+//@[024:00064) |   |   | └─InstanceFunctionCallSyntax
+//@[024:00026) |   |   |   ├─VariableAccessSyntax
+//@[024:00026) |   |   |   | └─IdentifierSyntax
+//@[024:00026) |   |   |   |   └─Token(Identifier) |kv|
+//@[026:00027) |   |   |   ├─Token(Dot) |.|
+//@[027:00036) |   |   |   ├─IdentifierSyntax
+//@[027:00036) |   |   |   | └─Token(Identifier) |getSecret|
+//@[036:00037) |   |   |   ├─Token(LeftParen) |(|
+//@[037:00047) |   |   |   ├─FunctionArgumentSyntax
+//@[037:00047) |   |   |   | └─StringSyntax
+//@[037:00047) |   |   |   |   └─Token(StringComplete) |'mySecret'|
+//@[047:00048) |   |   |   ├─Token(Comma) |,|
+//@[048:00063) |   |   |   ├─FunctionArgumentSyntax
+//@[048:00063) |   |   |   | └─StringSyntax
+//@[048:00063) |   |   |   |   └─Token(StringComplete) |'secretVersion'|
+//@[063:00064) |   |   |   └─Token(RightParen) |)|
+//@[064:00066) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[000:00134) ├─ResourceDeclarationSyntax
+//@[000:00008) | ├─Token(Identifier) |resource|
+//@[009:00017) | ├─IdentifierSyntax
+//@[009:00017) | | └─Token(Identifier) |scopedKv|
+//@[018:00056) | ├─StringSyntax
+//@[018:00056) | | └─Token(StringComplete) |'Microsoft.KeyVault/vaults@2019-09-01'|
+//@[057:00065) | ├─Token(Identifier) |existing|
+//@[066:00067) | ├─Token(Assignment) |=|
+//@[068:00134) | └─ObjectSyntax
+//@[068:00069) |   ├─Token(LeftBrace) |{|
+//@[069:00071) |   ├─Token(NewLine) |\r\n|
+  name: 'testkeyvault'
+//@[002:00022) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00022) |   | └─StringSyntax
+//@[008:00022) |   |   └─Token(StringComplete) |'testkeyvault'|
+//@[022:00024) |   ├─Token(NewLine) |\r\n|
+  scope: resourceGroup('otherGroup')
+//@[002:00036) |   ├─ObjectPropertySyntax
+//@[002:00007) |   | ├─IdentifierSyntax
+//@[002:00007) |   | | └─Token(Identifier) |scope|
+//@[007:00008) |   | ├─Token(Colon) |:|
+//@[009:00036) |   | └─FunctionCallSyntax
+//@[009:00022) |   |   ├─IdentifierSyntax
+//@[009:00022) |   |   | └─Token(Identifier) |resourceGroup|
+//@[022:00023) |   |   ├─Token(LeftParen) |(|
+//@[023:00035) |   |   ├─FunctionArgumentSyntax
+//@[023:00035) |   |   | └─StringSyntax
+//@[023:00035) |   |   |   └─Token(StringComplete) |'otherGroup'|
+//@[035:00036) |   |   └─Token(RightParen) |)|
+//@[036:00038) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module secureModule2 'child/secureParams.bicep' = {
+//@[000:00225) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00020) | ├─IdentifierSyntax
+//@[007:00020) | | └─Token(Identifier) |secureModule2|
+//@[021:00047) | ├─StringSyntax
+//@[021:00047) | | └─Token(StringComplete) |'child/secureParams.bicep'|
+//@[048:00049) | ├─Token(Assignment) |=|
+//@[050:00225) | └─ObjectSyntax
+//@[050:00051) |   ├─Token(LeftBrace) |{|
+//@[051:00053) |   ├─Token(NewLine) |\r\n|
+  name: 'secureModule2'
+//@[002:00023) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00023) |   | └─StringSyntax
+//@[008:00023) |   |   └─Token(StringComplete) |'secureModule2'|
+//@[023:00025) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00144) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00144) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    secureStringParam1: scopedKv.getSecret('mySecret')
+//@[004:00054) |   |   ├─ObjectPropertySyntax
+//@[004:00022) |   |   | ├─IdentifierSyntax
+//@[004:00022) |   |   | | └─Token(Identifier) |secureStringParam1|
+//@[022:00023) |   |   | ├─Token(Colon) |:|
+//@[024:00054) |   |   | └─InstanceFunctionCallSyntax
+//@[024:00032) |   |   |   ├─VariableAccessSyntax
+//@[024:00032) |   |   |   | └─IdentifierSyntax
+//@[024:00032) |   |   |   |   └─Token(Identifier) |scopedKv|
+//@[032:00033) |   |   |   ├─Token(Dot) |.|
+//@[033:00042) |   |   |   ├─IdentifierSyntax
+//@[033:00042) |   |   |   | └─Token(Identifier) |getSecret|
+//@[042:00043) |   |   |   ├─Token(LeftParen) |(|
+//@[043:00053) |   |   |   ├─FunctionArgumentSyntax
+//@[043:00053) |   |   |   | └─StringSyntax
+//@[043:00053) |   |   |   |   └─Token(StringComplete) |'mySecret'|
+//@[053:00054) |   |   |   └─Token(RightParen) |)|
+//@[054:00056) |   |   ├─Token(NewLine) |\r\n|
+    secureStringParam2: scopedKv.getSecret('mySecret','secretVersion')
+//@[004:00070) |   |   ├─ObjectPropertySyntax
+//@[004:00022) |   |   | ├─IdentifierSyntax
+//@[004:00022) |   |   | | └─Token(Identifier) |secureStringParam2|
+//@[022:00023) |   |   | ├─Token(Colon) |:|
+//@[024:00070) |   |   | └─InstanceFunctionCallSyntax
+//@[024:00032) |   |   |   ├─VariableAccessSyntax
+//@[024:00032) |   |   |   | └─IdentifierSyntax
+//@[024:00032) |   |   |   |   └─Token(Identifier) |scopedKv|
+//@[032:00033) |   |   |   ├─Token(Dot) |.|
+//@[033:00042) |   |   |   ├─IdentifierSyntax
+//@[033:00042) |   |   |   | └─Token(Identifier) |getSecret|
+//@[042:00043) |   |   |   ├─Token(LeftParen) |(|
+//@[043:00053) |   |   |   ├─FunctionArgumentSyntax
+//@[043:00053) |   |   |   | └─StringSyntax
+//@[043:00053) |   |   |   |   └─Token(StringComplete) |'mySecret'|
+//@[053:00054) |   |   |   ├─Token(Comma) |,|
+//@[054:00069) |   |   |   ├─FunctionArgumentSyntax
+//@[054:00069) |   |   |   | └─StringSyntax
+//@[054:00069) |   |   |   |   └─Token(StringComplete) |'secretVersion'|
+//@[069:00070) |   |   |   └─Token(RightParen) |)|
+//@[070:00072) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+//looped module with looped existing resource (Issue #2862)
+//@[059:00061) ├─Token(NewLine) |\r\n|
+var vaults = [
+//@[000:00200) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00010) | ├─IdentifierSyntax
+//@[004:00010) | | └─Token(Identifier) |vaults|
+//@[011:00012) | ├─Token(Assignment) |=|
+//@[013:00200) | └─ArraySyntax
+//@[013:00014) |   ├─Token(LeftSquare) |[|
+//@[014:00016) |   ├─Token(NewLine) |\r\n|
+  {
+//@[002:00089) |   ├─ArrayItemSyntax
+//@[002:00089) |   | └─ObjectSyntax
+//@[002:00003) |   |   ├─Token(LeftBrace) |{|
+//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
+    vaultName: 'test-1-kv'
+//@[004:00026) |   |   ├─ObjectPropertySyntax
+//@[004:00013) |   |   | ├─IdentifierSyntax
+//@[004:00013) |   |   | | └─Token(Identifier) |vaultName|
+//@[013:00014) |   |   | ├─Token(Colon) |:|
+//@[015:00026) |   |   | └─StringSyntax
+//@[015:00026) |   |   |   └─Token(StringComplete) |'test-1-kv'|
+//@[026:00028) |   |   ├─Token(NewLine) |\r\n|
+    vaultRG: 'test-1-rg'
+//@[004:00024) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |vaultRG|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00024) |   |   | └─StringSyntax
+//@[013:00024) |   |   |   └─Token(StringComplete) |'test-1-rg'|
+//@[024:00026) |   |   ├─Token(NewLine) |\r\n|
+    vaultSub: 'abcd-efgh'
+//@[004:00025) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |vaultSub|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00025) |   |   | └─StringSyntax
+//@[014:00025) |   |   |   └─Token(StringComplete) |'abcd-efgh'|
+//@[025:00027) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+  {
+//@[002:00090) |   ├─ArrayItemSyntax
+//@[002:00090) |   | └─ObjectSyntax
+//@[002:00003) |   |   ├─Token(LeftBrace) |{|
+//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
+    vaultName: 'test-2-kv'
+//@[004:00026) |   |   ├─ObjectPropertySyntax
+//@[004:00013) |   |   | ├─IdentifierSyntax
+//@[004:00013) |   |   | | └─Token(Identifier) |vaultName|
+//@[013:00014) |   |   | ├─Token(Colon) |:|
+//@[015:00026) |   |   | └─StringSyntax
+//@[015:00026) |   |   |   └─Token(StringComplete) |'test-2-kv'|
+//@[026:00028) |   |   ├─Token(NewLine) |\r\n|
+    vaultRG: 'test-2-rg'
+//@[004:00024) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |vaultRG|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00024) |   |   | └─StringSyntax
+//@[013:00024) |   |   |   └─Token(StringComplete) |'test-2-rg'|
+//@[024:00026) |   |   ├─Token(NewLine) |\r\n|
+    vaultSub: 'ijkl-1adg1'
+//@[004:00026) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |vaultSub|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00026) |   |   | └─StringSyntax
+//@[014:00026) |   |   |   └─Token(StringComplete) |'ijkl-1adg1'|
+//@[026:00028) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+]
+//@[000:00001) |   └─Token(RightSquare) |]|
+//@[001:00003) ├─Token(NewLine) |\r\n|
+var secrets = [
+//@[000:00132) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00011) | ├─IdentifierSyntax
+//@[004:00011) | | └─Token(Identifier) |secrets|
+//@[012:00013) | ├─Token(Assignment) |=|
+//@[014:00132) | └─ArraySyntax
+//@[014:00015) |   ├─Token(LeftSquare) |[|
+//@[015:00017) |   ├─Token(NewLine) |\r\n|
+  {
+//@[002:00055) |   ├─ArrayItemSyntax
+//@[002:00055) |   | └─ObjectSyntax
+//@[002:00003) |   |   ├─Token(LeftBrace) |{|
+//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
+    name: 'secret01'
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00008) |   |   | ├─IdentifierSyntax
+//@[004:00008) |   |   | | └─Token(Identifier) |name|
+//@[008:00009) |   |   | ├─Token(Colon) |:|
+//@[010:00020) |   |   | └─StringSyntax
+//@[010:00020) |   |   |   └─Token(StringComplete) |'secret01'|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    version: 'versionA'
+//@[004:00023) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |version|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00023) |   |   | └─StringSyntax
+//@[013:00023) |   |   |   └─Token(StringComplete) |'versionA'|
+//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+  {
+//@[002:00055) |   ├─ArrayItemSyntax
+//@[002:00055) |   | └─ObjectSyntax
+//@[002:00003) |   |   ├─Token(LeftBrace) |{|
+//@[003:00005) |   |   ├─Token(NewLine) |\r\n|
+    name: 'secret02'
+//@[004:00020) |   |   ├─ObjectPropertySyntax
+//@[004:00008) |   |   | ├─IdentifierSyntax
+//@[004:00008) |   |   | | └─Token(Identifier) |name|
+//@[008:00009) |   |   | ├─Token(Colon) |:|
+//@[010:00020) |   |   | └─StringSyntax
+//@[010:00020) |   |   |   └─Token(StringComplete) |'secret02'|
+//@[020:00022) |   |   ├─Token(NewLine) |\r\n|
+    version: 'versionB'
+//@[004:00023) |   |   ├─ObjectPropertySyntax
+//@[004:00011) |   |   | ├─IdentifierSyntax
+//@[004:00011) |   |   | | └─Token(Identifier) |version|
+//@[011:00012) |   |   | ├─Token(Colon) |:|
+//@[013:00023) |   |   | └─StringSyntax
+//@[013:00023) |   |   |   └─Token(StringComplete) |'versionB'|
+//@[023:00025) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+]
+//@[000:00001) |   └─Token(RightSquare) |]|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [for vault in vaults: {
+//@[000:00175) ├─ResourceDeclarationSyntax
+//@[000:00008) | ├─Token(Identifier) |resource|
+//@[009:00017) | ├─IdentifierSyntax
+//@[009:00017) | | └─Token(Identifier) |loopedKv|
+//@[018:00056) | ├─StringSyntax
+//@[018:00056) | | └─Token(StringComplete) |'Microsoft.KeyVault/vaults@2019-09-01'|
+//@[057:00065) | ├─Token(Identifier) |existing|
+//@[066:00067) | ├─Token(Assignment) |=|
+//@[068:00175) | └─ForSyntax
+//@[068:00069) |   ├─Token(LeftSquare) |[|
+//@[069:00072) |   ├─Token(Identifier) |for|
+//@[073:00078) |   ├─LocalVariableSyntax
+//@[073:00078) |   | └─IdentifierSyntax
+//@[073:00078) |   |   └─Token(Identifier) |vault|
+//@[079:00081) |   ├─Token(Identifier) |in|
+//@[082:00088) |   ├─VariableAccessSyntax
+//@[082:00088) |   | └─IdentifierSyntax
+//@[082:00088) |   |   └─Token(Identifier) |vaults|
+//@[088:00089) |   ├─Token(Colon) |:|
+//@[090:00174) |   ├─ObjectSyntax
+//@[090:00091) |   | ├─Token(LeftBrace) |{|
+//@[091:00093) |   | ├─Token(NewLine) |\r\n|
+  name: vault.vaultName
+//@[002:00023) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00023) |   | | └─PropertyAccessSyntax
+//@[008:00013) |   | |   ├─VariableAccessSyntax
+//@[008:00013) |   | |   | └─IdentifierSyntax
+//@[008:00013) |   | |   |   └─Token(Identifier) |vault|
+//@[013:00014) |   | |   ├─Token(Dot) |.|
+//@[014:00023) |   | |   └─IdentifierSyntax
+//@[014:00023) |   | |     └─Token(Identifier) |vaultName|
+//@[023:00025) |   | ├─Token(NewLine) |\r\n|
+  scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+//@[002:00053) |   | ├─ObjectPropertySyntax
+//@[002:00007) |   | | ├─IdentifierSyntax
+//@[002:00007) |   | | | └─Token(Identifier) |scope|
+//@[007:00008) |   | | ├─Token(Colon) |:|
+//@[009:00053) |   | | └─FunctionCallSyntax
+//@[009:00022) |   | |   ├─IdentifierSyntax
+//@[009:00022) |   | |   | └─Token(Identifier) |resourceGroup|
+//@[022:00023) |   | |   ├─Token(LeftParen) |(|
+//@[023:00037) |   | |   ├─FunctionArgumentSyntax
+//@[023:00037) |   | |   | └─PropertyAccessSyntax
+//@[023:00028) |   | |   |   ├─VariableAccessSyntax
+//@[023:00028) |   | |   |   | └─IdentifierSyntax
+//@[023:00028) |   | |   |   |   └─Token(Identifier) |vault|
+//@[028:00029) |   | |   |   ├─Token(Dot) |.|
+//@[029:00037) |   | |   |   └─IdentifierSyntax
+//@[029:00037) |   | |   |     └─Token(Identifier) |vaultSub|
+//@[037:00038) |   | |   ├─Token(Comma) |,|
+//@[039:00052) |   | |   ├─FunctionArgumentSyntax
+//@[039:00052) |   | |   | └─PropertyAccessSyntax
+//@[039:00044) |   | |   |   ├─VariableAccessSyntax
+//@[039:00044) |   | |   |   | └─IdentifierSyntax
+//@[039:00044) |   | |   |   |   └─Token(Identifier) |vault|
+//@[044:00045) |   | |   |   ├─Token(Dot) |.|
+//@[045:00052) |   | |   |   └─IdentifierSyntax
+//@[045:00052) |   | |   |     └─Token(Identifier) |vaultRG|
+//@[052:00053) |   | |   └─Token(RightParen) |)|
+//@[053:00055) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secrets: {
+//@[000:00278) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00025) | ├─IdentifierSyntax
+//@[007:00025) | | └─Token(Identifier) |secureModuleLooped|
+//@[026:00052) | ├─StringSyntax
+//@[026:00052) | | └─Token(StringComplete) |'child/secureParams.bicep'|
+//@[053:00054) | ├─Token(Assignment) |=|
+//@[055:00278) | └─ForSyntax
+//@[055:00056) |   ├─Token(LeftSquare) |[|
+//@[056:00059) |   ├─Token(Identifier) |for|
+//@[060:00071) |   ├─VariableBlockSyntax
+//@[060:00061) |   | ├─Token(LeftParen) |(|
+//@[061:00067) |   | ├─LocalVariableSyntax
+//@[061:00067) |   | | └─IdentifierSyntax
+//@[061:00067) |   | |   └─Token(Identifier) |secret|
+//@[067:00068) |   | ├─Token(Comma) |,|
+//@[069:00070) |   | ├─LocalVariableSyntax
+//@[069:00070) |   | | └─IdentifierSyntax
+//@[069:00070) |   | |   └─Token(Identifier) |i|
+//@[070:00071) |   | └─Token(RightParen) |)|
+//@[072:00074) |   ├─Token(Identifier) |in|
+//@[075:00082) |   ├─VariableAccessSyntax
+//@[075:00082) |   | └─IdentifierSyntax
+//@[075:00082) |   |   └─Token(Identifier) |secrets|
+//@[082:00083) |   ├─Token(Colon) |:|
+//@[084:00277) |   ├─ObjectSyntax
+//@[084:00085) |   | ├─Token(LeftBrace) |{|
+//@[085:00087) |   | ├─Token(NewLine) |\r\n|
+  name: 'secureModuleLooped-${i}'
+//@[002:00033) |   | ├─ObjectPropertySyntax
+//@[002:00006) |   | | ├─IdentifierSyntax
+//@[002:00006) |   | | | └─Token(Identifier) |name|
+//@[006:00007) |   | | ├─Token(Colon) |:|
+//@[008:00033) |   | | └─StringSyntax
+//@[008:00030) |   | |   ├─Token(StringLeftPiece) |'secureModuleLooped-${|
+//@[030:00031) |   | |   ├─VariableAccessSyntax
+//@[030:00031) |   | |   | └─IdentifierSyntax
+//@[030:00031) |   | |   |   └─Token(Identifier) |i|
+//@[031:00033) |   | |   └─Token(StringRightPiece) |}'|
+//@[033:00035) |   | ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00152) |   | ├─ObjectPropertySyntax
+//@[002:00008) |   | | ├─IdentifierSyntax
+//@[002:00008) |   | | | └─Token(Identifier) |params|
+//@[008:00009) |   | | ├─Token(Colon) |:|
+//@[010:00152) |   | | └─ObjectSyntax
+//@[010:00011) |   | |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   | |   ├─Token(NewLine) |\r\n|
+    secureStringParam1: loopedKv[i].getSecret(secret.name)
+//@[004:00058) |   | |   ├─ObjectPropertySyntax
+//@[004:00022) |   | |   | ├─IdentifierSyntax
+//@[004:00022) |   | |   | | └─Token(Identifier) |secureStringParam1|
+//@[022:00023) |   | |   | ├─Token(Colon) |:|
+//@[024:00058) |   | |   | └─InstanceFunctionCallSyntax
+//@[024:00035) |   | |   |   ├─ArrayAccessSyntax
+//@[024:00032) |   | |   |   | ├─VariableAccessSyntax
+//@[024:00032) |   | |   |   | | └─IdentifierSyntax
+//@[024:00032) |   | |   |   | |   └─Token(Identifier) |loopedKv|
+//@[032:00033) |   | |   |   | ├─Token(LeftSquare) |[|
+//@[033:00034) |   | |   |   | ├─VariableAccessSyntax
+//@[033:00034) |   | |   |   | | └─IdentifierSyntax
+//@[033:00034) |   | |   |   | |   └─Token(Identifier) |i|
+//@[034:00035) |   | |   |   | └─Token(RightSquare) |]|
+//@[035:00036) |   | |   |   ├─Token(Dot) |.|
+//@[036:00045) |   | |   |   ├─IdentifierSyntax
+//@[036:00045) |   | |   |   | └─Token(Identifier) |getSecret|
+//@[045:00046) |   | |   |   ├─Token(LeftParen) |(|
+//@[046:00057) |   | |   |   ├─FunctionArgumentSyntax
+//@[046:00057) |   | |   |   | └─PropertyAccessSyntax
+//@[046:00052) |   | |   |   |   ├─VariableAccessSyntax
+//@[046:00052) |   | |   |   |   | └─IdentifierSyntax
+//@[046:00052) |   | |   |   |   |   └─Token(Identifier) |secret|
+//@[052:00053) |   | |   |   |   ├─Token(Dot) |.|
+//@[053:00057) |   | |   |   |   └─IdentifierSyntax
+//@[053:00057) |   | |   |   |     └─Token(Identifier) |name|
+//@[057:00058) |   | |   |   └─Token(RightParen) |)|
+//@[058:00060) |   | |   ├─Token(NewLine) |\r\n|
+    secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+//@[004:00074) |   | |   ├─ObjectPropertySyntax
+//@[004:00022) |   | |   | ├─IdentifierSyntax
+//@[004:00022) |   | |   | | └─Token(Identifier) |secureStringParam2|
+//@[022:00023) |   | |   | ├─Token(Colon) |:|
+//@[024:00074) |   | |   | └─InstanceFunctionCallSyntax
+//@[024:00035) |   | |   |   ├─ArrayAccessSyntax
+//@[024:00032) |   | |   |   | ├─VariableAccessSyntax
+//@[024:00032) |   | |   |   | | └─IdentifierSyntax
+//@[024:00032) |   | |   |   | |   └─Token(Identifier) |loopedKv|
+//@[032:00033) |   | |   |   | ├─Token(LeftSquare) |[|
+//@[033:00034) |   | |   |   | ├─VariableAccessSyntax
+//@[033:00034) |   | |   |   | | └─IdentifierSyntax
+//@[033:00034) |   | |   |   | |   └─Token(Identifier) |i|
+//@[034:00035) |   | |   |   | └─Token(RightSquare) |]|
+//@[035:00036) |   | |   |   ├─Token(Dot) |.|
+//@[036:00045) |   | |   |   ├─IdentifierSyntax
+//@[036:00045) |   | |   |   | └─Token(Identifier) |getSecret|
+//@[045:00046) |   | |   |   ├─Token(LeftParen) |(|
+//@[046:00057) |   | |   |   ├─FunctionArgumentSyntax
+//@[046:00057) |   | |   |   | └─PropertyAccessSyntax
+//@[046:00052) |   | |   |   |   ├─VariableAccessSyntax
+//@[046:00052) |   | |   |   |   | └─IdentifierSyntax
+//@[046:00052) |   | |   |   |   |   └─Token(Identifier) |secret|
+//@[052:00053) |   | |   |   |   ├─Token(Dot) |.|
+//@[053:00057) |   | |   |   |   └─IdentifierSyntax
+//@[053:00057) |   | |   |   |     └─Token(Identifier) |name|
+//@[057:00058) |   | |   |   ├─Token(Comma) |,|
+//@[059:00073) |   | |   |   ├─FunctionArgumentSyntax
+//@[059:00073) |   | |   |   | └─PropertyAccessSyntax
+//@[059:00065) |   | |   |   |   ├─VariableAccessSyntax
+//@[059:00065) |   | |   |   |   | └─IdentifierSyntax
+//@[059:00065) |   | |   |   |   |   └─Token(Identifier) |secret|
+//@[065:00066) |   | |   |   |   ├─Token(Dot) |.|
+//@[066:00073) |   | |   |   |   └─IdentifierSyntax
+//@[066:00073) |   | |   |   |     └─Token(Identifier) |version|
+//@[073:00074) |   | |   |   └─Token(RightParen) |)|
+//@[074:00076) |   | |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   | |   └─Token(RightBrace) |}|
+//@[003:00005) |   | ├─Token(NewLine) |\r\n|
+}]
+//@[000:00001) |   | └─Token(RightBrace) |}|
+//@[001:00002) |   └─Token(RightSquare) |]|
+//@[002:00006) ├─Token(NewLine) |\r\n\r\n|
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+//@[000:00285) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00028) | ├─IdentifierSyntax
+//@[007:00028) | | └─Token(Identifier) |secureModuleCondition|
+//@[029:00055) | ├─StringSyntax
+//@[029:00055) | | └─Token(StringComplete) |'child/secureParams.bicep'|
+//@[056:00057) | ├─Token(Assignment) |=|
+//@[058:00285) | └─ObjectSyntax
+//@[058:00059) |   ├─Token(LeftBrace) |{|
+//@[059:00061) |   ├─Token(NewLine) |\r\n|
+  name: 'secureModuleCondition'
+//@[002:00031) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00031) |   | └─StringSyntax
+//@[008:00031) |   |   └─Token(StringComplete) |'secureModuleCondition'|
+//@[031:00033) |   ├─Token(NewLine) |\r\n|
+  params: {
+//@[002:00188) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[010:00188) |   | └─ObjectSyntax
+//@[010:00011) |   |   ├─Token(LeftBrace) |{|
+//@[011:00013) |   |   ├─Token(NewLine) |\r\n|
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+//@[004:00067) |   |   ├─ObjectPropertySyntax
+//@[004:00022) |   |   | ├─IdentifierSyntax
+//@[004:00022) |   |   | | └─Token(Identifier) |secureStringParam1|
+//@[022:00023) |   |   | ├─Token(Colon) |:|
+//@[024:00067) |   |   | └─TernaryOperationSyntax
+//@[024:00028) |   |   |   ├─BooleanLiteralSyntax
+//@[024:00028) |   |   |   | └─Token(TrueKeyword) |true|
+//@[029:00030) |   |   |   ├─Token(Question) |?|
+//@[031:00055) |   |   |   ├─InstanceFunctionCallSyntax
+//@[031:00033) |   |   |   | ├─VariableAccessSyntax
+//@[031:00033) |   |   |   | | └─IdentifierSyntax
+//@[031:00033) |   |   |   | |   └─Token(Identifier) |kv|
+//@[033:00034) |   |   |   | ├─Token(Dot) |.|
+//@[034:00043) |   |   |   | ├─IdentifierSyntax
+//@[034:00043) |   |   |   | | └─Token(Identifier) |getSecret|
+//@[043:00044) |   |   |   | ├─Token(LeftParen) |(|
+//@[044:00054) |   |   |   | ├─FunctionArgumentSyntax
+//@[044:00054) |   |   |   | | └─StringSyntax
+//@[044:00054) |   |   |   | |   └─Token(StringComplete) |'mySecret'|
+//@[054:00055) |   |   |   | └─Token(RightParen) |)|
+//@[056:00057) |   |   |   ├─Token(Colon) |:|
+//@[058:00067) |   |   |   └─StringSyntax
+//@[058:00067) |   |   |     └─Token(StringComplete) |'notTrue'|
+//@[067:00069) |   |   ├─Token(NewLine) |\r\n|
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret','secretVersion') : 'notTrue'
+//@[004:00101) |   |   ├─ObjectPropertySyntax
+//@[004:00022) |   |   | ├─IdentifierSyntax
+//@[004:00022) |   |   | | └─Token(Identifier) |secureStringParam2|
+//@[022:00023) |   |   | ├─Token(Colon) |:|
+//@[024:00101) |   |   | └─TernaryOperationSyntax
+//@[024:00028) |   |   |   ├─BooleanLiteralSyntax
+//@[024:00028) |   |   |   | └─Token(TrueKeyword) |true|
+//@[029:00030) |   |   |   ├─Token(Question) |?|
+//@[031:00089) |   |   |   ├─TernaryOperationSyntax
+//@[031:00036) |   |   |   | ├─BooleanLiteralSyntax
+//@[031:00036) |   |   |   | | └─Token(FalseKeyword) |false|
+//@[037:00038) |   |   |   | ├─Token(Question) |?|
+//@[039:00046) |   |   |   | ├─StringSyntax
+//@[039:00046) |   |   |   | | └─Token(StringComplete) |'false'|
+//@[047:00048) |   |   |   | ├─Token(Colon) |:|
+//@[049:00089) |   |   |   | └─InstanceFunctionCallSyntax
+//@[049:00051) |   |   |   |   ├─VariableAccessSyntax
+//@[049:00051) |   |   |   |   | └─IdentifierSyntax
+//@[049:00051) |   |   |   |   |   └─Token(Identifier) |kv|
+//@[051:00052) |   |   |   |   ├─Token(Dot) |.|
+//@[052:00061) |   |   |   |   ├─IdentifierSyntax
+//@[052:00061) |   |   |   |   | └─Token(Identifier) |getSecret|
+//@[061:00062) |   |   |   |   ├─Token(LeftParen) |(|
+//@[062:00072) |   |   |   |   ├─FunctionArgumentSyntax
+//@[062:00072) |   |   |   |   | └─StringSyntax
+//@[062:00072) |   |   |   |   |   └─Token(StringComplete) |'mySecret'|
+//@[072:00073) |   |   |   |   ├─Token(Comma) |,|
+//@[073:00088) |   |   |   |   ├─FunctionArgumentSyntax
+//@[073:00088) |   |   |   |   | └─StringSyntax
+//@[073:00088) |   |   |   |   |   └─Token(StringComplete) |'secretVersion'|
+//@[088:00089) |   |   |   |   └─Token(RightParen) |)|
+//@[090:00091) |   |   |   ├─Token(Colon) |:|
+//@[092:00101) |   |   |   └─StringSyntax
+//@[092:00101) |   |   |     └─Token(StringComplete) |'notTrue'|
+//@[101:00103) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+// END: Key Vault Secret Reference
+//@[034:00038) ├─Token(NewLine) |\r\n\r\n|
+
+module withSpace 'module with space.bicep' = {
+//@[000:00070) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00016) | ├─IdentifierSyntax
+//@[007:00016) | | └─Token(Identifier) |withSpace|
+//@[017:00042) | ├─StringSyntax
+//@[017:00042) | | └─Token(StringComplete) |'module with space.bicep'|
+//@[043:00044) | ├─Token(Assignment) |=|
+//@[045:00070) | └─ObjectSyntax
+//@[045:00046) |   ├─Token(LeftBrace) |{|
+//@[046:00048) |   ├─Token(NewLine) |\r\n|
+  name: 'withSpace'
+//@[002:00019) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00019) |   | └─StringSyntax
+//@[008:00019) |   |   └─Token(StringComplete) |'withSpace'|
+//@[019:00021) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+//@[000:00104) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00022) | ├─IdentifierSyntax
+//@[007:00022) | | └─Token(Identifier) |folderWithSpace|
+//@[023:00071) | ├─StringSyntax
+//@[023:00071) | | └─Token(StringComplete) |'child/folder with space/child with space.bicep'|
+//@[072:00073) | ├─Token(Assignment) |=|
+//@[074:00104) | └─ObjectSyntax
+//@[074:00075) |   ├─Token(LeftBrace) |{|
+//@[075:00077) |   ├─Token(NewLine) |\r\n|
+  name: 'childWithSpace'
+//@[002:00024) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00024) |   | └─StringSyntax
+//@[008:00024) |   |   └─Token(StringComplete) |'childWithSpace'|
+//@[024:00026) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+// nameof
+//@[009:00013) ├─Token(NewLine) |\r\n\r\n|
+
+var nameofModule = nameof(folderWithSpace)
+//@[000:00042) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00016) | ├─IdentifierSyntax
+//@[004:00016) | | └─Token(Identifier) |nameofModule|
+//@[017:00018) | ├─Token(Assignment) |=|
+//@[019:00042) | └─FunctionCallSyntax
+//@[019:00025) |   ├─IdentifierSyntax
+//@[019:00025) |   | └─Token(Identifier) |nameof|
+//@[025:00026) |   ├─Token(LeftParen) |(|
+//@[026:00041) |   ├─FunctionArgumentSyntax
+//@[026:00041) |   | └─VariableAccessSyntax
+//@[026:00041) |   |   └─IdentifierSyntax
+//@[026:00041) |   |     └─Token(Identifier) |folderWithSpace|
+//@[041:00042) |   └─Token(RightParen) |)|
+//@[042:00044) ├─Token(NewLine) |\r\n|
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+//@[000:00081) ├─VariableDeclarationSyntax
+//@[000:00003) | ├─Token(Identifier) |var|
+//@[004:00021) | ├─IdentifierSyntax
+//@[004:00021) | | └─Token(Identifier) |nameofModuleParam|
+//@[022:00023) | ├─Token(Assignment) |=|
+//@[024:00081) | └─FunctionCallSyntax
+//@[024:00030) |   ├─IdentifierSyntax
+//@[024:00030) |   | └─Token(Identifier) |nameof|
+//@[030:00031) |   ├─Token(LeftParen) |(|
+//@[031:00080) |   ├─FunctionArgumentSyntax
+//@[031:00080) |   | └─PropertyAccessSyntax
+//@[031:00060) |   |   ├─PropertyAccessSyntax
+//@[031:00052) |   |   | ├─VariableAccessSyntax
+//@[031:00052) |   |   | | └─IdentifierSyntax
+//@[031:00052) |   |   | |   └─Token(Identifier) |secureModuleCondition|
+//@[052:00053) |   |   | ├─Token(Dot) |.|
+//@[053:00060) |   |   | └─IdentifierSyntax
+//@[053:00060) |   |   |   └─Token(Identifier) |outputs|
+//@[060:00061) |   |   ├─Token(Dot) |.|
+//@[061:00080) |   |   └─IdentifierSyntax
+//@[061:00080) |   |     └─Token(Identifier) |exposedSecureString|
+//@[080:00081) |   └─Token(RightParen) |)|
+//@[081:00085) ├─Token(NewLine) |\r\n\r\n|
+
+module moduleWithNameof 'modulea.bicep' = {
+//@[000:00358) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00023) | ├─IdentifierSyntax
+//@[007:00023) | | └─Token(Identifier) |moduleWithNameof|
+//@[024:00039) | ├─StringSyntax
+//@[024:00039) | | └─Token(StringComplete) |'modulea.bicep'|
+//@[040:00041) | ├─Token(Assignment) |=|
+//@[042:00358) | └─ObjectSyntax
+//@[042:00043) |   ├─Token(LeftBrace) |{|
+//@[043:00045) |   ├─Token(NewLine) |\r\n|
+  name: 'nameofModule'
+//@[002:00022) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00022) |   | └─StringSyntax
+//@[008:00022) |   |   └─Token(StringComplete) |'nameofModule'|
+//@[022:00024) |   ├─Token(NewLine) |\r\n|
+  scope: resourceGroup(nameof(nameofModuleParam))
+//@[002:00049) |   ├─ObjectPropertySyntax
+//@[002:00007) |   | ├─IdentifierSyntax
+//@[002:00007) |   | | └─Token(Identifier) |scope|
+//@[007:00008) |   | ├─Token(Colon) |:|
+//@[009:00049) |   | └─FunctionCallSyntax
+//@[009:00022) |   |   ├─IdentifierSyntax
+//@[009:00022) |   |   | └─Token(Identifier) |resourceGroup|
+//@[022:00023) |   |   ├─Token(LeftParen) |(|
+//@[023:00048) |   |   ├─FunctionArgumentSyntax
+//@[023:00048) |   |   | └─FunctionCallSyntax
+//@[023:00029) |   |   |   ├─IdentifierSyntax
+//@[023:00029) |   |   |   | └─Token(Identifier) |nameof|
+//@[029:00030) |   |   |   ├─Token(LeftParen) |(|
+//@[030:00047) |   |   |   ├─FunctionArgumentSyntax
+//@[030:00047) |   |   |   | └─VariableAccessSyntax
+//@[030:00047) |   |   |   |   └─IdentifierSyntax
+//@[030:00047) |   |   |   |     └─Token(Identifier) |nameofModuleParam|
+//@[047:00048) |   |   |   └─Token(RightParen) |)|
+//@[048:00049) |   |   └─Token(RightParen) |)|
+//@[049:00051) |   ├─Token(NewLine) |\r\n|
+  params:{
+//@[002:00235) |   ├─ObjectPropertySyntax
+//@[002:00008) |   | ├─IdentifierSyntax
+//@[002:00008) |   | | └─Token(Identifier) |params|
+//@[008:00009) |   | ├─Token(Colon) |:|
+//@[009:00235) |   | └─ObjectSyntax
+//@[009:00010) |   |   ├─Token(LeftBrace) |{|
+//@[010:00012) |   |   ├─Token(NewLine) |\r\n|
+    stringParamA: nameof(withSpace)
+//@[004:00035) |   |   ├─ObjectPropertySyntax
+//@[004:00016) |   |   | ├─IdentifierSyntax
+//@[004:00016) |   |   | | └─Token(Identifier) |stringParamA|
+//@[016:00017) |   |   | ├─Token(Colon) |:|
+//@[018:00035) |   |   | └─FunctionCallSyntax
+//@[018:00024) |   |   |   ├─IdentifierSyntax
+//@[018:00024) |   |   |   | └─Token(Identifier) |nameof|
+//@[024:00025) |   |   |   ├─Token(LeftParen) |(|
+//@[025:00034) |   |   |   ├─FunctionArgumentSyntax
+//@[025:00034) |   |   |   | └─VariableAccessSyntax
+//@[025:00034) |   |   |   |   └─IdentifierSyntax
+//@[025:00034) |   |   |   |     └─Token(Identifier) |withSpace|
+//@[034:00035) |   |   |   └─Token(RightParen) |)|
+//@[035:00037) |   |   ├─Token(NewLine) |\r\n|
+    stringParamB: nameof(folderWithSpace)
+//@[004:00041) |   |   ├─ObjectPropertySyntax
+//@[004:00016) |   |   | ├─IdentifierSyntax
+//@[004:00016) |   |   | | └─Token(Identifier) |stringParamB|
+//@[016:00017) |   |   | ├─Token(Colon) |:|
+//@[018:00041) |   |   | └─FunctionCallSyntax
+//@[018:00024) |   |   |   ├─IdentifierSyntax
+//@[018:00024) |   |   |   | └─Token(Identifier) |nameof|
+//@[024:00025) |   |   |   ├─Token(LeftParen) |(|
+//@[025:00040) |   |   |   ├─FunctionArgumentSyntax
+//@[025:00040) |   |   |   | └─VariableAccessSyntax
+//@[025:00040) |   |   |   |   └─IdentifierSyntax
+//@[025:00040) |   |   |   |     └─Token(Identifier) |folderWithSpace|
+//@[040:00041) |   |   |   └─Token(RightParen) |)|
+//@[041:00043) |   |   ├─Token(NewLine) |\r\n|
+    objParam: {
+//@[004:00090) |   |   ├─ObjectPropertySyntax
+//@[004:00012) |   |   | ├─IdentifierSyntax
+//@[004:00012) |   |   | | └─Token(Identifier) |objParam|
+//@[012:00013) |   |   | ├─Token(Colon) |:|
+//@[014:00090) |   |   | └─ObjectSyntax
+//@[014:00015) |   |   |   ├─Token(LeftBrace) |{|
+//@[015:00017) |   |   |   ├─Token(NewLine) |\r\n|
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+//@[006:00066) |   |   |   ├─ObjectPropertySyntax
+//@[006:00007) |   |   |   | ├─IdentifierSyntax
+//@[006:00007) |   |   |   | | └─Token(Identifier) |a|
+//@[007:00008) |   |   |   | ├─Token(Colon) |:|
+//@[009:00066) |   |   |   | └─FunctionCallSyntax
+//@[009:00015) |   |   |   |   ├─IdentifierSyntax
+//@[009:00015) |   |   |   |   | └─Token(Identifier) |nameof|
+//@[015:00016) |   |   |   |   ├─Token(LeftParen) |(|
+//@[016:00065) |   |   |   |   ├─FunctionArgumentSyntax
+//@[016:00065) |   |   |   |   | └─PropertyAccessSyntax
+//@[016:00045) |   |   |   |   |   ├─PropertyAccessSyntax
+//@[016:00037) |   |   |   |   |   | ├─VariableAccessSyntax
+//@[016:00037) |   |   |   |   |   | | └─IdentifierSyntax
+//@[016:00037) |   |   |   |   |   | |   └─Token(Identifier) |secureModuleCondition|
+//@[037:00038) |   |   |   |   |   | ├─Token(Dot) |.|
+//@[038:00045) |   |   |   |   |   | └─IdentifierSyntax
+//@[038:00045) |   |   |   |   |   |   └─Token(Identifier) |outputs|
+//@[045:00046) |   |   |   |   |   ├─Token(Dot) |.|
+//@[046:00065) |   |   |   |   |   └─IdentifierSyntax
+//@[046:00065) |   |   |   |   |     └─Token(Identifier) |exposedSecureString|
+//@[065:00066) |   |   |   |   └─Token(RightParen) |)|
+//@[066:00068) |   |   |   ├─Token(NewLine) |\r\n|
+    }
+//@[004:00005) |   |   |   └─Token(RightBrace) |}|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+    arrayParam: [
+//@[004:00046) |   |   ├─ObjectPropertySyntax
+//@[004:00014) |   |   | ├─IdentifierSyntax
+//@[004:00014) |   |   | | └─Token(Identifier) |arrayParam|
+//@[014:00015) |   |   | ├─Token(Colon) |:|
+//@[016:00046) |   |   | └─ArraySyntax
+//@[016:00017) |   |   |   ├─Token(LeftSquare) |[|
+//@[017:00019) |   |   |   ├─Token(NewLine) |\r\n|
+      nameof(vaults)
+//@[006:00020) |   |   |   ├─ArrayItemSyntax
+//@[006:00020) |   |   |   | └─FunctionCallSyntax
+//@[006:00012) |   |   |   |   ├─IdentifierSyntax
+//@[006:00012) |   |   |   |   | └─Token(Identifier) |nameof|
+//@[012:00013) |   |   |   |   ├─Token(LeftParen) |(|
+//@[013:00019) |   |   |   |   ├─FunctionArgumentSyntax
+//@[013:00019) |   |   |   |   | └─VariableAccessSyntax
+//@[013:00019) |   |   |   |   |   └─IdentifierSyntax
+//@[013:00019) |   |   |   |   |     └─Token(Identifier) |vaults|
+//@[019:00020) |   |   |   |   └─Token(RightParen) |)|
+//@[020:00022) |   |   |   ├─Token(NewLine) |\r\n|
+    ]
+//@[004:00005) |   |   |   └─Token(RightSquare) |]|
+//@[005:00007) |   |   ├─Token(NewLine) |\r\n|
+  }
+//@[002:00003) |   |   └─Token(RightBrace) |}|
+//@[003:00005) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+//@[000:00096) ├─ModuleDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |module|
+//@[007:00032) | ├─IdentifierSyntax
+//@[007:00032) | | └─Token(Identifier) |moduleWithNullableOutputs|
+//@[033:00062) | ├─StringSyntax
+//@[033:00062) | | └─Token(StringComplete) |'child/nullableOutputs.bicep'|
+//@[063:00064) | ├─Token(Assignment) |=|
+//@[065:00096) | └─ObjectSyntax
+//@[065:00066) |   ├─Token(LeftBrace) |{|
+//@[066:00068) |   ├─Token(NewLine) |\r\n|
+  name: 'nullableOutputs'
+//@[002:00025) |   ├─ObjectPropertySyntax
+//@[002:00006) |   | ├─IdentifierSyntax
+//@[002:00006) |   | | └─Token(Identifier) |name|
+//@[006:00007) |   | ├─Token(Colon) |:|
+//@[008:00025) |   | └─StringSyntax
+//@[008:00025) |   |   └─Token(StringComplete) |'nullableOutputs'|
+//@[025:00027) |   ├─Token(NewLine) |\r\n|
+}
+//@[000:00001) |   └─Token(RightBrace) |}|
+//@[001:00005) ├─Token(NewLine) |\r\n\r\n|
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+//@[000:00081) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00021) | ├─IdentifierSyntax
+//@[007:00021) | | └─Token(Identifier) |nullableString|
+//@[022:00029) | ├─NullableTypeSyntax
+//@[022:00028) | | ├─TypeVariableAccessSyntax
+//@[022:00028) | | | └─IdentifierSyntax
+//@[022:00028) | | |   └─Token(Identifier) |string|
+//@[028:00029) | | └─Token(Question) |?|
+//@[030:00031) | ├─Token(Assignment) |=|
+//@[032:00081) | └─PropertyAccessSyntax
+//@[032:00065) |   ├─PropertyAccessSyntax
+//@[032:00057) |   | ├─VariableAccessSyntax
+//@[032:00057) |   | | └─IdentifierSyntax
+//@[032:00057) |   | |   └─Token(Identifier) |moduleWithNullableOutputs|
+//@[057:00058) |   | ├─Token(Dot) |.|
+//@[058:00065) |   | └─IdentifierSyntax
+//@[058:00065) |   |   └─Token(Identifier) |outputs|
+//@[065:00066) |   ├─Token(Dot) |.|
+//@[066:00067) |   ├─Token(Question) |?|
+//@[067:00081) |   └─IdentifierSyntax
+//@[067:00081) |     └─Token(Identifier) |nullableString|
+//@[081:00083) ├─Token(NewLine) |\r\n|
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+//@[000:00107) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00027) | ├─IdentifierSyntax
+//@[007:00027) | | └─Token(Identifier) |deeplyNestedProperty|
+//@[028:00035) | ├─NullableTypeSyntax
+//@[028:00034) | | ├─TypeVariableAccessSyntax
+//@[028:00034) | | | └─IdentifierSyntax
+//@[028:00034) | | |   └─Token(Identifier) |string|
+//@[034:00035) | | └─Token(Question) |?|
+//@[036:00037) | ├─Token(Assignment) |=|
+//@[038:00107) | └─PropertyAccessSyntax
+//@[038:00098) |   ├─PropertyAccessSyntax
+//@[038:00091) |   | ├─PropertyAccessSyntax
+//@[038:00084) |   | | ├─PropertyAccessSyntax
+//@[038:00071) |   | | | ├─PropertyAccessSyntax
+//@[038:00063) |   | | | | ├─VariableAccessSyntax
+//@[038:00063) |   | | | | | └─IdentifierSyntax
+//@[038:00063) |   | | | | |   └─Token(Identifier) |moduleWithNullableOutputs|
+//@[063:00064) |   | | | | ├─Token(Dot) |.|
+//@[064:00071) |   | | | | └─IdentifierSyntax
+//@[064:00071) |   | | | |   └─Token(Identifier) |outputs|
+//@[071:00072) |   | | | ├─Token(Dot) |.|
+//@[072:00073) |   | | | ├─Token(Question) |?|
+//@[073:00084) |   | | | └─IdentifierSyntax
+//@[073:00084) |   | | |   └─Token(Identifier) |nullableObj|
+//@[084:00085) |   | | ├─Token(Dot) |.|
+//@[085:00091) |   | | └─IdentifierSyntax
+//@[085:00091) |   | |   └─Token(Identifier) |deeply|
+//@[091:00092) |   | ├─Token(Dot) |.|
+//@[092:00098) |   | └─IdentifierSyntax
+//@[092:00098) |   |   └─Token(Identifier) |nested|
+//@[098:00099) |   ├─Token(Dot) |.|
+//@[099:00107) |   └─IdentifierSyntax
+//@[099:00107) |     └─Token(Identifier) |property|
+//@[107:00109) ├─Token(NewLine) |\r\n|
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+//@[000:00108) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00028) | ├─IdentifierSyntax
+//@[007:00028) | | └─Token(Identifier) |deeplyNestedArrayItem|
+//@[029:00036) | ├─NullableTypeSyntax
+//@[029:00035) | | ├─TypeVariableAccessSyntax
+//@[029:00035) | | | └─IdentifierSyntax
+//@[029:00035) | | |   └─Token(Identifier) |string|
+//@[035:00036) | | └─Token(Question) |?|
+//@[037:00038) | ├─Token(Assignment) |=|
+//@[039:00108) | └─ArrayAccessSyntax
+//@[039:00105) |   ├─PropertyAccessSyntax
+//@[039:00099) |   | ├─PropertyAccessSyntax
+//@[039:00092) |   | | ├─PropertyAccessSyntax
+//@[039:00085) |   | | | ├─PropertyAccessSyntax
+//@[039:00072) |   | | | | ├─PropertyAccessSyntax
+//@[039:00064) |   | | | | | ├─VariableAccessSyntax
+//@[039:00064) |   | | | | | | └─IdentifierSyntax
+//@[039:00064) |   | | | | | |   └─Token(Identifier) |moduleWithNullableOutputs|
+//@[064:00065) |   | | | | | ├─Token(Dot) |.|
+//@[065:00072) |   | | | | | └─IdentifierSyntax
+//@[065:00072) |   | | | | |   └─Token(Identifier) |outputs|
+//@[072:00073) |   | | | | ├─Token(Dot) |.|
+//@[073:00074) |   | | | | ├─Token(Question) |?|
+//@[074:00085) |   | | | | └─IdentifierSyntax
+//@[074:00085) |   | | | |   └─Token(Identifier) |nullableObj|
+//@[085:00086) |   | | | ├─Token(Dot) |.|
+//@[086:00092) |   | | | └─IdentifierSyntax
+//@[086:00092) |   | | |   └─Token(Identifier) |deeply|
+//@[092:00093) |   | | ├─Token(Dot) |.|
+//@[093:00099) |   | | └─IdentifierSyntax
+//@[093:00099) |   | |   └─Token(Identifier) |nested|
+//@[099:00100) |   | ├─Token(Dot) |.|
+//@[100:00105) |   | └─IdentifierSyntax
+//@[100:00105) |   |   └─Token(Identifier) |array|
+//@[105:00106) |   ├─Token(LeftSquare) |[|
+//@[106:00107) |   ├─IntegerLiteralSyntax
+//@[106:00107) |   | └─Token(Integer) |0|
+//@[107:00108) |   └─Token(RightSquare) |]|
+//@[108:00110) ├─Token(NewLine) |\r\n|
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+//@[000:00116) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00035) | ├─IdentifierSyntax
+//@[007:00035) | | └─Token(Identifier) |deeplyNestedArrayItemFromEnd|
+//@[036:00043) | ├─NullableTypeSyntax
+//@[036:00042) | | ├─TypeVariableAccessSyntax
+//@[036:00042) | | | └─IdentifierSyntax
+//@[036:00042) | | |   └─Token(Identifier) |string|
+//@[042:00043) | | └─Token(Question) |?|
+//@[044:00045) | ├─Token(Assignment) |=|
+//@[046:00116) | └─ArrayAccessSyntax
+//@[046:00112) |   ├─PropertyAccessSyntax
+//@[046:00106) |   | ├─PropertyAccessSyntax
+//@[046:00099) |   | | ├─PropertyAccessSyntax
+//@[046:00092) |   | | | ├─PropertyAccessSyntax
+//@[046:00079) |   | | | | ├─PropertyAccessSyntax
+//@[046:00071) |   | | | | | ├─VariableAccessSyntax
+//@[046:00071) |   | | | | | | └─IdentifierSyntax
+//@[046:00071) |   | | | | | |   └─Token(Identifier) |moduleWithNullableOutputs|
+//@[071:00072) |   | | | | | ├─Token(Dot) |.|
+//@[072:00079) |   | | | | | └─IdentifierSyntax
+//@[072:00079) |   | | | | |   └─Token(Identifier) |outputs|
+//@[079:00080) |   | | | | ├─Token(Dot) |.|
+//@[080:00081) |   | | | | ├─Token(Question) |?|
+//@[081:00092) |   | | | | └─IdentifierSyntax
+//@[081:00092) |   | | | |   └─Token(Identifier) |nullableObj|
+//@[092:00093) |   | | | ├─Token(Dot) |.|
+//@[093:00099) |   | | | └─IdentifierSyntax
+//@[093:00099) |   | | |   └─Token(Identifier) |deeply|
+//@[099:00100) |   | | ├─Token(Dot) |.|
+//@[100:00106) |   | | └─IdentifierSyntax
+//@[100:00106) |   | |   └─Token(Identifier) |nested|
+//@[106:00107) |   | ├─Token(Dot) |.|
+//@[107:00112) |   | └─IdentifierSyntax
+//@[107:00112) |   |   └─Token(Identifier) |array|
+//@[112:00113) |   ├─Token(LeftSquare) |[|
+//@[113:00114) |   ├─Token(Hat) |^|
+//@[114:00115) |   ├─IntegerLiteralSyntax
+//@[114:00115) |   | └─Token(Integer) |1|
+//@[115:00116) |   └─Token(RightSquare) |]|
+//@[116:00118) ├─Token(NewLine) |\r\n|
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]
+//@[000:00124) ├─OutputDeclarationSyntax
+//@[000:00006) | ├─Token(Identifier) |output|
+//@[007:00042) | ├─IdentifierSyntax
+//@[007:00042) | | └─Token(Identifier) |deeplyNestedArrayItemFromEndAttempt|
+//@[043:00050) | ├─NullableTypeSyntax
+//@[043:00049) | | ├─TypeVariableAccessSyntax
+//@[043:00049) | | | └─IdentifierSyntax
+//@[043:00049) | | |   └─Token(Identifier) |string|
+//@[049:00050) | | └─Token(Question) |?|
+//@[051:00052) | ├─Token(Assignment) |=|
+//@[053:00124) | └─ArrayAccessSyntax
+//@[053:00119) |   ├─PropertyAccessSyntax
+//@[053:00113) |   | ├─PropertyAccessSyntax
+//@[053:00106) |   | | ├─PropertyAccessSyntax
+//@[053:00099) |   | | | ├─PropertyAccessSyntax
+//@[053:00086) |   | | | | ├─PropertyAccessSyntax
+//@[053:00078) |   | | | | | ├─VariableAccessSyntax
+//@[053:00078) |   | | | | | | └─IdentifierSyntax
+//@[053:00078) |   | | | | | |   └─Token(Identifier) |moduleWithNullableOutputs|
+//@[078:00079) |   | | | | | ├─Token(Dot) |.|
+//@[079:00086) |   | | | | | └─IdentifierSyntax
+//@[079:00086) |   | | | | |   └─Token(Identifier) |outputs|
+//@[086:00087) |   | | | | ├─Token(Dot) |.|
+//@[087:00088) |   | | | | ├─Token(Question) |?|
+//@[088:00099) |   | | | | └─IdentifierSyntax
+//@[088:00099) |   | | | |   └─Token(Identifier) |nullableObj|
+//@[099:00100) |   | | | ├─Token(Dot) |.|
+//@[100:00106) |   | | | └─IdentifierSyntax
+//@[100:00106) |   | | |   └─Token(Identifier) |deeply|
+//@[106:00107) |   | | ├─Token(Dot) |.|
+//@[107:00113) |   | | └─IdentifierSyntax
+//@[107:00113) |   | |   └─Token(Identifier) |nested|
+//@[113:00114) |   | ├─Token(Dot) |.|
+//@[114:00119) |   | └─IdentifierSyntax
+//@[114:00119) |   |   └─Token(Identifier) |array|
+//@[119:00120) |   ├─Token(LeftSquare) |[|
+//@[120:00121) |   ├─Token(Question) |?|
+//@[121:00122) |   ├─Token(Hat) |^|
+//@[122:00123) |   ├─IntegerLiteralSyntax
+//@[122:00123) |   | └─Token(Integer) |1|
+//@[123:00124) |   └─Token(RightSquare) |]|
+//@[124:00126) ├─Token(NewLine) |\r\n|
+
+//@[000:00000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/main.tokens.bicep
@@ -1,0 +1,2340 @@
+
+//@[000:002) NewLine |\r\n|
+@sys.description('this is deployTimeSuffix param')
+//@[000:001) At |@|
+//@[001:004) Identifier |sys|
+//@[004:005) Dot |.|
+//@[005:016) Identifier |description|
+//@[016:017) LeftParen |(|
+//@[017:049) StringComplete |'this is deployTimeSuffix param'|
+//@[049:050) RightParen |)|
+//@[050:052) NewLine |\r\n|
+param deployTimeSuffix string = newGuid()
+//@[000:005) Identifier |param|
+//@[006:022) Identifier |deployTimeSuffix|
+//@[023:029) Identifier |string|
+//@[030:031) Assignment |=|
+//@[032:039) Identifier |newGuid|
+//@[039:040) LeftParen |(|
+//@[040:041) RightParen |)|
+//@[041:045) NewLine |\r\n\r\n|
+
+@sys.description('this module a')
+//@[000:001) At |@|
+//@[001:004) Identifier |sys|
+//@[004:005) Dot |.|
+//@[005:016) Identifier |description|
+//@[016:017) LeftParen |(|
+//@[017:032) StringComplete |'this module a'|
+//@[032:033) RightParen |)|
+//@[033:035) NewLine |\r\n|
+module modATest './modulea.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:015) Identifier |modATest|
+//@[016:033) StringComplete |'./modulea.bicep'|
+//@[034:035) Assignment |=|
+//@[036:037) LeftBrace |{|
+//@[037:039) NewLine |\r\n|
+  name: 'modATest'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:018) StringComplete |'modATest'|
+//@[018:020) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    stringParamB: 'hello!'
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:026) StringComplete |'hello!'|
+//@[026:028) NewLine |\r\n|
+    objParam: {
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:017) NewLine |\r\n|
+      a: 'b'
+//@[006:007) Identifier |a|
+//@[007:008) Colon |:|
+//@[009:012) StringComplete |'b'|
+//@[012:014) NewLine |\r\n|
+    }
+//@[004:005) RightBrace |}|
+//@[005:007) NewLine |\r\n|
+    arrayParam: [
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:019) NewLine |\r\n|
+      {
+//@[006:007) LeftBrace |{|
+//@[007:009) NewLine |\r\n|
+        a: 'b'
+//@[008:009) Identifier |a|
+//@[009:010) Colon |:|
+//@[011:014) StringComplete |'b'|
+//@[014:016) NewLine |\r\n|
+      }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+      'abc'
+//@[006:011) StringComplete |'abc'|
+//@[011:013) NewLine |\r\n|
+    ]
+//@[004:005) RightSquare |]|
+//@[005:007) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:007) NewLine |\r\n\r\n\r\n|
+
+
+@sys.description('this module b')
+//@[000:001) At |@|
+//@[001:004) Identifier |sys|
+//@[004:005) Dot |.|
+//@[005:016) Identifier |description|
+//@[016:017) LeftParen |(|
+//@[017:032) StringComplete |'this module b'|
+//@[032:033) RightParen |)|
+//@[033:035) NewLine |\r\n|
+module modB './child/moduleb.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:011) Identifier |modB|
+//@[012:035) StringComplete |'./child/moduleb.bicep'|
+//@[036:037) Assignment |=|
+//@[038:039) LeftBrace |{|
+//@[039:041) NewLine |\r\n|
+  name: 'modB'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:014) StringComplete |'modB'|
+//@[014:016) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    location: 'West US'
+//@[004:012) Identifier |location|
+//@[012:013) Colon |:|
+//@[014:023) StringComplete |'West US'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+@sys.description('this is just module b with a condition')
+//@[000:001) At |@|
+//@[001:004) Identifier |sys|
+//@[004:005) Dot |.|
+//@[005:016) Identifier |description|
+//@[016:017) LeftParen |(|
+//@[017:057) StringComplete |'this is just module b with a condition'|
+//@[057:058) RightParen |)|
+//@[058:060) NewLine |\r\n|
+module modBWithCondition './child/moduleb.bicep' = if (1 + 1 == 2) {
+//@[000:006) Identifier |module|
+//@[007:024) Identifier |modBWithCondition|
+//@[025:048) StringComplete |'./child/moduleb.bicep'|
+//@[049:050) Assignment |=|
+//@[051:053) Identifier |if|
+//@[054:055) LeftParen |(|
+//@[055:056) Integer |1|
+//@[057:058) Plus |+|
+//@[059:060) Integer |1|
+//@[061:063) Equals |==|
+//@[064:065) Integer |2|
+//@[065:066) RightParen |)|
+//@[067:068) LeftBrace |{|
+//@[068:070) NewLine |\r\n|
+  name: 'modBWithCondition'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:027) StringComplete |'modBWithCondition'|
+//@[027:029) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    location: 'East US'
+//@[004:012) Identifier |location|
+//@[012:013) Colon |:|
+//@[014:023) StringComplete |'East US'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module modBWithCondition2 './child/moduleb.bicep' =
+//@[000:006) Identifier |module|
+//@[007:025) Identifier |modBWithCondition2|
+//@[026:049) StringComplete |'./child/moduleb.bicep'|
+//@[050:051) Assignment |=|
+//@[051:053) NewLine |\r\n|
+// awkward comment
+//@[018:020) NewLine |\r\n|
+if (1 + 1 == 2) {
+//@[000:002) Identifier |if|
+//@[003:004) LeftParen |(|
+//@[004:005) Integer |1|
+//@[006:007) Plus |+|
+//@[008:009) Integer |1|
+//@[010:012) Equals |==|
+//@[013:014) Integer |2|
+//@[014:015) RightParen |)|
+//@[016:017) LeftBrace |{|
+//@[017:019) NewLine |\r\n|
+  name: 'modBWithCondition2'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:028) StringComplete |'modBWithCondition2'|
+//@[028:030) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    location: 'East US'
+//@[004:012) Identifier |location|
+//@[012:013) Colon |:|
+//@[014:023) StringComplete |'East US'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module modC './child/modulec.json' = {
+//@[000:006) Identifier |module|
+//@[007:011) Identifier |modC|
+//@[012:034) StringComplete |'./child/modulec.json'|
+//@[035:036) Assignment |=|
+//@[037:038) LeftBrace |{|
+//@[038:040) NewLine |\r\n|
+  name: 'modC'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:014) StringComplete |'modC'|
+//@[014:016) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    location: 'West US'
+//@[004:012) Identifier |location|
+//@[012:013) Colon |:|
+//@[014:023) StringComplete |'West US'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module modCWithCondition './child/modulec.json' = if (2 - 1 == 1) {
+//@[000:006) Identifier |module|
+//@[007:024) Identifier |modCWithCondition|
+//@[025:047) StringComplete |'./child/modulec.json'|
+//@[048:049) Assignment |=|
+//@[050:052) Identifier |if|
+//@[053:054) LeftParen |(|
+//@[054:055) Integer |2|
+//@[056:057) Minus |-|
+//@[058:059) Integer |1|
+//@[060:062) Equals |==|
+//@[063:064) Integer |1|
+//@[064:065) RightParen |)|
+//@[066:067) LeftBrace |{|
+//@[067:069) NewLine |\r\n|
+  name: 'modCWithCondition'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:027) StringComplete |'modCWithCondition'|
+//@[027:029) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    location: 'East US'
+//@[004:012) Identifier |location|
+//@[012:013) Colon |:|
+//@[014:023) StringComplete |'East US'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module optionalWithNoParams1 './child/optionalParams.bicep'= {
+//@[000:006) Identifier |module|
+//@[007:028) Identifier |optionalWithNoParams1|
+//@[029:059) StringComplete |'./child/optionalParams.bicep'|
+//@[059:060) Assignment |=|
+//@[061:062) LeftBrace |{|
+//@[062:064) NewLine |\r\n|
+  name: 'optionalWithNoParams1'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:031) StringComplete |'optionalWithNoParams1'|
+//@[031:033) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module optionalWithNoParams2 './child/optionalParams.bicep'= {
+//@[000:006) Identifier |module|
+//@[007:028) Identifier |optionalWithNoParams2|
+//@[029:059) StringComplete |'./child/optionalParams.bicep'|
+//@[059:060) Assignment |=|
+//@[061:062) LeftBrace |{|
+//@[062:064) NewLine |\r\n|
+  name: 'optionalWithNoParams2'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:031) StringComplete |'optionalWithNoParams2'|
+//@[031:033) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module optionalWithAllParams './child/optionalParams.bicep'= {
+//@[000:006) Identifier |module|
+//@[007:028) Identifier |optionalWithAllParams|
+//@[029:059) StringComplete |'./child/optionalParams.bicep'|
+//@[059:060) Assignment |=|
+//@[061:062) LeftBrace |{|
+//@[062:064) NewLine |\r\n|
+  name: 'optionalWithNoParams3'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:031) StringComplete |'optionalWithNoParams3'|
+//@[031:033) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    optionalString: 'abc'
+//@[004:018) Identifier |optionalString|
+//@[018:019) Colon |:|
+//@[020:025) StringComplete |'abc'|
+//@[025:027) NewLine |\r\n|
+    optionalInt: 42
+//@[004:015) Identifier |optionalInt|
+//@[015:016) Colon |:|
+//@[017:019) Integer |42|
+//@[019:021) NewLine |\r\n|
+    optionalObj: { }
+//@[004:015) Identifier |optionalObj|
+//@[015:016) Colon |:|
+//@[017:018) LeftBrace |{|
+//@[019:020) RightBrace |}|
+//@[020:022) NewLine |\r\n|
+    optionalArray: [ ]
+//@[004:017) Identifier |optionalArray|
+//@[017:018) Colon |:|
+//@[019:020) LeftSquare |[|
+//@[021:022) RightSquare |]|
+//@[022:024) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+resource resWithDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:008) Identifier |resource|
+//@[009:028) Identifier |resWithDependencies|
+//@[029:062) StringComplete |'Mock.Rp/mockResource@2020-01-01'|
+//@[063:064) Assignment |=|
+//@[065:066) LeftBrace |{|
+//@[066:068) NewLine |\r\n|
+  name: 'harry'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:015) StringComplete |'harry'|
+//@[015:017) NewLine |\r\n|
+  properties: {
+//@[002:012) Identifier |properties|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:017) NewLine |\r\n|
+    modADep: modATest.outputs.stringOutputA
+//@[004:011) Identifier |modADep|
+//@[011:012) Colon |:|
+//@[013:021) Identifier |modATest|
+//@[021:022) Dot |.|
+//@[022:029) Identifier |outputs|
+//@[029:030) Dot |.|
+//@[030:043) Identifier |stringOutputA|
+//@[043:045) NewLine |\r\n|
+    modBDep: modB.outputs.myResourceId
+//@[004:011) Identifier |modBDep|
+//@[011:012) Colon |:|
+//@[013:017) Identifier |modB|
+//@[017:018) Dot |.|
+//@[018:025) Identifier |outputs|
+//@[025:026) Dot |.|
+//@[026:038) Identifier |myResourceId|
+//@[038:040) NewLine |\r\n|
+    modCDep: modC.outputs.myResourceId
+//@[004:011) Identifier |modCDep|
+//@[011:012) Colon |:|
+//@[013:017) Identifier |modC|
+//@[017:018) Dot |.|
+//@[018:025) Identifier |outputs|
+//@[025:026) Dot |.|
+//@[026:038) Identifier |myResourceId|
+//@[038:040) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module optionalWithAllParamsAndManualDependency './child/optionalParams.bicep'= {
+//@[000:006) Identifier |module|
+//@[007:047) Identifier |optionalWithAllParamsAndManualDependency|
+//@[048:078) StringComplete |'./child/optionalParams.bicep'|
+//@[078:079) Assignment |=|
+//@[080:081) LeftBrace |{|
+//@[081:083) NewLine |\r\n|
+  name: 'optionalWithAllParamsAndManualDependency'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:050) StringComplete |'optionalWithAllParamsAndManualDependency'|
+//@[050:052) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    optionalString: 'abc'
+//@[004:018) Identifier |optionalString|
+//@[018:019) Colon |:|
+//@[020:025) StringComplete |'abc'|
+//@[025:027) NewLine |\r\n|
+    optionalInt: 42
+//@[004:015) Identifier |optionalInt|
+//@[015:016) Colon |:|
+//@[017:019) Integer |42|
+//@[019:021) NewLine |\r\n|
+    optionalObj: { }
+//@[004:015) Identifier |optionalObj|
+//@[015:016) Colon |:|
+//@[017:018) LeftBrace |{|
+//@[019:020) RightBrace |}|
+//@[020:022) NewLine |\r\n|
+    optionalArray: [ ]
+//@[004:017) Identifier |optionalArray|
+//@[017:018) Colon |:|
+//@[019:020) LeftSquare |[|
+//@[021:022) RightSquare |]|
+//@[022:024) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+  dependsOn: [
+//@[002:011) Identifier |dependsOn|
+//@[011:012) Colon |:|
+//@[013:014) LeftSquare |[|
+//@[014:016) NewLine |\r\n|
+    resWithDependencies
+//@[004:023) Identifier |resWithDependencies|
+//@[023:025) NewLine |\r\n|
+    optionalWithAllParams
+//@[004:025) Identifier |optionalWithAllParams|
+//@[025:027) NewLine |\r\n|
+  ]
+//@[002:003) RightSquare |]|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module optionalWithImplicitDependency './child/optionalParams.bicep'= {
+//@[000:006) Identifier |module|
+//@[007:037) Identifier |optionalWithImplicitDependency|
+//@[038:068) StringComplete |'./child/optionalParams.bicep'|
+//@[068:069) Assignment |=|
+//@[070:071) LeftBrace |{|
+//@[071:073) NewLine |\r\n|
+  name: 'optionalWithImplicitDependency'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:040) StringComplete |'optionalWithImplicitDependency'|
+//@[040:042) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[004:018) Identifier |optionalString|
+//@[018:019) Colon |:|
+//@[020:026) Identifier |concat|
+//@[026:027) LeftParen |(|
+//@[027:046) Identifier |resWithDependencies|
+//@[046:047) Dot |.|
+//@[047:049) Identifier |id|
+//@[049:050) Comma |,|
+//@[051:091) Identifier |optionalWithAllParamsAndManualDependency|
+//@[091:092) Dot |.|
+//@[092:096) Identifier |name|
+//@[096:097) RightParen |)|
+//@[097:099) NewLine |\r\n|
+    optionalInt: 42
+//@[004:015) Identifier |optionalInt|
+//@[015:016) Colon |:|
+//@[017:019) Integer |42|
+//@[019:021) NewLine |\r\n|
+    optionalObj: { }
+//@[004:015) Identifier |optionalObj|
+//@[015:016) Colon |:|
+//@[017:018) LeftBrace |{|
+//@[019:020) RightBrace |}|
+//@[020:022) NewLine |\r\n|
+    optionalArray: [ ]
+//@[004:017) Identifier |optionalArray|
+//@[017:018) Colon |:|
+//@[019:020) LeftSquare |[|
+//@[021:022) RightSquare |]|
+//@[022:024) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module moduleWithCalculatedName './child/optionalParams.bicep'= {
+//@[000:006) Identifier |module|
+//@[007:031) Identifier |moduleWithCalculatedName|
+//@[032:062) StringComplete |'./child/optionalParams.bicep'|
+//@[062:063) Assignment |=|
+//@[064:065) LeftBrace |{|
+//@[065:067) NewLine |\r\n|
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:011) StringLeftPiece |'${|
+//@[011:051) Identifier |optionalWithAllParamsAndManualDependency|
+//@[051:052) Dot |.|
+//@[052:056) Identifier |name|
+//@[056:059) StringMiddlePiece |}${|
+//@[059:075) Identifier |deployTimeSuffix|
+//@[075:077) StringRightPiece |}'|
+//@[077:079) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    optionalString: concat(resWithDependencies.id, optionalWithAllParamsAndManualDependency.name)
+//@[004:018) Identifier |optionalString|
+//@[018:019) Colon |:|
+//@[020:026) Identifier |concat|
+//@[026:027) LeftParen |(|
+//@[027:046) Identifier |resWithDependencies|
+//@[046:047) Dot |.|
+//@[047:049) Identifier |id|
+//@[049:050) Comma |,|
+//@[051:091) Identifier |optionalWithAllParamsAndManualDependency|
+//@[091:092) Dot |.|
+//@[092:096) Identifier |name|
+//@[096:097) RightParen |)|
+//@[097:099) NewLine |\r\n|
+    optionalInt: 42
+//@[004:015) Identifier |optionalInt|
+//@[015:016) Colon |:|
+//@[017:019) Integer |42|
+//@[019:021) NewLine |\r\n|
+    optionalObj: { }
+//@[004:015) Identifier |optionalObj|
+//@[015:016) Colon |:|
+//@[017:018) LeftBrace |{|
+//@[019:020) RightBrace |}|
+//@[020:022) NewLine |\r\n|
+    optionalArray: [ ]
+//@[004:017) Identifier |optionalArray|
+//@[017:018) Colon |:|
+//@[019:020) LeftSquare |[|
+//@[021:022) RightSquare |]|
+//@[022:024) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+resource resWithCalculatedNameDependencies 'Mock.Rp/mockResource@2020-01-01' = {
+//@[000:008) Identifier |resource|
+//@[009:042) Identifier |resWithCalculatedNameDependencies|
+//@[043:076) StringComplete |'Mock.Rp/mockResource@2020-01-01'|
+//@[077:078) Assignment |=|
+//@[079:080) LeftBrace |{|
+//@[080:082) NewLine |\r\n|
+  name: '${optionalWithAllParamsAndManualDependency.name}${deployTimeSuffix}'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:011) StringLeftPiece |'${|
+//@[011:051) Identifier |optionalWithAllParamsAndManualDependency|
+//@[051:052) Dot |.|
+//@[052:056) Identifier |name|
+//@[056:059) StringMiddlePiece |}${|
+//@[059:075) Identifier |deployTimeSuffix|
+//@[075:077) StringRightPiece |}'|
+//@[077:079) NewLine |\r\n|
+  properties: {
+//@[002:012) Identifier |properties|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:017) NewLine |\r\n|
+    modADep: moduleWithCalculatedName.outputs.outputObj
+//@[004:011) Identifier |modADep|
+//@[011:012) Colon |:|
+//@[013:037) Identifier |moduleWithCalculatedName|
+//@[037:038) Dot |.|
+//@[038:045) Identifier |outputs|
+//@[045:046) Dot |.|
+//@[046:055) Identifier |outputObj|
+//@[055:057) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+output stringOutputA string = modATest.outputs.stringOutputA
+//@[000:006) Identifier |output|
+//@[007:020) Identifier |stringOutputA|
+//@[021:027) Identifier |string|
+//@[028:029) Assignment |=|
+//@[030:038) Identifier |modATest|
+//@[038:039) Dot |.|
+//@[039:046) Identifier |outputs|
+//@[046:047) Dot |.|
+//@[047:060) Identifier |stringOutputA|
+//@[060:062) NewLine |\r\n|
+output stringOutputB string = modATest.outputs.stringOutputB
+//@[000:006) Identifier |output|
+//@[007:020) Identifier |stringOutputB|
+//@[021:027) Identifier |string|
+//@[028:029) Assignment |=|
+//@[030:038) Identifier |modATest|
+//@[038:039) Dot |.|
+//@[039:046) Identifier |outputs|
+//@[046:047) Dot |.|
+//@[047:060) Identifier |stringOutputB|
+//@[060:062) NewLine |\r\n|
+output objOutput object = modATest.outputs.objOutput
+//@[000:006) Identifier |output|
+//@[007:016) Identifier |objOutput|
+//@[017:023) Identifier |object|
+//@[024:025) Assignment |=|
+//@[026:034) Identifier |modATest|
+//@[034:035) Dot |.|
+//@[035:042) Identifier |outputs|
+//@[042:043) Dot |.|
+//@[043:052) Identifier |objOutput|
+//@[052:054) NewLine |\r\n|
+output arrayOutput array = modATest.outputs.arrayOutput
+//@[000:006) Identifier |output|
+//@[007:018) Identifier |arrayOutput|
+//@[019:024) Identifier |array|
+//@[025:026) Assignment |=|
+//@[027:035) Identifier |modATest|
+//@[035:036) Dot |.|
+//@[036:043) Identifier |outputs|
+//@[043:044) Dot |.|
+//@[044:055) Identifier |arrayOutput|
+//@[055:057) NewLine |\r\n|
+output modCalculatedNameOutput object = moduleWithCalculatedName.outputs.outputObj
+//@[000:006) Identifier |output|
+//@[007:030) Identifier |modCalculatedNameOutput|
+//@[031:037) Identifier |object|
+//@[038:039) Assignment |=|
+//@[040:064) Identifier |moduleWithCalculatedName|
+//@[064:065) Dot |.|
+//@[065:072) Identifier |outputs|
+//@[072:073) Dot |.|
+//@[073:082) Identifier |outputObj|
+//@[082:086) NewLine |\r\n\r\n|
+
+/*
+  valid loop cases
+*/
+//@[002:006) NewLine |\r\n\r\n|
+
+@sys.description('this is myModules')
+//@[000:001) At |@|
+//@[001:004) Identifier |sys|
+//@[004:005) Dot |.|
+//@[005:016) Identifier |description|
+//@[016:017) LeftParen |(|
+//@[017:036) StringComplete |'this is myModules'|
+//@[036:037) RightParen |)|
+//@[037:039) NewLine |\r\n|
+var myModules = [
+//@[000:003) Identifier |var|
+//@[004:013) Identifier |myModules|
+//@[014:015) Assignment |=|
+//@[016:017) LeftSquare |[|
+//@[017:019) NewLine |\r\n|
+  {
+//@[002:003) LeftBrace |{|
+//@[003:005) NewLine |\r\n|
+    name: 'one'
+//@[004:008) Identifier |name|
+//@[008:009) Colon |:|
+//@[010:015) StringComplete |'one'|
+//@[015:017) NewLine |\r\n|
+    location: 'eastus2'
+//@[004:012) Identifier |location|
+//@[012:013) Colon |:|
+//@[014:023) StringComplete |'eastus2'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+  {
+//@[002:003) LeftBrace |{|
+//@[003:005) NewLine |\r\n|
+    name: 'two'
+//@[004:008) Identifier |name|
+//@[008:009) Colon |:|
+//@[010:015) StringComplete |'two'|
+//@[015:017) NewLine |\r\n|
+    location: 'westus'
+//@[004:012) Identifier |location|
+//@[012:013) Colon |:|
+//@[014:022) StringComplete |'westus'|
+//@[022:024) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+]
+//@[000:001) RightSquare |]|
+//@[001:005) NewLine |\r\n\r\n|
+
+var emptyArray = []
+//@[000:003) Identifier |var|
+//@[004:014) Identifier |emptyArray|
+//@[015:016) Assignment |=|
+//@[017:018) LeftSquare |[|
+//@[018:019) RightSquare |]|
+//@[019:023) NewLine |\r\n\r\n|
+
+// simple module loop
+//@[021:023) NewLine |\r\n|
+module storageResources 'modulea.bicep' = [for module in myModules: {
+//@[000:006) Identifier |module|
+//@[007:023) Identifier |storageResources|
+//@[024:039) StringComplete |'modulea.bicep'|
+//@[040:041) Assignment |=|
+//@[042:043) LeftSquare |[|
+//@[043:046) Identifier |for|
+//@[047:053) Identifier |module|
+//@[054:056) Identifier |in|
+//@[057:066) Identifier |myModules|
+//@[066:067) Colon |:|
+//@[068:069) LeftBrace |{|
+//@[069:071) NewLine |\r\n|
+  name: module.name
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:014) Identifier |module|
+//@[014:015) Dot |.|
+//@[015:019) Identifier |name|
+//@[019:021) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    arrayParam: []
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:018) RightSquare |]|
+//@[018:020) NewLine |\r\n|
+    objParam: module
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:020) Identifier |module|
+//@[020:022) NewLine |\r\n|
+    stringParamB: module.location
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:024) Identifier |module|
+//@[024:025) Dot |.|
+//@[025:033) Identifier |location|
+//@[033:035) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+// simple indexed module loop
+//@[029:031) NewLine |\r\n|
+module storageResourcesWithIndex 'modulea.bicep' = [for (module, i) in myModules: {
+//@[000:006) Identifier |module|
+//@[007:032) Identifier |storageResourcesWithIndex|
+//@[033:048) StringComplete |'modulea.bicep'|
+//@[049:050) Assignment |=|
+//@[051:052) LeftSquare |[|
+//@[052:055) Identifier |for|
+//@[056:057) LeftParen |(|
+//@[057:063) Identifier |module|
+//@[063:064) Comma |,|
+//@[065:066) Identifier |i|
+//@[066:067) RightParen |)|
+//@[068:070) Identifier |in|
+//@[071:080) Identifier |myModules|
+//@[080:081) Colon |:|
+//@[082:083) LeftBrace |{|
+//@[083:085) NewLine |\r\n|
+  name: module.name
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:014) Identifier |module|
+//@[014:015) Dot |.|
+//@[015:019) Identifier |name|
+//@[019:021) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    arrayParam: [
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:019) NewLine |\r\n|
+      i + 1
+//@[006:007) Identifier |i|
+//@[008:009) Plus |+|
+//@[010:011) Integer |1|
+//@[011:013) NewLine |\r\n|
+    ]
+//@[004:005) RightSquare |]|
+//@[005:007) NewLine |\r\n|
+    objParam: module
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:020) Identifier |module|
+//@[020:022) NewLine |\r\n|
+    stringParamB: module.location
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:024) Identifier |module|
+//@[024:025) Dot |.|
+//@[025:033) Identifier |location|
+//@[033:035) NewLine |\r\n|
+    stringParamA: concat('a', i)
+//@[004:016) Identifier |stringParamA|
+//@[016:017) Colon |:|
+//@[018:024) Identifier |concat|
+//@[024:025) LeftParen |(|
+//@[025:028) StringComplete |'a'|
+//@[028:029) Comma |,|
+//@[030:031) Identifier |i|
+//@[031:032) RightParen |)|
+//@[032:034) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+// nested module loop
+//@[021:023) NewLine |\r\n|
+module nestedModuleLoop 'modulea.bicep' = [for module in myModules: {
+//@[000:006) Identifier |module|
+//@[007:023) Identifier |nestedModuleLoop|
+//@[024:039) StringComplete |'modulea.bicep'|
+//@[040:041) Assignment |=|
+//@[042:043) LeftSquare |[|
+//@[043:046) Identifier |for|
+//@[047:053) Identifier |module|
+//@[054:056) Identifier |in|
+//@[057:066) Identifier |myModules|
+//@[066:067) Colon |:|
+//@[068:069) LeftBrace |{|
+//@[069:071) NewLine |\r\n|
+  name: module.name
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:014) Identifier |module|
+//@[014:015) Dot |.|
+//@[015:019) Identifier |name|
+//@[019:021) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    arrayParam: [for i in range(0,3): concat('test-', i, '-', module.name)]
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:020) Identifier |for|
+//@[021:022) Identifier |i|
+//@[023:025) Identifier |in|
+//@[026:031) Identifier |range|
+//@[031:032) LeftParen |(|
+//@[032:033) Integer |0|
+//@[033:034) Comma |,|
+//@[034:035) Integer |3|
+//@[035:036) RightParen |)|
+//@[036:037) Colon |:|
+//@[038:044) Identifier |concat|
+//@[044:045) LeftParen |(|
+//@[045:052) StringComplete |'test-'|
+//@[052:053) Comma |,|
+//@[054:055) Identifier |i|
+//@[055:056) Comma |,|
+//@[057:060) StringComplete |'-'|
+//@[060:061) Comma |,|
+//@[062:068) Identifier |module|
+//@[068:069) Dot |.|
+//@[069:073) Identifier |name|
+//@[073:074) RightParen |)|
+//@[074:075) RightSquare |]|
+//@[075:077) NewLine |\r\n|
+    objParam: module
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:020) Identifier |module|
+//@[020:022) NewLine |\r\n|
+    stringParamB: module.location
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:024) Identifier |module|
+//@[024:025) Dot |.|
+//@[025:033) Identifier |location|
+//@[033:035) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[074:076) NewLine |\r\n|
+module duplicateIdentifiersWithinLoop 'modulea.bicep' = [for x in emptyArray:{
+//@[000:006) Identifier |module|
+//@[007:037) Identifier |duplicateIdentifiersWithinLoop|
+//@[038:053) StringComplete |'modulea.bicep'|
+//@[054:055) Assignment |=|
+//@[056:057) LeftSquare |[|
+//@[057:060) Identifier |for|
+//@[061:062) Identifier |x|
+//@[063:065) Identifier |in|
+//@[066:076) Identifier |emptyArray|
+//@[076:077) Colon |:|
+//@[077:078) LeftBrace |{|
+//@[078:080) NewLine |\r\n|
+  name: 'hello-${x}'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:017) StringLeftPiece |'hello-${|
+//@[017:018) Identifier |x|
+//@[018:020) StringRightPiece |}'|
+//@[020:022) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    objParam: {}
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:016) RightBrace |}|
+//@[016:018) NewLine |\r\n|
+    stringParamA: 'test'
+//@[004:016) Identifier |stringParamA|
+//@[016:017) Colon |:|
+//@[018:024) StringComplete |'test'|
+//@[024:026) NewLine |\r\n|
+    stringParamB: 'test'
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:024) StringComplete |'test'|
+//@[024:026) NewLine |\r\n|
+    arrayParam: [for x in emptyArray: x]
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:020) Identifier |for|
+//@[021:022) Identifier |x|
+//@[023:025) Identifier |in|
+//@[026:036) Identifier |emptyArray|
+//@[036:037) Colon |:|
+//@[038:039) Identifier |x|
+//@[039:040) RightSquare |]|
+//@[040:042) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+// duplicate identifiers across scopes are allowed (inner hides the outer)
+//@[074:076) NewLine |\r\n|
+var duplicateAcrossScopes = 'hello'
+//@[000:003) Identifier |var|
+//@[004:025) Identifier |duplicateAcrossScopes|
+//@[026:027) Assignment |=|
+//@[028:035) StringComplete |'hello'|
+//@[035:037) NewLine |\r\n|
+module duplicateInGlobalAndOneLoop 'modulea.bicep' = [for duplicateAcrossScopes in []: {
+//@[000:006) Identifier |module|
+//@[007:034) Identifier |duplicateInGlobalAndOneLoop|
+//@[035:050) StringComplete |'modulea.bicep'|
+//@[051:052) Assignment |=|
+//@[053:054) LeftSquare |[|
+//@[054:057) Identifier |for|
+//@[058:079) Identifier |duplicateAcrossScopes|
+//@[080:082) Identifier |in|
+//@[083:084) LeftSquare |[|
+//@[084:085) RightSquare |]|
+//@[085:086) Colon |:|
+//@[087:088) LeftBrace |{|
+//@[088:090) NewLine |\r\n|
+  name: 'hello-${duplicateAcrossScopes}'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:017) StringLeftPiece |'hello-${|
+//@[017:038) Identifier |duplicateAcrossScopes|
+//@[038:040) StringRightPiece |}'|
+//@[040:042) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    objParam: {}
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:016) RightBrace |}|
+//@[016:018) NewLine |\r\n|
+    stringParamA: 'test'
+//@[004:016) Identifier |stringParamA|
+//@[016:017) Colon |:|
+//@[018:024) StringComplete |'test'|
+//@[024:026) NewLine |\r\n|
+    stringParamB: 'test'
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:024) StringComplete |'test'|
+//@[024:026) NewLine |\r\n|
+    arrayParam: [for x in emptyArray: x]
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:020) Identifier |for|
+//@[021:022) Identifier |x|
+//@[023:025) Identifier |in|
+//@[026:036) Identifier |emptyArray|
+//@[036:037) Colon |:|
+//@[038:039) Identifier |x|
+//@[039:040) RightSquare |]|
+//@[040:042) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+var someDuplicate = true
+//@[000:003) Identifier |var|
+//@[004:017) Identifier |someDuplicate|
+//@[018:019) Assignment |=|
+//@[020:024) TrueKeyword |true|
+//@[024:026) NewLine |\r\n|
+var otherDuplicate = false
+//@[000:003) Identifier |var|
+//@[004:018) Identifier |otherDuplicate|
+//@[019:020) Assignment |=|
+//@[021:026) FalseKeyword |false|
+//@[026:028) NewLine |\r\n|
+module duplicatesEverywhere 'modulea.bicep' = [for someDuplicate in []: {
+//@[000:006) Identifier |module|
+//@[007:027) Identifier |duplicatesEverywhere|
+//@[028:043) StringComplete |'modulea.bicep'|
+//@[044:045) Assignment |=|
+//@[046:047) LeftSquare |[|
+//@[047:050) Identifier |for|
+//@[051:064) Identifier |someDuplicate|
+//@[065:067) Identifier |in|
+//@[068:069) LeftSquare |[|
+//@[069:070) RightSquare |]|
+//@[070:071) Colon |:|
+//@[072:073) LeftBrace |{|
+//@[073:075) NewLine |\r\n|
+  name: 'hello-${someDuplicate}'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:017) StringLeftPiece |'hello-${|
+//@[017:030) Identifier |someDuplicate|
+//@[030:032) StringRightPiece |}'|
+//@[032:034) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    objParam: {}
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:016) RightBrace |}|
+//@[016:018) NewLine |\r\n|
+    stringParamB: 'test'
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:024) StringComplete |'test'|
+//@[024:026) NewLine |\r\n|
+    arrayParam: [for otherDuplicate in emptyArray: '${someDuplicate}-${otherDuplicate}']
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:020) Identifier |for|
+//@[021:035) Identifier |otherDuplicate|
+//@[036:038) Identifier |in|
+//@[039:049) Identifier |emptyArray|
+//@[049:050) Colon |:|
+//@[051:054) StringLeftPiece |'${|
+//@[054:067) Identifier |someDuplicate|
+//@[067:071) StringMiddlePiece |}-${|
+//@[071:085) Identifier |otherDuplicate|
+//@[085:087) StringRightPiece |}'|
+//@[087:088) RightSquare |]|
+//@[088:090) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+module propertyLoopInsideParameterValue 'modulea.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:039) Identifier |propertyLoopInsideParameterValue|
+//@[040:055) StringComplete |'modulea.bicep'|
+//@[056:057) Assignment |=|
+//@[058:059) LeftBrace |{|
+//@[059:061) NewLine |\r\n|
+  name: 'propertyLoopInsideParameterValue'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:042) StringComplete |'propertyLoopInsideParameterValue'|
+//@[042:044) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    objParam: {
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:017) NewLine |\r\n|
+      a: [for i in range(0,10): i]
+//@[006:007) Identifier |a|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) Identifier |i|
+//@[016:018) Identifier |in|
+//@[019:024) Identifier |range|
+//@[024:025) LeftParen |(|
+//@[025:026) Integer |0|
+//@[026:027) Comma |,|
+//@[027:029) Integer |10|
+//@[029:030) RightParen |)|
+//@[030:031) Colon |:|
+//@[032:033) Identifier |i|
+//@[033:034) RightSquare |]|
+//@[034:036) NewLine |\r\n|
+      b: [for i in range(1,2): i]
+//@[006:007) Identifier |b|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) Identifier |i|
+//@[016:018) Identifier |in|
+//@[019:024) Identifier |range|
+//@[024:025) LeftParen |(|
+//@[025:026) Integer |1|
+//@[026:027) Comma |,|
+//@[027:028) Integer |2|
+//@[028:029) RightParen |)|
+//@[029:030) Colon |:|
+//@[031:032) Identifier |i|
+//@[032:033) RightSquare |]|
+//@[033:035) NewLine |\r\n|
+      c: {
+//@[006:007) Identifier |c|
+//@[007:008) Colon |:|
+//@[009:010) LeftBrace |{|
+//@[010:012) NewLine |\r\n|
+        d: [for j in range(2,3): j]
+//@[008:009) Identifier |d|
+//@[009:010) Colon |:|
+//@[011:012) LeftSquare |[|
+//@[012:015) Identifier |for|
+//@[016:017) Identifier |j|
+//@[018:020) Identifier |in|
+//@[021:026) Identifier |range|
+//@[026:027) LeftParen |(|
+//@[027:028) Integer |2|
+//@[028:029) Comma |,|
+//@[029:030) Integer |3|
+//@[030:031) RightParen |)|
+//@[031:032) Colon |:|
+//@[033:034) Identifier |j|
+//@[034:035) RightSquare |]|
+//@[035:037) NewLine |\r\n|
+      }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+      e: [for k in range(4,4): {
+//@[006:007) Identifier |e|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) Identifier |k|
+//@[016:018) Identifier |in|
+//@[019:024) Identifier |range|
+//@[024:025) LeftParen |(|
+//@[025:026) Integer |4|
+//@[026:027) Comma |,|
+//@[027:028) Integer |4|
+//@[028:029) RightParen |)|
+//@[029:030) Colon |:|
+//@[031:032) LeftBrace |{|
+//@[032:034) NewLine |\r\n|
+        f: k
+//@[008:009) Identifier |f|
+//@[009:010) Colon |:|
+//@[011:012) Identifier |k|
+//@[012:014) NewLine |\r\n|
+      }]
+//@[006:007) RightBrace |}|
+//@[007:008) RightSquare |]|
+//@[008:010) NewLine |\r\n|
+    }
+//@[004:005) RightBrace |}|
+//@[005:007) NewLine |\r\n|
+    stringParamB: ''
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:020) StringComplete |''|
+//@[020:022) NewLine |\r\n|
+    arrayParam: [
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:019) NewLine |\r\n|
+      {
+//@[006:007) LeftBrace |{|
+//@[007:009) NewLine |\r\n|
+        e: [for j in range(7,7): j]
+//@[008:009) Identifier |e|
+//@[009:010) Colon |:|
+//@[011:012) LeftSquare |[|
+//@[012:015) Identifier |for|
+//@[016:017) Identifier |j|
+//@[018:020) Identifier |in|
+//@[021:026) Identifier |range|
+//@[026:027) LeftParen |(|
+//@[027:028) Integer |7|
+//@[028:029) Comma |,|
+//@[029:030) Integer |7|
+//@[030:031) RightParen |)|
+//@[031:032) Colon |:|
+//@[033:034) Identifier |j|
+//@[034:035) RightSquare |]|
+//@[035:037) NewLine |\r\n|
+      }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+    ]
+//@[004:005) RightSquare |]|
+//@[005:007) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module propertyLoopInsideParameterValueWithIndexes 'modulea.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:050) Identifier |propertyLoopInsideParameterValueWithIndexes|
+//@[051:066) StringComplete |'modulea.bicep'|
+//@[067:068) Assignment |=|
+//@[069:070) LeftBrace |{|
+//@[070:072) NewLine |\r\n|
+  name: 'propertyLoopInsideParameterValueWithIndexes'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:053) StringComplete |'propertyLoopInsideParameterValueWithIndexes'|
+//@[053:055) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    objParam: {
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:017) NewLine |\r\n|
+      a: [for (i, i2) in range(0,10): i + i2]
+//@[006:007) Identifier |a|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) LeftParen |(|
+//@[015:016) Identifier |i|
+//@[016:017) Comma |,|
+//@[018:020) Identifier |i2|
+//@[020:021) RightParen |)|
+//@[022:024) Identifier |in|
+//@[025:030) Identifier |range|
+//@[030:031) LeftParen |(|
+//@[031:032) Integer |0|
+//@[032:033) Comma |,|
+//@[033:035) Integer |10|
+//@[035:036) RightParen |)|
+//@[036:037) Colon |:|
+//@[038:039) Identifier |i|
+//@[040:041) Plus |+|
+//@[042:044) Identifier |i2|
+//@[044:045) RightSquare |]|
+//@[045:047) NewLine |\r\n|
+      b: [for (i, i2) in range(1,2): i / i2]
+//@[006:007) Identifier |b|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) LeftParen |(|
+//@[015:016) Identifier |i|
+//@[016:017) Comma |,|
+//@[018:020) Identifier |i2|
+//@[020:021) RightParen |)|
+//@[022:024) Identifier |in|
+//@[025:030) Identifier |range|
+//@[030:031) LeftParen |(|
+//@[031:032) Integer |1|
+//@[032:033) Comma |,|
+//@[033:034) Integer |2|
+//@[034:035) RightParen |)|
+//@[035:036) Colon |:|
+//@[037:038) Identifier |i|
+//@[039:040) Slash |/|
+//@[041:043) Identifier |i2|
+//@[043:044) RightSquare |]|
+//@[044:046) NewLine |\r\n|
+      c: {
+//@[006:007) Identifier |c|
+//@[007:008) Colon |:|
+//@[009:010) LeftBrace |{|
+//@[010:012) NewLine |\r\n|
+        d: [for (j, j2) in range(2,3): j * j2]
+//@[008:009) Identifier |d|
+//@[009:010) Colon |:|
+//@[011:012) LeftSquare |[|
+//@[012:015) Identifier |for|
+//@[016:017) LeftParen |(|
+//@[017:018) Identifier |j|
+//@[018:019) Comma |,|
+//@[020:022) Identifier |j2|
+//@[022:023) RightParen |)|
+//@[024:026) Identifier |in|
+//@[027:032) Identifier |range|
+//@[032:033) LeftParen |(|
+//@[033:034) Integer |2|
+//@[034:035) Comma |,|
+//@[035:036) Integer |3|
+//@[036:037) RightParen |)|
+//@[037:038) Colon |:|
+//@[039:040) Identifier |j|
+//@[041:042) Asterisk |*|
+//@[043:045) Identifier |j2|
+//@[045:046) RightSquare |]|
+//@[046:048) NewLine |\r\n|
+      }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+      e: [for (k, k2) in range(4,4): {
+//@[006:007) Identifier |e|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) LeftParen |(|
+//@[015:016) Identifier |k|
+//@[016:017) Comma |,|
+//@[018:020) Identifier |k2|
+//@[020:021) RightParen |)|
+//@[022:024) Identifier |in|
+//@[025:030) Identifier |range|
+//@[030:031) LeftParen |(|
+//@[031:032) Integer |4|
+//@[032:033) Comma |,|
+//@[033:034) Integer |4|
+//@[034:035) RightParen |)|
+//@[035:036) Colon |:|
+//@[037:038) LeftBrace |{|
+//@[038:040) NewLine |\r\n|
+        f: k
+//@[008:009) Identifier |f|
+//@[009:010) Colon |:|
+//@[011:012) Identifier |k|
+//@[012:014) NewLine |\r\n|
+        g: k2
+//@[008:009) Identifier |g|
+//@[009:010) Colon |:|
+//@[011:013) Identifier |k2|
+//@[013:015) NewLine |\r\n|
+      }]
+//@[006:007) RightBrace |}|
+//@[007:008) RightSquare |]|
+//@[008:010) NewLine |\r\n|
+    }
+//@[004:005) RightBrace |}|
+//@[005:007) NewLine |\r\n|
+    stringParamB: ''
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:020) StringComplete |''|
+//@[020:022) NewLine |\r\n|
+    arrayParam: [
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:019) NewLine |\r\n|
+      {
+//@[006:007) LeftBrace |{|
+//@[007:009) NewLine |\r\n|
+        e: [for j in range(7,7): j]
+//@[008:009) Identifier |e|
+//@[009:010) Colon |:|
+//@[011:012) LeftSquare |[|
+//@[012:015) Identifier |for|
+//@[016:017) Identifier |j|
+//@[018:020) Identifier |in|
+//@[021:026) Identifier |range|
+//@[026:027) LeftParen |(|
+//@[027:028) Integer |7|
+//@[028:029) Comma |,|
+//@[029:030) Integer |7|
+//@[030:031) RightParen |)|
+//@[031:032) Colon |:|
+//@[033:034) Identifier |j|
+//@[034:035) RightSquare |]|
+//@[035:037) NewLine |\r\n|
+      }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+    ]
+//@[004:005) RightSquare |]|
+//@[005:007) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module propertyLoopInsideParameterValueInsideModuleLoop 'modulea.bicep' = [for thing in range(0,1): {
+//@[000:006) Identifier |module|
+//@[007:055) Identifier |propertyLoopInsideParameterValueInsideModuleLoop|
+//@[056:071) StringComplete |'modulea.bicep'|
+//@[072:073) Assignment |=|
+//@[074:075) LeftSquare |[|
+//@[075:078) Identifier |for|
+//@[079:084) Identifier |thing|
+//@[085:087) Identifier |in|
+//@[088:093) Identifier |range|
+//@[093:094) LeftParen |(|
+//@[094:095) Integer |0|
+//@[095:096) Comma |,|
+//@[096:097) Integer |1|
+//@[097:098) RightParen |)|
+//@[098:099) Colon |:|
+//@[100:101) LeftBrace |{|
+//@[101:103) NewLine |\r\n|
+  name: 'propertyLoopInsideParameterValueInsideModuleLoop'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:058) StringComplete |'propertyLoopInsideParameterValueInsideModuleLoop'|
+//@[058:060) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    objParam: {
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:017) NewLine |\r\n|
+      a: [for i in range(0,10): i + thing]
+//@[006:007) Identifier |a|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) Identifier |i|
+//@[016:018) Identifier |in|
+//@[019:024) Identifier |range|
+//@[024:025) LeftParen |(|
+//@[025:026) Integer |0|
+//@[026:027) Comma |,|
+//@[027:029) Integer |10|
+//@[029:030) RightParen |)|
+//@[030:031) Colon |:|
+//@[032:033) Identifier |i|
+//@[034:035) Plus |+|
+//@[036:041) Identifier |thing|
+//@[041:042) RightSquare |]|
+//@[042:044) NewLine |\r\n|
+      b: [for i in range(1,2): i * thing]
+//@[006:007) Identifier |b|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) Identifier |i|
+//@[016:018) Identifier |in|
+//@[019:024) Identifier |range|
+//@[024:025) LeftParen |(|
+//@[025:026) Integer |1|
+//@[026:027) Comma |,|
+//@[027:028) Integer |2|
+//@[028:029) RightParen |)|
+//@[029:030) Colon |:|
+//@[031:032) Identifier |i|
+//@[033:034) Asterisk |*|
+//@[035:040) Identifier |thing|
+//@[040:041) RightSquare |]|
+//@[041:043) NewLine |\r\n|
+      c: {
+//@[006:007) Identifier |c|
+//@[007:008) Colon |:|
+//@[009:010) LeftBrace |{|
+//@[010:012) NewLine |\r\n|
+        d: [for j in range(2,3): j]
+//@[008:009) Identifier |d|
+//@[009:010) Colon |:|
+//@[011:012) LeftSquare |[|
+//@[012:015) Identifier |for|
+//@[016:017) Identifier |j|
+//@[018:020) Identifier |in|
+//@[021:026) Identifier |range|
+//@[026:027) LeftParen |(|
+//@[027:028) Integer |2|
+//@[028:029) Comma |,|
+//@[029:030) Integer |3|
+//@[030:031) RightParen |)|
+//@[031:032) Colon |:|
+//@[033:034) Identifier |j|
+//@[034:035) RightSquare |]|
+//@[035:037) NewLine |\r\n|
+      }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+      e: [for k in range(4,4): {
+//@[006:007) Identifier |e|
+//@[007:008) Colon |:|
+//@[009:010) LeftSquare |[|
+//@[010:013) Identifier |for|
+//@[014:015) Identifier |k|
+//@[016:018) Identifier |in|
+//@[019:024) Identifier |range|
+//@[024:025) LeftParen |(|
+//@[025:026) Integer |4|
+//@[026:027) Comma |,|
+//@[027:028) Integer |4|
+//@[028:029) RightParen |)|
+//@[029:030) Colon |:|
+//@[031:032) LeftBrace |{|
+//@[032:034) NewLine |\r\n|
+        f: k - thing
+//@[008:009) Identifier |f|
+//@[009:010) Colon |:|
+//@[011:012) Identifier |k|
+//@[013:014) Minus |-|
+//@[015:020) Identifier |thing|
+//@[020:022) NewLine |\r\n|
+      }]
+//@[006:007) RightBrace |}|
+//@[007:008) RightSquare |]|
+//@[008:010) NewLine |\r\n|
+    }
+//@[004:005) RightBrace |}|
+//@[005:007) NewLine |\r\n|
+    stringParamB: ''
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:020) StringComplete |''|
+//@[020:022) NewLine |\r\n|
+    arrayParam: [
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:019) NewLine |\r\n|
+      {
+//@[006:007) LeftBrace |{|
+//@[007:009) NewLine |\r\n|
+        e: [for j in range(7,7): j % (thing + 1)]
+//@[008:009) Identifier |e|
+//@[009:010) Colon |:|
+//@[011:012) LeftSquare |[|
+//@[012:015) Identifier |for|
+//@[016:017) Identifier |j|
+//@[018:020) Identifier |in|
+//@[021:026) Identifier |range|
+//@[026:027) LeftParen |(|
+//@[027:028) Integer |7|
+//@[028:029) Comma |,|
+//@[029:030) Integer |7|
+//@[030:031) RightParen |)|
+//@[031:032) Colon |:|
+//@[033:034) Identifier |j|
+//@[035:036) Modulo |%|
+//@[037:038) LeftParen |(|
+//@[038:043) Identifier |thing|
+//@[044:045) Plus |+|
+//@[046:047) Integer |1|
+//@[047:048) RightParen |)|
+//@[048:049) RightSquare |]|
+//@[049:051) NewLine |\r\n|
+      }
+//@[006:007) RightBrace |}|
+//@[007:009) NewLine |\r\n|
+    ]
+//@[004:005) RightSquare |]|
+//@[005:007) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:008) NewLine |\r\n\r\n\r\n|
+
+
+// BEGIN: Key Vault Secret Reference
+//@[036:040) NewLine |\r\n\r\n|
+
+resource kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[000:008) Identifier |resource|
+//@[009:011) Identifier |kv|
+//@[012:050) StringComplete |'Microsoft.KeyVault/vaults@2019-09-01'|
+//@[051:059) Identifier |existing|
+//@[060:061) Assignment |=|
+//@[062:063) LeftBrace |{|
+//@[063:065) NewLine |\r\n|
+  name: 'testkeyvault'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:022) StringComplete |'testkeyvault'|
+//@[022:024) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module secureModule1 'child/secureParams.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:020) Identifier |secureModule1|
+//@[021:047) StringComplete |'child/secureParams.bicep'|
+//@[048:049) Assignment |=|
+//@[050:051) LeftBrace |{|
+//@[051:053) NewLine |\r\n|
+  name: 'secureModule1'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:023) StringComplete |'secureModule1'|
+//@[023:025) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    secureStringParam1: kv.getSecret('mySecret')
+//@[004:022) Identifier |secureStringParam1|
+//@[022:023) Colon |:|
+//@[024:026) Identifier |kv|
+//@[026:027) Dot |.|
+//@[027:036) Identifier |getSecret|
+//@[036:037) LeftParen |(|
+//@[037:047) StringComplete |'mySecret'|
+//@[047:048) RightParen |)|
+//@[048:050) NewLine |\r\n|
+    secureStringParam2: kv.getSecret('mySecret','secretVersion')
+//@[004:022) Identifier |secureStringParam2|
+//@[022:023) Colon |:|
+//@[024:026) Identifier |kv|
+//@[026:027) Dot |.|
+//@[027:036) Identifier |getSecret|
+//@[036:037) LeftParen |(|
+//@[037:047) StringComplete |'mySecret'|
+//@[047:048) Comma |,|
+//@[048:063) StringComplete |'secretVersion'|
+//@[063:064) RightParen |)|
+//@[064:066) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+resource scopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+//@[000:008) Identifier |resource|
+//@[009:017) Identifier |scopedKv|
+//@[018:056) StringComplete |'Microsoft.KeyVault/vaults@2019-09-01'|
+//@[057:065) Identifier |existing|
+//@[066:067) Assignment |=|
+//@[068:069) LeftBrace |{|
+//@[069:071) NewLine |\r\n|
+  name: 'testkeyvault'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:022) StringComplete |'testkeyvault'|
+//@[022:024) NewLine |\r\n|
+  scope: resourceGroup('otherGroup')
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:022) Identifier |resourceGroup|
+//@[022:023) LeftParen |(|
+//@[023:035) StringComplete |'otherGroup'|
+//@[035:036) RightParen |)|
+//@[036:038) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module secureModule2 'child/secureParams.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:020) Identifier |secureModule2|
+//@[021:047) StringComplete |'child/secureParams.bicep'|
+//@[048:049) Assignment |=|
+//@[050:051) LeftBrace |{|
+//@[051:053) NewLine |\r\n|
+  name: 'secureModule2'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:023) StringComplete |'secureModule2'|
+//@[023:025) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    secureStringParam1: scopedKv.getSecret('mySecret')
+//@[004:022) Identifier |secureStringParam1|
+//@[022:023) Colon |:|
+//@[024:032) Identifier |scopedKv|
+//@[032:033) Dot |.|
+//@[033:042) Identifier |getSecret|
+//@[042:043) LeftParen |(|
+//@[043:053) StringComplete |'mySecret'|
+//@[053:054) RightParen |)|
+//@[054:056) NewLine |\r\n|
+    secureStringParam2: scopedKv.getSecret('mySecret','secretVersion')
+//@[004:022) Identifier |secureStringParam2|
+//@[022:023) Colon |:|
+//@[024:032) Identifier |scopedKv|
+//@[032:033) Dot |.|
+//@[033:042) Identifier |getSecret|
+//@[042:043) LeftParen |(|
+//@[043:053) StringComplete |'mySecret'|
+//@[053:054) Comma |,|
+//@[054:069) StringComplete |'secretVersion'|
+//@[069:070) RightParen |)|
+//@[070:072) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+//looped module with looped existing resource (Issue #2862)
+//@[059:061) NewLine |\r\n|
+var vaults = [
+//@[000:003) Identifier |var|
+//@[004:010) Identifier |vaults|
+//@[011:012) Assignment |=|
+//@[013:014) LeftSquare |[|
+//@[014:016) NewLine |\r\n|
+  {
+//@[002:003) LeftBrace |{|
+//@[003:005) NewLine |\r\n|
+    vaultName: 'test-1-kv'
+//@[004:013) Identifier |vaultName|
+//@[013:014) Colon |:|
+//@[015:026) StringComplete |'test-1-kv'|
+//@[026:028) NewLine |\r\n|
+    vaultRG: 'test-1-rg'
+//@[004:011) Identifier |vaultRG|
+//@[011:012) Colon |:|
+//@[013:024) StringComplete |'test-1-rg'|
+//@[024:026) NewLine |\r\n|
+    vaultSub: 'abcd-efgh'
+//@[004:012) Identifier |vaultSub|
+//@[012:013) Colon |:|
+//@[014:025) StringComplete |'abcd-efgh'|
+//@[025:027) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+  {
+//@[002:003) LeftBrace |{|
+//@[003:005) NewLine |\r\n|
+    vaultName: 'test-2-kv'
+//@[004:013) Identifier |vaultName|
+//@[013:014) Colon |:|
+//@[015:026) StringComplete |'test-2-kv'|
+//@[026:028) NewLine |\r\n|
+    vaultRG: 'test-2-rg'
+//@[004:011) Identifier |vaultRG|
+//@[011:012) Colon |:|
+//@[013:024) StringComplete |'test-2-rg'|
+//@[024:026) NewLine |\r\n|
+    vaultSub: 'ijkl-1adg1'
+//@[004:012) Identifier |vaultSub|
+//@[012:013) Colon |:|
+//@[014:026) StringComplete |'ijkl-1adg1'|
+//@[026:028) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+]
+//@[000:001) RightSquare |]|
+//@[001:003) NewLine |\r\n|
+var secrets = [
+//@[000:003) Identifier |var|
+//@[004:011) Identifier |secrets|
+//@[012:013) Assignment |=|
+//@[014:015) LeftSquare |[|
+//@[015:017) NewLine |\r\n|
+  {
+//@[002:003) LeftBrace |{|
+//@[003:005) NewLine |\r\n|
+    name: 'secret01'
+//@[004:008) Identifier |name|
+//@[008:009) Colon |:|
+//@[010:020) StringComplete |'secret01'|
+//@[020:022) NewLine |\r\n|
+    version: 'versionA'
+//@[004:011) Identifier |version|
+//@[011:012) Colon |:|
+//@[013:023) StringComplete |'versionA'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+  {
+//@[002:003) LeftBrace |{|
+//@[003:005) NewLine |\r\n|
+    name: 'secret02'
+//@[004:008) Identifier |name|
+//@[008:009) Colon |:|
+//@[010:020) StringComplete |'secret02'|
+//@[020:022) NewLine |\r\n|
+    version: 'versionB'
+//@[004:011) Identifier |version|
+//@[011:012) Colon |:|
+//@[013:023) StringComplete |'versionB'|
+//@[023:025) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+]
+//@[000:001) RightSquare |]|
+//@[001:005) NewLine |\r\n\r\n|
+
+resource loopedKv 'Microsoft.KeyVault/vaults@2019-09-01' existing = [for vault in vaults: {
+//@[000:008) Identifier |resource|
+//@[009:017) Identifier |loopedKv|
+//@[018:056) StringComplete |'Microsoft.KeyVault/vaults@2019-09-01'|
+//@[057:065) Identifier |existing|
+//@[066:067) Assignment |=|
+//@[068:069) LeftSquare |[|
+//@[069:072) Identifier |for|
+//@[073:078) Identifier |vault|
+//@[079:081) Identifier |in|
+//@[082:088) Identifier |vaults|
+//@[088:089) Colon |:|
+//@[090:091) LeftBrace |{|
+//@[091:093) NewLine |\r\n|
+  name: vault.vaultName
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:013) Identifier |vault|
+//@[013:014) Dot |.|
+//@[014:023) Identifier |vaultName|
+//@[023:025) NewLine |\r\n|
+  scope: resourceGroup(vault.vaultSub, vault.vaultRG)
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:022) Identifier |resourceGroup|
+//@[022:023) LeftParen |(|
+//@[023:028) Identifier |vault|
+//@[028:029) Dot |.|
+//@[029:037) Identifier |vaultSub|
+//@[037:038) Comma |,|
+//@[039:044) Identifier |vault|
+//@[044:045) Dot |.|
+//@[045:052) Identifier |vaultRG|
+//@[052:053) RightParen |)|
+//@[053:055) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+module secureModuleLooped 'child/secureParams.bicep' = [for (secret, i) in secrets: {
+//@[000:006) Identifier |module|
+//@[007:025) Identifier |secureModuleLooped|
+//@[026:052) StringComplete |'child/secureParams.bicep'|
+//@[053:054) Assignment |=|
+//@[055:056) LeftSquare |[|
+//@[056:059) Identifier |for|
+//@[060:061) LeftParen |(|
+//@[061:067) Identifier |secret|
+//@[067:068) Comma |,|
+//@[069:070) Identifier |i|
+//@[070:071) RightParen |)|
+//@[072:074) Identifier |in|
+//@[075:082) Identifier |secrets|
+//@[082:083) Colon |:|
+//@[084:085) LeftBrace |{|
+//@[085:087) NewLine |\r\n|
+  name: 'secureModuleLooped-${i}'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:030) StringLeftPiece |'secureModuleLooped-${|
+//@[030:031) Identifier |i|
+//@[031:033) StringRightPiece |}'|
+//@[033:035) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    secureStringParam1: loopedKv[i].getSecret(secret.name)
+//@[004:022) Identifier |secureStringParam1|
+//@[022:023) Colon |:|
+//@[024:032) Identifier |loopedKv|
+//@[032:033) LeftSquare |[|
+//@[033:034) Identifier |i|
+//@[034:035) RightSquare |]|
+//@[035:036) Dot |.|
+//@[036:045) Identifier |getSecret|
+//@[045:046) LeftParen |(|
+//@[046:052) Identifier |secret|
+//@[052:053) Dot |.|
+//@[053:057) Identifier |name|
+//@[057:058) RightParen |)|
+//@[058:060) NewLine |\r\n|
+    secureStringParam2: loopedKv[i].getSecret(secret.name, secret.version)
+//@[004:022) Identifier |secureStringParam2|
+//@[022:023) Colon |:|
+//@[024:032) Identifier |loopedKv|
+//@[032:033) LeftSquare |[|
+//@[033:034) Identifier |i|
+//@[034:035) RightSquare |]|
+//@[035:036) Dot |.|
+//@[036:045) Identifier |getSecret|
+//@[045:046) LeftParen |(|
+//@[046:052) Identifier |secret|
+//@[052:053) Dot |.|
+//@[053:057) Identifier |name|
+//@[057:058) Comma |,|
+//@[059:065) Identifier |secret|
+//@[065:066) Dot |.|
+//@[066:073) Identifier |version|
+//@[073:074) RightParen |)|
+//@[074:076) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}]
+//@[000:001) RightBrace |}|
+//@[001:002) RightSquare |]|
+//@[002:006) NewLine |\r\n\r\n|
+
+module secureModuleCondition 'child/secureParams.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:028) Identifier |secureModuleCondition|
+//@[029:055) StringComplete |'child/secureParams.bicep'|
+//@[056:057) Assignment |=|
+//@[058:059) LeftBrace |{|
+//@[059:061) NewLine |\r\n|
+  name: 'secureModuleCondition'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:031) StringComplete |'secureModuleCondition'|
+//@[031:033) NewLine |\r\n|
+  params: {
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[010:011) LeftBrace |{|
+//@[011:013) NewLine |\r\n|
+    secureStringParam1: true ? kv.getSecret('mySecret') : 'notTrue'
+//@[004:022) Identifier |secureStringParam1|
+//@[022:023) Colon |:|
+//@[024:028) TrueKeyword |true|
+//@[029:030) Question |?|
+//@[031:033) Identifier |kv|
+//@[033:034) Dot |.|
+//@[034:043) Identifier |getSecret|
+//@[043:044) LeftParen |(|
+//@[044:054) StringComplete |'mySecret'|
+//@[054:055) RightParen |)|
+//@[056:057) Colon |:|
+//@[058:067) StringComplete |'notTrue'|
+//@[067:069) NewLine |\r\n|
+    secureStringParam2: true ? false ? 'false' : kv.getSecret('mySecret','secretVersion') : 'notTrue'
+//@[004:022) Identifier |secureStringParam2|
+//@[022:023) Colon |:|
+//@[024:028) TrueKeyword |true|
+//@[029:030) Question |?|
+//@[031:036) FalseKeyword |false|
+//@[037:038) Question |?|
+//@[039:046) StringComplete |'false'|
+//@[047:048) Colon |:|
+//@[049:051) Identifier |kv|
+//@[051:052) Dot |.|
+//@[052:061) Identifier |getSecret|
+//@[061:062) LeftParen |(|
+//@[062:072) StringComplete |'mySecret'|
+//@[072:073) Comma |,|
+//@[073:088) StringComplete |'secretVersion'|
+//@[088:089) RightParen |)|
+//@[090:091) Colon |:|
+//@[092:101) StringComplete |'notTrue'|
+//@[101:103) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+// END: Key Vault Secret Reference
+//@[034:038) NewLine |\r\n\r\n|
+
+module withSpace 'module with space.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:016) Identifier |withSpace|
+//@[017:042) StringComplete |'module with space.bicep'|
+//@[043:044) Assignment |=|
+//@[045:046) LeftBrace |{|
+//@[046:048) NewLine |\r\n|
+  name: 'withSpace'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:019) StringComplete |'withSpace'|
+//@[019:021) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module folderWithSpace 'child/folder with space/child with space.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:022) Identifier |folderWithSpace|
+//@[023:071) StringComplete |'child/folder with space/child with space.bicep'|
+//@[072:073) Assignment |=|
+//@[074:075) LeftBrace |{|
+//@[075:077) NewLine |\r\n|
+  name: 'childWithSpace'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:024) StringComplete |'childWithSpace'|
+//@[024:026) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+// nameof
+//@[009:013) NewLine |\r\n\r\n|
+
+var nameofModule = nameof(folderWithSpace)
+//@[000:003) Identifier |var|
+//@[004:016) Identifier |nameofModule|
+//@[017:018) Assignment |=|
+//@[019:025) Identifier |nameof|
+//@[025:026) LeftParen |(|
+//@[026:041) Identifier |folderWithSpace|
+//@[041:042) RightParen |)|
+//@[042:044) NewLine |\r\n|
+var nameofModuleParam = nameof(secureModuleCondition.outputs.exposedSecureString)
+//@[000:003) Identifier |var|
+//@[004:021) Identifier |nameofModuleParam|
+//@[022:023) Assignment |=|
+//@[024:030) Identifier |nameof|
+//@[030:031) LeftParen |(|
+//@[031:052) Identifier |secureModuleCondition|
+//@[052:053) Dot |.|
+//@[053:060) Identifier |outputs|
+//@[060:061) Dot |.|
+//@[061:080) Identifier |exposedSecureString|
+//@[080:081) RightParen |)|
+//@[081:085) NewLine |\r\n\r\n|
+
+module moduleWithNameof 'modulea.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:023) Identifier |moduleWithNameof|
+//@[024:039) StringComplete |'modulea.bicep'|
+//@[040:041) Assignment |=|
+//@[042:043) LeftBrace |{|
+//@[043:045) NewLine |\r\n|
+  name: 'nameofModule'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:022) StringComplete |'nameofModule'|
+//@[022:024) NewLine |\r\n|
+  scope: resourceGroup(nameof(nameofModuleParam))
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:022) Identifier |resourceGroup|
+//@[022:023) LeftParen |(|
+//@[023:029) Identifier |nameof|
+//@[029:030) LeftParen |(|
+//@[030:047) Identifier |nameofModuleParam|
+//@[047:048) RightParen |)|
+//@[048:049) RightParen |)|
+//@[049:051) NewLine |\r\n|
+  params:{
+//@[002:008) Identifier |params|
+//@[008:009) Colon |:|
+//@[009:010) LeftBrace |{|
+//@[010:012) NewLine |\r\n|
+    stringParamA: nameof(withSpace)
+//@[004:016) Identifier |stringParamA|
+//@[016:017) Colon |:|
+//@[018:024) Identifier |nameof|
+//@[024:025) LeftParen |(|
+//@[025:034) Identifier |withSpace|
+//@[034:035) RightParen |)|
+//@[035:037) NewLine |\r\n|
+    stringParamB: nameof(folderWithSpace)
+//@[004:016) Identifier |stringParamB|
+//@[016:017) Colon |:|
+//@[018:024) Identifier |nameof|
+//@[024:025) LeftParen |(|
+//@[025:040) Identifier |folderWithSpace|
+//@[040:041) RightParen |)|
+//@[041:043) NewLine |\r\n|
+    objParam: {
+//@[004:012) Identifier |objParam|
+//@[012:013) Colon |:|
+//@[014:015) LeftBrace |{|
+//@[015:017) NewLine |\r\n|
+      a: nameof(secureModuleCondition.outputs.exposedSecureString)
+//@[006:007) Identifier |a|
+//@[007:008) Colon |:|
+//@[009:015) Identifier |nameof|
+//@[015:016) LeftParen |(|
+//@[016:037) Identifier |secureModuleCondition|
+//@[037:038) Dot |.|
+//@[038:045) Identifier |outputs|
+//@[045:046) Dot |.|
+//@[046:065) Identifier |exposedSecureString|
+//@[065:066) RightParen |)|
+//@[066:068) NewLine |\r\n|
+    }
+//@[004:005) RightBrace |}|
+//@[005:007) NewLine |\r\n|
+    arrayParam: [
+//@[004:014) Identifier |arrayParam|
+//@[014:015) Colon |:|
+//@[016:017) LeftSquare |[|
+//@[017:019) NewLine |\r\n|
+      nameof(vaults)
+//@[006:012) Identifier |nameof|
+//@[012:013) LeftParen |(|
+//@[013:019) Identifier |vaults|
+//@[019:020) RightParen |)|
+//@[020:022) NewLine |\r\n|
+    ]
+//@[004:005) RightSquare |]|
+//@[005:007) NewLine |\r\n|
+  }
+//@[002:003) RightBrace |}|
+//@[003:005) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+module moduleWithNullableOutputs 'child/nullableOutputs.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:032) Identifier |moduleWithNullableOutputs|
+//@[033:062) StringComplete |'child/nullableOutputs.bicep'|
+//@[063:064) Assignment |=|
+//@[065:066) LeftBrace |{|
+//@[066:068) NewLine |\r\n|
+  name: 'nullableOutputs'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:025) StringComplete |'nullableOutputs'|
+//@[025:027) NewLine |\r\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:005) NewLine |\r\n\r\n|
+
+output nullableString string? = moduleWithNullableOutputs.outputs.?nullableString
+//@[000:006) Identifier |output|
+//@[007:021) Identifier |nullableString|
+//@[022:028) Identifier |string|
+//@[028:029) Question |?|
+//@[030:031) Assignment |=|
+//@[032:057) Identifier |moduleWithNullableOutputs|
+//@[057:058) Dot |.|
+//@[058:065) Identifier |outputs|
+//@[065:066) Dot |.|
+//@[066:067) Question |?|
+//@[067:081) Identifier |nullableString|
+//@[081:083) NewLine |\r\n|
+output deeplyNestedProperty string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.property
+//@[000:006) Identifier |output|
+//@[007:027) Identifier |deeplyNestedProperty|
+//@[028:034) Identifier |string|
+//@[034:035) Question |?|
+//@[036:037) Assignment |=|
+//@[038:063) Identifier |moduleWithNullableOutputs|
+//@[063:064) Dot |.|
+//@[064:071) Identifier |outputs|
+//@[071:072) Dot |.|
+//@[072:073) Question |?|
+//@[073:084) Identifier |nullableObj|
+//@[084:085) Dot |.|
+//@[085:091) Identifier |deeply|
+//@[091:092) Dot |.|
+//@[092:098) Identifier |nested|
+//@[098:099) Dot |.|
+//@[099:107) Identifier |property|
+//@[107:109) NewLine |\r\n|
+output deeplyNestedArrayItem string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[0]
+//@[000:006) Identifier |output|
+//@[007:028) Identifier |deeplyNestedArrayItem|
+//@[029:035) Identifier |string|
+//@[035:036) Question |?|
+//@[037:038) Assignment |=|
+//@[039:064) Identifier |moduleWithNullableOutputs|
+//@[064:065) Dot |.|
+//@[065:072) Identifier |outputs|
+//@[072:073) Dot |.|
+//@[073:074) Question |?|
+//@[074:085) Identifier |nullableObj|
+//@[085:086) Dot |.|
+//@[086:092) Identifier |deeply|
+//@[092:093) Dot |.|
+//@[093:099) Identifier |nested|
+//@[099:100) Dot |.|
+//@[100:105) Identifier |array|
+//@[105:106) LeftSquare |[|
+//@[106:107) Integer |0|
+//@[107:108) RightSquare |]|
+//@[108:110) NewLine |\r\n|
+output deeplyNestedArrayItemFromEnd string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[^1]
+//@[000:006) Identifier |output|
+//@[007:035) Identifier |deeplyNestedArrayItemFromEnd|
+//@[036:042) Identifier |string|
+//@[042:043) Question |?|
+//@[044:045) Assignment |=|
+//@[046:071) Identifier |moduleWithNullableOutputs|
+//@[071:072) Dot |.|
+//@[072:079) Identifier |outputs|
+//@[079:080) Dot |.|
+//@[080:081) Question |?|
+//@[081:092) Identifier |nullableObj|
+//@[092:093) Dot |.|
+//@[093:099) Identifier |deeply|
+//@[099:100) Dot |.|
+//@[100:106) Identifier |nested|
+//@[106:107) Dot |.|
+//@[107:112) Identifier |array|
+//@[112:113) LeftSquare |[|
+//@[113:114) Hat |^|
+//@[114:115) Integer |1|
+//@[115:116) RightSquare |]|
+//@[116:118) NewLine |\r\n|
+output deeplyNestedArrayItemFromEndAttempt string? = moduleWithNullableOutputs.outputs.?nullableObj.deeply.nested.array[?^1]
+//@[000:006) Identifier |output|
+//@[007:042) Identifier |deeplyNestedArrayItemFromEndAttempt|
+//@[043:049) Identifier |string|
+//@[049:050) Question |?|
+//@[051:052) Assignment |=|
+//@[053:078) Identifier |moduleWithNullableOutputs|
+//@[078:079) Dot |.|
+//@[079:086) Identifier |outputs|
+//@[086:087) Dot |.|
+//@[087:088) Question |?|
+//@[088:099) Identifier |nullableObj|
+//@[099:100) Dot |.|
+//@[100:106) Identifier |deeply|
+//@[106:107) Dot |.|
+//@[107:113) Identifier |nested|
+//@[113:114) Dot |.|
+//@[114:119) Identifier |array|
+//@[119:120) LeftSquare |[|
+//@[120:121) Question |?|
+//@[121:122) Hat |^|
+//@[122:123) Integer |1|
+//@[123:124) RightSquare |]|
+//@[124:126) NewLine |\r\n|
+
+//@[000:000) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/module with space.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/module with space.bicep
@@ -1,0 +1,2 @@
+param location string = 'westus'
+output loc string = location

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/modulea.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/modulea.bicep
@@ -1,0 +1,22 @@
+param stringParamA string = 'test'
+param stringParamB string
+param objParam object
+param arrayParam array
+
+resource basicStorage 'Mock.Rp/mockResource@2020-01-01' = {
+  name: 'basicblobs'
+  location: stringParamA
+}
+
+resource dnsZone 'Mock.Rp/mockResource@2020-01-01' = {
+  name: 'myZone'
+  location: stringParamB
+}
+
+output stringOutputA string = stringParamA
+output stringOutputB string = stringParamB
+output objOutput object = basicStorage.properties
+output arrayOutput array = [
+  basicStorage.id
+  dnsZone.id
+]

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/modulereprob.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesContentManifest_CRLF/modulereprob.bicep
@@ -1,0 +1,22 @@
+var myModules = [
+  {
+    name: 'one'
+    location: 'eastus2'
+  }
+  {
+    name: 'two'
+    location: 'westus'
+  }
+]
+
+var emptyArray = []
+
+// simple module loop
+module storageResources 'modulea.bicep' = [for module in myModules: {
+  name: module.name
+  params: {
+    arrayParam: []
+    objParam: module
+    stringParamB: module.location
+  }
+}]

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/bicepconfig.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+    "experimentalFeaturesEnabled": {
+        "moduleContentDeduplication": true
+    }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.bicep
@@ -1,0 +1,28 @@
+﻿targetScope = 'tenant'
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup')
+}
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup2')
+}
+module mySubscriptionMod 'modules/subscription.bicep' = {
+  name: 'mySubscriptionMod'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+  name: 'mySubscriptionModWithCondition'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+  name: 'mySubscriptionMod'
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+}
+
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.diagnostics.bicep
@@ -1,0 +1,29 @@
+targetScope = 'tenant'
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup')
+}
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup2')
+}
+module mySubscriptionMod 'modules/subscription.bicep' = {
+  name: 'mySubscriptionMod'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+  name: 'mySubscriptionModWithCondition'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+  name: 'mySubscriptionMod'
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+}
+
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.formatted.bicep
@@ -1,0 +1,27 @@
+targetScope = 'tenant'
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup')
+}
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup2')
+}
+module mySubscriptionMod 'modules/subscription.bicep' = {
+  name: 'mySubscriptionMod'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+  name: 'mySubscriptionModWithCondition'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+  name: 'mySubscriptionMod'
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+}
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.ir.bicep
@@ -1,0 +1,70 @@
+targetScope = 'tenant'
+//@[000:1047) ProgramExpression
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+//@[000:0142) ├─DeclaredModuleExpression
+//@[062:0142) | └─ObjectExpression
+  name: 'myManagementGroupMod'
+//@[002:0030) |   └─ObjectPropertyExpression
+//@[002:0006) |     ├─StringLiteralExpression { Value = name }
+//@[008:0030) |     └─StringLiteralExpression { Value = myManagementGroupMod }
+  scope: managementGroup('myManagementGroup')
+}
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+//@[000:0184) ├─DeclaredModuleExpression
+//@[103:0184) | └─ObjectExpression
+  name: 'myManagementGroupMod'
+//@[002:0030) |   └─ObjectPropertyExpression
+//@[002:0006) |     ├─StringLiteralExpression { Value = name }
+//@[008:0030) |     └─StringLiteralExpression { Value = myManagementGroupMod }
+  scope: managementGroup('myManagementGroup2')
+}
+module mySubscriptionMod 'modules/subscription.bicep' = {
+//@[000:0149) ├─DeclaredModuleExpression
+//@[056:0149) | └─ObjectExpression
+  name: 'mySubscriptionMod'
+//@[002:0027) |   └─ObjectPropertyExpression
+//@[002:0006) |     ├─StringLiteralExpression { Value = name }
+//@[008:0027) |     └─StringLiteralExpression { Value = mySubscriptionMod }
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+//@[000:0199) ├─DeclaredModuleExpression
+//@[073:0091) | └─ConditionExpression
+//@[073:0091) |   ├─BinaryExpression { Operator = Equals }
+//@[073:0086) |   | ├─FunctionCallExpression { Name = length }
+//@[080:0085) |   | | └─StringLiteralExpression { Value = foo }
+//@[090:0091) |   | └─IntegerLiteralExpression { Value = 3 }
+//@[093:0199) |   └─ObjectExpression
+  name: 'mySubscriptionModWithCondition'
+//@[002:0040) |     └─ObjectPropertyExpression
+//@[002:0006) |       ├─StringLiteralExpression { Value = name }
+//@[008:0040) |       └─StringLiteralExpression { Value = mySubscriptionModWithCondition }
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+//@[000:0190) ├─DeclaredModuleExpression
+//@[097:0190) | └─ObjectExpression
+  name: 'mySubscriptionMod'
+//@[002:0027) |   └─ObjectPropertyExpression
+//@[002:0006) |     ├─StringLiteralExpression { Value = name }
+//@[008:0027) |     └─StringLiteralExpression { Value = mySubscriptionMod }
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+}
+
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+//@[000:0077) ├─DeclaredOutputExpression { Name = myManagementGroupOutput }
+//@[031:0037) | ├─AmbientTypeReferenceExpression { Name = string }
+//@[040:0077) | └─ModuleOutputPropertyAccessExpression { PropertyName = myOutput }
+//@[040:0068) |   └─PropertyAccessExpression { PropertyName = outputs }
+//@[040:0060) |     └─ModuleReferenceExpression
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
+//@[000:0071) └─DeclaredOutputExpression { Name = mySubscriptionOutput }
+//@[028:0034)   ├─AmbientTypeReferenceExpression { Name = string }
+//@[037:0071)   └─ModuleOutputPropertyAccessExpression { PropertyName = myOutput }
+//@[037:0062)     └─PropertyAccessExpression { PropertyName = outputs }
+//@[037:0054)       └─ModuleReferenceExpression
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.json
@@ -1,0 +1,463 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Enable content-addressed deduplication of nested module templates"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "10799161342671961670"
+    }
+  },
+  "resources": {
+    "myManagementGroupMod": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "myManagementGroupMod",
+      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup')]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:b0e48580ec85bc7699c01af9e91baaa9334c074fa4b1241d39cdd0b25e7b69b7"
+        }
+      }
+    },
+    "myManagementGroupModWithDuplicatedNameButDifferentScope": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "myManagementGroupMod",
+      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:bd47cb5084e5d04753b7182536f3cd22b11ad5a276e72dd2f732399aef62ae9e"
+        }
+      }
+    },
+    "mySubscriptionMod": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "mySubscriptionMod",
+      "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa"
+        }
+      }
+    },
+    "mySubscriptionModWithCondition": {
+      "condition": "[equals(length('foo'), 3)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "mySubscriptionModWithCondition",
+      "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa"
+        }
+      }
+    },
+    "mySubscriptionModWithDuplicatedNameButDifferentScope": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "mySubscriptionMod",
+      "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+        }
+      }
+    }
+  },
+  "outputs": {
+    "myManagementGroupOutput": {
+      "type": "string",
+      "value": "[reference('myManagementGroupMod').outputs.myOutput.value]"
+    },
+    "mySubscriptionOutput": {
+      "type": "string",
+      "value": "[reference('mySubscriptionMod').outputs.myOutput.value]"
+    }
+  },
+  "content": {
+    "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "12211336549599938349"
+          }
+        },
+        "resources": {
+          "myTenantMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myTenantMod",
+            "scope": "/",
+            "location": "[resourceGroup().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e"
+              }
+            }
+          },
+          "myOtherResourceGroup": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myOtherResourceGroup",
+            "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
+            "resourceGroup": "myOtherRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:86e4a3f6d830d73dbe20895f01e7420a16e91557d00789222eef0e07d0d3e796"
+              }
+            }
+          },
+          "mySubscription": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "mySubscription",
+            "subscriptionId": "[subscription().subscriptionId]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+              }
+            }
+          },
+          "otherSubscription": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "otherSubscription",
+            "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
+            "location": "[resourceGroup().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+              }
+            }
+          }
+        },
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "[reference('myTenantMod').outputs.myOutput.value]"
+          },
+          "myOutputResourceGroup": {
+            "type": "string",
+            "value": "[reference('myOtherResourceGroup').outputs.myOutput.value]"
+          }
+        }
+      }
+    },
+    "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "15924331173791733922"
+          }
+        },
+        "resources": {
+          "myResourceGroupMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myResourceGroupMod",
+            "resourceGroup": "myRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443"
+              }
+            }
+          },
+          "myResourceGroupMod2": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myResourceGroupMod2",
+            "resourceGroup": "myRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443"
+              }
+            }
+          },
+          "myResourceGroupMod3": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myResourceGroupMod3",
+            "subscriptionId": "subId",
+            "resourceGroup": "myRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443"
+              }
+            }
+          },
+          "myTenantMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myTenantMod",
+            "scope": "/",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e"
+              }
+            }
+          }
+        },
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "[reference('myTenantMod').outputs.myOutput.value]"
+          },
+          "myOutputRgMod": {
+            "type": "string",
+            "value": "[reference('myResourceGroupMod').outputs.myOutput.value]"
+          },
+          "myOutputRgMod2": {
+            "type": "string",
+            "value": "[reference('myResourceGroupMod2').outputs.myOutput.value]"
+          }
+        }
+      }
+    },
+    "sha256:86e4a3f6d830d73dbe20895f01e7420a16e91557d00789222eef0e07d0d3e796": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "8688843110047013828"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "hello!"
+          }
+        }
+      }
+    },
+    "sha256:b0e48580ec85bc7699c01af9e91baaa9334c074fa4b1241d39cdd0b25e7b69b7": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "902531172735975563"
+          }
+        },
+        "resources": {
+          "myTenantMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myTenantMod",
+            "scope": "/",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e"
+              }
+            }
+          },
+          "myManagementGroupModWithDuplicatedNameButInSeparateModule": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myManagementGroupMod",
+            "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:bd47cb5084e5d04753b7182536f3cd22b11ad5a276e72dd2f732399aef62ae9e"
+              }
+            }
+          },
+          "mySubscriptionModWithDuplicatedNameButInSeparateModule": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "mySubscriptionMod",
+            "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+              }
+            }
+          }
+        },
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "[reference('myTenantMod').outputs.myOutput.value]"
+          }
+        }
+      }
+    },
+    "sha256:bd47cb5084e5d04753b7182536f3cd22b11ad5a276e72dd2f732399aef62ae9e": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "10060721982683105121"
+          }
+        },
+        "resources": {}
+      }
+    },
+    "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "3756952332756885582"
+          }
+        },
+        "resources": {}
+      }
+    },
+    "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "18232673065688289497"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "hello!"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.json
@@ -106,7 +106,7 @@
       "value": "[reference('mySubscriptionMod').outputs.myOutput.value]"
     }
   },
-  "content": {
+  "contentManifest": {
     "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443": {
       "value": {
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.sourcemap.bicep
@@ -1,0 +1,118 @@
+targetScope = 'tenant'
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+//@    "myManagementGroupMod": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup')]",
+//@      "location": "[deployment().location]",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:b0e48580ec85bc7699c01af9e91baaa9334c074fa4b1241d39cdd0b25e7b69b7"
+//@        }
+//@      }
+//@    },
+  name: 'myManagementGroupMod'
+//@      "name": "myManagementGroupMod",
+  scope: managementGroup('myManagementGroup')
+}
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+//@    "myManagementGroupModWithDuplicatedNameButDifferentScope": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
+//@      "location": "[deployment().location]",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:bd47cb5084e5d04753b7182536f3cd22b11ad5a276e72dd2f732399aef62ae9e"
+//@        }
+//@      }
+//@    },
+  name: 'myManagementGroupMod'
+//@      "name": "myManagementGroupMod",
+  scope: managementGroup('myManagementGroup2')
+}
+module mySubscriptionMod 'modules/subscription.bicep' = {
+//@    "mySubscriptionMod": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "location": "[deployment().location]",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa"
+//@        }
+//@      }
+//@    },
+  name: 'mySubscriptionMod'
+//@      "name": "mySubscriptionMod",
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+//@      "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
+}
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+//@    "mySubscriptionModWithCondition": {
+//@      "condition": "[equals(length('foo'), 3)]",
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "location": "[deployment().location]",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa"
+//@        }
+//@      }
+//@    },
+  name: 'mySubscriptionModWithCondition'
+//@      "name": "mySubscriptionModWithCondition",
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+//@      "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
+}
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+//@    "mySubscriptionModWithDuplicatedNameButDifferentScope": {
+//@      "type": "Microsoft.Resources/deployments",
+//@      "apiVersion": "2025-04-01",
+//@      "location": "[deployment().location]",
+//@      "properties": {
+//@        "expressionEvaluationOptions": {
+//@          "scope": "inner"
+//@        },
+//@        "mode": "Incremental",
+//@        "templateLink": {
+//@          "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+//@        }
+//@      }
+//@    }
+  name: 'mySubscriptionMod'
+//@      "name": "mySubscriptionMod",
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+//@      "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
+}
+
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+//@    "myManagementGroupOutput": {
+//@      "type": "string",
+//@      "value": "[reference('myManagementGroupMod').outputs.myOutput.value]"
+//@    },
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
+//@    "mySubscriptionOutput": {
+//@      "type": "string",
+//@      "value": "[reference('mySubscriptionMod').outputs.myOutput.value]"
+//@    }
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.symbolicnames.json
@@ -1,0 +1,463 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+  "languageVersion": "2.1-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+    "_EXPERIMENTAL_FEATURES_ENABLED": [
+      "Enable content-addressed deduplication of nested module templates"
+    ],
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "10799161342671961670"
+    }
+  },
+  "resources": {
+    "myManagementGroupMod": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "myManagementGroupMod",
+      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup')]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:b0e48580ec85bc7699c01af9e91baaa9334c074fa4b1241d39cdd0b25e7b69b7"
+        }
+      }
+    },
+    "myManagementGroupModWithDuplicatedNameButDifferentScope": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "myManagementGroupMod",
+      "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:bd47cb5084e5d04753b7182536f3cd22b11ad5a276e72dd2f732399aef62ae9e"
+        }
+      }
+    },
+    "mySubscriptionMod": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "mySubscriptionMod",
+      "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa"
+        }
+      }
+    },
+    "mySubscriptionModWithCondition": {
+      "condition": "[equals(length('foo'), 3)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "mySubscriptionModWithCondition",
+      "subscriptionId": "ee44cd78-68c6-43d9-874e-e684ec8d1191",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa"
+        }
+      }
+    },
+    "mySubscriptionModWithDuplicatedNameButDifferentScope": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "mySubscriptionMod",
+      "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "templateLink": {
+          "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+        }
+      }
+    }
+  },
+  "outputs": {
+    "myManagementGroupOutput": {
+      "type": "string",
+      "value": "[reference('myManagementGroupMod').outputs.myOutput.value]"
+    },
+    "mySubscriptionOutput": {
+      "type": "string",
+      "value": "[reference('mySubscriptionMod').outputs.myOutput.value]"
+    }
+  },
+  "content": {
+    "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "12211336549599938349"
+          }
+        },
+        "resources": {
+          "myTenantMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myTenantMod",
+            "scope": "/",
+            "location": "[resourceGroup().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e"
+              }
+            }
+          },
+          "myOtherResourceGroup": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myOtherResourceGroup",
+            "subscriptionId": "db90cfef-a146-4f67-b32f-b263518bd216",
+            "resourceGroup": "myOtherRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:86e4a3f6d830d73dbe20895f01e7420a16e91557d00789222eef0e07d0d3e796"
+              }
+            }
+          },
+          "mySubscription": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "mySubscription",
+            "subscriptionId": "[subscription().subscriptionId]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+              }
+            }
+          },
+          "otherSubscription": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "otherSubscription",
+            "subscriptionId": "cd780357-07f5-49cc-b945-a3fe15863860",
+            "location": "[resourceGroup().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+              }
+            }
+          }
+        },
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "[reference('myTenantMod').outputs.myOutput.value]"
+          },
+          "myOutputResourceGroup": {
+            "type": "string",
+            "value": "[reference('myOtherResourceGroup').outputs.myOutput.value]"
+          }
+        }
+      }
+    },
+    "sha256:2f751175cb9be0ad11a72de9fca59bf11ec3565b3fb1f2892483c0026c2352aa": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "15924331173791733922"
+          }
+        },
+        "resources": {
+          "myResourceGroupMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myResourceGroupMod",
+            "resourceGroup": "myRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443"
+              }
+            }
+          },
+          "myResourceGroupMod2": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myResourceGroupMod2",
+            "resourceGroup": "myRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443"
+              }
+            }
+          },
+          "myResourceGroupMod3": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myResourceGroupMod3",
+            "subscriptionId": "subId",
+            "resourceGroup": "myRg",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443"
+              }
+            }
+          },
+          "myTenantMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myTenantMod",
+            "scope": "/",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e"
+              }
+            }
+          }
+        },
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "[reference('myTenantMod').outputs.myOutput.value]"
+          },
+          "myOutputRgMod": {
+            "type": "string",
+            "value": "[reference('myResourceGroupMod').outputs.myOutput.value]"
+          },
+          "myOutputRgMod2": {
+            "type": "string",
+            "value": "[reference('myResourceGroupMod2').outputs.myOutput.value]"
+          }
+        }
+      }
+    },
+    "sha256:86e4a3f6d830d73dbe20895f01e7420a16e91557d00789222eef0e07d0d3e796": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "8688843110047013828"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "hello!"
+          }
+        }
+      }
+    },
+    "sha256:b0e48580ec85bc7699c01af9e91baaa9334c074fa4b1241d39cdd0b25e7b69b7": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "902531172735975563"
+          }
+        },
+        "resources": {
+          "myTenantMod": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myTenantMod",
+            "scope": "/",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e"
+              }
+            }
+          },
+          "myManagementGroupModWithDuplicatedNameButInSeparateModule": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "myManagementGroupMod",
+            "scope": "[format('Microsoft.Management/managementGroups/{0}', 'myManagementGroup2')]",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:bd47cb5084e5d04753b7182536f3cd22b11ad5a276e72dd2f732399aef62ae9e"
+              }
+            }
+          },
+          "mySubscriptionModWithDuplicatedNameButInSeparateModule": {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2025-04-01",
+            "name": "mySubscriptionMod",
+            "subscriptionId": "1ad827ac-2669-4c2f-9970-282b93c3c550",
+            "location": "[deployment().location]",
+            "properties": {
+              "expressionEvaluationOptions": {
+                "scope": "inner"
+              },
+              "mode": "Incremental",
+              "templateLink": {
+                "contentId": "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf"
+              }
+            }
+          }
+        },
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "[reference('myTenantMod').outputs.myOutput.value]"
+          }
+        }
+      }
+    },
+    "sha256:bd47cb5084e5d04753b7182536f3cd22b11ad5a276e72dd2f732399aef62ae9e": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "10060721982683105121"
+          }
+        },
+        "resources": {}
+      }
+    },
+    "sha256:d365b89e1f679dd5ca5bfec42c89146fd1f66e650b1c54fd7f2fda13dce48bcf": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "3756952332756885582"
+          }
+        },
+        "resources": {}
+      }
+    },
+    "sha256:d497d1af0b5ffc7c828ef9f61c19fb8f5ce0d22fe519295f9a290f869a44923e": {
+      "value": {
+        "$schema": "https://schema.management.azure.com/schemas/2019-08-01/tenantDeploymentTemplate.json#",
+        "languageVersion": "2.1-experimental",
+        "contentVersion": "1.0.0.0",
+        "metadata": {
+          "_EXPERIMENTAL_WARNING": "This template uses ARM features that are experimental. Experimental features should be enabled for testing purposes only, as there are no guarantees about the quality or stability of these features. Do not enable these settings for any production usage, or your production environment may be subject to breaking.",
+          "_EXPERIMENTAL_FEATURES_ENABLED": [
+            "Enable content-addressed deduplication of nested module templates"
+          ],
+          "_generator": {
+            "name": "bicep",
+            "version": "dev",
+            "templateHash": "18232673065688289497"
+          }
+        },
+        "resources": {},
+        "outputs": {
+          "myOutput": {
+            "type": "string",
+            "value": "hello!"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.symbolicnames.json
@@ -106,7 +106,7 @@
       "value": "[reference('mySubscriptionMod').outputs.myOutput.value]"
     }
   },
-  "content": {
+  "contentManifest": {
     "sha256:0e9b9f29d09e7acf34705168ea2fc1a685d825c60ac9f45827bab8be0859b443": {
       "value": {
         "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.symbols.bicep
@@ -1,0 +1,36 @@
+targetScope = 'tenant'
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+//@[7:27) Module myManagementGroupMod. Type: module. Declaration start char: 0, length: 142
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup')
+}
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+//@[7:62) Module myManagementGroupModWithDuplicatedNameButDifferentScope. Type: module. Declaration start char: 0, length: 184
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup2')
+}
+module mySubscriptionMod 'modules/subscription.bicep' = {
+//@[7:24) Module mySubscriptionMod. Type: module. Declaration start char: 0, length: 149
+  name: 'mySubscriptionMod'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+//@[7:37) Module mySubscriptionModWithCondition. Type: module. Declaration start char: 0, length: 199
+  name: 'mySubscriptionModWithCondition'
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+}
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+//@[7:59) Module mySubscriptionModWithDuplicatedNameButDifferentScope. Type: module. Declaration start char: 0, length: 190
+  name: 'mySubscriptionMod'
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+}
+
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+//@[7:30) Output myManagementGroupOutput. Type: string. Declaration start char: 0, length: 77
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
+//@[7:27) Output mySubscriptionOutput. Type: string. Declaration start char: 0, length: 71
+

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.syntax.bicep
@@ -1,0 +1,254 @@
+targetScope = 'tenant'
+//@[000:1047) ProgramSyntax
+//@[000:0022) ├─TargetScopeSyntax
+//@[000:0011) | ├─Token(Identifier) |targetScope|
+//@[012:0013) | ├─Token(Assignment) |=|
+//@[014:0022) | └─StringSyntax
+//@[014:0022) |   └─Token(StringComplete) |'tenant'|
+//@[022:0024) ├─Token(NewLine) |\n\n|
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+//@[000:0142) ├─ModuleDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |module|
+//@[007:0027) | ├─IdentifierSyntax
+//@[007:0027) | | └─Token(Identifier) |myManagementGroupMod|
+//@[028:0059) | ├─StringSyntax
+//@[028:0059) | | └─Token(StringComplete) |'modules/managementgroup.bicep'|
+//@[060:0061) | ├─Token(Assignment) |=|
+//@[062:0142) | └─ObjectSyntax
+//@[062:0063) |   ├─Token(LeftBrace) |{|
+//@[063:0064) |   ├─Token(NewLine) |\n|
+  name: 'myManagementGroupMod'
+//@[002:0030) |   ├─ObjectPropertySyntax
+//@[002:0006) |   | ├─IdentifierSyntax
+//@[002:0006) |   | | └─Token(Identifier) |name|
+//@[006:0007) |   | ├─Token(Colon) |:|
+//@[008:0030) |   | └─StringSyntax
+//@[008:0030) |   |   └─Token(StringComplete) |'myManagementGroupMod'|
+//@[030:0031) |   ├─Token(NewLine) |\n|
+  scope: managementGroup('myManagementGroup')
+//@[002:0045) |   ├─ObjectPropertySyntax
+//@[002:0007) |   | ├─IdentifierSyntax
+//@[002:0007) |   | | └─Token(Identifier) |scope|
+//@[007:0008) |   | ├─Token(Colon) |:|
+//@[009:0045) |   | └─FunctionCallSyntax
+//@[009:0024) |   |   ├─IdentifierSyntax
+//@[009:0024) |   |   | └─Token(Identifier) |managementGroup|
+//@[024:0025) |   |   ├─Token(LeftParen) |(|
+//@[025:0044) |   |   ├─FunctionArgumentSyntax
+//@[025:0044) |   |   | └─StringSyntax
+//@[025:0044) |   |   |   └─Token(StringComplete) |'myManagementGroup'|
+//@[044:0045) |   |   └─Token(RightParen) |)|
+//@[045:0046) |   ├─Token(NewLine) |\n|
+}
+//@[000:0001) |   └─Token(RightBrace) |}|
+//@[001:0002) ├─Token(NewLine) |\n|
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+//@[000:0184) ├─ModuleDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |module|
+//@[007:0062) | ├─IdentifierSyntax
+//@[007:0062) | | └─Token(Identifier) |myManagementGroupModWithDuplicatedNameButDifferentScope|
+//@[063:0100) | ├─StringSyntax
+//@[063:0100) | | └─Token(StringComplete) |'modules/managementgroup_empty.bicep'|
+//@[101:0102) | ├─Token(Assignment) |=|
+//@[103:0184) | └─ObjectSyntax
+//@[103:0104) |   ├─Token(LeftBrace) |{|
+//@[104:0105) |   ├─Token(NewLine) |\n|
+  name: 'myManagementGroupMod'
+//@[002:0030) |   ├─ObjectPropertySyntax
+//@[002:0006) |   | ├─IdentifierSyntax
+//@[002:0006) |   | | └─Token(Identifier) |name|
+//@[006:0007) |   | ├─Token(Colon) |:|
+//@[008:0030) |   | └─StringSyntax
+//@[008:0030) |   |   └─Token(StringComplete) |'myManagementGroupMod'|
+//@[030:0031) |   ├─Token(NewLine) |\n|
+  scope: managementGroup('myManagementGroup2')
+//@[002:0046) |   ├─ObjectPropertySyntax
+//@[002:0007) |   | ├─IdentifierSyntax
+//@[002:0007) |   | | └─Token(Identifier) |scope|
+//@[007:0008) |   | ├─Token(Colon) |:|
+//@[009:0046) |   | └─FunctionCallSyntax
+//@[009:0024) |   |   ├─IdentifierSyntax
+//@[009:0024) |   |   | └─Token(Identifier) |managementGroup|
+//@[024:0025) |   |   ├─Token(LeftParen) |(|
+//@[025:0045) |   |   ├─FunctionArgumentSyntax
+//@[025:0045) |   |   | └─StringSyntax
+//@[025:0045) |   |   |   └─Token(StringComplete) |'myManagementGroup2'|
+//@[045:0046) |   |   └─Token(RightParen) |)|
+//@[046:0047) |   ├─Token(NewLine) |\n|
+}
+//@[000:0001) |   └─Token(RightBrace) |}|
+//@[001:0002) ├─Token(NewLine) |\n|
+module mySubscriptionMod 'modules/subscription.bicep' = {
+//@[000:0149) ├─ModuleDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |module|
+//@[007:0024) | ├─IdentifierSyntax
+//@[007:0024) | | └─Token(Identifier) |mySubscriptionMod|
+//@[025:0053) | ├─StringSyntax
+//@[025:0053) | | └─Token(StringComplete) |'modules/subscription.bicep'|
+//@[054:0055) | ├─Token(Assignment) |=|
+//@[056:0149) | └─ObjectSyntax
+//@[056:0057) |   ├─Token(LeftBrace) |{|
+//@[057:0058) |   ├─Token(NewLine) |\n|
+  name: 'mySubscriptionMod'
+//@[002:0027) |   ├─ObjectPropertySyntax
+//@[002:0006) |   | ├─IdentifierSyntax
+//@[002:0006) |   | | └─Token(Identifier) |name|
+//@[006:0007) |   | ├─Token(Colon) |:|
+//@[008:0027) |   | └─StringSyntax
+//@[008:0027) |   |   └─Token(StringComplete) |'mySubscriptionMod'|
+//@[027:0028) |   ├─Token(NewLine) |\n|
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+//@[002:0061) |   ├─ObjectPropertySyntax
+//@[002:0007) |   | ├─IdentifierSyntax
+//@[002:0007) |   | | └─Token(Identifier) |scope|
+//@[007:0008) |   | ├─Token(Colon) |:|
+//@[009:0061) |   | └─FunctionCallSyntax
+//@[009:0021) |   |   ├─IdentifierSyntax
+//@[009:0021) |   |   | └─Token(Identifier) |subscription|
+//@[021:0022) |   |   ├─Token(LeftParen) |(|
+//@[022:0060) |   |   ├─FunctionArgumentSyntax
+//@[022:0060) |   |   | └─StringSyntax
+//@[022:0060) |   |   |   └─Token(StringComplete) |'ee44cd78-68c6-43d9-874e-e684ec8d1191'|
+//@[060:0061) |   |   └─Token(RightParen) |)|
+//@[061:0062) |   ├─Token(NewLine) |\n|
+}
+//@[000:0001) |   └─Token(RightBrace) |}|
+//@[001:0003) ├─Token(NewLine) |\n\n|
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+//@[000:0199) ├─ModuleDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |module|
+//@[007:0037) | ├─IdentifierSyntax
+//@[007:0037) | | └─Token(Identifier) |mySubscriptionModWithCondition|
+//@[038:0066) | ├─StringSyntax
+//@[038:0066) | | └─Token(StringComplete) |'modules/subscription.bicep'|
+//@[067:0068) | ├─Token(Assignment) |=|
+//@[069:0199) | └─IfConditionSyntax
+//@[069:0071) |   ├─Token(Identifier) |if|
+//@[072:0092) |   ├─ParenthesizedExpressionSyntax
+//@[072:0073) |   | ├─Token(LeftParen) |(|
+//@[073:0091) |   | ├─BinaryOperationSyntax
+//@[073:0086) |   | | ├─FunctionCallSyntax
+//@[073:0079) |   | | | ├─IdentifierSyntax
+//@[073:0079) |   | | | | └─Token(Identifier) |length|
+//@[079:0080) |   | | | ├─Token(LeftParen) |(|
+//@[080:0085) |   | | | ├─FunctionArgumentSyntax
+//@[080:0085) |   | | | | └─StringSyntax
+//@[080:0085) |   | | | |   └─Token(StringComplete) |'foo'|
+//@[085:0086) |   | | | └─Token(RightParen) |)|
+//@[087:0089) |   | | ├─Token(Equals) |==|
+//@[090:0091) |   | | └─IntegerLiteralSyntax
+//@[090:0091) |   | |   └─Token(Integer) |3|
+//@[091:0092) |   | └─Token(RightParen) |)|
+//@[093:0199) |   └─ObjectSyntax
+//@[093:0094) |     ├─Token(LeftBrace) |{|
+//@[094:0095) |     ├─Token(NewLine) |\n|
+  name: 'mySubscriptionModWithCondition'
+//@[002:0040) |     ├─ObjectPropertySyntax
+//@[002:0006) |     | ├─IdentifierSyntax
+//@[002:0006) |     | | └─Token(Identifier) |name|
+//@[006:0007) |     | ├─Token(Colon) |:|
+//@[008:0040) |     | └─StringSyntax
+//@[008:0040) |     |   └─Token(StringComplete) |'mySubscriptionModWithCondition'|
+//@[040:0041) |     ├─Token(NewLine) |\n|
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+//@[002:0061) |     ├─ObjectPropertySyntax
+//@[002:0007) |     | ├─IdentifierSyntax
+//@[002:0007) |     | | └─Token(Identifier) |scope|
+//@[007:0008) |     | ├─Token(Colon) |:|
+//@[009:0061) |     | └─FunctionCallSyntax
+//@[009:0021) |     |   ├─IdentifierSyntax
+//@[009:0021) |     |   | └─Token(Identifier) |subscription|
+//@[021:0022) |     |   ├─Token(LeftParen) |(|
+//@[022:0060) |     |   ├─FunctionArgumentSyntax
+//@[022:0060) |     |   | └─StringSyntax
+//@[022:0060) |     |   |   └─Token(StringComplete) |'ee44cd78-68c6-43d9-874e-e684ec8d1191'|
+//@[060:0061) |     |   └─Token(RightParen) |)|
+//@[061:0062) |     ├─Token(NewLine) |\n|
+}
+//@[000:0001) |     └─Token(RightBrace) |}|
+//@[001:0003) ├─Token(NewLine) |\n\n|
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+//@[000:0190) ├─ModuleDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |module|
+//@[007:0059) | ├─IdentifierSyntax
+//@[007:0059) | | └─Token(Identifier) |mySubscriptionModWithDuplicatedNameButDifferentScope|
+//@[060:0094) | ├─StringSyntax
+//@[060:0094) | | └─Token(StringComplete) |'modules/subscription_empty.bicep'|
+//@[095:0096) | ├─Token(Assignment) |=|
+//@[097:0190) | └─ObjectSyntax
+//@[097:0098) |   ├─Token(LeftBrace) |{|
+//@[098:0099) |   ├─Token(NewLine) |\n|
+  name: 'mySubscriptionMod'
+//@[002:0027) |   ├─ObjectPropertySyntax
+//@[002:0006) |   | ├─IdentifierSyntax
+//@[002:0006) |   | | └─Token(Identifier) |name|
+//@[006:0007) |   | ├─Token(Colon) |:|
+//@[008:0027) |   | └─StringSyntax
+//@[008:0027) |   |   └─Token(StringComplete) |'mySubscriptionMod'|
+//@[027:0028) |   ├─Token(NewLine) |\n|
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+//@[002:0061) |   ├─ObjectPropertySyntax
+//@[002:0007) |   | ├─IdentifierSyntax
+//@[002:0007) |   | | └─Token(Identifier) |scope|
+//@[007:0008) |   | ├─Token(Colon) |:|
+//@[009:0061) |   | └─FunctionCallSyntax
+//@[009:0021) |   |   ├─IdentifierSyntax
+//@[009:0021) |   |   | └─Token(Identifier) |subscription|
+//@[021:0022) |   |   ├─Token(LeftParen) |(|
+//@[022:0060) |   |   ├─FunctionArgumentSyntax
+//@[022:0060) |   |   | └─StringSyntax
+//@[022:0060) |   |   |   └─Token(StringComplete) |'1ad827ac-2669-4c2f-9970-282b93c3c550'|
+//@[060:0061) |   |   └─Token(RightParen) |)|
+//@[061:0062) |   ├─Token(NewLine) |\n|
+}
+//@[000:0001) |   └─Token(RightBrace) |}|
+//@[001:0004) ├─Token(NewLine) |\n\n\n|
+
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+//@[000:0077) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0030) | ├─IdentifierSyntax
+//@[007:0030) | | └─Token(Identifier) |myManagementGroupOutput|
+//@[031:0037) | ├─TypeVariableAccessSyntax
+//@[031:0037) | | └─IdentifierSyntax
+//@[031:0037) | |   └─Token(Identifier) |string|
+//@[038:0039) | ├─Token(Assignment) |=|
+//@[040:0077) | └─PropertyAccessSyntax
+//@[040:0068) |   ├─PropertyAccessSyntax
+//@[040:0060) |   | ├─VariableAccessSyntax
+//@[040:0060) |   | | └─IdentifierSyntax
+//@[040:0060) |   | |   └─Token(Identifier) |myManagementGroupMod|
+//@[060:0061) |   | ├─Token(Dot) |.|
+//@[061:0068) |   | └─IdentifierSyntax
+//@[061:0068) |   |   └─Token(Identifier) |outputs|
+//@[068:0069) |   ├─Token(Dot) |.|
+//@[069:0077) |   └─IdentifierSyntax
+//@[069:0077) |     └─Token(Identifier) |myOutput|
+//@[077:0078) ├─Token(NewLine) |\n|
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
+//@[000:0071) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0027) | ├─IdentifierSyntax
+//@[007:0027) | | └─Token(Identifier) |mySubscriptionOutput|
+//@[028:0034) | ├─TypeVariableAccessSyntax
+//@[028:0034) | | └─IdentifierSyntax
+//@[028:0034) | |   └─Token(Identifier) |string|
+//@[035:0036) | ├─Token(Assignment) |=|
+//@[037:0071) | └─PropertyAccessSyntax
+//@[037:0062) |   ├─PropertyAccessSyntax
+//@[037:0054) |   | ├─VariableAccessSyntax
+//@[037:0054) |   | | └─IdentifierSyntax
+//@[037:0054) |   | |   └─Token(Identifier) |mySubscriptionMod|
+//@[054:0055) |   | ├─Token(Dot) |.|
+//@[055:0062) |   | └─IdentifierSyntax
+//@[055:0062) |   |   └─Token(Identifier) |outputs|
+//@[062:0063) |   ├─Token(Dot) |.|
+//@[063:0071) |   └─IdentifierSyntax
+//@[063:0071) |     └─Token(Identifier) |myOutput|
+//@[071:0072) ├─Token(NewLine) |\n|
+
+//@[000:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/main.tokens.bicep
@@ -1,0 +1,158 @@
+targetScope = 'tenant'
+//@[000:011) Identifier |targetScope|
+//@[012:013) Assignment |=|
+//@[014:022) StringComplete |'tenant'|
+//@[022:024) NewLine |\n\n|
+
+module myManagementGroupMod 'modules/managementgroup.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:027) Identifier |myManagementGroupMod|
+//@[028:059) StringComplete |'modules/managementgroup.bicep'|
+//@[060:061) Assignment |=|
+//@[062:063) LeftBrace |{|
+//@[063:064) NewLine |\n|
+  name: 'myManagementGroupMod'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:030) StringComplete |'myManagementGroupMod'|
+//@[030:031) NewLine |\n|
+  scope: managementGroup('myManagementGroup')
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:024) Identifier |managementGroup|
+//@[024:025) LeftParen |(|
+//@[025:044) StringComplete |'myManagementGroup'|
+//@[044:045) RightParen |)|
+//@[045:046) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:002) NewLine |\n|
+module myManagementGroupModWithDuplicatedNameButDifferentScope 'modules/managementgroup_empty.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:062) Identifier |myManagementGroupModWithDuplicatedNameButDifferentScope|
+//@[063:100) StringComplete |'modules/managementgroup_empty.bicep'|
+//@[101:102) Assignment |=|
+//@[103:104) LeftBrace |{|
+//@[104:105) NewLine |\n|
+  name: 'myManagementGroupMod'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:030) StringComplete |'myManagementGroupMod'|
+//@[030:031) NewLine |\n|
+  scope: managementGroup('myManagementGroup2')
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:024) Identifier |managementGroup|
+//@[024:025) LeftParen |(|
+//@[025:045) StringComplete |'myManagementGroup2'|
+//@[045:046) RightParen |)|
+//@[046:047) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:002) NewLine |\n|
+module mySubscriptionMod 'modules/subscription.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:024) Identifier |mySubscriptionMod|
+//@[025:053) StringComplete |'modules/subscription.bicep'|
+//@[054:055) Assignment |=|
+//@[056:057) LeftBrace |{|
+//@[057:058) NewLine |\n|
+  name: 'mySubscriptionMod'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:027) StringComplete |'mySubscriptionMod'|
+//@[027:028) NewLine |\n|
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:021) Identifier |subscription|
+//@[021:022) LeftParen |(|
+//@[022:060) StringComplete |'ee44cd78-68c6-43d9-874e-e684ec8d1191'|
+//@[060:061) RightParen |)|
+//@[061:062) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:003) NewLine |\n\n|
+
+module mySubscriptionModWithCondition 'modules/subscription.bicep' = if (length('foo') == 3) {
+//@[000:006) Identifier |module|
+//@[007:037) Identifier |mySubscriptionModWithCondition|
+//@[038:066) StringComplete |'modules/subscription.bicep'|
+//@[067:068) Assignment |=|
+//@[069:071) Identifier |if|
+//@[072:073) LeftParen |(|
+//@[073:079) Identifier |length|
+//@[079:080) LeftParen |(|
+//@[080:085) StringComplete |'foo'|
+//@[085:086) RightParen |)|
+//@[087:089) Equals |==|
+//@[090:091) Integer |3|
+//@[091:092) RightParen |)|
+//@[093:094) LeftBrace |{|
+//@[094:095) NewLine |\n|
+  name: 'mySubscriptionModWithCondition'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:040) StringComplete |'mySubscriptionModWithCondition'|
+//@[040:041) NewLine |\n|
+  scope: subscription('ee44cd78-68c6-43d9-874e-e684ec8d1191')
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:021) Identifier |subscription|
+//@[021:022) LeftParen |(|
+//@[022:060) StringComplete |'ee44cd78-68c6-43d9-874e-e684ec8d1191'|
+//@[060:061) RightParen |)|
+//@[061:062) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:003) NewLine |\n\n|
+
+module mySubscriptionModWithDuplicatedNameButDifferentScope 'modules/subscription_empty.bicep' = {
+//@[000:006) Identifier |module|
+//@[007:059) Identifier |mySubscriptionModWithDuplicatedNameButDifferentScope|
+//@[060:094) StringComplete |'modules/subscription_empty.bicep'|
+//@[095:096) Assignment |=|
+//@[097:098) LeftBrace |{|
+//@[098:099) NewLine |\n|
+  name: 'mySubscriptionMod'
+//@[002:006) Identifier |name|
+//@[006:007) Colon |:|
+//@[008:027) StringComplete |'mySubscriptionMod'|
+//@[027:028) NewLine |\n|
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:021) Identifier |subscription|
+//@[021:022) LeftParen |(|
+//@[022:060) StringComplete |'1ad827ac-2669-4c2f-9970-282b93c3c550'|
+//@[060:061) RightParen |)|
+//@[061:062) NewLine |\n|
+}
+//@[000:001) RightBrace |}|
+//@[001:004) NewLine |\n\n\n|
+
+
+output myManagementGroupOutput string = myManagementGroupMod.outputs.myOutput
+//@[000:006) Identifier |output|
+//@[007:030) Identifier |myManagementGroupOutput|
+//@[031:037) Identifier |string|
+//@[038:039) Assignment |=|
+//@[040:060) Identifier |myManagementGroupMod|
+//@[060:061) Dot |.|
+//@[061:068) Identifier |outputs|
+//@[068:069) Dot |.|
+//@[069:077) Identifier |myOutput|
+//@[077:078) NewLine |\n|
+output mySubscriptionOutput string = mySubscriptionMod.outputs.myOutput
+//@[000:006) Identifier |output|
+//@[007:027) Identifier |mySubscriptionOutput|
+//@[028:034) Identifier |string|
+//@[035:036) Assignment |=|
+//@[037:054) Identifier |mySubscriptionMod|
+//@[054:055) Dot |.|
+//@[055:062) Identifier |outputs|
+//@[062:063) Dot |.|
+//@[063:071) Identifier |myOutput|
+//@[071:072) NewLine |\n|
+
+//@[000:000) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/managementgroup.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/managementgroup.bicep
@@ -1,0 +1,16 @@
+targetScope = 'managementGroup'
+
+module myTenantMod 'tenant.bicep' = {
+  name: 'myTenantMod'
+  scope: tenant()
+}
+module myManagementGroupModWithDuplicatedNameButInSeparateModule 'managementgroup_empty.bicep' = {
+  name: 'myManagementGroupMod'
+  scope: managementGroup('myManagementGroup2')
+}
+module mySubscriptionModWithDuplicatedNameButInSeparateModule 'subscription_empty.bicep' = {
+  name: 'mySubscriptionMod'
+  scope: subscription('1ad827ac-2669-4c2f-9970-282b93c3c550')
+}
+
+output myOutput string = myTenantMod.outputs.myOutput

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/managementgroup_empty.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/managementgroup_empty.bicep
@@ -1,0 +1,1 @@
+targetScope = 'managementGroup'

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/resourcegroup.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/resourcegroup.bicep
@@ -1,0 +1,24 @@
+targetScope = 'resourceGroup'
+
+module myTenantMod 'tenant.bicep' = {
+  name: 'myTenantMod'
+  scope: tenant()
+}
+
+module myOtherResourceGroup 'resourcegroup_other.bicep' = {
+  name: 'myOtherResourceGroup'
+  scope: resourceGroup('db90cfef-a146-4f67-b32f-b263518bd216', 'myOtherRg')
+}
+
+module mySubscription 'subscription_empty.bicep' = {
+  name: 'mySubscription'
+  scope: subscription()
+}
+
+module otherSubscription 'subscription_empty.bicep' = {
+  name: 'otherSubscription'
+  scope: subscription('cd780357-07f5-49cc-b945-a3fe15863860')
+}
+
+output myOutput string = myTenantMod.outputs.myOutput
+output myOutputResourceGroup string = myOtherResourceGroup.outputs.myOutput

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/resourcegroup_other.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/resourcegroup_other.bicep
@@ -1,0 +1,1 @@
+output myOutput string = 'hello!'

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/subscription.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/subscription.bicep
@@ -1,0 +1,26 @@
+targetScope = 'subscription'
+
+module myResourceGroupMod 'resourcegroup.bicep' = {
+  name: 'myResourceGroupMod'
+  scope: resourceGroup('myRg')
+}
+
+module myResourceGroupMod2 'resourcegroup.bicep' = {
+  name: 'myResourceGroupMod2'
+  scope: resourceGroup('myRg')
+}
+
+module myResourceGroupMod3 'resourcegroup.bicep' = {
+  name: 'myResourceGroupMod3'
+  scope: resourceGroup('subId', 'myRg')
+}
+
+
+module myTenantMod 'tenant.bicep' = {
+  name: 'myTenantMod'
+  scope: tenant()
+}
+
+output myOutput string = myTenantMod.outputs.myOutput
+output myOutputRgMod string = myResourceGroupMod.outputs.myOutput
+output myOutputRgMod2 string = myResourceGroupMod2.outputs.myOutput

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/subscription_empty.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/subscription_empty.bicep
@@ -1,0 +1,1 @@
+targetScope = 'subscription'

--- a/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/tenant.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/ModulesWithScopesContentManifest_LF/modules/tenant.bicep
@@ -1,0 +1,3 @@
+targetScope = 'tenant'
+
+output myOutput string = 'hello!'

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -114,7 +114,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "localDeploy": false,
           "resourceInfoCodegen": false,
           "userDefinedConstraints": false,
-          "deployCommands": false
+          "deployCommands": false,
+          "moduleContentDeduplication": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -199,7 +200,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "resourceInfoCodegen": false,
           "moduleExtensionConfigs": false,
           "userDefinedConstraints": false,
-          "deployCommands": false
+          "deployCommands": false,
+          "moduleContentDeduplication": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -306,7 +308,8 @@ namespace Bicep.Core.UnitTests.Configuration
           "resourceInfoCodegen": false,
           "moduleExtensionConfigs": false,
           "userDefinedConstraints": false,
-          "deployCommands": false
+          "deployCommands": false,
+          "moduleContentDeduplication": false
         },
         "formatting": {
           "indentKind": "Space",
@@ -391,7 +394,8 @@ namespace Bicep.Core.UnitTests.Configuration
                 ResourceInfoCodegen: false,
                 ModuleExtensionConfigs: false,
                 UserDefinedConstraints: false,
-                DeployCommands: false);
+                DeployCommands: false,
+                ModuleContentDeduplication: false);
 
             configuration.WithExperimentalFeaturesEnabled(experimentalFeaturesEnabled).Should().HaveContents(/*lang=json,strict*/ """
             {
@@ -477,7 +481,8 @@ namespace Bicep.Core.UnitTests.Configuration
                 "resourceInfoCodegen": false,
                 "moduleExtensionConfigs": false,
                 "userDefinedConstraints": false,
-                "deployCommands": false
+                "deployCommands": false,
+                "moduleContentDeduplication": false
             },
             "formatting": {
                 "indentKind": "Space",
@@ -832,7 +837,8 @@ namespace Bicep.Core.UnitTests.Configuration
                     "resourceInfoCodegen": false,
                     "moduleExtensionConfigs": false,
                     "userDefinedConstraints": false,
-                    "deployCommands": false
+                    "deployCommands": false,
+                    "moduleContentDeduplication": false
                   },
                   "formatting": {
                     "indentKind": "Space",

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderOverrides.cs
@@ -24,7 +24,8 @@ public record FeatureProviderOverrides(
     string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
     bool? ModuleExtensionConfigsEnabled = default,
     bool? UserDefinedConstraintsEnabled = default,
-    bool? DeployCommandsEnabled = default)
+    bool? DeployCommandsEnabled = default,
+    bool? ModuleContentDeduplicationEnabled = default)
 {
     public FeatureProviderOverrides(
         TestContext testContext,
@@ -43,7 +44,8 @@ public record FeatureProviderOverrides(
         string? AssemblyVersion = BicepTestConstants.DevAssemblyFileVersion,
         bool? ModuleExtensionConfigsEnabled = default,
         bool? UserDefinedConstraintsEnabled = default,
-        bool? DeployCommandsEnabled = default) : this(
+        bool? DeployCommandsEnabled = default,
+        bool? ModuleContentDeduplicationEnabled = default) : this(
             FileHelper.GetCacheRootDirectory(testContext),
             RegistryEnabled,
             OciEnabled,
@@ -60,6 +62,7 @@ public record FeatureProviderOverrides(
             AssemblyVersion,
             ModuleExtensionConfigsEnabled,
             UserDefinedConstraintsEnabled,
-            DeployCommandsEnabled)
+            DeployCommandsEnabled,
+            ModuleContentDeduplicationEnabled)
     { }
 }

--- a/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
+++ b/src/Bicep.Core.UnitTests/Features/OverriddenFeatureProvider.cs
@@ -46,4 +46,6 @@ public class OverriddenFeatureProvider : IFeatureProvider
     public bool UserDefinedConstraintsEnabled => overrides.UserDefinedConstraintsEnabled ?? features.UserDefinedConstraintsEnabled;
 
     public bool DeployCommandsEnabled => overrides.DeployCommandsEnabled ?? features.DeployCommandsEnabled;
+
+    public bool ModuleContentDeduplicationEnabled => overrides.ModuleContentDeduplicationEnabled ?? features.ModuleContentDeduplicationEnabled;
 }

--- a/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
+++ b/src/Bicep.Core/Configuration/ExperimentalFeaturesEnabled.cs
@@ -22,7 +22,8 @@ public record ExperimentalFeaturesEnabled(
     bool ResourceInfoCodegen,
     bool ModuleExtensionConfigs,
     bool UserDefinedConstraints,
-    bool DeployCommands)
+    bool DeployCommands,
+    bool ModuleContentDeduplication)
 {
     public static ExperimentalFeaturesEnabled Bind(JsonElement element)
         => element.ToNonNullObject<ExperimentalFeaturesEnabled>();
@@ -42,5 +43,6 @@ public record ExperimentalFeaturesEnabled(
         ResourceInfoCodegen: false,
         ModuleExtensionConfigs: false,
         UserDefinedConstraints: false,
-        DeployCommands: false);
+        DeployCommands: false,
+        ModuleContentDeduplication: false);
 }

--- a/src/Bicep.Core/Emit/ModuleContentStore.cs
+++ b/src/Bicep.Core/Emit/ModuleContentStore.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bicep.Core.Emit
+{
+    /// <summary>
+    /// A content-addressed store of nested module templates that is shared across all levels of a
+    /// compilation. Identical template bodies are stored once and referenced by their sha256 digest
+    /// via a module's <c>templateLink.contentId</c> property, instead of being inlined repeatedly.
+    /// </summary>
+    public sealed class ModuleContentStore
+    {
+        // Ordered by digest so the emitted "content" section is deterministic.
+        private readonly SortedDictionary<string, JToken> contentByContentId = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Adds a template body to the store if it is not already present and returns its contentId
+        /// (e.g. "sha256:abc123...").
+        /// </summary>
+        public string Add(JToken content)
+        {
+            // Serialize without indentation and hash the UTF-8 bytes so that byte-identical templates
+            // always produce the same digest regardless of platform line endings.
+            var serialized = content.ToString(Formatting.None);
+            var digest = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(serialized))).ToLowerInvariant();
+            var contentId = $"sha256:{digest}";
+
+            contentByContentId.TryAdd(contentId, content);
+
+            return contentId;
+        }
+
+        public bool IsEmpty => contentByContentId.Count == 0;
+
+        public IEnumerable<KeyValuePair<string, JToken>> Entries => contentByContentId;
+    }
+}

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -171,7 +171,7 @@ namespace Bicep.Core.Emit
                 return;
             }
 
-            emitter.EmitObjectProperty("content", () =>
+            emitter.EmitObjectProperty("contentManifest", () =>
             {
                 foreach (var (contentId, nestedTemplate) in store.Entries)
                 {

--- a/src/Bicep.Core/Emit/TemplateWriter.cs
+++ b/src/Bicep.Core/Emit/TemplateWriter.cs
@@ -68,10 +68,22 @@ namespace Bicep.Core.Emit
         private ExpressionBuilder ExpressionBuilder { get; }
         private ImmutableDictionary<string, DeclaredTypeExpression> declaredTypesByName;
 
-        public TemplateWriter(SemanticModel semanticModel)
+        // Shared content-addressed store for nested module templates. Non-null only when the
+        // moduleContentDeduplication experimental feature is enabled. The root writer owns the store
+        // (and emits the top-level "content" section); nested writers share the root's store.
+        private readonly ModuleContentStore? contentStore;
+        private readonly bool ownsContentStore;
+
+        public TemplateWriter(SemanticModel semanticModel, ModuleContentStore? contentStore = null)
         {
             ExpressionBuilder = new ExpressionBuilder(new EmitterContext(semanticModel));
             declaredTypesByName = [];
+
+            if (semanticModel.Features.ModuleContentDeduplicationEnabled)
+            {
+                this.contentStore = contentStore ?? new ModuleContentStore();
+                this.ownsContentStore = contentStore is null;
+            }
         }
 
         public void Write(SourceAwareJsonTextWriter writer)
@@ -143,10 +155,33 @@ namespace Bicep.Core.Emit
 
             this.EmitAssertsIfPresent(emitter, program.Asserts);
 
+            this.EmitContentStoreIfPresent(emitter, jsonWriter);
+
             jsonWriter.WriteEndObject();
 
             var content = jsonWriter.ToString();
             return (Template.FromJson<Template>(content), content.FromJson<JToken>());
+        }
+
+        private void EmitContentStoreIfPresent(ExpressionEmitter emitter, PositionTrackingJsonTextWriter jsonWriter)
+        {
+            // Only the root writer that owns the store emits the shared content section.
+            if (this.contentStore is not { } store || !this.ownsContentStore || store.IsEmpty)
+            {
+                return;
+            }
+
+            emitter.EmitObjectProperty("content", () =>
+            {
+                foreach (var (contentId, nestedTemplate) in store.Entries)
+                {
+                    emitter.EmitObjectProperty(contentId, () =>
+                    {
+                        jsonWriter.WritePropertyName("value");
+                        nestedTemplate.WriteTo(jsonWriter);
+                    });
+                }
+            });
         }
 
         private void EmitTypeDefinitionsIfPresent(ExpressionEmitter emitter, IEnumerable<DeclaredTypeExpression> types)
@@ -1564,10 +1599,14 @@ namespace Bicep.Core.Emit
 
                     var moduleSemanticModel = GetModuleSemanticModel(moduleSymbol);
 
-                    // If it is a template spec module, emit templateLink instead of template contents.
-                    jsonWriter.WritePropertyName(moduleSemanticModel is TemplateSpecSemanticModel ? "templateLink" : "template");
+                    if (this.contentStore is { } store && moduleSemanticModel is not TemplateSpecSemanticModel)
                     {
-                        var moduleWriter = TemplateWriterFactory.CreateTemplateWriter(moduleSemanticModel);
+                        // Emit the nested template into the shared content store and reference it by
+                        // contentId instead of inlining it. Bicep child modules share the same store so
+                        // their own nested modules are deduplicated too; ARM template modules do not nest
+                        // further, so they are stored without a child store.
+                        var childStore = moduleSemanticModel is SemanticModel ? store : null;
+                        var moduleWriter = TemplateWriterFactory.CreateTemplateWriter(moduleSemanticModel, childStore);
                         var moduleBicepFile = (moduleSemanticModel as SemanticModel)?.SourceFile;
                         var moduleTextWriter = new StringWriter();
                         var moduleJsonWriter = new SourceAwareJsonTextWriter(moduleTextWriter, moduleBicepFile);
@@ -1576,7 +1615,29 @@ namespace Bicep.Core.Emit
                         jsonWriter.AddNestedSourceMap(moduleJsonWriter.TrackingJsonWriter);
 
                         var nestedTemplate = moduleTextWriter.ToString().FromJson<JToken>();
-                        nestedTemplate.WriteTo(jsonWriter);
+                        var contentId = store.Add(nestedTemplate);
+
+                        emitter.EmitObjectProperty("templateLink", () =>
+                        {
+                            emitter.EmitProperty("contentId", contentId);
+                        });
+                    }
+                    else
+                    {
+                        // If it is a template spec module, emit templateLink instead of template contents.
+                        jsonWriter.WritePropertyName(moduleSemanticModel is TemplateSpecSemanticModel ? "templateLink" : "template");
+                        {
+                            var moduleWriter = TemplateWriterFactory.CreateTemplateWriter(moduleSemanticModel);
+                            var moduleBicepFile = (moduleSemanticModel as SemanticModel)?.SourceFile;
+                            var moduleTextWriter = new StringWriter();
+                            var moduleJsonWriter = new SourceAwareJsonTextWriter(moduleTextWriter, moduleBicepFile);
+
+                            moduleWriter.Write(moduleJsonWriter);
+                            jsonWriter.AddNestedSourceMap(moduleJsonWriter.TrackingJsonWriter);
+
+                            var nestedTemplate = moduleTextWriter.ToString().FromJson<JToken>();
+                            nestedTemplate.WriteTo(jsonWriter);
+                        }
                     }
                 });
 

--- a/src/Bicep.Core/Emit/TemplateWriterFactory.cs
+++ b/src/Bicep.Core/Emit/TemplateWriterFactory.cs
@@ -7,9 +7,9 @@ namespace Bicep.Core.Emit
 {
     public static class TemplateWriterFactory
     {
-        public static ITemplateWriter CreateTemplateWriter(ISemanticModel semanticModel) => semanticModel switch
+        public static ITemplateWriter CreateTemplateWriter(ISemanticModel semanticModel, ModuleContentStore? contentStore = null) => semanticModel switch
         {
-            SemanticModel bicepModel => new TemplateWriter(bicepModel),
+            SemanticModel bicepModel => new TemplateWriter(bicepModel, contentStore),
             ArmTemplateSemanticModel armTemplateModel => new ArmTemplateWriter(armTemplateModel),
             TemplateSpecSemanticModel templateSpecModel => new TemplateSpecWriter(templateSpecModel),
             _ => throw new ArgumentException($"Unknown semantic model type: \"{semanticModel.GetType()}\"."),

--- a/src/Bicep.Core/Features/FeatureProvider.cs
+++ b/src/Bicep.Core/Features/FeatureProvider.cs
@@ -54,6 +54,8 @@ namespace Bicep.Core.Features
 
         public bool DeployCommandsEnabled => configuration.ExperimentalFeaturesEnabled.DeployCommands;
 
+        public bool ModuleContentDeduplicationEnabled => configuration.ExperimentalFeaturesEnabled.ModuleContentDeduplication;
+
         private static bool ReadBooleanEnvVar(string envVar, bool defaultValue)
             => bool.TryParse(Environment.GetEnvironmentVariable(envVar), out var value) ? value : defaultValue;
 

--- a/src/Bicep.Core/Features/IFeatureProvider.cs
+++ b/src/Bicep.Core/Features/IFeatureProvider.cs
@@ -37,6 +37,8 @@ public interface IFeatureProvider
 
     bool DeployCommandsEnabled { get; }
 
+    bool ModuleContentDeduplicationEnabled { get; }
+
     IEnumerable<(string name, bool impactsCompilation, bool usesExperimentalArmEngineFeature)> EnabledFeatureMetadata
     {
         get
@@ -57,6 +59,7 @@ public interface IFeatureProvider
                 (ModuleExtensionConfigsEnabled, "Enable defining extension configs for modules", true, true),
                 (UserDefinedConstraintsEnabled, "Enable @validate() decorator", true, true),
                 (DeployCommandsEnabled, "Enable deploy commands", true, true),
+                (ModuleContentDeduplicationEnabled, "Enable content-addressed deduplication of nested module templates", true, true),
             })
             {
                 if (enabled)

--- a/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
+++ b/src/Bicep.Core/Features/RecordBasedFeatureProvider.cs
@@ -25,5 +25,6 @@ namespace Bicep.Core.Features
         public bool ModuleExtensionConfigsEnabled => features.ModuleExtensionConfigs;
         public bool UserDefinedConstraintsEnabled => features.UserDefinedConstraints;
         public bool DeployCommandsEnabled => features.DeployCommands;
+        public bool ModuleContentDeduplicationEnabled => features.ModuleContentDeduplication;
     }
 }

--- a/src/vscode-bicep/schemas/bicepconfig.schema.json
+++ b/src/vscode-bicep/schemas/bicepconfig.schema.json
@@ -984,6 +984,10 @@
         "deployCommands": {
           "type": "boolean",
           "description": "Allows you to access the 'deploy', 'what-if' and 'teardown' commands. See https://aka.ms/bicep/experimental-features#deploycommands"
+        },
+        "moduleContentDeduplication": {
+          "type": "boolean",
+          "description": "Emits nested module templates into a content-addressed store referenced via 'templateLink.contentId' instead of inlining them. See https://aka.ms/bicep/experimental-features#modulecontentdeduplication"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Description

Export of symbols containing non-pure functions should not be blocked outright. 
Block importing such symbols specifically in .bicepparam files.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20054)