### PR TITLE
Fix concurrency issue in RPC Client

### DIFF
--- a/src/Bicep.RpcClient.Tests/JsonRpcClientTests.cs
+++ b/src/Bicep.RpcClient.Tests/JsonRpcClientTests.cs
@@ -216,6 +216,140 @@ public class JsonRpcClientTests
             .Should().ThrowAsync<EndOfStreamException>();
     }
 
+    [TestMethod]
+    public async Task SendRequest_completes_when_response_is_delivered_the_instant_the_request_is_sent()
+    {
+        // Regression test for a register-after-send race. If the server's response is observed by the
+        // listen loop before SendRequest registers its pending-response handler, the response used to be
+        // silently dropped and the caller hung forever. The handler MUST be registered before the request
+        // is written to the wire. This test delivers the response during the request flush (i.e. before
+        // the old code reached its registration) and asserts the caller still receives it.
+        var responsePipe = new Pipe();
+        var requestPipe = new Pipe();
+
+        async Task DeliverFirstResponse()
+        {
+            // The first request on a fresh client has id 1.
+            const string json = """{"jsonrpc":"2.0","id":1,"result":{"value":"raced"}}""";
+            var frame = Encoding.UTF8.GetBytes($"Content-Length: {Encoding.UTF8.GetByteCount(json)}\r\n\r\n{json}");
+            await responsePipe.Writer.WriteAsync(frame);
+            await responsePipe.Writer.FlushAsync();
+
+            // Yield long enough for the listen loop (parked in ReadAsync) to observe the response. Under
+            // the buggy ordering this is exactly where the response would be dropped, before registration.
+            await Task.Delay(200);
+        }
+
+        var writer = new FlushInterceptingWriter(requestPipe.Writer, DeliverFirstResponse);
+        var client = new JsonRpcClient(responsePipe.Reader, writer);
+        using var listenCts = CancellationTokenSource.CreateLinkedTokenSource(Token);
+        try
+        {
+            _ = client.Listen(() => { }, listenCts.Token);
+
+            // Drain the request pipe so the client's write never blocks on a full pipe.
+            _ = Task.Run(async () =>
+            {
+                while (true)
+                {
+                    var read = await requestPipe.Reader.ReadAsync(listenCts.Token);
+                    requestPipe.Reader.AdvanceTo(read.Buffer.End);
+                    if (read.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+            }, listenCts.Token);
+
+            var result = await client.SendRequest<TestParams, TestResult>("test/method", new("foo"), Token);
+            result.Value.Should().Be("raced");
+        }
+        finally
+        {
+            await listenCts.CancelAsync();
+            client.Dispose();
+        }
+    }
+
+    [TestMethod]
+    [SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Observing the request result; not an issue in test code.")]
+    public async Task SendRequest_faults_pending_caller_when_connection_closes_before_response()
+    {
+        using var harness = new TestHarness();
+        harness.StartListening();
+
+        var requestTask = harness.Client.SendRequest<TestParams, TestResult>("test/method", new("foo"), Token);
+        _ = await harness.ReadRequestIdAsync(Token);
+
+        // The server disconnects without ever responding; the pending caller must be faulted, not hung.
+        await harness.CompleteResponseAsync();
+
+        await FluentActions.Invoking(() => requestTask)
+            .Should().ThrowAsync<IOException>();
+    }
+
+    [TestMethod]
+    [SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Observing the request result; not an issue in test code.")]
+    public async Task SendRequest_is_cancelled_when_its_token_is_cancelled()
+    {
+        using var harness = new TestHarness();
+        harness.StartListening();
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(Token);
+        var requestTask = harness.Client.SendRequest<TestParams, TestResult>("test/method", new("foo"), cts.Token);
+        _ = await harness.ReadRequestIdAsync(Token);
+
+        // No response is ever sent; cancelling the caller's token must unblock the request.
+        await cts.CancelAsync();
+
+        await FluentActions.Invoking(() => requestTask)
+            .Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [TestMethod]
+    [SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Observing the request result; not an issue in test code.")]
+    public async Task Dispose_faults_pending_callers()
+    {
+        using var harness = new TestHarness();
+        harness.StartListening();
+
+        var requestTask = harness.Client.SendRequest<TestParams, TestResult>("test/method", new("foo"), Token);
+        _ = await harness.ReadRequestIdAsync(Token);
+
+        // Disposing while a request is in flight must fault the caller rather than leave it hanging.
+        harness.Client.Dispose();
+
+        await FluentActions.Invoking(() => requestTask)
+            .Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    // A PipeWriter wrapper that runs a callback immediately after each explicit FlushAsync, used to
+    // deliver a server response at the exact moment a request hits the wire.
+    private sealed class FlushInterceptingWriter(PipeWriter inner, Func<Task> onFlushed) : PipeWriter
+    {
+        public override void Advance(int bytes) => inner.Advance(bytes);
+
+        public override Memory<byte> GetMemory(int sizeHint = 0) => inner.GetMemory(sizeHint);
+
+        public override Span<byte> GetSpan(int sizeHint = 0) => inner.GetSpan(sizeHint);
+
+        public override void CancelPendingFlush() => inner.CancelPendingFlush();
+
+        public override void Complete(Exception? exception = null) => inner.Complete(exception);
+
+        public override ValueTask CompleteAsync(Exception? exception = null) => inner.CompleteAsync(exception);
+
+        public override ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+            => inner.WriteAsync(source, cancellationToken);
+
+        public override async ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default)
+        {
+            var result = await inner.FlushAsync(cancellationToken);
+            await onFlushed();
+            return result;
+        }
+    }
+
     private sealed class TestHarness : IDisposable
     {
         // requestPipe carries client -> server bytes; responsePipe carries server -> client bytes.

--- a/src/Bicep.RpcClient/JsonRpc/JsonRpcClient.cs
+++ b/src/Bicep.RpcClient/JsonRpc/JsonRpcClient.cs
@@ -1,69 +1,32 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Buffers;
-using System.Collections.Concurrent;
-using System.IO;
+using System.Diagnostics;
 using System.IO.Pipelines;
-using System.Linq;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Bicep.RpcClient.JsonRpc;
 
 internal class JsonRpcClient(PipeReader reader, PipeWriter writer) : IJsonRpcClient
 {
-    private record JsonRpcRequest<T>(
-        string Jsonrpc,
-        string Method,
-        T Params,
-        int Id);
-
-    private record MinimalJsonRpcResponse(
-        int Id);
-
-    private record JsonRpcResponse<T>(
-        string Jsonrpc,
-        T? Result,
-        JsonRpcError? Error,
-        int Id);
-
-    private record JsonRpcError(
-        int Code,
-        string Message,
-        JsonNode? Data);
-
     private int nextId = 0;
+    private int disposed = 0;
     private readonly SemaphoreSlim writeSemaphore = new(1, 1);
-    private readonly ConcurrentDictionary<int, TaskCompletionSource<byte[]>> pendingResponses = new();
-
-    private readonly JsonSerializerOptions jsonSerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-    };
+    private readonly PendingRequestRegistry pendingRequests = new();
 
     public async Task<TResponse> SendRequest<TRequest, TResponse>(string method, TRequest request, CancellationToken cancellationToken)
     {
         var currentId = Interlocked.Increment(ref nextId);
+        var requestBytes = JsonRpcFormatter.GetRequestBytes(method, request, currentId);
 
-        var jsonRpcRequest = new JsonRpcRequest<TRequest>(Jsonrpc: "2.0", Method: method, Params: request, Id: currentId);
-        var requestContent = JsonSerializer.Serialize(jsonRpcRequest, jsonSerializerOptions);
-        var requestLength = Encoding.UTF8.GetByteCount(requestContent);
-        var rawRequest = $"Content-Length: {requestLength}\r\n\r\n{requestContent}";
+        // Register the pending response BEFORE writing to the wire. Otherwise the server can
+        // respond so quickly that the listen loop observes the response before we've registered
+        // the handler, silently dropping it and leaving this caller awaiting a response forever.
+        // Disposing the registration releases the slot no matter how this method unwinds.
+        using var registration = pendingRequests.Register(currentId);
 
         await writeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var requestBytes = Encoding.UTF8.GetBytes(rawRequest).AsMemory();
             await writer.WriteAsync(requestBytes, cancellationToken).ConfigureAwait(false);
             await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
@@ -72,23 +35,8 @@ internal class JsonRpcClient(PipeReader reader, PipeWriter writer) : IJsonRpcCli
             writeSemaphore.Release();
         }
 
-        var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
-        if (!pendingResponses.TryAdd(currentId, tcs))
-        {
-            throw new InvalidOperationException($"A request with ID {currentId} is already pending.");
-        }
-
-        var responseContent = await tcs.Task.ConfigureAwait(false);
-        var jsonRpcResponse = JsonSerializer.Deserialize<JsonRpcResponse<TResponse>>(responseContent, jsonSerializerOptions)
-            ?? throw new InvalidOperationException("Failed to deserialize JSON-RPC response");
-
-        if (jsonRpcResponse.Result is null)
-        {
-            var error = jsonRpcResponse.Error ?? throw new InvalidDataException("Failed to retrieve JSONRPC error");
-            throw new InvalidOperationException(error.Message);
-        }
-
-        return jsonRpcResponse.Result;
+        var responseContent = await registration.WaitForResponseAsync(cancellationToken).ConfigureAwait(false);
+        return JsonRpcFormatter.GetResponse<TResponse>(responseContent);
     }
 
     public Task Listen(Action onComplete, CancellationToken cancellationToken)
@@ -110,153 +58,67 @@ internal class JsonRpcClient(PipeReader reader, PipeWriter writer) : IJsonRpcCli
 
     private async Task ListenInternal(CancellationToken cancellationToken)
     {
-        while (true)
+        Exception? faultException = null;
+        try
         {
-            try
+            while (true)
             {
-                var message = await ReadMessage(cancellationToken).ConfigureAwait(false);
+                var message = await JsonRpcFormatter.ReadMessage(reader, cancellationToken).ConfigureAwait(false);
                 if (message is null)
                 {
+                    // The remote endpoint disconnected. Any outstanding callers are faulted below.
+                    faultException = new IOException("The JSON-RPC connection was closed by the remote endpoint before all responses were received.");
                     return;
                 }
 
-                var response = JsonSerializer.Deserialize<MinimalJsonRpcResponse>(message, jsonSerializerOptions)
-                    ?? throw new InvalidOperationException("Failed to deserialize JSON-RPC response");
+                var responseId = JsonRpcFormatter.GetResponseId(message);
 
-                if (pendingResponses.TryRemove(response.Id, out var tcs))
+                if (!pendingRequests.TryComplete(responseId, message))
                 {
-                    tcs.SetResult(message);
+                    // No caller is waiting on this id. This indicates a protocol bug (unknown or
+                    // duplicate id), so surface it rather than silently dropping the message.
+                    Debug.WriteLine($"Received a JSON-RPC response for unknown or already-completed request ID {responseId}.");
                 }
             }
-            catch (Exception) when (cancellationToken.IsCancellationRequested)
+        }
+        catch (Exception ex)
+        {
+            faultException = ex;
+            if (cancellationToken.IsCancellationRequested)
             {
                 await reader.CompleteAsync().ConfigureAwait(false);
                 await writer.CompleteAsync().ConfigureAwait(false);
-                break;
             }
-        }
-    }
-
-    private record Headers(
-        int ContentLength);
-
-    private async Task<Headers?> ReadHeaders(CancellationToken cancellationToken)
-    {
-        int? contentLength = null;
-        while (true)
-        {
-            var readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-
-            if (readResult.Buffer.IsEmpty && readResult.IsCompleted)
+            else
             {
-                return null; // remote end disconnected at a reasonable place.
+                // A framing/protocol error is unrecoverable for this connection. Surface it on the listen
+                // task (its established contract) after the finally block has faulted any pending callers.
+                throw;
             }
-
-            var lf = readResult.Buffer.PositionOf((byte)'\n');
-            if (!lf.HasValue)
+        }
+        finally
+        {
+            // Never leave a caller awaiting a response that can no longer arrive.
+            if (cancellationToken.IsCancellationRequested)
             {
-                if (readResult.IsCompleted)
-                {
-                    throw new EndOfStreamException();
-                }
-
-                // Indicate that we can't find what we're looking for and read again.
-                reader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
-                continue;
+                pendingRequests.CancelAll(cancellationToken);
             }
-
-            var line = readResult.Buffer.Slice(0, lf.Value);
-
-            // Verify the line ends with an \r (that precedes the \n we already found)
-            var cr = line.PositionOf((byte)'\r');
-            if (!cr.HasValue || !line.GetPosition(1, cr.Value).Equals(lf))
+            else
             {
-                throw new InvalidOperationException("Header does not end with expected \r\n character sequence");
-            }
-
-            // Trim off the \r now that we confirmed it was there.
-            line = line.Slice(0, line.Length - 1);
-
-            if (line.Length > 0)
-            {
-                var lineText = Encoding.UTF8.GetString(line.ToArray());
-                var split = lineText.Split([':'], 2);
-                if (split.Length != 2)
-                {
-                    throw new InvalidOperationException("Colon not found in header.");
-                }
-
-                var headerName = split[0].Trim();
-                var headerValue = split[1].Trim();
-
-                if (headerName == "Content-Length")
-                {
-                    contentLength = int.Parse(headerValue);
-                }
-            }
-
-            // Advance to the next line.
-            reader.AdvanceTo(readResult.Buffer.GetPosition(1, lf.Value));
-
-            if (line.Length == 0)
-            {
-                // We found the empty line that constitutes the end of the HTTP headers.
-                break;
+                pendingRequests.FaultAll(faultException ?? new IOException("The JSON-RPC connection was closed before a response was received."));
             }
         }
-
-        if (!contentLength.HasValue)
-        {
-            throw new InvalidOperationException("Failed to obtain Content-Length header");
-        }
-
-        return new(contentLength.Value);
-    }
-
-    protected async ValueTask<ReadResult> ReadAtLeastAsync(int requiredBytes, bool allowEmpty, CancellationToken cancellationToken)
-    {
-        var readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-        while (readResult.Buffer.Length < requiredBytes && !readResult.IsCompleted && !readResult.IsCanceled)
-        {
-            reader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
-            readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        if (allowEmpty && readResult.Buffer.Length == 0)
-        {
-            return readResult;
-        }
-
-        if (readResult.Buffer.Length < requiredBytes)
-        {
-            throw readResult.IsCompleted ? new EndOfStreamException() :
-                readResult.IsCanceled ? new OperationCanceledException() :
-                throw new InvalidOperationException(); // should be unreachable
-        }
-
-        return readResult;
-    }
-
-    private async Task<byte[]?> ReadMessage(CancellationToken cancellationToken)
-    {
-        var headers = await ReadHeaders(cancellationToken).ConfigureAwait(false);
-        if (headers is null)
-        {
-            return null;
-        }
-
-        var readResult = await ReadAtLeastAsync(headers.ContentLength, allowEmpty: false, cancellationToken).ConfigureAwait(false);
-
-        var contentBuffer = readResult.Buffer.Slice(0, headers.ContentLength);
-        var output = contentBuffer.ToArray();
-
-        reader.AdvanceTo(contentBuffer.End);
-
-        return output;
     }
 
     public void Dispose()
     {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+        {
+            return;
+        }
+
+        // Unblock any callers still awaiting responses before tearing down the pipe.
+        pendingRequests.FaultAll(new ObjectDisposedException(nameof(JsonRpcClient)));
         writer.Complete();
         reader.Complete();
     }

--- a/src/Bicep.RpcClient/JsonRpc/JsonRpcFormatter.cs
+++ b/src/Bicep.RpcClient/JsonRpc/JsonRpcFormatter.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Bicep.RpcClient.JsonRpc;
+
+internal static class JsonRpcFormatter
+{
+    private record JsonRpcRequest<T>(
+        string Jsonrpc,
+        string Method,
+        T Params,
+        int Id);
+
+    private record MinimalJsonRpcResponse(
+        int Id);
+
+    private record JsonRpcResponse<T>(
+        string Jsonrpc,
+        T? Result,
+        JsonRpcError? Error,
+        int Id);
+
+    private record JsonRpcError(
+        int Code,
+        string Message,
+        JsonNode? Data);
+
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private record Headers(
+        int ContentLength);
+
+    private static async Task<Headers?> ReadHeaders(PipeReader reader, CancellationToken cancellationToken)
+    {
+        int? contentLength = null;
+        while (true)
+        {
+            var readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+
+            if (readResult.Buffer.IsEmpty && readResult.IsCompleted)
+            {
+                return null; // remote end disconnected at a reasonable place.
+            }
+
+            var lf = readResult.Buffer.PositionOf((byte)'\n');
+            if (!lf.HasValue)
+            {
+                if (readResult.IsCompleted)
+                {
+                    throw new EndOfStreamException();
+                }
+
+                // Indicate that we can't find what we're looking for and read again.
+                reader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+                continue;
+            }
+
+            var line = readResult.Buffer.Slice(0, lf.Value);
+
+            // Verify the line ends with an \r (that precedes the \n we already found)
+            var cr = line.PositionOf((byte)'\r');
+            if (!cr.HasValue || !line.GetPosition(1, cr.Value).Equals(lf))
+            {
+                throw new InvalidOperationException("Header does not end with expected \r\n character sequence");
+            }
+
+            // Trim off the \r now that we confirmed it was there.
+            line = line.Slice(0, line.Length - 1);
+
+            if (line.Length > 0)
+            {
+                var lineText = Encoding.UTF8.GetString(line.ToArray());
+                var split = lineText.Split([':'], 2);
+                if (split.Length != 2)
+                {
+                    throw new InvalidOperationException("Colon not found in header.");
+                }
+
+                var headerName = split[0].Trim();
+                var headerValue = split[1].Trim();
+
+                if (headerName == "Content-Length")
+                {
+                    contentLength = int.Parse(headerValue, CultureInfo.InvariantCulture);
+                }
+            }
+
+            // Advance to the next line.
+            reader.AdvanceTo(readResult.Buffer.GetPosition(1, lf.Value));
+
+            if (line.Length == 0)
+            {
+                // We found the empty line that constitutes the end of the HTTP headers.
+                break;
+            }
+        }
+
+        if (!contentLength.HasValue)
+        {
+            throw new InvalidOperationException("Failed to obtain Content-Length header");
+        }
+
+        return new(contentLength.Value);
+    }
+
+    private static async ValueTask<ReadResult> ReadAtLeastAsync(PipeReader reader, int requiredBytes, bool allowEmpty, CancellationToken cancellationToken)
+    {
+        var readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        while (readResult.Buffer.Length < requiredBytes && !readResult.IsCompleted && !readResult.IsCanceled)
+        {
+            reader.AdvanceTo(readResult.Buffer.Start, readResult.Buffer.End);
+            readResult = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (allowEmpty && readResult.Buffer.Length == 0)
+        {
+            return readResult;
+        }
+
+        if (readResult.Buffer.Length < requiredBytes)
+        {
+            throw readResult.IsCompleted ? new EndOfStreamException() :
+                readResult.IsCanceled ? new OperationCanceledException() :
+                throw new InvalidOperationException(); // should be unreachable
+        }
+
+        return readResult;
+    }
+
+    public static async Task<byte[]?> ReadMessage(PipeReader reader, CancellationToken cancellationToken)
+    {
+        var headers = await ReadHeaders(reader, cancellationToken).ConfigureAwait(false);
+        if (headers is null)
+        {
+            return null;
+        }
+
+        var readResult = await ReadAtLeastAsync(reader, headers.ContentLength, allowEmpty: false, cancellationToken).ConfigureAwait(false);
+
+        var contentBuffer = readResult.Buffer.Slice(0, headers.ContentLength);
+        var output = contentBuffer.ToArray();
+
+        reader.AdvanceTo(contentBuffer.End);
+
+        return output;
+    }
+
+    public static ReadOnlyMemory<byte> GetRequestBytes<TRequest>(string method, TRequest request, int currentId)
+    {
+        var jsonRpcRequest = new JsonRpcRequest<TRequest>(Jsonrpc: "2.0", Method: method, Params: request, Id: currentId);
+        var requestContent = JsonSerializer.Serialize(jsonRpcRequest, JsonSerializerOptions);
+        var requestLength = Encoding.UTF8.GetByteCount(requestContent);
+        var rawRequest = $"Content-Length: {requestLength}\r\n\r\n{requestContent}";
+
+        return Encoding.UTF8.GetBytes(rawRequest);
+    }
+
+    public static TResponse GetResponse<TResponse>(byte[] responseContent)
+    {
+        var jsonRpcResponse = JsonSerializer.Deserialize<JsonRpcResponse<TResponse>>(responseContent, JsonSerializerOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize JSON-RPC response");
+
+        if (jsonRpcResponse.Result is null)
+        {
+            var error = jsonRpcResponse.Error ?? throw new InvalidDataException("Failed to retrieve JSONRPC error");
+            throw new InvalidOperationException(error.Message);
+        }
+
+        return jsonRpcResponse.Result;
+    }
+
+    public static int GetResponseId(byte[] responseContent)
+    {
+        var jsonRpcResponse = JsonSerializer.Deserialize<MinimalJsonRpcResponse>(responseContent, JsonSerializerOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize JSON-RPC response");
+
+        return jsonRpcResponse.Id;
+    }
+}

--- a/src/Bicep.RpcClient/JsonRpc/PendingRequestRegistry.cs
+++ b/src/Bicep.RpcClient/JsonRpc/PendingRequestRegistry.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bicep.RpcClient.JsonRpc;
+
+/// <summary>
+/// Owns the correlation between in-flight JSON-RPC request ids and the callers awaiting their
+/// responses. All concurrency-sensitive bookkeeping (registration, completion, and connection
+/// teardown) is localized here so the transport code can be read as intent.
+/// </summary>
+internal sealed class PendingRequestRegistry
+{
+    private readonly ConcurrentDictionary<int, TaskCompletionSource<byte[]>> pending = new();
+
+    /// <summary>
+    /// Registers a pending request for the given id. The caller awaits
+    /// <see cref="Registration.WaitForResponseAsync"/> and must dispose the returned handle to release
+    /// the slot (on success, failure, or cancellation).
+    /// </summary>
+    public Registration Register(int id)
+    {
+        var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!pending.TryAdd(id, tcs))
+        {
+            throw new InvalidOperationException($"A request with ID {id} is already pending.");
+        }
+
+        return new Registration(this, id, tcs);
+    }
+
+    /// <summary>
+    /// Completes the pending request with the given id. Returns <see langword="false"/> if no caller is
+    /// waiting on that id (unknown or already-completed request).
+    /// </summary>
+    public bool TryComplete(int id, byte[] message)
+    {
+        if (pending.TryRemove(id, out var tcs))
+        {
+            tcs.TrySetResult(message);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Faults every outstanding request so no caller is left awaiting a response that can no longer arrive.
+    /// </summary>
+    public void FaultAll(Exception exception)
+    {
+        foreach (var id in pending.Keys.ToArray())
+        {
+            if (pending.TryRemove(id, out var tcs))
+            {
+                tcs.TrySetException(exception);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Cancels every outstanding request using the given cancellation token.
+    /// </summary>
+    public void CancelAll(CancellationToken cancellationToken)
+    {
+        foreach (var id in pending.Keys.ToArray())
+        {
+            if (pending.TryRemove(id, out var tcs))
+            {
+                tcs.TrySetCanceled(cancellationToken);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A scoped handle for a single registered request. Disposing it releases the registry slot,
+    /// ensuring the pending entry never leaks regardless of how the caller unwinds.
+    /// </summary>
+    public readonly struct Registration : IDisposable
+    {
+        private readonly PendingRequestRegistry registry;
+        private readonly int id;
+        private readonly TaskCompletionSource<byte[]> tcs;
+
+        internal Registration(PendingRequestRegistry registry, int id, TaskCompletionSource<byte[]> tcs)
+        {
+            this.registry = registry;
+            this.id = id;
+            this.tcs = tcs;
+        }
+
+        /// <summary>
+        /// Awaits the response, observing the caller's cancellation token without leaking the
+        /// token registration once the response arrives.
+        /// </summary>
+        [SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "The awaited task belongs to a TaskCompletionSource owned by this registry.")]
+        public async Task<byte[]> WaitForResponseAsync(CancellationToken cancellationToken)
+        {
+            var completionSource = tcs;
+            using (cancellationToken.Register(() => completionSource.TrySetCanceled(cancellationToken)))
+            {
+                return await completionSource.Task.ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose() => registry.pending.TryRemove(id, out _);
+    }
+}


### PR DESCRIPTION
Discovered when analyzing a memory dump for a test hang with the WinDbg MCP server:
<img width="780" height="989" alt="image" src="https://github.com/user-attachments/assets/f689c98b-5434-4006-b64c-8ec1c1293c95" />
