### PR TITLE
Bump System.Security.Cryptography.Xml

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -104,8 +104,8 @@
     <PackageVersion Include="System.Memory.Data" Version="10.0.9" />
     <!-- force an upgrade of this dependency as it seems to cause build flakiness for unknown reasons -->
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <!-- pin to patched version to resolve CVE-2026-33116 (https://github.com/advisories/GHSA-37gx-xxp4-5rgx) -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <!-- pin to patched version to resolve known vulnerabilities -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="Tools.InnoSetup" Version="6.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary
- Bump `System.Security.Cryptography.Xml` from `8.0.3` to `10.0.10` to resolve NuGet vulnerability warnings.
- Update the central package pin comment to cover known vulnerabilities more generally.

## Validation
- `dotnet restore f:\bicep\src\Bicep.Cli.UnitTests\Bicep.Cli.UnitTests.csproj /property:GenerateFullPaths=true`
- `dotnet list f:\bicep\src\Bicep.Cli.UnitTests\Bicep.Cli.UnitTests.csproj package --vulnerable --include-transitive --no-restore`
- `dotnet build f:\bicep\src\Bicep.Cli.UnitTests\Bicep.Cli.UnitTests.csproj --no-restore /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20101)