### PR TITLE
Fix external inputs breaking base parameter spreads

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -712,6 +712,44 @@ param stringParam =  /*TODO*/
         }
 
         [TestMethod]
+        public void Base_array_spread_should_not_evaluate_unreferenced_external_input()
+        {
+            var result = CompilationHelper.CompileParams(
+              ("parameters.bicepparam", @"
+                using 'main.bicep'
+                extends 'shared.bicepparam'
+                param values = [
+                  ...base.values
+                  'child'
+                ]
+              "),
+              ("shared.bicepparam", @"
+                using none
+                param enabled = bool(externalInput('feature', 'enabled'))
+                param values = [
+                  'parent'
+                ]
+              "),
+              ("main.bicep", @"
+                param enabled bool
+                param values array
+              "));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Parameters.Should().HaveJsonAtPath("parameters.values.value", @"[
+              ""parent"",
+              ""child""
+            ]");
+            result.Parameters.Should().HaveValueAtPath("parameters.enabled.expression", "[bool(externalInputs('feature_0'))]");
+            result.Parameters.Should().HaveJsonAtPath("externalInputDefinitions", @"{
+              ""feature_0"": {
+                ""kind"": ""feature"",
+                ""config"": ""enabled""
+              }
+            }");
+        }
+
+        [TestMethod]
         public void Decorators_on_using_param_and_extends_statements_should_raise_errors()
         {
             var result = CompilationHelper.CompileParams(

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -821,6 +821,38 @@ param stringParam =  /*TODO*/
         }
 
         [TestMethod]
+        public void Base_spread_should_preserve_function_bindings_in_selected_parent_parameter()
+        {
+            var result = CompilationHelper.CompileParams(
+              ("parameters.bicepparam", @"
+                using 'main.bicep'
+                extends 'shared.bicepparam'
+                param tags = {
+                  ...base.tags
+                  child: 'child'
+                }
+              "),
+              ("shared.bicepparam", @"
+                using none
+                param external = externalInput('foo')
+                param tags = {
+                  parent: toLower('PARENT')
+                }
+              "),
+              ("main.bicep", @"
+                param external object
+                param tags object
+              "));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Parameters.Should().HaveJsonAtPath("parameters.tags.value", @"{
+              ""parent"": ""parent"",
+              ""child"": ""child""
+            }");
+            result.Parameters.Should().HaveValueAtPath("parameters.external.expression", "[externalInputs('foo_0')]");
+        }
+
+        [TestMethod]
         public void Decorators_on_using_param_and_extends_statements_should_raise_errors()
         {
             var result = CompilationHelper.CompileParams(

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -712,6 +712,40 @@ param stringParam =  /*TODO*/
         }
 
         [TestMethod]
+        public void Base_object_spread_should_support_referenced_external_input()
+        {
+            var result = CompilationHelper.CompileParams(
+              ("parameters.bicepparam", @"
+                using 'main.bicep'
+                extends 'shared.bicepparam'
+                param B = {
+                  ...base.external
+                  something: 'something'
+                }
+              "),
+              ("shared.bicepparam", @"
+                using none
+                param external = externalInput('foo', 'bar')
+                param B = {
+                  parent: 'parent'
+                }
+              "),
+              ("main.bicep", @"
+                param external object
+                param B object
+              "));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Parameters.Should().HaveValueAtPath("parameters.B.expression", "[shallowMerge(createArray(externalInputs('foo_0'), createObject('something', 'something')))]");
+            result.Parameters.Should().HaveJsonAtPath("externalInputDefinitions", @"{
+              ""foo_0"": {
+                ""kind"": ""foo"",
+                ""config"": ""bar""
+              }
+            }");
+        }
+
+        [TestMethod]
         public void Base_array_spread_should_not_evaluate_unreferenced_external_input()
         {
             var result = CompilationHelper.CompileParams(

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -780,6 +780,47 @@ param stringParam =  /*TODO*/
         }
 
         [TestMethod]
+        public void Nested_base_spreads_should_not_evaluate_unreferenced_external_input()
+        {
+            var result = CompilationHelper.CompileParams(
+              ("parameters.bicepparam", @"
+                using 'main.bicep'
+                extends 'middle.bicepparam'
+                param tags = {
+                  ...base.tags
+                  child: 'child'
+                }
+              "),
+              ("middle.bicepparam", @"
+                using none
+                extends 'base.bicepparam'
+                param tags = {
+                  ...base.tags
+                  middle: 'middle'
+                }
+              "),
+              ("base.bicepparam", @"
+                using none
+                param external = externalInput('foo')
+                param tags = {
+                  parent: 'parent'
+                }
+              "),
+              ("main.bicep", @"
+                param external object
+                param tags object
+              "));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Parameters.Should().HaveJsonAtPath("parameters.tags.value", @"{
+              ""parent"": ""parent"",
+              ""middle"": ""middle"",
+              ""child"": ""child""
+            }");
+            result.Parameters.Should().HaveValueAtPath("parameters.external.expression", "[externalInputs('foo_0')]");
+        }
+
+        [TestMethod]
         public void Decorators_on_using_param_and_extends_statements_should_raise_errors()
         {
             var result = CompilationHelper.CompileParams(

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -674,6 +674,44 @@ param stringParam =  /*TODO*/
         }
 
         [TestMethod]
+        public void Base_object_spread_should_not_evaluate_unreferenced_external_input()
+        {
+            var result = CompilationHelper.CompileParams(
+              ("parameters.bicepparam", @"
+                using 'main.bicep'
+                extends 'shared.bicepparam'
+                param B = {
+                  ...base.B
+                  something: 'something'
+                }
+              "),
+              ("shared.bicepparam", @"
+                using none
+                param external = externalInput('foo', 'bar')
+                param B = {
+                  parent: 'parent'
+                }
+              "),
+              ("main.bicep", @"
+                param external object
+                param B object
+              "));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Parameters.Should().HaveJsonAtPath("parameters.B.value", @"{
+              ""parent"": ""parent"",
+              ""something"": ""something""
+            }");
+            result.Parameters.Should().HaveValueAtPath("parameters.external.expression", "[externalInputs('foo_0')]");
+            result.Parameters.Should().HaveJsonAtPath("externalInputDefinitions", @"{
+              ""foo_0"": {
+                ""kind"": ""foo"",
+                ""config"": ""bar""
+              }
+            }");
+        }
+
+        [TestMethod]
         public void Decorators_on_using_param_and_extends_statements_should_raise_errors()
         {
             var result = CompilationHelper.CompileParams(

--- a/src/Bicep.Core.IntegrationTests/ParametersTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParametersTests.cs
@@ -750,6 +750,36 @@ param stringParam =  /*TODO*/
         }
 
         [TestMethod]
+        public void Base_property_accesses_should_not_evaluate_unreferenced_external_input()
+        {
+            var result = CompilationHelper.CompileParams(
+              ("parameters.bicepparam", @"
+                using 'main.bicep'
+                extends 'shared.bicepparam'
+                param dotAccess = base.selected.value
+                param bracketAccess = base['selected'].value
+              "),
+              ("shared.bicepparam", @"
+                using none
+                param external = externalInput('foo')
+                param selected = {
+                  value: 'parent'
+                }
+              "),
+              ("main.bicep", @"
+                param external object
+                param selected object
+                param dotAccess string
+                param bracketAccess string
+              "));
+
+            result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+            result.Parameters.Should().HaveValueAtPath("parameters.dotAccess.value", "parent");
+            result.Parameters.Should().HaveValueAtPath("parameters.bracketAccess.value", "parent");
+            result.Parameters.Should().HaveValueAtPath("parameters.external.expression", "[externalInputs('foo_0')]");
+        }
+
+        [TestMethod]
         public void Decorators_on_using_param_and_extends_statements_should_raise_errors()
         {
             var result = CompilationHelper.CompileParams(

--- a/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
+++ b/src/Bicep.Core/Emit/InlineDependencyVisitor.cs
@@ -287,48 +287,14 @@ namespace Bicep.Core.Emit
                 return;
             }
 
-            void ProcessInlinableSymbol(DeclaredSymbol symbol, string identifierName)
-            {
-                var previousStack = this.currentStack;
-                if (!shouldInlineCache.TryGetValue(symbol, out var shouldInline))
-                {
-                    this.currentStack = this.currentStack?.Push(identifierName);
-
-                    // recursively visit dependent symbols
-                    this.Visit(symbol.DeclaringSyntax);
-
-                    if (!shouldInlineCache.TryGetValue(symbol, out shouldInline))
-                    {
-                        shouldInline = Decision.NotInline;
-                    }
-
-                    if (shouldInline == Decision.Inline && this.targetVariable is not null && this.capturedSequence is null)
-                    {
-                        // this point is where the decision is made to inline the variable
-                        // the variable access stack will be the deepest here
-                        // (once captured, we will not reset because the visitor will be short-circuiting and
-                        //  unrolling the recursion which would produce shorter and inaccurate paths)
-
-                        // capture the sequence of variable accesses
-                        this.capturedSequence = this.currentStack;
-                    }
-                }
-
-                // if we depend on a symbol that requires inlining, then we also require inlining
-                var newValue = shouldInlineCache[currentDeclaration] == Decision.Inline || shouldInline == Decision.Inline;
-                SetInlineCache(newValue);
-
-                this.currentStack = previousStack;
-            }
-
             switch (model.GetSymbolInfo(syntax))
             {
                 case VariableSymbol variableSymbol:
-                    ProcessInlinableSymbol(variableSymbol, syntax.Name.IdentifierName);
+                    ProcessInlinableSymbol(currentDeclaration, variableSymbol, syntax.Name.IdentifierName);
                     return;
 
                 case ParameterAssignmentSymbol parameterAssignmentSymbol:
-                    ProcessInlinableSymbol(parameterAssignmentSymbol, syntax.Name.IdentifierName);
+                    ProcessInlinableSymbol(currentDeclaration, parameterAssignmentSymbol, syntax.Name.IdentifierName);
                     return;
 
                 case ResourceSymbol:
@@ -341,6 +307,40 @@ namespace Bicep.Core.Emit
                     }
                     return;
             }
+        }
+
+        private void ProcessInlinableSymbol(DeclaredSymbol referencingDeclaration, DeclaredSymbol symbol, string identifierName)
+        {
+            var previousStack = this.currentStack;
+            if (!shouldInlineCache.TryGetValue(symbol, out var shouldInline))
+            {
+                this.currentStack = this.currentStack?.Push(identifierName);
+
+                // recursively visit dependent symbols
+                this.Visit(symbol.DeclaringSyntax);
+
+                if (!shouldInlineCache.TryGetValue(symbol, out shouldInline))
+                {
+                    shouldInline = Decision.NotInline;
+                }
+
+                if (shouldInline == Decision.Inline && this.targetVariable is not null && this.capturedSequence is null)
+                {
+                    // this point is where the decision is made to inline the variable
+                    // the variable access stack will be the deepest here
+                    // (once captured, we will not reset because the visitor will be short-circuiting and
+                    //  unrolling the recursion which would produce shorter and inaccurate paths)
+
+                    // capture the sequence of variable accesses
+                    this.capturedSequence = this.currentStack;
+                }
+            }
+
+            // if we depend on a symbol that requires inlining, then we also require inlining
+            var newValue = shouldInlineCache[referencingDeclaration] == Decision.Inline || shouldInline == Decision.Inline;
+            SetInlineCache(newValue);
+
+            this.currentStack = previousStack;
         }
 
         public override void VisitPropertyAccessSyntax(PropertyAccessSyntax syntax)
@@ -357,6 +357,13 @@ namespace Bicep.Core.Emit
             if (shouldInlineCache[currentDeclaration] == Decision.Inline)
             {
                 // we've already made a decision to inline
+                return;
+            }
+
+            if (model.GetSymbolInfo(syntax.BaseExpression) is BaseParametersSymbol baseParameters &&
+                baseParameters.ParentAssignments.FirstOrDefault(assignment => LanguageConstants.IdentifierComparer.Equals(assignment.Name, syntax.PropertyName.IdentifierName)) is { } parentAssignment)
+            {
+                ProcessInlinableSymbol(currentDeclaration, parentAssignment, syntax.PropertyName.IdentifierName);
                 return;
             }
 

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -979,6 +979,13 @@ public class ExpressionBuilder
             }
         }
 
+        if (arrayAccess.IndexExpression is StringSyntax indexString &&
+            indexString.TryGetLiteralValue() is { } propertyName &&
+            TryGetBaseParameterAssignment(arrayAccess.BaseExpression, propertyName) is { } parentAssignment)
+        {
+            return ConvertWithoutLowering(parentAssignment.DeclaringParameterAssignment.Value);
+        }
+
         var convertedBase = ConvertWithoutLowering(arrayAccess.BaseExpression);
         var convertedIndex = ConvertWithoutLowering(arrayAccess.IndexExpression);
 

--- a/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
+++ b/src/Bicep.Core/Intermediate/ExpressionBuilder.cs
@@ -1030,6 +1030,11 @@ public class ExpressionBuilder
     {
         var flags = GetAccessExpressionFlags(propertyAccess);
 
+        if (TryGetBaseParameterAssignment(propertyAccess.BaseExpression, propertyAccess.PropertyName.IdentifierName) is { } parentAssignment)
+        {
+            return ConvertWithoutLowering(parentAssignment.DeclaringParameterAssignment.Value);
+        }
+
         // Looking for: myResource.someProp (where myResource is a resource declared in-file)
         if (Context.SemanticModel.ResourceMetadata.TryLookup(propertyAccess.BaseExpression) is DeclaredResourceMetadata resource)
         {
@@ -1097,6 +1102,11 @@ public class ExpressionBuilder
             propertyAccess.PropertyName.IdentifierName,
             flags);
     }
+
+    private ParameterAssignmentSymbol? TryGetBaseParameterAssignment(SyntaxBase baseExpression, string propertyName)
+        => Context.SemanticModel.GetSymbolInfo(baseExpression) is BaseParametersSymbol baseParameters
+            ? baseParameters.ParentAssignments.FirstOrDefault(assignment => LanguageConstants.IdentifierComparer.Equals(assignment.Name, propertyName))
+            : null;
 
     private Expression ConvertResourceAccess(ResourceAccessSyntax resourceAccessSyntax)
     {


### PR DESCRIPTION
## Description

Fixes #19954.

When a parent parameter file contains an `externalInput`, using the spread operator with another inherited parameter could fail with `BCP338`.

_In this PR;_

I've added tests that reproduce the issue with `...base.B`

I've fixed the issue in `ExpressionBuilder` by evaluating only the selected base parameter

I've also added coverage for object and array spreads, property access, bracket access, and nested parameter files

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20062)