### PR TITLE
Migrate Core unit tests to TestCompiler

### DIFF
--- a/docs/uri-cleanup-plan.md
+++ b/docs/uri-cleanup-plan.md
@@ -38,7 +38,7 @@ Status legend:
 Use this for tests that only need a synthetic `main.bicep` and do not need restore:
 
 ```csharp
-var result = await TestCompiler
+var result = TestCompiler
     .ForInMemoryCompilation()
     .WithEmptyAzResources()
     .CompileWithoutRestore(bicepText);
@@ -48,12 +48,14 @@ var compilation = result.Compilation;
 
 Use `result.Template` and `result.Diagnostics` when needed. They are lazy, so params-file tests can safely use the same result type without forcing template emission.
 
+`CompileWithoutRestore(...)` is synchronous and uses `BicepCompiler.CreateCompilationWithoutRestore(...)`. Use the asynchronous `Compile(...)` overloads only when artifact restore is required.
+
 ### Params-File Entry Points
 
 Use `CompileWithoutRestore(entryPointPath, files)` and then inspect `result.Compilation`:
 
 ```csharp
-var result = await TestCompiler
+var result = TestCompiler
     .ForInMemoryCompilation()
     .WithEmptyAzResources()
     .CompileWithoutRestore(
@@ -75,7 +77,7 @@ private static readonly IOUri ParamsUri = TestFileUri.FromInMemoryPath("main.bic
 Use fluent `TestCompiler` extensions:
 
 ```csharp
-var result = await TestCompiler
+var result = TestCompiler
     .ForInMemoryCompilation()
     .WithConfiguration(BicepTestConstants.BuiltInConfigurationWithStableAnalyzers)
     .WithEmptyAzResources()
@@ -83,7 +85,7 @@ var result = await TestCompiler
 ```
 
 ```csharp
-var result = await TestCompiler
+var result = TestCompiler
     .ForInMemoryCompilation()
     .WithAzResources(BuiltInTestTypes.Types)
     .CompileWithoutRestore(bicepText);
@@ -122,122 +124,166 @@ Leave these categories alone unless a PR explicitly targets their owning behavio
 
 ## Progress Tracker
 
-- `[x]` LangServer refresh APIs use `DocumentUri` instead of round-tripping through `System.Uri`.
-  - Commit: `9f6498394 Use DocumentUri for LangServer refreshes`
-  - Files covered:
-    - `src/Bicep.LangServer/CompilationManager/ICompilationManager.cs`
-    - `src/Bicep.LangServer/BicepCompilationManager.cs`
-    - `src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs`
-    - `src/Bicep.LangServer/Handlers/BicepForceModulesRestoreCommandHandler.cs`
-- `[x]` `TestCompiler` consistently returns `TestCompilationResult`, with lazy `Template` and `Diagnostics`.
-  - Files covered:
-    - `src/Bicep.Testing/Utils/TestCompiler.cs`
-    - `src/Bicep.Testing/Utils/TestCompilerExtensions.cs`
-    - `src/Bicep.Testing/Utils/TestServices.cs`
-    - `src/Bicep.Testing/Utils/TestCompilationResult.cs`
-- `[x]` Initial Core unit-test migration to `TestCompiler.ForInMemoryCompilation()`.
-  - Files covered:
-    - `src/Bicep.Core.UnitTests/Semantics/BaseParametersSymbolTests.cs`
-    - `src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecureParamsInParametersFileRuleTests.cs`
-    - `src/Bicep.Core.UnitTests/Emit/ExpressionConverterTests.cs`
-    - `src/Bicep.Core.UnitTests/Emit/InlineDependencyVisitorTests.cs`
-    - `src/Bicep.Core.UnitTests/Emit/PositionTrackingJsonTextWriterTests.cs`
-    - `src/Bicep.Core.UnitTests/Semantics/SymbolContextTests.cs`
-    - `src/Bicep.Core.UnitTests/SourceGraph/BicepFileTests.cs`
-    - `src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs`
-- `[x]` Direct workspace helpers accept `IOUri` without `IOUri -> Uri -> IOUri` round-trips.
-  - Files covered:
-    - `src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs`
-    - `src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs`
-- `[ ]` Remaining Core unit-test call sites.
-- `[ ]` Move shared assertions, constants, mocks, and helper APIs out of `Bicep.Core.UnitTests` into `Bicep.Testing`.
-- `[ ]` Remove non-Core-unit-test project references to `Bicep.Core.UnitTests`.
+- `[x]` LangServer refresh APIs use `DocumentUri` without `System.Uri` round-trips (`9f6498394`).
+- `[x]` `TestCompiler` provides in-memory and mock-file-system compilation, synchronous no-restore compilation, restore-capable compilation, and lazy template/parameters/diagnostics results.
+- `[x]` Initial Core unit-test slices use `TestCompiler`, including params emission and linter/extension scenarios.
+- `[ ]` Replace all `CompilationHelper` call sites with `TestCompiler` and delete `CompilationHelper` and its result types.
+- `[ ]` Replace `ServiceBuilder`, `ServiceBuilderExtensions`, and related Core-unit-test DI extensions with `TestCompiler`, `TestServices`, or focused fixtures, then delete them.
+- `[ ]` Consolidate reusable assertions, feature fixtures, mocks, and data builders in `Bicep.Testing`; rewrite or remove obsolete helpers instead of moving them wholesale.
+- `[ ]` Remove all non-Core-unit-test project references to `Bicep.Core.UnitTests`.
 - `[ ]` Core integration test URI dictionaries.
 - `[ ]` Incidental `MockFileSystem` usage that only creates compiler-visible files.
 - `[ ]` `DocumentUriExtensions.ToUriEncoded` deprecation and removal.
 
 ## Current PR Baseline
 
-Current PR scope:
+Completed in this PR:
 
-- Add lazy `TestCompilationResult` properties.
-- Add `TestCompiler.Compile(...)` and `CompileWithoutRestore(...)` source-text overloads.
-- Add fluent `TestCompiler` service customization extensions.
-- Replace first Core unit-test slice with `TestCompiler.ForInMemoryCompilation()`.
-- Keep restore-based, params-emission, linter-infrastructure, CLI, and file-system behavior tests for later PRs.
+- Added lazy params emission and made no-restore compilation synchronous.
+- Migrated the planned Core unit-test slice to `TestCompiler`, including extension restore setup.
 
-Validation already run:
-
-```powershell
-dotnet test .\src\Bicep.Core.UnitTests\Bicep.Core.UnitTests.csproj --no-restore -- --filter "FullyQualifiedName~BaseParametersSymbolTests|FullyQualifiedName~SecureParamsInParametersFileRuleTests|FullyQualifiedName~PositionTrackingJsonTextWriterTests|FullyQualifiedName~SymbolContextTests|FullyQualifiedName~BicepFileTests|FullyQualifiedName~ExpressionConverterTests|FullyQualifiedName~InlineDependencyVisitorTests"
-```
-
-```powershell
-dotnet test .\src\Bicep.Core.IntegrationTests\Bicep.Core.IntegrationTests.csproj --no-restore -- --filter FullyQualifiedName~LoadJsonFunction_LocalDeploy_NoCharacterCountLimit
-```
-
-Latest results: 76 Core unit tests passed; `LoadJsonFunction_LocalDeploy_NoCharacterCountLimit` passed.
+Validation: all 6,808 Core unit tests passed; full solution build succeeded.
 
 ## Work Queue
 
-### PR A: Remaining Core Unit Test Compiler Setup
+### Workstream B: Retire Legacy Test Infrastructure
 
-Goal: migrate remaining unit tests that still use `ServiceBuilder.BuildCompilation` or `CompilationHelper` only for synthetic compiler setup.
+Goal: remove the shared test infrastructure owned by `Bicep.Core.UnitTests`. `CompilationHelper`, `ServiceBuilder`, and their forwarding extensions are migration sources, not APIs to move into `Bicep.Testing`.
 
-Candidates:
+This is an umbrella workstream, not one PR. Pick one package below and keep each PR scoped to a coherent test area or helper boundary.
 
-- `src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/StacksExtensibilityCompatibilityRuleTests.cs`
-- `src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoHardcodedLocationRuleTests.cs`
-- `src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoLocationExprOutsideParamsRuleTests.cs`
-- `src/Bicep.Core.UnitTests/Emit/ParameterAssignmentEvaluatorTests.cs`
+#### Next PR: Linter Test Infrastructure
+
+Migrate the shared linter compilation path before taking more individual linter classes:
+
+- Replace `CompilationHelper` and `ServiceBuilder` in `LinterRuleTestsBase` with `TestCompiler`.
+- Add focused `TestCompiler` configuration for configuration patches, feature overrides, custom analyzers, and resource type loaders as required.
+- Replace `CompilationHelper.InputFile` with `TestFileData` tuples in code-fix helpers.
+- Migrate the linter tests coupled to those helper signatures, starting with:
+  - `ExplicitValuesForLocationParamsRuleTests`
+  - `NoHardcodedOutputsRuleTests`
+  - `NoModuleNameRuleTests`
+  - `NoUnusedImportsRuleTests`
+  - `UseSafeAccessRuleTests`
+- Preserve diagnostic annotations and code-fix assertion behavior.
 
 Validation:
 
-- Run touched classes by `FullyQualifiedName` filter.
-- If linter helper infrastructure changes, run the affected linter rule test class and one neighboring linter rule class.
+- Run `LinterRuleTestsBase` consumers touched by the signature changes using `FullyQualifiedName` filters.
+- Run one unchanged neighboring linter class to detect shared-helper regressions.
+- Build `Bicep.Core.UnitTests` and use zero-result searches for `CompilationHelper.InputFile` in migrated files.
 
-Notes:
+#### B1: Close `Bicep.Testing` API Gaps
 
-- Treat params-emission tests as their own small slice if they require new `TestCompilationResult` support.
-- Treat linter-helper refactors as their own slice if they affect shared linter assertion behavior.
+Add only the capabilities required to remove callers of the legacy helpers:
 
-### PR B: Shared Helper Ownership
+- Map `CompilationHelper.Compile(...)` and `CompileParams(...)` to synchronous `TestCompiler.CompileWithoutRestore(...)` calls.
+- Map `RestoreAndCompile(...)` and `RestoreAndCompileParams(...)` to asynchronous `TestCompiler.Compile(...)` calls.
+- Use explicit entry-point paths and `TestFileSet`/`TestFileData` instead of `InputFile`, `CreateFileDictionary`, or workspace-building helpers.
+- Extend `TestCompilationResult` and its assertions when callers need template, parameters, diagnostics, source-file, or filtered-diagnostic behavior. Do not retain parallel `CompilationResult` and `ParamsCompilationResult` types.
+- Add focused `TestCompiler` or `TestServices` customization for configuration patches, feature overrides, analyzers, namespaces, resource types, environment variables, and artifact managers as migration needs arise.
+- Prefer replacing an existing service registration over stacking another singleton registration.
 
-Goal: move shared helper ownership from `Bicep.Core.UnitTests` to `Bicep.Testing` so other test projects stop depending on `Bicep.Core.UnitTests`.
+Do not add a `Bicep.Testing.CompilationHelper`, a generic compatibility facade, or forwarding overloads that preserve the old API shape.
 
-Candidates:
+#### B2: Replace `CompilationHelper` Callers
+
+Migrate callers by test area:
+
+- Single-file and multi-file synthetic compilation should use `TestCompiler.ForInMemoryCompilation()`.
+- Tests that intentionally validate `IFileSystem` behavior should use `TestCompiler.ForMockFileSystemCompilation()` or their existing file-system fixture.
+- Restore and registry tests should use `TestExternalArtifactManager` and restore-capable `Compile(...)` overloads.
+- Params tests should compile the `.bicepparam` entry point and consume `TestCompilationResult.Parameters`.
+- Replace tuple deconstruction and legacy result assertions with `TestCompilationResult` assertions.
+- Replace `CompilationHelper.InputFile` with `(string FilePath, TestFileData FileData)` or a local scenario type when additional metadata is genuinely needed.
+
+Delete these when the last caller is gone:
 
 - `src/Bicep.Core.UnitTests/Utils/CompilationHelper.cs`
+- `CompilationHelper.ICompilationResult`
+- `CompilationHelper.CompilationResult`
+- `CompilationHelper.ParamsCompilationResult`
+- `CompilationHelper.InputFile`
+- `src/Bicep.Core.UnitTests/Assertions/CompilationResultAssertions.cs`
+- `src/Bicep.Core.UnitTests/Assertions/ParamsCompilationResultAssertions.cs`
+- extensions that exist only for the legacy result types
+
+#### B3: Replace `ServiceBuilder` And DI Extensions
+
+`ServiceBuilder` and its extensions should disappear rather than move:
+
+- Compilation-oriented setup should become fluent `TestCompiler` configuration.
+- Tests that only construct services should use `TestServices.Get<T>()` or a focused fixture in `Bicep.Testing`; do not recreate a generic builder facade.
+- Move reusable service-registration behavior into focused `TestServices` methods or `TestCompiler` extensions.
+- Delete forwarding methods that only wrap `IServiceCollection` registration.
+- Replace `BuildCompilation*` extensions with `TestCompiler.CompileWithoutRestore(...)` or `Compile(...)`.
+- Keep direct `IServiceCollection` setup local only when a test explicitly validates DI registration behavior.
+
+Deletion targets include:
+
+- `src/Bicep.Core.UnitTests/ServiceBuilder.cs`
 - `src/Bicep.Core.UnitTests/Utils/ServiceBuilderExtensions.cs`
-- `src/Bicep.Core.UnitTests/BicepTestConstants.cs`
-- `src/Bicep.Core.UnitTests/Assertions/*`
-- `src/Bicep.Core.UnitTests/Features/*`
-- `src/Bicep.Core.UnitTests/Mock/*`
-- `src/Bicep.Core.UnitTests/Utils/FileHelper.cs`
-- `src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs`
-- `src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs`
+- `src/Bicep.Core.UnitTests/IServiceCollectionExtensions.cs` after its reusable registrations have focused replacements
+- `IDependencyHelper` and `IDependencyHelperExtensions`
 
-Guidance:
+#### B4: Consolidate Assertions
 
-- Move reusable compiler/test-file behavior, assertions, constants, mocks, and test data builders into `Bicep.Testing`.
-- Leave only tests and Core-unit-test-only fixtures in `Bicep.Core.UnitTests`.
-- Prefer namespace moves that make consumers use `Bicep.Testing.*` directly.
-- Keep temporary compatibility wrappers only when needed to keep a PR small, and track their removal in this document.
+Do not move the whole assertions directory unchanged. Classify each assertion by its subject and consumers:
 
-Validation:
+- Merge duplicate implementations already present in `Bicep.Testing`, such as diagnostic assertion infrastructure.
+- Expand `TestCompilationResultAssertions` to replace legacy compilation-result assertions, including template/parameters emission and diagnostic filtering where still useful.
+- Move broadly reusable assertions such as diagnostics, syntax, JSON tokens, strings, code fixes, and configuration assertions when non-Core projects consume them.
+- Keep Core-unit-test-only assertions local when no other project needs them.
+- Remove obsolete assertion APIs, misspelled methods, duplicate FluentAssertions entry points, and assertions tied only to deleted wrappers.
+- Preserve rich source annotations and assertion scopes during consolidation.
 
-- Run the Core unit tests touched in PR A plus representative integration tests that still call `CompilationHelper`.
+#### B5: Consolidate Features, Mocks, Constants, And Helpers
+
+Treat each family separately:
+
+- Move feature overrides and their provider factory to `Bicep.Testing` if they remain the shared way to configure compiler features. This should allow `TestCompiler.WithFeatureOverrides(...)` to become non-generic.
+- Delete the Core `StrictMock` duplicate and use `Bicep.Testing.Mocks.StrictMock`.
+- Prefer `TestExternalArtifactManager` and `Bicep.Testing.Fakes.ContainerRegistry` over moving registry mocks and `RegistryHelper` wholesale.
+- Split `BicepTestConstants` by responsibility. Move only shared configuration, feature, registry, and test-type fixtures; keep Core-specific constants local or inline them.
+- Replace compiler-file uses of `FileHelper` with `TestFileSet`. Move only reusable temporary-directory, output-file, or cache-root behavior that intentionally uses the real file system.
+- Move reusable type builders from `TestTypeHelper` and `FakeResourceTypes` into `Bicep.Testing.Fakes.TypeSystem`; remove overlapping implementations.
+- Rewrite or delete helpers whose only purpose was adapting `ServiceBuilder`, `CompilationHelper`, `System.Uri`, or `MockFileSystem`.
+
+#### B6: Deletion Gates
+
+Before declaring this workstream complete:
+
+- No references to `CompilationHelper`, `ServiceBuilder`, `ServiceBuilderExtensions`, or their legacy result types remain.
+- No shared helper in `Bicep.Core.UnitTests` has consumers outside that project.
+- `Bicep.Testing` contains one canonical implementation for each shared assertion, mock, feature fixture, and test-data builder.
+- The full solution builds after each legacy type or file is deleted.
+
+Validation for every package:
+
+- Run touched classes by `FullyQualifiedName` filter.
+- Build and test every consuming project changed by the package.
+- Run `dotnet build .\Bicep.sln --no-restore` at deletion milestones.
+- Use zero-result searches for the retired symbols as completion checks.
 
 ### PR C: Remove Project References To Bicep.Core.UnitTests
 
 Goal: no test project except `Bicep.Core.UnitTests` should reference `Bicep.Core.UnitTests` for shared helpers.
 
-Current known project-reference cleanup candidates:
+Current project-reference cleanup candidates:
 
 - `src/Bicep.Cli.IntegrationTests/Bicep.Cli.IntegrationTests.csproj`
 - `src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj`
 - `src/Bicep.Core.IntegrationTests/Bicep.Core.IntegrationTests.csproj`
 - `src/Bicep.Core.Samples/Bicep.Core.Samples.csproj`
+- `src/Bicep.Decompiler.IntegrationTests/Bicep.Decompiler.IntegrationTests.csproj`
+- `src/Bicep.Decompiler.UnitTests/Bicep.Decompiler.UnitTests.csproj`
+- `src/Bicep.LangServer.IntegrationTests/Bicep.LangServer.IntegrationTests.csproj`
+- `src/Bicep.Local.Deploy.IntegrationTests/Bicep.Local.Deploy.IntegrationTests.csproj`
+- `src/Bicep.Local.Extension.UnitTests/Bicep.Local.Extension.UnitTests.csproj`
+- `src/Bicep.McpServer.UnitTests/Bicep.McpServer.UnitTests.csproj`
+- `src/Bicep.RegistryModuleTool.TestFixtures/Bicep.RegistryModuleTool.TestFixtures.csproj`
+- `src/Bicep.RpcClient.Tests/Bicep.RpcClient.Tests.csproj`
+- `src/Bicep.Wasm.UnitTests/Bicep.Wasm.UnitTests.csproj`
 
 Likely import cleanup areas:
 
@@ -249,13 +295,15 @@ Likely import cleanup areas:
 
 Guidance:
 
-- Do this after the helpers those projects need have moved to `Bicep.Testing`.
+- Do this after each project's required helpers have been replaced, moved, consolidated, or deleted under Workstream B.
 - Remove one consuming project reference per PR when the usage is broad.
 - Validate the consuming test project, not just `Bicep.Core.UnitTests`.
 
 ### PR D: Core Integration URI Dictionaries
 
 Goal: migrate `Uri`-keyed synthetic file dictionaries in Core integration tests to `IOUri`, `TestCompiler`, and `Bicep.Testing.IO`.
+
+This is a focused execution package within Workstream B and should remove the affected `CompilationHelper`/`ServiceBuilder` usage rather than introduce adapters.
 
 Candidates:
 
@@ -275,6 +323,8 @@ Validation:
 ### PR E: Incidental MockFileSystem Cleanup
 
 Goal: remove direct `MockFileSystem` where it is only used to obtain an `IFileExplorer` or create compiler-visible files.
+
+This is a focused execution package within Workstream B. Prefer existing `Bicep.Testing` file sets and fakes; do not move incidental `MockFileSystem` setup into a new shared helper.
 
 Candidates:
 
@@ -309,10 +359,11 @@ Validation:
 
 ## Completion Criteria
 
-- Shared compiler/test-file helper APIs live in `Bicep.Testing`.
-- Shared assertions, constants, mocks, and helper APIs live in `Bicep.Testing`.
+- `CompilationHelper`, `ServiceBuilder`, their forwarding extensions, and their legacy result types are deleted.
+- `TestCompiler`, `TestServices`, test file sets, and focused fixtures provide the remaining shared compiler and service setup.
+- Every reusable assertion, feature fixture, mock, constant, and test-data builder has one canonical implementation in `Bicep.Testing`.
+- Helpers left in `Bicep.Core.UnitTests` are Core-unit-test-specific and have no consumers outside that project.
 - No non-Core-unit-test project references `Bicep.Core.UnitTests`.
-- `Bicep.Core.UnitTests.Utils` no longer contains broadly shared IO or compilation helpers.
 - Remaining file-oriented `System.Uri` usage in tests is intentional and sits at a compatibility boundary.
 - Remaining `DocumentUriExtensions.ToUriEncoded` usage is removed or isolated behind an explicitly named compatibility API.
 - Remaining direct `MockFileSystem` usage is intentional and covers `IFileSystem` behavior.

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoHardcodedLocationRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoHardcodedLocationRuleTests.cs
@@ -5,10 +5,9 @@ using Bicep.Core.Analyzers.Linter.Rules;
 using Bicep.Core.CodeAction;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests.Assertions;
-using Bicep.Core.UnitTests.Utils;
+using Bicep.Testing.Utils;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using static Bicep.Core.UnitTests.Utils.CompilationHelper;
 
 namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 {
@@ -16,10 +15,12 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
     public class NoHardcodedLocationRuleTests : LinterRuleTestsBase
     {
         // This linter rule is "Off" by default
-        private static ServiceBuilder Services => new ServiceBuilder().WithConfiguration(BicepTestConstants.BuiltInConfigurationWithStableAnalyzers);
+        private static TestCompiler CreateCompiler() => TestCompiler
+            .ForInMemoryCompilation()
+            .WithConfiguration(BicepTestConstants.BuiltInConfigurationWithStableAnalyzers);
 
-        private static CompilationResult Compile(string fileContents)
-            => CompilationHelper.Compile(Services, ("main.bicep", fileContents));
+        private static TestCompilationResult Compile(string fileContents)
+            => CreateCompiler().CompileWithoutRestore(fileContents);
 
         [TestMethod]
         public void If_ResLocationIs_Global_ShouldPass()
@@ -288,8 +289,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         [TestMethod]
         public void If_ResLocationIs_VariableDefinedAsLiteral_UsedInResourcesAndModules_ShouldFailJustOnVariableDef_WithFixToChangeToParam()
         {
-            var result = CompilationHelper.Compile(
-                Services,
+            var result = CreateCompiler().CompileWithoutRestore(
                 ("main.bicep", @"
                     module m1 'module1.bicep' = [for i in range(0, 10): {
                       params: {
@@ -612,8 +612,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         [TestMethod]
         public void ForLoop2_Module()
         {
-            var result = CompilationHelper.Compile(
-                Services,
+            var result = CreateCompiler().CompileWithoutRestore(
                 ("main.bicep", @"
                   module m2 'module1.bicep' = [for i in range(0, 10): {
                     params: {
@@ -636,8 +635,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         [TestMethod]
         public void ResLoc_If_Module_HasLocationProperty_WithDefault_AndStringLiteralPassedIn_ShouldFail()
         {
-            var result = CompilationHelper.Compile(
-                Services,
+            var result = CreateCompiler().CompileWithoutRestore(
                 ("main.bicep", @"
                     module m1 'module1.bicep' = {
                       params: {

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoLocationExprOutsideParamsRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/NoLocationExprOutsideParamsRuleTests.cs
@@ -4,10 +4,9 @@
 using Bicep.Core.Analyzers.Linter.Rules;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.UnitTests.Assertions;
-using Bicep.Core.UnitTests.Utils;
+using Bicep.Testing.Utils;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using static Bicep.Core.UnitTests.Utils.CompilationHelper;
 
 namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 {
@@ -27,10 +26,10 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         // This linter rule is "Off" by default
-        private static ServiceBuilder Services => new ServiceBuilder().WithConfiguration(BicepTestConstants.BuiltInConfigurationWithStableAnalyzers);
-
-        private static CompilationResult Compile(string fileContents)
-            => CompilationHelper.Compile(Services, ("main.bicep", fileContents));
+        private static TestCompilationResult Compile(string fileContents) => TestCompiler
+            .ForInMemoryCompilation()
+            .WithConfiguration(BicepTestConstants.BuiltInConfigurationWithStableAnalyzers)
+            .CompileWithoutRestore(fileContents);
 
         protected void ExpectPass(string bicepText, Options? options = null)
         {

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecureParamsInParametersFileRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/SecureParamsInParametersFileRuleTests.cs
@@ -23,9 +23,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
             .WithConfiguration(BicepTestConstants.BuiltInConfigurationWithStableAnalyzers)
             .WithEmptyAzResources();
 
-        private static async Task<Compilation> Compile(string mainBicep, string paramsBicep)
+        private static Compilation Compile(string mainBicep, string paramsBicep)
         {
-            var result = await CreateCompiler().CompileWithoutRestore(
+            var result = CreateCompiler().CompileWithoutRestore(
                 "main.bicepparam",
                 ("main.bicep", mainBicep),
                 ("main.bicepparam", paramsBicep));
@@ -34,9 +34,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task InsecureParamAssignedSecureParamValue_IsFlagged()
+        public void InsecureParamAssignedSecureParamValue_IsFlagged()
         {
-            var compilation = await Compile(
+            var compilation = Compile(
                 """
                 @secure()
                 param secureParam string
@@ -57,9 +57,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task SecureParamAssignedSecureParamValue_IsNotFlagged()
+        public void SecureParamAssignedSecureParamValue_IsNotFlagged()
         {
-            var compilation = await Compile(
+            var compilation = Compile(
                 """
                 @secure()
                 param secureParam string
@@ -78,9 +78,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task InsecureParamAssignedLiteralValue_IsNotFlagged()
+        public void InsecureParamAssignedLiteralValue_IsNotFlagged()
         {
-            var compilation = await Compile(
+            var compilation = Compile(
                 """
                 @secure()
                 param secureParam string
@@ -98,9 +98,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task InsecureParamAssignedInsecureParamValue_IsNotFlagged()
+        public void InsecureParamAssignedInsecureParamValue_IsNotFlagged()
         {
-            var compilation = await Compile(
+            var compilation = Compile(
                 """
                 param firstParam string
 
@@ -117,9 +117,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task InsecureParamTransitivelyReferencingSecureParam_IsFlagged()
+        public void InsecureParamTransitivelyReferencingSecureParam_IsFlagged()
         {
-            var compilation = await Compile(
+            var compilation = Compile(
                 """
                 @secure()
                 param secureParam string
@@ -141,9 +141,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task InsecureParamAssignedSecureParamInInterpolation_IsFlagged()
+        public void InsecureParamAssignedSecureParamInInterpolation_IsFlagged()
         {
-            var compilation = await Compile(
+            var compilation = Compile(
                 """
                 @secure()
                 param secureParam string
@@ -164,9 +164,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task SecureObjectParam_ReferencedByInsecureParam_IsFlagged()
+        public void SecureObjectParam_ReferencedByInsecureParam_IsFlagged()
         {
-            var compilation = await Compile(
+            var compilation = Compile(
                 """
                 @secure()
                 param secureObj object
@@ -187,9 +187,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         }
 
         [TestMethod]
-        public async Task Rule_DoesNotRunOnBicepFiles()
+        public void Rule_DoesNotRunOnBicepFiles()
         {
-            var compilation = (await CreateCompiler().CompileWithoutRestore(
+            var compilation = CreateCompiler().CompileWithoutRestore(
                 """
                     @secure()
                     param secureParam string
@@ -197,7 +197,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                     var insecureVar = secureParam
 
                     output insecureOutput string = insecureVar
-            """)).Compilation;
+            """).Compilation;
 
             compilation.GetSourceFileDiagnostics(MainUri).Should().NotContainDiagnostic(SecureParamsInParametersFileRule.Code);
         }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/StacksExtensibilityCompatibilityRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/StacksExtensibilityCompatibilityRuleTests.cs
@@ -4,9 +4,14 @@
 using Azure.Bicep.Types.Concrete;
 using Bicep.Core.Analyzers.Linter.Rules;
 using Bicep.Core.Diagnostics;
+using Bicep.Core.Semantics;
 using Bicep.Core.UnitTests.Assertions;
+using Bicep.Core.UnitTests.Features;
 using Bicep.Core.UnitTests.Utils;
+using Bicep.IO.Abstraction;
+using Bicep.Testing.IO;
 using Bicep.Testing.Mocks;
+using Bicep.Testing.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
@@ -14,6 +19,9 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
     [TestClass]
     public class StacksExtensibilityCompatibilityRuleTests : LinterRuleTestsBase
     {
+        private static readonly IOUri MainUri = TestFileUri.FromInMemoryPath("main.bicep");
+        private static readonly IOUri ParamsUri = TestFileUri.FromInMemoryPath("main.bicepparam");
+
         public TestContext TestContext { get; set; } = null!;
 
         [DataTestMethod]
@@ -34,46 +42,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         )]
         public async Task Does_not_flag_stack_compatible_assignments(string scenario, string extConfigAssignments, string moduleBody)
         {
-            var paramsUri = new Uri("file:///main.bicepparam");
-            var mainUri = new Uri("file:///main.bicep");
-            var moduleAUri = new Uri("file:///modulea.bicep");
-
-            var extDeclarations =
-                """
-                extension 'br:mcr.microsoft.com/bicep/extensions/mockext/v1:1.2.3' as mockExt
-                """;
-
-            var files = new Dictionary<Uri, string>
-            {
-                [paramsUri] =
-                    $$"""
-                      using 'main.bicep'
-
-                      {{extConfigAssignments}}
-                      """,
-                [mainUri] =
-                    $$"""
-                      {{extDeclarations}}
-
-                      resource kv 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
-                        name: 'kv'
-                      }
-
-                      module modulea 'modulea.bicep' = {
-                        {{moduleBody}}
-                      }
-                      """,
-                [moduleAUri] =
-                    $$"""
-                      {{extDeclarations}}
-                      """
-            };
-
-            var services = CreateServiceBuilder();
-
-            await ExtensionTestHelper.AddMockExtensions(services, TestContext, CreateMockExt());
-
-            var compilation = await services.BuildCompilationWithRestore(files, paramsUri);
+            var compilation = await Compile(extConfigAssignments, moduleBody);
 
             compilation.Should().NotHaveAnyDiagnostics_WithAssertionScoping(d => d.IsError() || d.Code == StacksExtensibilityCompatibilityRule.Code);
         }
@@ -120,46 +89,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
         )]
         public async Task Provides_diagnostic_for_stacks_incompatible_assignments(string scenario, string extConfigAssignments, string moduleBody, bool paramsFileDiagExpected, bool mainFileDiagExpected, bool expectError)
         {
-            var paramsUri = new Uri("file:///main.bicepparam");
-            var mainUri = new Uri("file:///main.bicep");
-            var moduleAUri = new Uri("file:///modulea.bicep");
-
-            var extDeclarations =
-                """
-                extension 'br:mcr.microsoft.com/bicep/extensions/mockext/v1:1.2.3' as mockExt
-                """;
-
-            var files = new Dictionary<Uri, string>
-            {
-                [paramsUri] =
-                    $$"""
-                      using 'main.bicep'
-
-                      {{extConfigAssignments}}
-                      """,
-                [mainUri] =
-                    $$"""
-                      {{extDeclarations}}
-
-                      resource kv 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
-                        name: 'kv'
-                      }
-
-                      module modulea 'modulea.bicep' = {
-                        {{moduleBody}}
-                      }
-                      """,
-                [moduleAUri] =
-                    $$"""
-                      {{extDeclarations}}
-                      """
-            };
-
-            var services = CreateServiceBuilder();
-
-            await ExtensionTestHelper.AddMockExtensions(services, TestContext, CreateMockExt());
-
-            var compilation = await services.BuildCompilationWithRestore(files, paramsUri);
+            var compilation = await Compile(extConfigAssignments, moduleBody);
 
             if (!expectError)
             {
@@ -168,7 +98,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 
             if (scenario is "NonSecurePropertyReferencesAreCoveredByGetSecretValidation_MainFile")
             {
-                compilation.GetSourceFileDiagnostics(mainUri).Should().ContainSingleDiagnostic("BCP180", DiagnosticLevel.Error, "Function \"getSecret\" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator or a secure extension configuration property.", because: "param files should have this validation");
+                compilation.GetSourceFileDiagnostics(MainUri).Should().ContainSingleDiagnostic("BCP180", DiagnosticLevel.Error, "Function \"getSecret\" is not valid at this location. It can only be used when directly assigning to a module parameter with a secure decorator or a secure extension configuration property.", because: "param files should have this validation");
 
                 return;
             }
@@ -182,27 +112,62 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
 
             if (paramsFileDiagExpected)
             {
-                compilation.GetSourceFileDiagnostics(paramsUri).Should().ContainSingleDiagnostic(StacksExtensibilityCompatibilityRule.Code, DiagnosticLevel.Info, expectedMessage, because: "param files should have this validation");
+                compilation.GetSourceFileDiagnostics(ParamsUri).Should().ContainSingleDiagnostic(StacksExtensibilityCompatibilityRule.Code, DiagnosticLevel.Info, expectedMessage, because: "param files should have this validation");
             }
             else
             {
-                compilation.GetSourceFileDiagnostics(paramsUri).Should().NotContainDiagnostic(StacksExtensibilityCompatibilityRule.Code);
+                compilation.GetSourceFileDiagnostics(ParamsUri).Should().NotContainDiagnostic(StacksExtensibilityCompatibilityRule.Code);
             }
 
             if (mainFileDiagExpected)
             {
-                compilation.GetSourceFileDiagnostics(mainUri).Should().ContainSingleDiagnostic(StacksExtensibilityCompatibilityRule.Code, DiagnosticLevel.Info, expectedMessage, because: "bicep files should have this validation");
+                compilation.GetSourceFileDiagnostics(MainUri).Should().ContainSingleDiagnostic(StacksExtensibilityCompatibilityRule.Code, DiagnosticLevel.Info, expectedMessage, because: "bicep files should have this validation");
             }
             else
             {
-                compilation.GetSourceFileDiagnostics(mainUri).Should().NotContainDiagnostic(StacksExtensibilityCompatibilityRule.Code);
+                compilation.GetSourceFileDiagnostics(MainUri).Should().NotContainDiagnostic(StacksExtensibilityCompatibilityRule.Code);
             }
         }
 
         #region Helpers
 
-        private static ServiceBuilder CreateServiceBuilder() => new ServiceBuilder()
-            .WithFeaturesOverridden(f => f with { ModuleExtensionConfigsEnabled = true });
+        private async Task<Compilation> Compile(string extConfigAssignments, string moduleBody)
+        {
+            const string extDeclarations = """
+                extension 'br:mcr.microsoft.com/bicep/extensions/mockext/v1:1.2.3' as mockExt
+                """;
+
+            var compiler = TestCompiler
+                .ForInMemoryCompilation()
+                .WithFeatureOverrides<FeatureProviderOverrides, OverriddenFeatureProviderFactory>(
+                    new(TestContext, ModuleExtensionConfigsEnabled: true));
+            var artifactManager = new TestExternalArtifactManager(compiler);
+            await artifactManager.PublishExtension(CreateMockExt());
+
+            var result = await compiler.Compile(
+                "main.bicepparam",
+                ("main.bicepparam", $$"""
+                    using 'main.bicep'
+
+                    {{extConfigAssignments}}
+                    """),
+                ("main.bicep", $$"""
+                    {{extDeclarations}}
+
+                    resource kv 'Microsoft.KeyVault/vaults@2021-06-01-preview' existing = {
+                      name: 'kv'
+                    }
+
+                    module modulea 'modulea.bicep' = {
+                      {{moduleBody}}
+                    }
+                    """),
+                ("modulea.bicep", $$"""
+                    {{extDeclarations}}
+                    """));
+
+            return result.Compilation;
+        }
 
         private static MockExtensionData CreateMockExt(string extName = "mockext") =>
             ExtensionTestHelper.CreateMockExtensionMockData(

--- a/src/Bicep.Core.UnitTests/Emit/ExpressionConverterTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/ExpressionConverterTests.cs
@@ -65,10 +65,10 @@ namespace Bicep.Core.UnitTests.Emit
         [DataRow("{fizz: 'buzz'}.key.and.nested.property.accesses[0]['stringKey']", "[createObject('fizz', 'buzz').key.and.nested.property.accesses[0].stringKey]")]
         [DataRow("{fizz: 'buzz'}.?key.and.nested.?property.accesses[0]['stringKey']", "[tryGet(tryGet(createObject('fizz', 'buzz'), 'key', 'and', 'nested'), 'property', 'accesses', 0, 'stringKey')]")]
         [DataRow("({fizz: 'buzz'}.?key.and.nested).property.accesses[0]['stringKey']", "[tryGet(createObject('fizz', 'buzz'), 'key', 'and', 'nested').property.accesses[0].stringKey]")]
-        public async Task ShouldConvertExpressionsCorrectly(string text, string expected)
+        public void ShouldConvertExpressionsCorrectly(string text, string expected)
         {
             var programText = $"var test = {text}";
-            var compilation = (await CreateCompiler().CompileWithoutRestore(programText)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(programText).Compilation;
 
             var programSyntax = compilation.SourceFileGrouping.EntryPoint.ProgramSyntax;
             var variableDeclarationSyntax = programSyntax.Children.OfType<VariableDeclarationSyntax>().First();

--- a/src/Bicep.Core.UnitTests/Emit/InlineDependencyVisitorTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/InlineDependencyVisitorTests.cs
@@ -25,9 +25,9 @@ var runtimeLoop = [for (item, index) in []: indirection]
 var runtimeLoop2 = [for (item, index) in indirection.keys: 's']
 ";
         [TestMethod]
-        public async Task VisitorShouldCalculateInliningInBulk()
+        public void VisitorShouldCalculateInliningInBulk()
         {
-            var compilation = (await CreateCompiler().CompileWithoutRestore(Text)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(Text).Compilation;
 
             var inlineVariables = InlineDependencyVisitor.GetSymbolsToInline(compilation.GetEntrypointSemanticModel()).VariablesToInline;
 
@@ -42,9 +42,9 @@ var runtimeLoop2 = [for (item, index) in indirection.keys: 's']
 
         [DataRow("things")]
         [DataTestMethod]
-        public async Task VisitorShouldProduceNoChainForNonInlinedVariables(string variableName)
+        public void VisitorShouldProduceNoChainForNonInlinedVariables(string variableName)
         {
-            var compilation = (await CreateCompiler().CompileWithoutRestore(Text)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(Text).Compilation;
             VariableDeclarationSyntax variable = GetVariableByName(compilation, variableName);
 
             InlineDependencyVisitor.ShouldInlineVariable(compilation.GetEntrypointSemanticModel(), variable, out var chain).Should().BeFalse();
@@ -56,9 +56,9 @@ var runtimeLoop2 = [for (item, index) in indirection.keys: 's']
         [DataRow("runtimeLoop", "indirection,keys")]
         [DataRow("runtimeLoop2", "indirection,keys")]
         [DataTestMethod]
-        public async Task VisitorShouldProduceCorrectChainForInlinedVariables(string variableName, string expectedChain)
+        public void VisitorShouldProduceCorrectChainForInlinedVariables(string variableName, string expectedChain)
         {
-            var compilation = (await CreateCompiler().CompileWithoutRestore(Text)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(Text).Compilation;
             VariableDeclarationSyntax variable = GetVariableByName(compilation, variableName);
 
             InlineDependencyVisitor.ShouldInlineVariable(compilation.GetEntrypointSemanticModel(), variable, out var chain).Should().BeTrue();

--- a/src/Bicep.Core.UnitTests/Emit/ParameterAssignmentEvaluatorTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/ParameterAssignmentEvaluatorTests.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.UnitTests.Assertions;
-using Bicep.Core.UnitTests.Utils;
+using Bicep.Testing.Assertions;
+using Bicep.Testing.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 
@@ -11,19 +12,22 @@ namespace Bicep.Core.UnitTests.Emit;
 [TestClass]
 public class ParameterAssignmentEvaluatorTests
 {
+    private static TestCompilationResult CompileParams(string bicepParamsText) => TestCompiler
+        .ForInMemoryCompilation()
+        .WithEmptyAzResources()
+        .CompileWithoutRestore(
+            "parameters.bicepparam",
+            ("main.bicep", "param p int[]"),
+            ("parameters.bicepparam", bicepParamsText));
+
     [TestMethod]
     public void BuildParams_ForExpressionParameter_EvaluatesToValue()
     {
-        var services = new ServiceBuilder().WithEmptyAzResources();
-
-        var result = CompilationHelper.CompileParams(
-            services,
-            ("main.bicep", "param p int[]"),
-            ("parameters.bicepparam", """
+        var result = CompileParams("""
             using 'main.bicep'
 
             param p = [for item in range(0, 4): item * 2]
-            """));
+            """);
 
         result.Should().NotHaveAnyDiagnostics();
         result.Parameters.Should().HaveValueAtPath("parameters.p.value", JToken.Parse("[0, 2, 4, 6]"));
@@ -32,17 +36,12 @@ public class ParameterAssignmentEvaluatorTests
     [TestMethod]
     public void BuildParams_ForExpressionVariable_EvaluatesToValue()
     {
-        var services = new ServiceBuilder().WithEmptyAzResources();
-
-        var result = CompilationHelper.CompileParams(
-            services,
-            ("main.bicep", "param p int[]"),
-            ("parameters.bicepparam", """
+        var result = CompileParams("""
             using 'main.bicep'
 
             var x = [for item in [1, 2]: item * 2]
             param p = x
-            """));
+            """);
 
         result.Should().NotHaveAnyDiagnostics();
         result.Parameters.Should().HaveValueAtPath("parameters.p.value", JToken.Parse("[2, 4]"));

--- a/src/Bicep.Core.UnitTests/Emit/PositionTrackingJsonTextWriterTests.cs
+++ b/src/Bicep.Core.UnitTests/Emit/PositionTrackingJsonTextWriterTests.cs
@@ -22,9 +22,9 @@ namespace Bicep.Core.UnitTests.Emit
         private readonly string Text = $"{LeadingNodes}{BicepStatement}";
 
         [TestMethod]
-        public async Task SourceMapShouldAccountForDecoratorsInStatementSyntax()
+        public void SourceMapShouldAccountForDecoratorsInStatementSyntax()
         {
-            var compilation = (await CreateCompiler().CompileWithoutRestore(Text)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(Text).Compilation;
             var semanticModel = compilation.GetEntrypointSemanticModel();
             var parameterSymbol = semanticModel.Root.ParameterDeclarations.First();
 

--- a/src/Bicep.Core.UnitTests/Semantics/BaseParametersSymbolTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/BaseParametersSymbolTests.cs
@@ -17,13 +17,13 @@ namespace Bicep.Core.UnitTests.Semantics
         private static TestCompiler CreateCompiler() => TestCompiler.ForInMemoryCompilation()
             .WithEmptyAzResources();
 
-        private static async Task<Compilation> CompileParams(params (string FilePath, TestFileData FileData)[] files)
-            => (await CreateCompiler().CompileWithoutRestore("main.bicepparam", files)).Compilation;
+        private static Compilation CompileParams(params (string FilePath, TestFileData FileData)[] files)
+            => CreateCompiler().CompileWithoutRestore("main.bicepparam", files).Compilation;
 
         [TestMethod]
-        public async Task FileSymbol_should_include_base_parameters_symbol_when_extends_is_present()
+        public void FileSymbol_should_include_base_parameters_symbol_when_extends_is_present()
         {
-            var compilation = await CompileParams(
+            var compilation = CompileParams(
                 ("main.bicep", """
                     param one string = ''
                     param two string = ''
@@ -50,9 +50,9 @@ namespace Bicep.Core.UnitTests.Semantics
         }
 
         [TestMethod]
-        public async Task FileSymbol_should_not_include_base_parameters_symbol_when_extends_is_absent()
+        public void FileSymbol_should_not_include_base_parameters_symbol_when_extends_is_absent()
         {
-            var compilation = await CompileParams(
+            var compilation = CompileParams(
                 ("main.bicep", """
                     param one string = ''
                     param two string = ''
@@ -71,9 +71,9 @@ namespace Bicep.Core.UnitTests.Semantics
         }
 
         [TestMethod]
-        public async Task Base_parameters_symbol_should_include_all_inherited_assignments()
+        public void Base_parameters_symbol_should_include_all_inherited_assignments()
         {
-            var compilation = await CompileParams(
+            var compilation = CompileParams(
                 ("main.bicep", """
                     param one string = ''
                     param two string = ''
@@ -100,9 +100,9 @@ namespace Bicep.Core.UnitTests.Semantics
         }
 
         [TestMethod]
-        public async Task Base_variable_access_should_have_object_type_with_read_only_parent_properties()
+        public void Base_variable_access_should_have_object_type_with_read_only_parent_properties()
         {
-            var compilation = await CompileParams(
+            var compilation = CompileParams(
                 ("main.bicep", """
                     param one string = ''
                     param two string = ''
@@ -135,9 +135,9 @@ namespace Bicep.Core.UnitTests.Semantics
         }
 
         [TestMethod]
-        public async Task Base_variable_access_should_not_throw_when_inherited_params_include_object_and_array_values()
+        public void Base_variable_access_should_not_throw_when_inherited_params_include_object_and_array_values()
         {
-            var compilation = await CompileParams(
+            var compilation = CompileParams(
                 ("main.bicep", """
                                         param one string = ''
                                         param two string = ''

--- a/src/Bicep.Core.UnitTests/Semantics/SymbolContextTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/SymbolContextTests.cs
@@ -18,11 +18,11 @@ namespace Bicep.Core.UnitTests.Semantics
             .WithEmptyAzResources();
 
         [TestMethod]
-        public async Task LockedModeShouldBlockAccess()
+        public void LockedModeShouldBlockAccess()
         {
             const string expectedMessage = "Properties of the symbol context should not be accessed until name binding is completed.";
 
-            var compilation = (await CreateCompiler().CompileWithoutRestore("")).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore("").Compilation;
             var model = compilation.GetEntrypointSemanticModel();
             var bindings = new Dictionary<SyntaxBase, Symbol>();
             var cyclesBySymbol = new Dictionary<DeclaredSymbol, ImmutableArray<DeclaredSymbol>>();
@@ -39,7 +39,7 @@ namespace Bicep.Core.UnitTests.Semantics
         }
 
         [TestMethod]
-        public async Task TestHoverOnQuotedPropertyReturnsPropertySymbol()
+        public void TestHoverOnQuotedPropertyReturnsPropertySymbol()
         {
             var text = @"
 resource storage 'Microsoft.Storage/storageAccounts@2021-02-01' = {
@@ -54,7 +54,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2021-02-01' = {
             var namePropertyIndex = text.IndexOf("'name'", skuIndex);
             var cursor = namePropertyIndex + 2;
 
-            var compilation = (await CreateCompiler().CompileWithoutRestore(text)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(text).Compilation;
             var model = compilation.GetEntrypointSemanticModel();
 
             var programSyntax = model.SourceFile.ProgramSyntax;

--- a/src/Bicep.Core.UnitTests/SourceGraph/BicepFileTests.cs
+++ b/src/Bicep.Core.UnitTests/SourceGraph/BicepFileTests.cs
@@ -14,11 +14,11 @@ namespace Bicep.Core.UnitTests.Workspaces
             .WithEmptyAzResources();
 
         [TestMethod]
-        public async Task VerifyDisableNextLineDiagnosticDirectivesCache_WithDisableNextLineDiagnosticDirectivesInBicepFile()
+        public void VerifyDisableNextLineDiagnosticDirectivesCache_WithDisableNextLineDiagnosticDirectivesInBicepFile()
         {
             string bicepFileContents = @"#disable-next-line no-unused-params
 param storageAccount string = 'testStorageAccount'";
-            var compilation = (await CreateCompiler().CompileWithoutRestore(bicepFileContents)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(bicepFileContents).Compilation;
 
             var bicepFile = compilation.GetEntrypointSemanticModel().SourceFile;
 
@@ -31,10 +31,10 @@ param storageAccount string = 'testStorageAccount'";
         }
 
         [TestMethod]
-        public async Task VerifyDisableNextLineDiagnosticDirectivesCache_WithNoDisableNextLineDiagnosticDirectivesInBicepFile()
+        public void VerifyDisableNextLineDiagnosticDirectivesCache_WithNoDisableNextLineDiagnosticDirectivesInBicepFile()
         {
             string bicepFileContents = @"param storageAccount string = 'testStorageAccount'";
-            var compilation = (await CreateCompiler().CompileWithoutRestore(bicepFileContents)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(bicepFileContents).Compilation;
             var bicepFile = compilation.GetEntrypointSemanticModel().SourceFile;
 
             var disabledDiagnosticsCache = bicepFile.DisabledDiagnosticsCache;
@@ -44,7 +44,7 @@ param storageAccount string = 'testStorageAccount'";
         }
 
         [TestMethod]
-        public async Task VerifyDisableNextLineDiagnosticDirectivesCache_WithMultipleDisableNextLineDiagnosticDirectivesInBicepFile()
+        public void VerifyDisableNextLineDiagnosticDirectivesCache_WithMultipleDisableNextLineDiagnosticDirectivesInBicepFile()
         {
             string bicepFileContents = @"#disable-next-line no-unused-params
 param storageAccount string = 'testStorageAccount'
@@ -67,7 +67,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
 
 
 ";
-            var compilation = (await CreateCompiler().CompileWithoutRestore(bicepFileContents)).Compilation;
+            var compilation = CreateCompiler().CompileWithoutRestore(bicepFileContents).Compilation;
             var bicepFile = compilation.GetEntrypointSemanticModel().SourceFile;
 
             var disabledDiagnosticsCache = bicepFile.DisabledDiagnosticsCache;

--- a/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/TypeSystem/Az/AzResourceTypeProviderTests.cs
@@ -153,29 +153,29 @@ namespace Bicep.Core.UnitTests.TypeSystem.Az
         }
 
         [TestMethod]
-        public async Task AzResourceTypeProvider_should_warn_for_missing_resource_types()
+        public void AzResourceTypeProvider_should_warn_for_missing_resource_types()
         {
             // Missing top-level properties - should be an error
-            var compilation = (await TestCompiler.ForInMemoryCompilation().CompileWithoutRestore(@"
+            var compilation = TestCompiler.ForInMemoryCompilation().CompileWithoutRestore(@"
 resource missingResource 'Mock.Rp/madeUpResourceType@2020-01-01' = {
   name: 'missingResource'
 }
-")).Compilation;
+").Compilation;
             compilation.Should().HaveDiagnostics(new[] {
                 ("BCP081", DiagnosticLevel.Warning, "Resource type \"Mock.Rp/madeUpResourceType@2020-01-01\" does not have types available. Bicep is unable to validate resource properties prior to deployment, but this will not block the resource from being deployed.")
             });
         }
 
         [TestMethod]
-        public async Task AzResourceTypeProvider_should_error_for_top_level_system_properties_and_warn_for_rest()
+        public void AzResourceTypeProvider_should_error_for_top_level_system_properties_and_warn_for_rest()
         {
-            async Task<Compilation> CreateCompilation(string program) => (await TestCompiler
+            Compilation CreateCompilation(string program) => TestCompiler
                 .ForInMemoryCompilation()
                 .WithAzResources(BuiltInTestTypes.Types)
-                .CompileWithoutRestore(program)).Compilation;
+                .CompileWithoutRestore(program).Compilation;
 
             // Missing top-level properties - should be an error
-            var compilation = await CreateCompilation(@"
+            var compilation = CreateCompilation(@"
 resource missingRequired 'Test.Rp/readWriteTests@2020-01-01' = {
   properties: {
     required: 'hello!'
@@ -186,7 +186,7 @@ resource missingRequired 'Test.Rp/readWriteTests@2020-01-01' = {
                 ("BCP035", DiagnosticLevel.Error, "The specified \"resource\" declaration is missing the following required properties: \"name\".")
             });
 
-                        compilation = await CreateCompilation(@"
+                        compilation = CreateCompilation(@"
 resource missingRequired 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'missingRequired'
 }
@@ -196,7 +196,7 @@ resource missingRequired 'Test.Rp/readWriteTests@2020-01-01' = {
             });
 
             // Top-level properties that aren't part of the type definition - should be an error
-                        compilation = await CreateCompilation(@"
+                        compilation = CreateCompilation(@"
 resource unexpectedTopLevel 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'unexpectedTopLevel'
   properties: {
@@ -210,7 +210,7 @@ resource unexpectedTopLevel 'Test.Rp/readWriteTests@2020-01-01' = {
             });
 
             // Missing non top-level properties - should be a warning
-                        compilation = await CreateCompilation(@"
+                        compilation = CreateCompilation(@"
 resource missingRequiredProperty 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'missingRequiredProperty'
   properties: {
@@ -222,7 +222,7 @@ resource missingRequiredProperty 'Test.Rp/readWriteTests@2020-01-01' = {
             });
 
             // Non top-level properties that aren't part of the type definition - should be a warning
-                        compilation = await CreateCompilation(@"
+                        compilation = CreateCompilation(@"
 resource unexpectedPropertiesProperty 'Test.Rp/readWriteTests@2020-01-01' = {
   name: 'unexpectedPropertiesProperty'
   properties: {

--- a/src/Bicep.Testing/Utils/TestCompilationResult.cs
+++ b/src/Bicep.Testing/Utils/TestCompilationResult.cs
@@ -13,14 +13,18 @@ namespace Bicep.Testing.Utils
     public class TestCompilationResult
     {
         private readonly Lazy<ImmutableArray<IDiagnostic>> diagnostics;
+        private readonly Lazy<JToken?> parameters;
         private readonly Lazy<JToken?> template;
 
         private TestCompilationResult(Compilation compilation)
         {
             this.Compilation = compilation;
             this.diagnostics = new(this.GetDiagnostics);
+            this.parameters = new(this.GetParameters);
             this.template = new(this.GetTemplate);
         }
+
+        public JToken? Parameters => this.parameters.Value;
 
         public JToken? Template => this.template.Value;
 
@@ -35,6 +39,28 @@ namespace Bicep.Testing.Utils
 
         private ImmutableArray<IDiagnostic> GetDiagnostics()
             => this.Compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+
+        private JToken? GetParameters()
+        {
+            var semanticModel = this.Compilation.GetEntrypointSemanticModel();
+            if (semanticModel.SourceFileKind is not BicepSourceFileKind.ParamsFile)
+            {
+                return null;
+            }
+
+            var emitter = new ParametersEmitter(semanticModel);
+            if (semanticModel.HasErrors())
+            {
+                return null;
+            }
+
+            var stringWriter = new StringWriter();
+            var result = emitter.Emit(stringWriter);
+
+            return result.Status != EmitStatus.Failed
+                ? JToken.Parse(stringWriter.ToString())
+                : null;
+        }
 
         private JToken? GetTemplate()
         {

--- a/src/Bicep.Testing/Utils/TestCompiler.cs
+++ b/src/Bicep.Testing/Utils/TestCompiler.cs
@@ -51,15 +51,21 @@ namespace Bicep.Testing.Utils
 
         public T GetService<T>() where T : notnull => this.services.Get<T>();
 
-        public async Task<TestCompilationResult> Compile(string sourceText, bool skipRestore = false)
+        public async Task<TestCompilationResult> Compile(string sourceText)
         {
             using (this.CreateFileSetScope((DefaultEntryPointPath, sourceText)))
             {
-                return await this.CompileInternal(DefaultEntryPointPath, skipRestore: skipRestore);
+                return await this.CompileInternal(DefaultEntryPointPath);
             }
         }
 
-        public Task<TestCompilationResult> CompileWithoutRestore(string sourceText) => this.Compile(sourceText, skipRestore: true);
+        public TestCompilationResult CompileWithoutRestore(string sourceText)
+        {
+            using (this.CreateFileSetScope((DefaultEntryPointPath, sourceText)))
+            {
+                return this.CompileWithoutRestoreInternal(DefaultEntryPointPath);
+            }
+        }
 
         public Task<TestCompilationResult> Compile(params (string FilePath, TestFileData FileData)[] files) => this.Compile(DefaultEntryPointPath, files);
 
@@ -67,24 +73,32 @@ namespace Bicep.Testing.Utils
         {
             using (this.CreateFileSetScope(files))
             {
-                return await this.CompileInternal(entryPointPath, skipRestore: false);
+                return await this.CompileInternal(entryPointPath);
             }
         }
 
-        public Task<TestCompilationResult> CompileWithoutRestore(params (string FilePath, TestFileData FileData)[] files) => this.CompileWithoutRestore(DefaultEntryPointPath, files);
+        public TestCompilationResult CompileWithoutRestore(params (string FilePath, TestFileData FileData)[] files) => this.CompileWithoutRestore(DefaultEntryPointPath, files);
 
-        public async Task<TestCompilationResult> CompileWithoutRestore(string entryPointPath, params (string FilePath, TestFileData FileData)[] files)
+        public TestCompilationResult CompileWithoutRestore(string entryPointPath, params (string FilePath, TestFileData FileData)[] files)
         {
             using (this.CreateFileSetScope(files))
             {
-                return await this.CompileInternal(entryPointPath, skipRestore: true);
+                return this.CompileWithoutRestoreInternal(entryPointPath);
             }
         }
 
-        private async Task<TestCompilationResult> CompileInternal(string entryPointPath, bool skipRestore)
+        private async Task<TestCompilationResult> CompileInternal(string entryPointPath)
         {
             var compiler = this.services.Get<BicepCompiler>();
-            var compilation = await compiler.CreateCompilation(this.FileSet.GetUri(entryPointPath), skipRestore: skipRestore);
+            var compilation = await compiler.CreateCompilation(this.FileSet.GetUri(entryPointPath));
+
+            return TestCompilationResult.FromCompilation(compilation);
+        }
+
+        private TestCompilationResult CompileWithoutRestoreInternal(string entryPointPath)
+        {
+            var compiler = this.services.Get<BicepCompiler>();
+            var compilation = compiler.CreateCompilationWithoutRestore(this.FileSet.GetUri(entryPointPath));
 
             return TestCompilationResult.FromCompilation(compilation);
         }


### PR DESCRIPTION
## Description

Migrates another Core unit-test slice from `CompilationHelper` and `ServiceBuilder` to `TestCompiler`. Adds lazy parameters emission, makes no-restore compilation synchronous, and updates the URI cleanup plan with the next linter-infrastructure package.

## Validation

- `dotnet test .\src\Bicep.Core.UnitTests\Bicep.Core.UnitTests.csproj --no-restore --no-build` (6,808 passed)
- `dotnet build .\Bicep.sln --no-restore`

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20109)