### PR TITLE
Validate deployment-context functions in parameter file imports

### DIFF
--- a/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
+++ b/src/Bicep.Core.IntegrationTests/CompileTimeImportTests.cs
@@ -113,6 +113,41 @@ public class CompileTimeImportTests
     }
 
     [TestMethod]
+    public void Exporting_declarations_that_reference_deployment_context_functions_should_compile()
+    {
+        var result = CompilationHelper.Compile("""
+            @export()
+            var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+
+            @export()
+            func getLocation() string => resourceGroup().location
+            """);
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+    }
+
+    // https://github.com/Azure/bicep/issues/20041
+    [TestMethod]
+    public void Importing_function_that_references_deployment_context_function_into_bicep_should_compile()
+    {
+        var result = CompilationHelper.Compile(
+            ("main.bicep", """
+                import { getBuiltInRoleId } from 'roles.bicep'
+
+                output foundryUserRoleId string = getBuiltInRoleId('53ca6127-db72-4b80-b1b0-d745d6d5456d')
+                """),
+            ("roles.bicep", """
+                @export()
+                func getBuiltInRoleId(roleDefinitionId string) string => resourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+                """));
+
+        result.ExcludingLinterDiagnostics().Should().NotHaveAnyDiagnostics();
+        result.Template.Should().HaveValueAtPath(
+            "functions[0].members.getBuiltInRoleId.output.value",
+            "[resourceId('Microsoft.Authorization/roleDefinitions', parameters('roleDefinitionId'))]");
+    }
+
+    [TestMethod]
     public void Importing_non_template_should_not_raise_diagnostic()
     {
         var result = CompilationHelper.Compile(

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -585,7 +585,7 @@ param bar2 = externalInput('kind', foo)
     }
 
     [TestMethod]
-    public void ExternalInput_parameter_with_unevaluable_imported_variable_references_returns_diagnostic()
+    public void ExternalInput_parameter_with_non_pure_imported_variable_references_returns_diagnostic()
     {
         var result = CompilationHelper.CompileParams(
             ("parameters.bicepparam", @"
@@ -598,9 +598,114 @@ param bar2 = externalInput('kind', foo)
     var foo = resourceGroup().location // cannot be evaluated in bicepparam file
     "));
         result.Should().OnlyContainDiagnostic(
-            "BCP338",
+            "BCP452",
             DiagnosticLevel.Error,
-            "Failed to evaluate parameter \"foo2\": Failed to evaluate variable \"foo\": The template function 'RESOURCEGROUP' is not expected at this location. Please see https://aka.ms/arm-functions for usage details.");
+            "The imported symbol \"foo\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceGroup\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [TestMethod]
+    public void Imported_variable_with_deployment_context_function_reference_returns_diagnostic_even_when_unused()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { defaultSubnetId } from 'variables.bicep'
+                """),
+            ("variables.bicep", """
+                @export()
+                var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+                """));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            "The imported symbol \"defaultSubnetId\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceId\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [TestMethod]
+    public void Imported_variable_with_transitive_pure_function_reference_compiles_successfully()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { normalizedValue } from 'variables.bicep'
+
+                param value = normalizedValue
+                """),
+            ("variables.bicep", """
+                var normalizedValueCore = toLower('HELLO')
+
+                @export()
+                var normalizedValue = normalizedValueCore
+                """));
+
+        result.Should().NotHaveAnyDiagnostics();
+        var parameters = TemplateHelper.ConvertAndAssertParameters(result.Parameters);
+        parameters["value"].Value.Should().DeepEqual("hello");
+    }
+
+    [TestMethod]
+    public void Imported_variable_with_transitive_deployment_context_function_reference_returns_diagnostic_even_when_unused()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { defaultSubnetId } from 'variables.bicep'
+                """),
+            ("variables.bicep", """
+                var defaultSubnetIdCore = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+
+                @export()
+                var defaultSubnetId = defaultSubnetIdCore
+                """));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            "The imported symbol \"defaultSubnetId\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceId\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [TestMethod]
+    public void Wildcard_import_with_deployment_context_function_reference_returns_diagnostic_even_when_unused()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import * as values from 'variables.bicep'
+                """),
+            ("variables.bicep", """
+                @export()
+                var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+                """));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            "The imported symbol \"values\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceId\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [TestMethod]
+    public void Wildcard_import_with_deployment_context_function_reference_returns_diagnostic_for_pure_member_usage()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import * as values from 'variables.bicep'
+
+                param value = values.safeValue
+                """),
+            ("variables.bicep", """
+                @export()
+                var safeValue = toLower('HELLO')
+
+                @export()
+                var defaultSubnetId = resourceId('resourceGroup', 'Microsoft.Network/virtualNetworks/subnets', 'vnet', 'subnet')
+                """));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            "The imported symbol \"values\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceId\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
     }
 
     [TestMethod]
@@ -631,7 +736,50 @@ param bar2 = externalInput('kind', foo)
     }
 
     [TestMethod]
-    public void ExternalInput_parameter_with_unevaluable_imported_function_returns_diagnostics()
+    public void Imported_function_with_transitive_pure_function_references_compiles_successfully()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { normalize } from 'functions.bicep'
+
+                param value = normalize('HELLO')
+                """),
+            ("functions.bicep", """
+                func normalizeCore(value string) string => toLower(value)
+
+                @export()
+                func normalize(value string) string => normalizeCore(value)
+                """));
+
+        result.Should().NotHaveAnyDiagnostics();
+        var parameters = TemplateHelper.ConvertAndAssertParameters(result.Parameters);
+        parameters["value"].Value.Should().DeepEqual("hello");
+    }
+
+    [TestMethod]
+    public void Imported_function_with_transitive_deployment_context_function_reference_returns_diagnostic_even_when_unused()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { getLocation } from 'functions.bicep'
+                """),
+            ("functions.bicep", """
+                func getLocationCore() string => resourceGroup().location
+
+                @export()
+                func getLocation() string => getLocationCore()
+                """));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            "The imported symbol \"getLocation\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceGroup\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [TestMethod]
+    public void ExternalInput_parameter_with_non_pure_imported_function_returns_diagnostics()
     {
         var result = CompilationHelper.CompileParams(
             ("parameters.bicepparam", @"
@@ -644,9 +792,9 @@ param bar2 = externalInput('kind', foo)
     func foo() string => resourceGroup().location // cannot be evaluated in bicepparam file
     "));
         result.Should().OnlyContainDiagnostic(
-            "BCP338",
+            "BCP452",
             DiagnosticLevel.Error,
-            "Failed to evaluate parameter \"foo2\": The template function 'RESOURCEGROUP' is not expected at this location. Please see https://aka.ms/arm-functions for usage details.");
+            "The imported symbol \"foo\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceGroup\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
     }
 
     [TestMethod]

--- a/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/sys.json
@@ -12,7 +12,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(value: any): any",
     "parameterTypeSignatures": [
       "value: any"
@@ -31,7 +31,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: any): array",
     "parameterTypeSignatures": [
       "valueToConvert: any"
@@ -50,7 +50,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(inputString: string): string",
     "parameterTypeSignatures": [
       "inputString: string"
@@ -69,7 +69,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(base64Value: string): any",
     "parameterTypeSignatures": [
       "base64Value: string"
@@ -88,7 +88,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(base64Value: string): string",
     "parameterTypeSignatures": [
       "base64Value: string"
@@ -107,7 +107,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(value: any): bool",
     "parameterTypeSignatures": [
       "value: any"
@@ -126,7 +126,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(components: parseUri): string",
     "parameterTypeSignatures": [
       "components: parseUri"
@@ -151,7 +151,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(network: string, hostIndex: int): string",
     "parameterTypeSignatures": [
       "network: string",
@@ -183,7 +183,7 @@
     ],
     "minimumArgumentCount": 3,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(network: string, cidr: int, subnetIndex: int): string",
     "parameterTypeSignatures": [
       "network: string",
@@ -202,7 +202,7 @@
       "type": "array",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : array): array",
     "parameterTypeSignatures": [
       "... : array"
@@ -219,7 +219,7 @@
       "type": "bool | int | string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : bool | int | string): string",
     "parameterTypeSignatures": [
       "... : bool | int | string"
@@ -244,7 +244,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object, propertyName: string): bool",
     "parameterTypeSignatures": [
       "object: object",
@@ -270,7 +270,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, itemToFind: any): bool",
     "parameterTypeSignatures": [
       "array: array",
@@ -296,7 +296,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(string: string, itemToFind: string): bool",
     "parameterTypeSignatures": [
       "string: string",
@@ -316,7 +316,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: any): string",
     "parameterTypeSignatures": [
       "valueToConvert: any"
@@ -335,7 +335,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(dataUriToConvert: string): string",
     "parameterTypeSignatures": [
       "dataUriToConvert: string"
@@ -366,7 +366,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(base: string, duration: string, [format: string]): string",
     "parameterTypeSignatures": [
       "base: string",
@@ -387,7 +387,7 @@
     ],
     "minimumArgumentCount": 0,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "([epochTime: int]): string",
     "parameterTypeSignatures": [
       "[epochTime: int]"
@@ -406,7 +406,7 @@
     ],
     "minimumArgumentCount": 0,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "([dateTime: string]): int",
     "parameterTypeSignatures": [
       "[dateTime: string]"
@@ -425,7 +425,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array): array",
     "parameterTypeSignatures": [
       "array: array"
@@ -444,7 +444,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(itemToTest: array | null | object | string): bool",
     "parameterTypeSignatures": [
       "itemToTest: array | null | object | string"
@@ -469,7 +469,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): bool",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -514,7 +514,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, predicate: (any[, int]) => bool): array",
     "parameterTypeSignatures": [
       "array: array",
@@ -534,7 +534,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array): any",
     "parameterTypeSignatures": [
       "array: array"
@@ -553,7 +553,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(string: string): string",
     "parameterTypeSignatures": [
       "string: string"
@@ -572,7 +572,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array[]): array",
     "parameterTypeSignatures": [
       "array: array[]"
@@ -596,7 +596,7 @@
       "type": "any",
       "minimumCount": 0
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(formatString: string, ... : any): string",
     "parameterTypeSignatures": [
       "formatString: string",
@@ -628,7 +628,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object",
     "parameterTypeSignatures": [
       "array: array",
@@ -647,7 +647,7 @@
       "type": "string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : string): string",
     "parameterTypeSignatures": [
       "... : string"
@@ -672,7 +672,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): int",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -698,7 +698,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, itemToFind: any): int",
     "parameterTypeSignatures": [
       "array: array",
@@ -718,7 +718,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: int | string): int",
     "parameterTypeSignatures": [
       "valueToConvert: int | string"
@@ -735,7 +735,7 @@
       "type": "object",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : object): object",
     "parameterTypeSignatures": [
       "... : object"
@@ -752,7 +752,7 @@
       "type": "array",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : array): array",
     "parameterTypeSignatures": [
       "... : array"
@@ -771,7 +771,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object): object[]",
     "parameterTypeSignatures": [
       "object: object"
@@ -796,7 +796,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(inputArray: (bool | int | string)[], delimiter: string): string",
     "parameterTypeSignatures": [
       "inputArray: (bool | int | string)[]",
@@ -816,7 +816,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(json: string): any",
     "parameterTypeSignatures": [
       "json: string"
@@ -835,7 +835,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array): any",
     "parameterTypeSignatures": [
       "array: array"
@@ -854,7 +854,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(string: string): string",
     "parameterTypeSignatures": [
       "string: string"
@@ -879,7 +879,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): int",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -905,7 +905,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, itemToFind: any): int",
     "parameterTypeSignatures": [
       "array: array",
@@ -925,7 +925,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(arg: object | string): int",
     "parameterTypeSignatures": [
       "arg: object | string"
@@ -944,7 +944,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(arg: array): int",
     "parameterTypeSignatures": [
       "arg: array"
@@ -969,7 +969,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(input: string, pattern: string): bool",
     "parameterTypeSignatures": [
       "input: string",
@@ -995,7 +995,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 2,
-    "flags": "generateIntermediateVariableAlways",
+    "flags": "generateIntermediateVariableAlways, pure",
     "typeSignature": "(directoryPath: string, [searchPattern: string]): any",
     "parameterTypeSignatures": [
       "directoryPath: string",
@@ -1015,7 +1015,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "generateIntermediateVariableOnIndirectAssignment",
+    "flags": "generateIntermediateVariableOnIndirectAssignment, pure",
     "typeSignature": "(filePath: string): string",
     "parameterTypeSignatures": [
       "filePath: string"
@@ -1046,7 +1046,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 3,
-    "flags": "generateIntermediateVariableAlways",
+    "flags": "generateIntermediateVariableAlways, pure",
     "typeSignature": "(filePath: string, [jsonPath: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any",
     "parameterTypeSignatures": [
       "filePath: string",
@@ -1073,7 +1073,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 2,
-    "flags": "generateIntermediateVariableOnIndirectAssignment",
+    "flags": "generateIntermediateVariableOnIndirectAssignment, pure",
     "typeSignature": "(filePath: string, [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): string",
     "parameterTypeSignatures": [
       "filePath: string",
@@ -1105,7 +1105,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 3,
-    "flags": "generateIntermediateVariableAlways",
+    "flags": "generateIntermediateVariableAlways, pure",
     "typeSignature": "(filePath: string, [pathFilter: string], [encoding: 'iso-8859-1' | 'us-ascii' | 'utf-16' | 'utf-16BE' | 'utf-8']): any",
     "parameterTypeSignatures": [
       "filePath: string",
@@ -1132,7 +1132,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, predicate: (any[, int]) => any): array",
     "parameterTypeSignatures": [
       "array: array",
@@ -1158,7 +1158,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object, predicate: any => any): array",
     "parameterTypeSignatures": [
       "object: object",
@@ -1176,7 +1176,7 @@
       "type": "int",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : int): int",
     "parameterTypeSignatures": [
       "... : int"
@@ -1195,7 +1195,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(intArray: int[]): int",
     "parameterTypeSignatures": [
       "intArray: int[]"
@@ -1212,7 +1212,7 @@
       "type": "int",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : int): int",
     "parameterTypeSignatures": [
       "... : int"
@@ -1231,7 +1231,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(intArray: int[]): int",
     "parameterTypeSignatures": [
       "intArray: int[]"
@@ -1250,7 +1250,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "isArgumentValueIndependent",
+    "flags": "isArgumentValueIndependent, pure",
     "typeSignature": "(symbol: any): string",
     "parameterTypeSignatures": [
       "symbol: any"
@@ -1279,7 +1279,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(object: object): string[]",
     "parameterTypeSignatures": [
       "object: object"
@@ -1310,7 +1310,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToPad: int | string, totalLength: int, [paddingCharacter: string]): string",
     "parameterTypeSignatures": [
       "valueToPad: int | string",
@@ -1331,7 +1331,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(network: string): parseCidr",
     "parameterTypeSignatures": [
       "network: string"
@@ -1350,7 +1350,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(baseUrl: string): parseUri",
     "parameterTypeSignatures": [
       "baseUrl: string"
@@ -1375,7 +1375,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(startIndex: int, count: int): int[]",
     "parameterTypeSignatures": [
       "startIndex: int",
@@ -1407,7 +1407,7 @@
     ],
     "minimumArgumentCount": 3,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, initialValue: any, predicate: (any, any[, int]) => any): any",
     "parameterTypeSignatures": [
       "array: array",
@@ -1440,7 +1440,7 @@
     ],
     "minimumArgumentCount": 3,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalString: string, oldString: string, newString: string): string",
     "parameterTypeSignatures": [
       "originalString: string",
@@ -1461,7 +1461,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(entries: object[]): object",
     "parameterTypeSignatures": [
       "entries: object[]"
@@ -1486,7 +1486,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: array, numberToSkip: int): array",
     "parameterTypeSignatures": [
       "originalValue: array",
@@ -1512,7 +1512,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: string, numberToSkip: int): string",
     "parameterTypeSignatures": [
       "originalValue: string",
@@ -1538,7 +1538,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, predicate: (any, any) => bool): array",
     "parameterTypeSignatures": [
       "array: array",
@@ -1564,7 +1564,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(inputString: string, delimiter: array | string): string[]",
     "parameterTypeSignatures": [
       "inputString: string",
@@ -1590,7 +1590,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToSearch: string, stringToFind: string): bool",
     "parameterTypeSignatures": [
       "stringToSearch: string",
@@ -1610,7 +1610,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(valueToConvert: any): string",
     "parameterTypeSignatures": [
       "valueToConvert: any"
@@ -1641,7 +1641,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToParse: string, startIndex: int, [length: int]): string",
     "parameterTypeSignatures": [
       "stringToParse: string",
@@ -1668,7 +1668,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: array, numberToTake: int): array",
     "parameterTypeSignatures": [
       "originalValue: array",
@@ -1694,7 +1694,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(originalValue: string, numberToTake: int): string",
     "parameterTypeSignatures": [
       "originalValue: string",
@@ -1714,7 +1714,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToChange: string): string",
     "parameterTypeSignatures": [
       "stringToChange: string"
@@ -1745,7 +1745,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 3,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(array: array, keyPredicate: any => string, [valuePredicate: any => any]): object",
     "parameterTypeSignatures": [
       "array: array",
@@ -1766,7 +1766,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToChange: string): string",
     "parameterTypeSignatures": [
       "stringToChange: string"
@@ -1785,7 +1785,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToTrim: string): string",
     "parameterTypeSignatures": [
       "stringToTrim: string"
@@ -1802,7 +1802,7 @@
       "type": "object",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : object): object",
     "parameterTypeSignatures": [
       "... : object"
@@ -1819,7 +1819,7 @@
       "type": "array",
       "minimumCount": 2
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : array): array",
     "parameterTypeSignatures": [
       "... : array"
@@ -1836,7 +1836,7 @@
       "type": "string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(... : string): string",
     "parameterTypeSignatures": [
       "... : string"
@@ -1861,7 +1861,7 @@
     ],
     "minimumArgumentCount": 2,
     "maximumArgumentCount": 2,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(baseUri: string, relativeUri: string): string",
     "parameterTypeSignatures": [
       "baseUri: string",
@@ -1881,7 +1881,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(stringToEncode: string): string",
     "parameterTypeSignatures": [
       "stringToEncode: string"
@@ -1900,7 +1900,7 @@
     ],
     "minimumArgumentCount": 1,
     "maximumArgumentCount": 1,
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(uriEncodedString: string): string",
     "parameterTypeSignatures": [
       "uriEncodedString: string"

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -2068,6 +2068,10 @@ namespace Bicep.Core.Diagnostics
             public Diagnostic InvalidOciArtifactModuleAliasMapToFilePath(string? aliasName, string path, string reason) => CoreError(
                 "BCP451",
                 $"The OCI artifact module alias{(aliasName is not null ? $" \"{aliasName}\"" : "")} has an invalid \"mapToFilePath\" path \"{path}\": {reason}");
+
+            public Diagnostic ImportedSymbolDependsOnDeploymentContextFunctions(string symbolName, IEnumerable<string> functionNames) => CoreError(
+                "BCP452",
+                @$"The imported symbol ""{symbolName}"" cannot be used in a {LanguageConstants.ParamsFileExtension} file because it depends on deployment-context functions: {ToQuotedString(functionNames)}. Imported declarations may only use functions that can be evaluated while building the parameters file.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -74,6 +74,19 @@ namespace Bicep.Core.Semantics
             .Select(fp => fp.Signature)
             .Concat(this.VariableParameter?.GenericSignature.AsEnumerable() ?? []);
 
+        public virtual FunctionOverload WithAdditionalFlags(FunctionFlags flags) =>
+            new(
+                Name,
+                GenericDescription,
+                Description,
+                ResultBuilder,
+                TypeSignatureSymbol,
+                FixedParameters,
+                VariableParameter,
+                Evaluator,
+                ArmExpressionEvaluator,
+                Flags | flags);
+
         public bool HasParameters => this.MinimumArgumentCount > 0 || this.MaximumArgumentCount > 0;
 
         public FunctionMatchResult Match(IList<TypeSymbol> argumentTypes, out ArgumentCountMismatch? argumentCountMismatch, out ArgumentTypeMismatch? argumentTypeMismatch)

--- a/src/Bicep.Core/Semantics/FunctionWildcardOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionWildcardOverload.cs
@@ -25,5 +25,19 @@ namespace Bicep.Core.Semantics
         }
 
         public Regex WildcardRegex { get; }
+
+        public override FunctionOverload WithAdditionalFlags(FunctionFlags flags) =>
+            new FunctionWildcardOverload(
+                Name,
+                GenericDescription,
+                Description,
+                WildcardRegex,
+                ResultBuilder,
+                TypeSignatureSymbol,
+                FixedParameters,
+                VariableParameter,
+                Evaluator,
+                ArmExpressionEvaluator,
+                Flags | flags);
     }
 }

--- a/src/Bicep.Core/Semantics/ImportedSymbol.cs
+++ b/src/Bicep.Core/Semantics/ImportedSymbol.cs
@@ -50,6 +50,11 @@ public abstract class ImportedSymbol<T> : ImportedSymbol where T : ExportMetadat
             yield return DiagnosticBuilder.ForPosition(DeclaringImportedSymbolsListItem.OriginalSymbolName)
                 .ImportedSymbolKindNotSupportedInSourceFileKind(ExportMetadata.Name, ExportMetadata.Kind, Context.SourceFile.FileKind);
         }
+
+        if (ParameterFileImportValidator.ValidateImport(this) is { } diagnostic)
+        {
+            yield return diagnostic;
+        }
     }
 
     private bool IsSupportedImportKind() => Context.SourceFile switch

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1318,9 +1318,14 @@ namespace Bicep.Core.Semantics.Namespaces
                     .Build();
             }
 
+            static FunctionOverload MarkPureIfEvaluableInParameterFile(FunctionOverload overload) =>
+                LanguageConstants.IdentifierComparer.Equals(overload.Name, "fail") || overload.Flags.HasFlag(FunctionFlags.ParamDefaultsOnly)
+                    ? overload
+                    : overload.WithAdditionalFlags(FunctionFlags.Pure);
+
             foreach (var overload in GetAlwaysPermittedOverloads())
             {
-                yield return new(overload, (_, _) => true);
+                yield return new(MarkPureIfEvaluableInParameterFile(overload), (_, _) => true);
             }
 
             foreach (var overload in GetParamsFilePermittedOverloads(featureProvider))

--- a/src/Bicep.Core/Semantics/ParameterFileImportValidator.cs
+++ b/src/Bicep.Core/Semantics/ParameterFileImportValidator.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
+using Bicep.Core.Semantics.Metadata;
+using Bicep.Core.Semantics.Namespaces;
+using Bicep.Core.SourceGraph;
+using Bicep.Core.Syntax;
+using Bicep.Core.Syntax.Visitors;
+using Bicep.Core.TypeSystem;
+using Bicep.Core.TypeSystem.Types;
+
+namespace Bicep.Core.Semantics;
+
+internal static class ParameterFileImportValidator
+{
+    public static Diagnostic? ValidateImport(ImportedSymbol importedSymbol)
+    {
+        if (importedSymbol.Context.SourceFile.FileKind != BicepSourceFileKind.ParamsFile ||
+            GetDeploymentContextFunctionNames(importedSymbol) is not { Length: > 0 } functionNames)
+        {
+            return null;
+        }
+
+        return DiagnosticBuilder.ForPosition(importedSymbol.DeclaringImportedSymbolsListItem.OriginalSymbolName)
+            .ImportedSymbolDependsOnDeploymentContextFunctions(importedSymbol.Name, functionNames);
+    }
+
+    public static Diagnostic? ValidateImport(WildcardImportSymbol wildcardImport)
+    {
+        if (wildcardImport.Context.SourceFile.FileKind != BicepSourceFileKind.ParamsFile ||
+            GetDeploymentContextFunctionNames(wildcardImport) is not { Length: > 0 } functionNames)
+        {
+            return null;
+        }
+
+        return DiagnosticBuilder.ForPosition(wildcardImport.DeclaringSyntax)
+            .ImportedSymbolDependsOnDeploymentContextFunctions(wildcardImport.Name, functionNames);
+    }
+
+    private static ImmutableArray<string> GetDeploymentContextFunctionNames(ImportedSymbol importedSymbol)
+    {
+        if (importedSymbol.SourceModel is not SemanticModel sourceModel ||
+            TryGetExportedValueDeclaration(sourceModel, importedSymbol) is not { } exportedSymbol)
+        {
+            return [];
+        }
+
+        return GetDeploymentContextFunctionNames(sourceModel, [exportedSymbol]);
+    }
+
+    private static ImmutableArray<string> GetDeploymentContextFunctionNames(WildcardImportSymbol wildcardImport)
+    {
+        if (wildcardImport.SourceModel is not SemanticModel sourceModel)
+        {
+            return [];
+        }
+
+        var exportedSymbols = sourceModel.Exports.Values
+            .Select(export => TryGetExportedValueDeclaration(sourceModel, export))
+            .WhereNotNull();
+
+        return GetDeploymentContextFunctionNames(sourceModel, exportedSymbols);
+    }
+
+    private static ImmutableArray<string> GetDeploymentContextFunctionNames(SemanticModel sourceModel, IEnumerable<DeclaredSymbol> exportedSymbols)
+    {
+        var visited = new HashSet<DeclaredSymbol>();
+        var functionNames = new HashSet<string>(LanguageConstants.IdentifierComparer);
+
+        foreach (var exportedSymbol in exportedSymbols)
+        {
+            CollectDeploymentContextFunctionNames(sourceModel, exportedSymbol, visited, functionNames);
+        }
+
+        return [.. functionNames.Order(StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static void CollectDeploymentContextFunctionNames(SemanticModel model, DeclaredSymbol rootSymbol, ISet<DeclaredSymbol> visited, ISet<string> functionNames)
+    {
+        foreach (var symbol in model.Binder.GetReferencedSymbolClosureFor(rootSymbol).Add(rootSymbol))
+        {
+            if (!visited.Add(symbol))
+            {
+                continue;
+            }
+
+            foreach (var syntax in GetValueSyntaxes(symbol))
+            {
+                CollectDeploymentContextFunctionNames(model, syntax, visited, functionNames);
+            }
+
+            switch (symbol)
+            {
+                case ImportedSymbol importedSymbol when importedSymbol.SourceModel is SemanticModel importedFrom &&
+                    TryGetExportedValueDeclaration(importedFrom, importedSymbol) is { } importedDeclaration:
+                    CollectDeploymentContextFunctionNames(importedFrom, importedDeclaration, visited, functionNames);
+                    break;
+            }
+        }
+    }
+
+    private static void CollectDeploymentContextFunctionNames(SemanticModel model, SyntaxBase syntax, ISet<DeclaredSymbol> visited, ISet<string> functionNames)
+    {
+        foreach (var functionCall in SyntaxAggregator.AggregateByType<FunctionCallSyntaxBase>(syntax))
+        {
+            switch (SymbolHelper.TryGetSymbolInfo(model.Binder, model.TypeManager.GetDeclaredType, functionCall))
+            {
+                case FunctionSymbol functionSymbol when !CanEvaluateFunctionWhileBuildingParametersFile(model, functionSymbol, functionCall):
+                    functionNames.Add(functionSymbol.Name);
+                    break;
+
+                case WildcardImportInstanceFunctionSymbol wildcardFunction when wildcardFunction.BaseSymbol.SourceModel is SemanticModel importedFrom &&
+                    TryGetExportedDeclaration<DeclaredFunctionSymbol>(importedFrom, wildcardFunction.Name) is { } importedDeclaration:
+                    CollectDeploymentContextFunctionNames(importedFrom, importedDeclaration, visited, functionNames);
+                    break;
+            }
+        }
+
+        foreach (var propertyAccess in SyntaxAggregator.AggregateByType<PropertyAccessSyntax>(syntax))
+        {
+            if (model.Binder.GetSymbolInfo(propertyAccess.BaseExpression) is WildcardImportSymbol wildcardImport &&
+                wildcardImport.SourceModel is SemanticModel importedFrom &&
+                TryGetExportedDeclaration<VariableSymbol>(importedFrom, propertyAccess.PropertyName.IdentifierName) is { } importedDeclaration)
+            {
+                CollectDeploymentContextFunctionNames(importedFrom, importedDeclaration, visited, functionNames);
+            }
+        }
+    }
+
+    private static bool CanEvaluateFunctionWhileBuildingParametersFile(SemanticModel model, FunctionSymbol functionSymbol, FunctionCallSyntaxBase functionCall)
+    {
+        var flags = model.TypeManager.GetMatchedFunctionOverload(functionCall)?.Flags ?? functionSymbol.FunctionFlags;
+
+        return flags.HasFlag(FunctionFlags.Pure);
+    }
+
+    private static IEnumerable<SyntaxBase> GetValueSyntaxes(DeclaredSymbol symbol) => symbol switch
+    {
+        VariableSymbol variable => [variable.DeclaringVariable.Value],
+        DeclaredFunctionSymbol function => [function.DeclaringFunction.Lambda],
+        _ => [],
+    };
+
+    private static DeclaredSymbol? TryGetExportedValueDeclaration(SemanticModel sourceModel, ImportedSymbol importedSymbol)
+    {
+        if (importedSymbol.OriginalSymbolName is not { } originalSymbolName)
+        {
+            return null;
+        }
+
+        return importedSymbol switch
+        {
+            ImportedVariableSymbol => TryGetExportedDeclaration<VariableSymbol>(sourceModel, originalSymbolName),
+            ImportedFunctionSymbol => TryGetExportedDeclaration<DeclaredFunctionSymbol>(sourceModel, originalSymbolName),
+            _ => null,
+        };
+    }
+
+    private static TSymbol? TryGetExportedDeclaration<TSymbol>(SemanticModel sourceModel, string name)
+        where TSymbol : DeclaredSymbol
+        => sourceModel.Root.GetDeclarationsByName(name)
+            .OfType<TSymbol>()
+            .FirstOrDefault(symbol => symbol.IsExported(sourceModel));
+
+    private static DeclaredSymbol? TryGetExportedValueDeclaration(SemanticModel sourceModel, ExportMetadata exportMetadata) => exportMetadata switch
+    {
+        ExportedVariableMetadata => TryGetExportedDeclaration<VariableSymbol>(sourceModel, exportMetadata.Name),
+        ExportedFunctionMetadata => TryGetExportedDeclaration<DeclaredFunctionSymbol>(sourceModel, exportMetadata.Name),
+        _ => null,
+    };
+}

--- a/src/Bicep.Core/Semantics/WildcardImportSymbol.cs
+++ b/src/Bicep.Core/Semantics/WildcardImportSymbol.cs
@@ -40,5 +40,10 @@ public class WildcardImportSymbol : DeclaredSymbol, INamespaceSymbol
             yield return DiagnosticBuilder.ForPosition(DeclaringSyntax).ImportedModelContainsAmbiguousExports(
                 SourceModel.Exports.Values.OfType<DuplicatedExportMetadata>().Select(md => md.Name));
         }
+
+        if (ParameterFileImportValidator.ValidateImport(this) is { } diagnostic)
+        {
+            yield return diagnostic;
+        }
     }
 }

--- a/src/Bicep.Core/TypeSystem/FunctionFlags.cs
+++ b/src/Bicep.Core/TypeSystem/FunctionFlags.cs
@@ -93,6 +93,11 @@ namespace Bicep.Core.TypeSystem
         RequiresExternalInput = 1 << 16,
 
         /// <summary>
+        /// The function can be evaluated from only its arguments without deployment context. The result of the function is guaranteed to be the same for the same arguments, regardless of deployment context. This is a stronger guarantee than <see cref="IsArgumentValueIndependent"/> because it also guarantees that the function does not depend on any external state (e.g. current time, deployment scope, etc.).
+        /// </summary>
+        Pure = 1 << 17,
+
+        /// <summary>
         /// The function can be used as a resource or module decorator.
         /// </summary>
         ResourceOrModuleDecorator = ResourceDecorator | ModuleDecorator,


### PR DESCRIPTION
## Description

Validates declarations imported into `.bicepparam` files and reports BCP452 when they directly or transitively depend on deployment-context functions. Regular `.bicep` imports remain supported, including exported declarations that use deployment-context functions, preserving the behavior reported in #20041.

The validation runs at the import boundary even when an import is unused, uses explicit function capability metadata, and covers named imports, wildcard imports, and transitive variable and function references.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20063)