### PR TITLE
Improve the error for nested `getSecret()` calls in parameter files

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -242,6 +242,40 @@ invalid file
         });
     }
 
+    [DataTestMethod]
+    [DataRow(
+        "object property",
+        """
+        type Credentials = {
+            @secure()
+            password: string
+        }
+
+        param input Credentials
+        """,
+        """
+        {
+            password: getSecret('subId', 'rgName', 'kvName', 'secretName')
+        }
+        """)]
+    public void GetSecret_nested_in_parameter_value_returns_direct_assignment_diagnostic(string scenario, string template, string parameterValue)
+    {
+        TestContext.WriteLine($"Scenario: {scenario}");
+
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", $$"""
+            using 'main.bicep'
+
+            param input = {{parameterValue}}
+            """),
+            ("main.bicep", template));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP351",
+            DiagnosticLevel.Error,
+            "Function \"getSecret\" is not valid at this location. It can only be used when directly assigning to a parameter.");
+    }
+
     [TestMethod]
     public void GetSecret_without_expressions_in_parameters_generates_expected_keyVault_reference()
     {

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -326,6 +326,21 @@ invalid file
             ]
         }
         """)]
+    [DataRow(
+        "namespaced function with a secret version",
+        """
+        type Credentials = {
+            @secure()
+            password: string
+        }
+
+        param input Credentials
+        """,
+        """
+        {
+            password: az.getSecret('subId', 'rgName', 'kvName', 'secretName', 'secretVersion')
+        }
+        """)]
     public void GetSecret_nested_in_parameter_value_returns_direct_assignment_diagnostic(string scenario, string template, string parameterValue)
     {
         TestContext.WriteLine($"Scenario: {scenario}");

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -341,6 +341,21 @@ invalid file
             password: az.getSecret('subId', 'rgName', 'kvName', 'secretName', 'secretVersion')
         }
         """)]
+    [DataRow(
+        "conditional object property",
+        """
+        type Credentials = {
+            @secure()
+            password: string
+        }
+
+        param input Credentials
+        """,
+        """
+        {
+            password: true ? getSecret('subId', 'rgName', 'kvName', 'secretName') : 'fallback'
+        }
+        """)]
     public void GetSecret_nested_in_parameter_value_returns_direct_assignment_diagnostic(string scenario, string template, string parameterValue)
     {
         TestContext.WriteLine($"Scenario: {scenario}");

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -279,6 +279,27 @@ invalid file
             }
         ]
         """)]
+    [DataRow(
+        "nested object property",
+        """
+        type Credentials = {
+            @secure()
+            password: string
+        }
+
+        type Input = {
+            credentials: Credentials
+        }
+
+        param input Input
+        """,
+        """
+        {
+            credentials: {
+                password: getSecret('subId', 'rgName', 'kvName', 'secretName')
+            }
+        }
+        """)]
     public void GetSecret_nested_in_parameter_value_returns_direct_assignment_diagnostic(string scenario, string template, string parameterValue)
     {
         TestContext.WriteLine($"Scenario: {scenario}");

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -258,6 +258,27 @@ invalid file
             password: getSecret('subId', 'rgName', 'kvName', 'secretName')
         }
         """)]
+    [DataRow(
+        "array element property",
+        """
+        @export()
+        type Login = {
+            username: string
+
+            @secure()
+            password: string
+        }
+
+        param input Login[]
+        """,
+        """
+        [
+            {
+                username: 'admin'
+                password: getSecret('subId', 'rgName', 'kvName', 'secretName')
+            }
+        ]
+        """)]
     public void GetSecret_nested_in_parameter_value_returns_direct_assignment_diagnostic(string scenario, string template, string parameterValue)
     {
         TestContext.WriteLine($"Scenario: {scenario}");

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -300,6 +300,32 @@ invalid file
             }
         }
         """)]
+    [DataRow(
+        "object property containing an array",
+        """
+        type Login = {
+            username: string
+
+            @secure()
+            password: string
+        }
+
+        type Input = {
+            logins: Login[]
+        }
+
+        param input Input
+        """,
+        """
+        {
+            logins: [
+                {
+                    username: 'admin'
+                    password: getSecret('subId', 'rgName', 'kvName', 'secretName')
+                }
+            ]
+        }
+        """)]
     public void GetSecret_nested_in_parameter_value_returns_direct_assignment_diagnostic(string scenario, string template, string parameterValue)
     {
         TestContext.WriteLine($"Scenario: {scenario}");

--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -356,6 +356,24 @@ invalid file
             password: true ? getSecret('subId', 'rgName', 'kvName', 'secretName') : 'fallback'
         }
         """)]
+    [DataRow(
+        "object property inside a loop",
+        """
+        type Login = {
+            username: string
+
+            @secure()
+            password: string
+        }
+
+        param input Login[]
+        """,
+        """
+        [for username in ['admin']: {
+            username: username
+            password: getSecret('subId', 'rgName', 'kvName', 'secretName')
+        }]
+        """)]
     public void GetSecret_nested_in_parameter_value_returns_direct_assignment_diagnostic(string scenario, string template, string parameterValue)
     {
         TestContext.WriteLine($"Scenario: {scenario}");

--- a/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
+++ b/src/Bicep.Core/Emit/FunctionPlacementValidatorVisitor.cs
@@ -106,7 +106,9 @@ namespace Bicep.Core.Emit
                 if (functionSymbol.FunctionFlags.HasFlag(FunctionFlags.DirectAssignment))
                 {
                     var (_, levelUpSymbol) = syntaxRecorder.Skip(1).SkipWhile(x => x.syntax is TernaryOperationSyntax).FirstOrDefault();
-                    if (levelUpSymbol is null)
+                    var parameterAssignment = syntaxRecorder.Select(x => x.syntax).OfType<ParameterAssignmentSyntax>().FirstOrDefault();
+                    if (levelUpSymbol is null ||
+                        (parameterAssignment is not null && !ReferenceEquals(parameterAssignment.Value, syntax)))
                     {
                         diagnosticWriter.Write(DiagnosticBuilder.ForPosition(syntax).FunctionOnlyValidWithDirectAssignment(functionSymbol.Name));
                     }


### PR DESCRIPTION
## Description

Fixes #19934

ARM supports Key Vault references as complete parameter values. It does not support them inside objects or arrays.

This change detects nested `getSecret()` calls earlier and reports `BCP351` error.

Top-level `getSecret()` assignments and supported extension configuration assignments continue to work.

I've added tests for `getSecret()` calls;

- Object properties
- Arrays of objects
- Nested objects and arrays
- Conditional expressions
- Loop expressions
- Namespaced `az.getSecret()` calls
- Calls that include a secret version

Before the fix, all new tests failed with `BCP338`, after the fix, they pass and report `BCP351` as expected.

The existing parameter-file and extension configuration tests also pass.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
