### PR TITLE
Only return list-prefixed functions in Az types

### DIFF
--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeLoaderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeLoaderTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using Azure.Bicep.Types;
+using Azure.Bicep.Types.Concrete;
+using Azure.Bicep.Types.Index;
+using Bicep.Core.Resources;
+using Bicep.Core.TypeSystem.Providers.Az;
+using Bicep.Core.UnitTests.Mock;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AzTypes = Azure.Bicep.Types.Concrete;
+
+namespace Bicep.Core.UnitTests.TypeSystem.Az
+{
+    [TestClass]
+    public class AzResourceTypeLoaderTests
+    {
+        [TestMethod]
+        public void LoadType_includes_only_list_prefixed_resource_functions()
+        {
+            var factory = new TypeFactory([]);
+            var stringType = factory.Create(() => new AzTypes.StringType());
+
+            var resourceBodyType = factory.Create(() => new AzTypes.ObjectType(
+                "TestResourceBody",
+                new Dictionary<string, ObjectTypeProperty>
+                {
+                    ["name"] = new(factory.GetReference(stringType), ObjectTypePropertyFlags.Required | ObjectTypePropertyFlags.Identifier, "Resource name"),
+                },
+                null,
+                null));
+
+            var resourceType = factory.Create(() => new AzTypes.ResourceType(
+                "Test.Rp/testResources@2020-01-01",
+                factory.GetReference(resourceBodyType),
+                functions: null,
+                writableScopes_in: ScopeType.ResourceGroup,
+                readableScopes_in: ScopeType.ResourceGroup,
+                scopeType: null,
+                readOnlyScopes: null,
+                flags: null));
+
+            var listFunctionType = factory.Create(() => new ResourceFunctionType(
+                "listSecrets",
+                "Test.Rp/testResources",
+                "2020-01-01",
+                factory.GetReference(stringType),
+                factory.GetReference(stringType)));
+
+            var nonListFunctionType = factory.Create(() => new ResourceFunctionType(
+                "getSecrets",
+                "Test.Rp/testResources",
+                "2020-01-01",
+                factory.GetReference(stringType),
+                factory.GetReference(stringType)));
+
+            var resourceRef = new CrossFileTypeReference("types.json", factory.GetIndex(resourceType));
+            var listFunctionRef = new CrossFileTypeReference("types.json", factory.GetIndex(listFunctionType));
+            var nonListFunctionRef = new CrossFileTypeReference("types.json", factory.GetIndex(nonListFunctionType));
+
+            var index = new TypeIndex(
+                resources: new Dictionary<string, CrossFileTypeReference>
+                {
+                    [resourceType.Name] = resourceRef,
+                },
+                resourceFunctions: new Dictionary<string, IReadOnlyDictionary<string, IReadOnlyList<CrossFileTypeReference>>>
+                {
+                    ["Test.Rp/testResources"] = new Dictionary<string, IReadOnlyList<CrossFileTypeReference>>
+                    {
+                        ["2020-01-01"] = [listFunctionRef, nonListFunctionRef],
+                    },
+                },
+                namespaceFunctions: [],
+                settings: new TypeSettings("Test", "1.0.0", isSingleton: false, isPreview: null, isDeprecated: null, configurationType: null),
+                fallbackResourceType: null);
+
+            var typeLoader = StrictMock.Of<ITypeLoader>();
+            typeLoader.Setup(x => x.LoadTypeIndex()).Returns(index);
+            typeLoader.Setup(x => x.LoadResourceType(resourceRef)).Returns(resourceType);
+            typeLoader.Setup(x => x.LoadResourceFunctionType(listFunctionRef)).Returns(listFunctionType);
+            typeLoader.Setup(x => x.LoadResourceFunctionType(nonListFunctionRef)).Returns(nonListFunctionType);
+
+            var loader = new AzResourceTypeLoader(typeLoader.Object);
+
+            var loaded = loader.LoadType(ResourceTypeReference.Parse(resourceType.Name));
+            var bodyType = loaded.Body.Type.Should().BeOfType<Bicep.Core.TypeSystem.Types.ObjectType>().Subject;
+            var functionSymbols = bodyType.MethodResolver.GetKnownFunctions();
+
+            functionSymbols.Keys.Should().BeEquivalentTo(["listSecrets"]);
+            functionSymbols["listSecrets"].Overloads.Should().HaveCount(2);
+        }
+    }
+}

--- a/src/Bicep.Core/TypeSystem/Providers/Az/AzResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Az/AzResourceTypeLoader.cs
@@ -6,6 +6,7 @@ using Azure.Bicep.Types.Index;
 using Bicep.Core.Extensions;
 using Bicep.Core.Resources;
 using Bicep.Core.TypeSystem.Types;
+using Microsoft.WindowsAzure.ResourceStack.Common.Extensions;
 
 namespace Bicep.Core.TypeSystem.Providers.Az
 {
@@ -50,7 +51,9 @@ namespace Bicep.Core.TypeSystem.Providers.Az
                 functions = [];
             }
 
-            var functionOverloads = functions.SelectMany(typeLocation => resourceTypeFactory.GetResourceFunctionOverloads(typeLoader.LoadResourceFunctionType(typeLocation)));
+            var functionOverloads = functions
+                .SelectMany(typeLocation => resourceTypeFactory.GetResourceFunctionOverloads(typeLoader.LoadResourceFunctionType(typeLocation)))
+                .Where(x => x.Name.StartsWithOrdinalInsensitively(LanguageConstants.ListFunctionPrefix));
 
             var serializedResourceType = typeLoader.LoadResourceType(typeLocation);
             return resourceTypeFactory.GetResourceType(serializedResourceType, functionOverloads);


### PR DESCRIPTION
The purpose of this PR is to ensure the additional APIs added with https://github.com/Azure/bicep-types-az/pull/2765 are not surfaced in Bicep