### PR TITLE
Revise grpcurl and grpcui installation methods

### DIFF
--- a/docs/experimental/local-deploy-dotnet-debugging-guide.md
+++ b/docs/experimental/local-deploy-dotnet-debugging-guide.md
@@ -22,8 +22,8 @@ grpcurl -plaintext -d '{"type":"MyResource","properties":"{}","config":"{}"}' \
 | Tool | Install | Description |
 |------|---------|-------------|
 | .NET 9 SDK | [dotnet.microsoft.com](https://dotnet.microsoft.com/download) | Required |
-| grpcurl | `choco install grpcurl` (Win) / `brew install grpcurl` (Mac) | CLI tool |
-| grpcui | `choco install grpcui` (Win) / `brew install grpcui` (Mac) | Web UI (optional) |
+| grpcurl | `go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest` | CLI tool |
+| grpcui | `go install github.com/fullstorydev/grpcui/cmd/grpcui@latest` (Mac) | Web UI (optional) |
 | Bicep CLI | v0.37.4+ | Required |
 
 ---


### PR DESCRIPTION
Updated installation instructions for grpcurl and grpcui to use Go installation commands.

## Description

Updated the debug guide to use `golang` command line for installing grpcurl and grpui 

- [ x ] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20061)