### PR TITLE
Add display name for null character test case

### DIFF
--- a/src/Bicep.Core.UnitTests/Parsing/LexerTests.cs
+++ b/src/Bicep.Core.UnitTests/Parsing/LexerTests.cs
@@ -22,7 +22,8 @@ namespace Bicep.Core.UnitTests.Parsing
         [DataRow(@"'\${foo}'", "${foo}")]
         [DataRow("'First line\\nSecond\\ttabbed\\tline'", "First line\nSecond\ttabbed\tline")]
         // escape ascii
-        [DataRow(@"'\u{0}'", "\0")]
+        // Use a printable display name so test discovery metadata does not contain a NUL character.
+        [DataRow(@"'\u{0}'", "\0", DisplayName = @"TryGetStringValue - '\u{0}' resolves to null char")]
         [DataRow(@"'\u{20}'", " ")]
         [DataRow(@"'hello\u{20}world\u{3f}'", "hello world?")]
         [DataRow(@"'new\u{0d}\u{A}line'", "new\r\nline")]


### PR DESCRIPTION
## Description
Recently VSCode Testing Panel cannot load all unit tests in the project under Bicep.Core.UnitTests. 
<img width="328" height="487" alt="Screenshot 2026-07-14 183313" src="https://github.com/user-attachments/assets/b406f70c-5450-42b2-b6bc-720b26ca98d9" />

C# Dev Kit shows below error during loading the test dll:
```
[error] Error during test discovery for 'Bicep.Core.UnitTests':
Error: Test IDs may not include the "…/Bicep.Core.UnitTests.Parsing/LexerTests/
TryGetStringValue_ValidStringLiteralToken_ShouldCalculateValueCorrectly ("'\u{0}'","\u0000")" symbol
```

## Root Cause:
For DataRow tests without an explicit DisplayName, MSTest generates the test case display name from the method name and argument values. The generated test case name for this row can include the actual NUL character.

The command-line test runner can still execute the test successfully, but the test metadata becomes problematic for C# Dev Kit Test Explorer. A NUL character in the generated test case name can break test discovery, causing tests to not appear in the Testing panel.

## Fix
Add an explicit printable DisplayName for the NUL-character data row:
```
[DataRow(@"'\u{0}'", "\0", DisplayName = @"TryGetStringValue - '\u{0}' resolves to null char")]
```

This ensures the generated test case metadata does not contain a NUL character.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20060)