### PR TITLE
Fix export of non-pure symbols

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -113,21 +113,18 @@ public class CompileTimeImportTests
     }
 
     [TestMethod]
-    public void Exporting_variable_that_references_non_pure_function_should_raise_diagnostic()
+    public void Exporting_variable_that_references_non_pure_function_should_not_raise_diagnostic()
     {
         var result = CompilationHelper.Compile("""
             @export()
             var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
             """);
 
-        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
-        {
-            ("BCP452", DiagnosticLevel.Error, "The \"@export()\" decorator may not be applied to variables or functions that reference deployment-context functions, either directly or indirectly. The target of this decorator contains direct or transitive references to the following functions: \"resourceId\"."),
-        });
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
 
     [TestMethod]
-    public void Exporting_variable_that_transitively_references_non_pure_function_should_raise_diagnostic()
+    public void Exporting_variable_that_transitively_references_non_pure_function_should_not_raise_diagnostic()
     {
         var result = CompilationHelper.Compile("""
             var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
@@ -136,10 +133,7 @@ public class CompileTimeImportTests
             var exportedSubnetId = defaultSubnetId
             """);
 
-        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
-        {
-            ("BCP452", DiagnosticLevel.Error, "The \"@export()\" decorator may not be applied to variables or functions that reference deployment-context functions, either directly or indirectly. The target of this decorator contains direct or transitive references to the following functions: \"resourceId\"."),
-        });
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }
 
     [TestMethod]
@@ -149,6 +143,115 @@ public class CompileTimeImportTests
             @export()
             var value = toLower('HELLO')
             """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void Importing_variable_that_references_non_pure_function_into_bicepparam_should_raise_diagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+
+                import { defaultSubnetId } from 'variables.bicep'
+
+                param foo = defaultSubnetId
+                """),
+            ("variables.bicep", """
+                @export()
+                var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP452", DiagnosticLevel.Error, "The imported symbol \"defaultSubnetId\" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: \"resourceId\"."),
+        });
+    }
+
+    [TestMethod]
+    public void Importing_function_that_references_non_pure_function_into_bicepparam_should_raise_diagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+
+                import { getLocation } from 'functions.bicep'
+
+                param foo = getLocation()
+                """),
+            ("functions.bicep", """
+                @export()
+                func getLocation() string => resourceGroup().location
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP452", DiagnosticLevel.Error, "The imported symbol \"getLocation\" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: \"resourceGroup\"."),
+        });
+    }
+
+    [TestMethod]
+    public void Importing_variable_that_references_pure_function_into_bicepparam_should_not_raise_diagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+
+                import { value } from 'variables.bicep'
+
+                param foo = value
+                """),
+            ("variables.bicep", """
+                @export()
+                var value = toLower('HELLO')
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void Wildcard_importing_symbols_that_reference_non_pure_functions_into_bicepparam_should_raise_diagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+
+                import * as exports from 'exports.bicep'
+
+                param foo = exports.defaultSubnetId
+                param bar = exports.getLocation()
+                """),
+            ("exports.bicep", """
+                @export()
+                var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+
+                @export()
+                func getLocation() string => resourceGroup().location
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().HaveDiagnostics(new[]
+        {
+            ("BCP452", DiagnosticLevel.Error, "The imported symbol \"defaultSubnetId\" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: \"resourceId\"."),
+            ("BCP452", DiagnosticLevel.Error, "The imported symbol \"getLocation\" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: \"resourceGroup\"."),
+        });
+    }
+
+    [TestMethod]
+    public void Wildcard_importing_symbols_that_reference_pure_functions_into_bicepparam_should_not_raise_diagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+
+                import * as exports from 'exports.bicep'
+
+                param foo = exports.value
+                """),
+            ("exports.bicep", """
+                @export()
+                var value = toLower('HELLO')
+                """));
 
         result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
     }

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -599,13 +599,12 @@ param bar2 = externalInput('kind', foo)
     "));
         result.Should().HaveDiagnostics(
             [
-                ("BCP104", DiagnosticLevel.Error, "The referenced module has errors."),
-                ("BCP063", DiagnosticLevel.Error, "The name \"foo\" is not a parameter, variable, resource or module."),
+                ("BCP452", DiagnosticLevel.Error, "The imported symbol \"foo\" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: \"resourceGroup\"."),
             ]);
     }
 
     [TestMethod]
-    public void Parameter_assignment_with_imported_resource_id_variable_returns_referenced_module_diagnostic()
+    public void Parameter_assignment_with_imported_resource_id_variable_returns_non_pure_diagnostic()
     {
         var result = CompilationHelper.CompileParams(
             ("main.bicep", """
@@ -625,8 +624,7 @@ param bar2 = externalInput('kind', foo)
 
         result.Should().HaveDiagnostics(
             [
-                ("BCP104", DiagnosticLevel.Error, "The referenced module has errors."),
-                ("BCP063", DiagnosticLevel.Error, "The name \"defaultSubnetId\" is not a parameter, variable, resource or module."),
+                ("BCP452", DiagnosticLevel.Error, "The imported symbol \"defaultSubnetId\" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: \"resourceId\"."),
             ]);
     }
 
@@ -672,8 +670,7 @@ param bar2 = externalInput('kind', foo)
     "));
         result.Should().HaveDiagnostics(
             [
-                ("BCP104", DiagnosticLevel.Error, "The referenced module has errors."),
-                ("BCP059", DiagnosticLevel.Error, "The name \"foo\" is not a function."),
+                ("BCP452", DiagnosticLevel.Error, "The imported symbol \"foo\" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: \"resourceGroup\"."),
             ]);
     }
 

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -2069,9 +2069,9 @@ namespace Bicep.Core.Diagnostics
                 "BCP451",
                 $"The OCI artifact module alias{(aliasName is not null ? $" \"{aliasName}\"" : "")} has an invalid \"mapToFilePath\" path \"{path}\": {reason}");
 
-            public Diagnostic ClosureContainsNonPureFunctions(IEnumerable<string> nonPureFunctions) => CoreError(
+            public Diagnostic ImportedSymbolReferencesNonPureFunctions(string symbolName, IEnumerable<string> nonPureFunctions) => CoreError(
                 "BCP452",
-                @$"The ""@export()"" decorator may not be applied to variables or functions that reference deployment-context functions, either directly or indirectly. The target of this decorator contains direct or transitive references to the following functions: {ToQuotedString(nonPureFunctions)}.");
+                @$"The imported symbol ""{symbolName}"" cannot be used in a Bicep parameters file because it contains direct or transitive references to the following deployment-context functions, which cannot be evaluated outside of a deployment: {ToQuotedString(nonPureFunctions)}.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
+++ b/src/Bicep.Core/Emit/EmitLimitationCalculator.cs
@@ -642,6 +642,30 @@ namespace Bicep.Core.Emit
                     continue;
                 }
 
+                if (symbol is ImportedSymbol { NonPureFunctionsInClosure.IsDefaultOrEmpty: false })
+                {
+                    // The imported symbol references deployment-context functions that cannot be evaluated in a
+                    // parameters file (a BCP452 error is already reported on the import). Skip evaluation to avoid
+                    // emitting a spurious secondary failure diagnostic for any parameter that references it.
+                    erroredSymbols.Add(symbol);
+                    continue;
+                }
+
+                if (GetNonPureWildcardImportReferences(model, symbol) is { Count: > 0 } nonPureWildcardReferences)
+                {
+                    // The symbol references deployment-context functions via a wildcard import property or function,
+                    // which cannot be evaluated in a parameters file. Report BCP452 at the reference and skip
+                    // evaluation to avoid emitting a spurious secondary failure diagnostic.
+                    foreach (var (referenceSyntax, exportName, nonPureFunctions) in nonPureWildcardReferences)
+                    {
+                        diagnostics.Write(DiagnosticBuilder.ForPosition(referenceSyntax)
+                            .ImportedSymbolReferencesNonPureFunctions(exportName, nonPureFunctions));
+                    }
+
+                    erroredSymbols.Add(symbol);
+                    continue;
+                }
+
                 var referencedValueHasError = false;
                 foreach (var referenced in referencesInValues[symbol])
                 {
@@ -696,6 +720,51 @@ namespace Bicep.Core.Emit
             }
 
             return (generated.ToImmutableDictionary(), usingConfig, externalInputDefinitions);
+        }
+
+        /// <summary>
+        /// Finds references to deployment-context ("non-pure") functions made through wildcard imports (either a
+        /// wildcard-imported variable property or a wildcard-imported function call) within the value assigned to the
+        /// given symbol. Such references cannot be evaluated in a Bicep parameters file.
+        /// </summary>
+        private static IReadOnlyList<(SyntaxBase syntax, string exportName, ImmutableArray<string> nonPureFunctions)> GetNonPureWildcardImportReferences(
+            SemanticModel model,
+            Symbol symbol)
+        {
+            var value = symbol switch
+            {
+                ParameterAssignmentSymbol parameterAssignment => parameterAssignment.DeclaringParameterAssignment.Value,
+                VariableSymbol variable => variable.DeclaringVariable.Value,
+                _ => (SyntaxBase?)null,
+            };
+
+            if (value is null)
+            {
+                return [];
+            }
+
+            var references = new List<(SyntaxBase, string, ImmutableArray<string>)>();
+            foreach (var node in SyntaxAggregator.AggregateByType<SyntaxBase>(value))
+            {
+                switch (node)
+                {
+                    case InstanceFunctionCallSyntax functionCall
+                        when model.GetSymbolInfo(functionCall) is WildcardImportInstanceFunctionSymbol wildcardFunction &&
+                            wildcardFunction.BaseSymbol.SourceModel.Exports.TryGetValue(functionCall.Name.IdentifierName, out var functionExport) &&
+                            functionExport is ExportedFunctionMetadata { NonPureFunctionsInClosure.IsDefaultOrEmpty: false } functionMetadata:
+                        references.Add((functionCall.Name, functionMetadata.Name, functionMetadata.NonPureFunctionsInClosure));
+                        break;
+
+                    case PropertyAccessSyntax propertyAccess
+                        when model.GetSymbolInfo(propertyAccess.BaseExpression) is WildcardImportSymbol wildcardImport &&
+                            wildcardImport.SourceModel.Exports.TryGetValue(propertyAccess.PropertyName.IdentifierName, out var variableExport) &&
+                            variableExport is ExportedVariableMetadata { NonPureFunctionsInClosure.IsDefaultOrEmpty: false } variableMetadata:
+                        references.Add((propertyAccess.PropertyName, variableMetadata.Name, variableMetadata.NonPureFunctionsInClosure));
+                        break;
+                }
+            }
+
+            return references;
         }
 
         private static ImmutableDictionary<ExtensionConfigAssignmentSymbol, ImmutableDictionary<string, ExtensionConfigAssignmentValue>> CalculateExtensionConfigAssignments(

--- a/src/Bicep.Core/Semantics/ImportedSymbol.cs
+++ b/src/Bicep.Core/Semantics/ImportedSymbol.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Registry;
 using Bicep.Core.Semantics.Metadata;
@@ -27,6 +28,12 @@ public abstract class ImportedSymbol : DeclaredSymbol
 
     public abstract string? Description { get; }
 
+    /// <summary>
+    /// The sorted, distinct names of deployment-context ("non-pure") functions referenced by the imported symbol,
+    /// either directly or transitively. Such functions cannot be evaluated in a Bicep parameters file.
+    /// </summary>
+    public abstract ImmutableArray<string> NonPureFunctionsInClosure { get; }
+
     public ResultWithDiagnosticBuilder<ArtifactReference> TryGetArtifactReference()
         => Context.ArtifactReferenceFactory.TryGetArtifactReference(this.Context.SourceFile, this.EnclosingDeclaration);
 }
@@ -50,7 +57,21 @@ public abstract class ImportedSymbol<T> : ImportedSymbol where T : ExportMetadat
             yield return DiagnosticBuilder.ForPosition(DeclaringImportedSymbolsListItem.OriginalSymbolName)
                 .ImportedSymbolKindNotSupportedInSourceFileKind(ExportMetadata.Name, ExportMetadata.Kind, Context.SourceFile.FileKind);
         }
+
+        if (Context.SourceFile is BicepParamFile &&
+            NonPureFunctionsInClosure is { IsDefaultOrEmpty: false } nonPureFunctions)
+        {
+            yield return DiagnosticBuilder.ForPosition(DeclaringImportedSymbolsListItem.OriginalSymbolName)
+                .ImportedSymbolReferencesNonPureFunctions(ExportMetadata.Name, nonPureFunctions);
+        }
     }
+
+    public override ImmutableArray<string> NonPureFunctionsInClosure => ExportMetadata switch
+    {
+        ExportedVariableMetadata variable => variable.NonPureFunctionsInClosure,
+        ExportedFunctionMetadata function => function.NonPureFunctionsInClosure,
+        _ => [],
+    };
 
     private bool IsSupportedImportKind() => Context.SourceFile switch
     {

--- a/src/Bicep.Core/Semantics/Metadata/ExportMetadata.cs
+++ b/src/Bicep.Core/Semantics/Metadata/ExportMetadata.cs
@@ -20,14 +20,28 @@ public record ExportedTypeMetadata(string Name, ITypeReference TypeReference, st
     : ExportMetadata(ExportMetadataKind.Type, Name, TypeReference, Description);
 
 public record ExportedVariableMetadata(string Name, ITypeReference TypeReference, string? Description, ITypeReference? DeclaredType)
-    : ExportMetadata(ExportMetadataKind.Variable, Name, TypeReference, Description);
+    : ExportMetadata(ExportMetadataKind.Variable, Name, TypeReference, Description)
+{
+    /// <summary>
+    /// The names of deployment-context ("non-pure") functions that this variable references, either directly or
+    /// transitively. Such functions cannot be evaluated in a Bicep parameters (.bicepparam) file.
+    /// </summary>
+    public ImmutableArray<string> NonPureFunctionsInClosure { get; init; } = [];
+}
 
 public record ExportedFunctionParameterMetadata(string Name, ITypeReference TypeReference, string? Description);
 
 public record ExportedFunctionReturnMetadata(ITypeReference TypeReference, string? Description);
 
 public record ExportedFunctionMetadata(string Name, ImmutableArray<ExportedFunctionParameterMetadata> Parameters, ExportedFunctionReturnMetadata Return, string? Description)
-    : ExportMetadata(ExportMetadataKind.Function, Name, new LambdaType([.. Parameters.Select(md => md.TypeReference)], [], Return.TypeReference), Description);
+    : ExportMetadata(ExportMetadataKind.Function, Name, new LambdaType([.. Parameters.Select(md => md.TypeReference)], [], Return.TypeReference), Description)
+{
+    /// <summary>
+    /// The names of deployment-context ("non-pure") functions that this function references, either directly or
+    /// transitively. Such functions cannot be evaluated in a Bicep parameters (.bicepparam) file.
+    /// </summary>
+    public ImmutableArray<string> NonPureFunctionsInClosure { get; init; } = [];
+}
 
 public record DuplicatedExportMetadata(string Name, ImmutableArray<string> ExportKindsWithSameName)
     : ExportMetadata(ExportMetadataKind.Error, Name, ErrorType.Empty(), $"The name \"{Name}\" is ambiguous because it refers to exports of the following kinds: {string.Join(", ", ExportKindsWithSameName)}.");

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -2144,7 +2144,7 @@ namespace Bicep.Core.Semantics.Namespaces
                         DeclaredFunctionExpression declaredFunction => declaredFunction with { Exported = functionCall },
                         _ => decorated,
                     })
-                    .WithValidator(static (decoratorName, decoratorSyntax, _, typeManager, binder, _, diagnosticWriter) =>
+                    .WithValidator(static (decoratorName, decoratorSyntax, _, _, binder, _, diagnosticWriter) =>
                     {
                         var decoratorTarget = binder.GetParent(decoratorSyntax);
 
@@ -2169,12 +2169,6 @@ namespace Bicep.Core.Semantics.Namespaces
                             if (nonExportableSymbolsInClosure.Any())
                             {
                                 diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).ClosureContainsNonExportableSymbols(nonExportableSymbolsInClosure));
-                            }
-
-                            var nonPureFunctionNamesInClosure = GetNonPureFunctionNamesInClosure(targetedDeclaration, typeManager, binder);
-                            if (nonPureFunctionNamesInClosure.Count > 0)
-                            {
-                                diagnosticWriter.Write(DiagnosticBuilder.ForPosition(decoratorSyntax).ClosureContainsNonPureFunctions(nonPureFunctionNamesInClosure.Order(StringComparer.OrdinalIgnoreCase)));
                             }
                         }
                     })
@@ -2222,30 +2216,6 @@ namespace Bicep.Core.Semantics.Namespaces
                 yield return new(decorator, (_, sfk) => sfk == BicepSourceFileKind.BicepFile);
             }
         }
-
-        private static FrozenSet<string> GetNonPureFunctionNamesInClosure(DeclaredSymbol targetedDeclaration, ITypeManager typeManager, IBinder binder)
-            => binder.GetReferencedSymbolClosureFor(targetedDeclaration)
-                .Add(targetedDeclaration)
-                .SelectMany(GetValueSyntaxesToValidateForExport)
-                .SelectMany(syntax => SyntaxAggregator.AggregateByType<FunctionCallSyntaxBase>(syntax))
-                .Select(functionCall => new
-                {
-                    FunctionCall = functionCall,
-                    Symbol = SymbolHelper.TryGetSymbolInfo(binder, typeManager.GetDeclaredType, functionCall) as FunctionSymbol,
-                })
-                .Where(x => x.Symbol is not null && !IsPureFunctionCall(x.Symbol, x.FunctionCall, typeManager))
-                .Select(x => x.Symbol!.Name)
-                .ToFrozenSet(LanguageConstants.IdentifierComparer);
-
-        private static IEnumerable<SyntaxBase> GetValueSyntaxesToValidateForExport(DeclaredSymbol symbol) => symbol switch
-        {
-            VariableSymbol variable => [variable.DeclaringVariable.Value],
-            DeclaredFunctionSymbol function => [function.DeclaringFunction.Lambda],
-            _ => [],
-        };
-
-        private static bool IsPureFunctionCall(FunctionSymbol functionSymbol, FunctionCallSyntaxBase functionCall, ITypeManager typeManager)
-            => (typeManager.GetMatchedFunctionOverload(functionCall)?.Flags ?? functionSymbol.FunctionFlags).HasFlag(FunctionFlags.Pure);
 
         private static void ValidateTypeDiscriminator(string decoratorName, DecoratorSyntax decoratorSyntax, TypeSymbol targetType, ITypeManager typeManager, IBinder binder, IDiagnosticLookup parsingErrorLookup, IDiagnosticWriter diagnosticWriter)
         {

--- a/src/Bicep.Core/Semantics/SemanticModel.cs
+++ b/src/Bicep.Core/Semantics/SemanticModel.cs
@@ -200,14 +200,47 @@ namespace Bicep.Core.Semantics
                 v.Name,
                 v.Type,
                 DescriptionHelper.TryGetFromDecorator(this, v.DeclaringVariable),
-                DeclaredType: GetDeclaredType(v.DeclaringVariable)));
+                DeclaredType: GetDeclaredType(v.DeclaringVariable))
+            {
+                NonPureFunctionsInClosure = GetNonPureFunctionNamesInClosure(v),
+            });
 
         private IEnumerable<ExportMetadata> FindExportedFunctions() => Root.FunctionDeclarations
             .Where(f => f.IsExported(this))
             .Select(f => new ExportedFunctionMetadata(f.Name,
                 [.. f.Overload.FixedParameters.Select(p => new ExportedFunctionParameterMetadata(p.Name, p.Type, p.Description))],
                 new(f.Overload.TypeSignatureSymbol, null),
-                DescriptionHelper.TryGetFromDecorator(this, f.DeclaringFunction)));
+                DescriptionHelper.TryGetFromDecorator(this, f.DeclaringFunction))
+            {
+                NonPureFunctionsInClosure = GetNonPureFunctionNamesInClosure(f),
+            });
+
+        /// <summary>
+        /// Returns the sorted, distinct names of deployment-context ("non-pure") functions referenced by the given
+        /// declaration, either directly or transitively. Such functions cannot be evaluated in a Bicep parameters file.
+        /// </summary>
+        private ImmutableArray<string> GetNonPureFunctionNamesInClosure(DeclaredSymbol targetedDeclaration)
+            => [.. Binder.GetReferencedSymbolClosureFor(targetedDeclaration)
+                .Add(targetedDeclaration)
+                .SelectMany(GetValueSyntaxesToValidateForExport)
+                .SelectMany(syntax => SyntaxAggregator.AggregateByType<FunctionCallSyntaxBase>(syntax))
+                .Select(functionCall => (
+                    functionCall,
+                    symbol: SymbolHelper.TryGetSymbolInfo(Binder, TypeManager.GetDeclaredType, functionCall) as FunctionSymbol))
+                .Where(x => x.symbol is not null && !IsPureFunctionCall(x.symbol, x.functionCall))
+                .Select(x => x.symbol!.Name)
+                .Distinct(LanguageConstants.IdentifierComparer)
+                .OrderBy(name => name, LanguageConstants.IdentifierComparer)];
+
+        private static IEnumerable<SyntaxBase> GetValueSyntaxesToValidateForExport(DeclaredSymbol symbol) => symbol switch
+        {
+            VariableSymbol variable => [variable.DeclaringVariable.Value],
+            DeclaredFunctionSymbol function => [function.DeclaringFunction.Lambda],
+            _ => [],
+        };
+
+        private bool IsPureFunctionCall(FunctionSymbol functionSymbol, FunctionCallSyntaxBase functionCall)
+            => (TypeManager.GetMatchedFunctionOverload(functionCall)?.Flags ?? functionSymbol.FunctionFlags).HasFlag(FunctionFlags.Pure);
 
         private static void TraceBuildOperation(BicepSourceFile sourceFile, IFeatureProvider features, RootConfiguration configuration)
         {


### PR DESCRIPTION
## Description

Export of symbols containing non-pure functions should not be blocked outright.
Block importing such symbols specifically in .bicepparam files.

## Example Usage

<!-- Provide example usage if you are making syntax or CLI changes. 
     Provide screenshots if you are making changes to editor user experience.
     Delete this section if it doesn't apply to your change. -->

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20055)