### PR TITLE
Fix resource ID imports in parameter files

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ParameterFileTests.cs
@@ -623,6 +623,161 @@ param bar2 = externalInput('kind', foo)
     }
 
     [TestMethod]
+    public void ImportedVariable_WithFullyQualifiedResourceId_Compiles()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { gatewayId } from 'variables.bicep'
+
+                param value = gatewayId
+                """),
+            ("variables.bicep", """
+                @export()
+                var gatewayId = resourceId(
+                  'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                  'rg-test',
+                  'Microsoft.HybridCompute/gateways',
+                  'arc01-gw')
+                """));
+
+        result.Should().NotHaveAnyDiagnostics();
+        var parameters = TemplateHelper.ConvertAndAssertParameters(result.Parameters);
+        parameters["value"].Value.Should().DeepEqual("/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/rg-test/providers/Microsoft.HybridCompute/gateways/arc01-gw");
+    }
+
+    [TestMethod]
+    public void ImportedVariable_WithFullyQualifiedNestedResourceId_Compiles()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { subnetId } from 'variables.bicep'
+
+                param value = subnetId
+                """),
+            ("variables.bicep", """
+                @export()
+                var subnetId = resourceId(
+                  'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                  'rg-test',
+                  'Microsoft.Network/virtualNetworks/subnets',
+                  'vnet',
+                  'subnet')
+                """));
+
+        result.Should().NotHaveAnyDiagnostics();
+    }
+
+    [TestMethod]
+    public void ImportedVariable_WithoutResourceGroupInResourceId_ReturnsDiagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { subnetId } from 'variables.bicep'
+                """),
+            ("variables.bicep", """
+                @export()
+                var subnetId = resourceId(
+                  'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                  'Microsoft.Network/virtualNetworks/subnets',
+                  'vnet',
+                  'subnet')
+                """));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            "The imported symbol \"subnetId\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceId\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [DataTestMethod]
+    [DataRow("subscriptionResourceId('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 'Microsoft.Authorization/roleDefinitions', 'role')")]
+    [DataRow("managementGroupResourceId('managementGroup', 'Microsoft.Authorization/policyDefinitions', 'policy')")]
+    [DataRow("tenantResourceId('Microsoft.Authorization/policyDefinitions', 'policy')")]
+    [DataRow("extensionResourceId('/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/resourceGroups/rg-test', 'Microsoft.Authorization/locks', 'lock')")]
+    public void ImportedVariable_WithContextIndependentResourceIdFunction_Compiles(string functionCall)
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { resourceIdValue } from 'variables.bicep'
+
+                param value = resourceIdValue
+                """),
+            ("variables.bicep", $@"
+                @export()
+                var resourceIdValue = {functionCall}
+                "));
+
+        result.Should().NotHaveAnyDiagnostics();
+    }
+
+    [DataTestMethod]
+    [DataRow("subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'role')", "subscriptionResourceId")]
+    [DataRow("managementGroupResourceId('Microsoft.Authorization/policyDefinitions', 'policy')", "managementGroupResourceId")]
+    public void ImportedVariable_WithContextDependentResourceIdFunction_ReturnsDiagnostic(string functionCall, string functionName)
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { resourceIdValue } from 'variables.bicep'
+                """),
+            ("variables.bicep", $@"
+                @export()
+                var resourceIdValue = {functionCall}
+                "));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            $"The imported symbol \"resourceIdValue\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"{functionName}\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [DataTestMethod]
+    [DataRow("extensionResourceId(resourceId('Microsoft.Storage/storageAccounts', 'storage'), 'Microsoft.Authorization/locks', 'lock')", "resourceId")]
+    [DataRow("tenantResourceId('Microsoft.Authorization/policyDefinitions', resourceGroup().name)", "resourceGroup")]
+    public void ImportedVariable_WithPureResourceIdFunctionWrappingContextDependentFunction_ReturnsDiagnostic(string functionCall, string functionName)
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { resourceIdValue } from 'variables.bicep'
+                """),
+            ("variables.bicep", $@"
+                @export()
+                var resourceIdValue = {functionCall}
+                "));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            $"The imported symbol \"resourceIdValue\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"{functionName}\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [TestMethod]
+    public void ImportedVariable_WithPureResourceIdFunctionUsingTransitivelyContextDependentArgument_ReturnsDiagnostic()
+    {
+        var result = CompilationHelper.CompileParams(
+            ("parameters.bicepparam", """
+                using none
+                import { lockId } from 'variables.bicep'
+                """),
+            ("variables.bicep", """
+                var storageAccountId = resourceId('Microsoft.Storage/storageAccounts', 'storage')
+
+                @export()
+                var lockId = extensionResourceId(storageAccountId, 'Microsoft.Authorization/locks', 'lock')
+                """));
+
+        result.Should().OnlyContainDiagnostic(
+            "BCP452",
+            DiagnosticLevel.Error,
+            "The imported symbol \"lockId\" cannot be used in a .bicepparam file because it depends on deployment-context functions: \"resourceId\". Imported declarations may only use functions that can be evaluated while building the parameters file.");
+    }
+
+    [TestMethod]
     public void Imported_variable_with_transitive_pure_function_reference_compiles_successfully()
     {
         var result = CompilationHelper.CompileParams(

--- a/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
@@ -53,7 +53,7 @@
       "type": "string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(resourceId: string, resourceType: string, ... : string): string",
     "parameterTypeSignatures": [
       "resourceId: string",
@@ -578,7 +578,7 @@
       "type": "string",
       "minimumCount": 1
     },
-    "flags": "default",
+    "flags": "pure",
     "typeSignature": "(resourceType: string, ... : string): string",
     "parameterTypeSignatures": [
       "resourceType: string",

--- a/src/Bicep.Core/Semantics/FunctionOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverload.cs
@@ -25,7 +25,11 @@ namespace Bicep.Core.Semantics
         public delegate LanguageExpression ArmExpressionEvaluatorDelegate(
             FunctionExpression expression);
 
-        public FunctionOverload(string name, string genericDescription, string description, ResultBuilderDelegate resultBuilder, TypeSymbol signatureType, IEnumerable<FixedFunctionParameter> fixedParameters, VariableFunctionParameter? variableParameter, EvaluatorDelegate? evaluator, ArmExpressionEvaluatorDelegate? armExpressionEvaluator, FunctionFlags flags = FunctionFlags.Default)
+        public delegate bool IsPurePredicate(
+            SemanticModel model,
+            FunctionCallSyntaxBase functionCall);
+
+        public FunctionOverload(string name, string genericDescription, string description, ResultBuilderDelegate resultBuilder, TypeSymbol signatureType, IEnumerable<FixedFunctionParameter> fixedParameters, VariableFunctionParameter? variableParameter, EvaluatorDelegate? evaluator, ArmExpressionEvaluatorDelegate? armExpressionEvaluator, FunctionFlags flags = FunctionFlags.Default, IsPurePredicate? isPure = null)
         {
             Name = name;
             GenericDescription = genericDescription;
@@ -36,6 +40,7 @@ namespace Bicep.Core.Semantics
             FixedParameters = [.. fixedParameters];
             VariableParameter = variableParameter;
             Flags = flags;
+            this.IsPure = isPure;
 
             MinimumArgumentCount = FixedParameters.Count(fp => fp.Required) + (VariableParameter?.MinimumCount ?? 0);
             MaximumArgumentCount = VariableParameter == null ? FixedParameters.Length : (int?)null;
@@ -68,6 +73,8 @@ namespace Bicep.Core.Semantics
 
         public FunctionFlags Flags { get; }
 
+        public IsPurePredicate? IsPure { get; }
+
         public string TypeSignature { get; }
 
         public IEnumerable<string> ParameterTypeSignatures => this.FixedParameters
@@ -85,7 +92,8 @@ namespace Bicep.Core.Semantics
                 VariableParameter,
                 Evaluator,
                 ArmExpressionEvaluator,
-                Flags | flags);
+                Flags | flags,
+                this.IsPure);
 
         public bool HasParameters => this.MinimumArgumentCount > 0 || this.MaximumArgumentCount > 0;
 

--- a/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
+++ b/src/Bicep.Core/Semantics/FunctionOverloadBuilder.cs
@@ -47,6 +47,8 @@ public class FunctionOverloadBuilder
 
     protected FunctionOverload.ArmExpressionEvaluatorDelegate? ArmExpressionEvaluator { get; private set; }
 
+    protected FunctionOverload.IsPurePredicate? IsPure { get; private set; }
+
     protected FunctionFlags Flags { get; private set; }
 
     public FunctionOverload Build()
@@ -66,7 +68,8 @@ public class FunctionOverloadBuilder
             VariableParameter,
             Evaluator,
             ArmExpressionEvaluator,
-            Flags);
+            Flags,
+            this.IsPure);
 
     public FunctionOverloadBuilder WithGenericDescription(string genericDescription)
     {
@@ -132,6 +135,12 @@ public class FunctionOverloadBuilder
     public FunctionOverloadBuilder WithArmExpressionEvaluator(FunctionOverload.ArmExpressionEvaluatorDelegate armExpressionEvaluator)
     {
         ArmExpressionEvaluator = armExpressionEvaluator;
+        return this;
+    }
+
+    public FunctionOverloadBuilder WithIsPurePredicate(FunctionOverload.IsPurePredicate isPure)
+    {
+        this.IsPure = isPure;
         return this;
     }
 

--- a/src/Bicep.Core/Semantics/FunctionWildcardOverload.cs
+++ b/src/Bicep.Core/Semantics/FunctionWildcardOverload.cs
@@ -18,8 +18,9 @@ namespace Bicep.Core.Semantics
             VariableFunctionParameter? variableArgumentType,
             EvaluatorDelegate? evaluator,
             ArmExpressionEvaluatorDelegate? armExpressionEvaluator,
-            FunctionFlags flags = FunctionFlags.Default)
-            : base(name, genericDescription, description, resultBuilder, returnType, fixedArgumentTypes, variableArgumentType, evaluator, armExpressionEvaluator, flags)
+            FunctionFlags flags = FunctionFlags.Default,
+            IsPurePredicate? isPure = null)
+            : base(name, genericDescription, description, resultBuilder, returnType, fixedArgumentTypes, variableArgumentType, evaluator, armExpressionEvaluator, flags, isPure)
         {
             WildcardRegex = wildcardRegex;
         }
@@ -38,6 +39,7 @@ namespace Bicep.Core.Semantics
                 VariableParameter,
                 Evaluator,
                 ArmExpressionEvaluator,
-                Flags | flags);
+                Flags | flags,
+                this.IsPure);
     }
 }

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
@@ -8,6 +8,7 @@ using Azure.Deployments.Core.Definitions.Identifiers;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Intermediate;
+using Bicep.Core.Resources;
 using Bicep.Core.SourceGraph;
 using Bicep.Core.Syntax;
 using Bicep.Core.TypeSystem;
@@ -65,6 +66,43 @@ namespace Bicep.Core.Semantics.Namespaces
             => new(
                 new ManagementGroupScopeType(functionCall.Arguments, []),
                 new ObjectExpression(functionCall, []));
+
+        private static bool IsResourceIdCallPure(SemanticModel model, FunctionCallSyntaxBase functionCall) =>
+            HasExplicitResourceIdScopeArguments(model, functionCall, requiredScopeArgumentCount: 2);
+
+        private static bool IsSubscriptionResourceIdCallPure(SemanticModel model, FunctionCallSyntaxBase functionCall) =>
+            HasExplicitResourceIdScopeArguments(model, functionCall, requiredScopeArgumentCount: 1);
+
+        private static bool IsManagementGroupResourceIdCallPure(SemanticModel model, FunctionCallSyntaxBase functionCall) =>
+            HasExplicitResourceIdScopeArguments(model, functionCall, requiredScopeArgumentCount: 1);
+
+        private static bool HasExplicitResourceIdScopeArguments(SemanticModel model, FunctionCallSyntaxBase functionCall, int requiredScopeArgumentCount)
+        {
+            if (functionCall.Arguments.Length < requiredScopeArgumentCount + 2)
+            {
+                return false;
+            }
+
+            for (var index = 0; index <= requiredScopeArgumentCount; index++)
+            {
+                if (model.GetTypeInfo(functionCall.Arguments[index].Expression) is not StringLiteralType stringLiteral)
+                {
+                    return false;
+                }
+
+                var resourceType = ResourceTypeReference.TryParse(stringLiteral.RawStringValue);
+                var isResourceType = resourceType is not null &&
+                    resourceType.TypeSegments.Length > 1 &&
+                    resourceType.TypeSegments[0].Contains('.');
+
+                if (isResourceType)
+                {
+                    return index == requiredScopeArgumentCount;
+                }
+            }
+
+            return false;
+        }
 
         private static FunctionResult GetTenantReturnResult(SemanticModel model, IDiagnosticWriter diagnostics, FunctionCallSyntaxBase functionCall, ImmutableArray<TypeSymbol> argumentTypes)
             => new(new TenantScopeType(functionCall.Arguments, new[]
@@ -440,6 +478,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithGenericDescription(resourceIdDescription)
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsResourceIdCallPure)
                     .Build();
 
                 yield return new FunctionOverloadBuilder(ResourceIdFunctionName)
@@ -448,6 +487,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("subscriptionId", LanguageConstants.String, "The subscription ID")
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsResourceIdCallPure)
                     .Build();
 
                 yield return new FunctionOverloadBuilder(ResourceIdFunctionName)
@@ -456,6 +496,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("resourceGroupName", LanguageConstants.String, "The resource group name")
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsResourceIdCallPure)
                     .Build();
 
                 yield return new FunctionOverloadBuilder(ResourceIdFunctionName)
@@ -465,6 +506,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("resourceGroupName", LanguageConstants.String, "The resource group name")
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsResourceIdCallPure)
                     .Build();
 
                 // the subscriptionResourceId function relies on leading optional parameters that are disambiguated at runtime
@@ -475,6 +517,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithGenericDescription(subscriptionResourceIdDescription)
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsSubscriptionResourceIdCallPure)
                     .Build();
 
                 yield return new FunctionOverloadBuilder("subscriptionResourceId")
@@ -483,6 +526,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("subscriptionId", LanguageConstants.String, "The subscription ID")
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsSubscriptionResourceIdCallPure)
                     .Build();
 
                 yield return new FunctionOverloadBuilder("tenantResourceId")
@@ -490,6 +534,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithGenericDescription("Returns the unique identifier for a resource deployed at the tenant level.")
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithFlags(FunctionFlags.Pure)
                     .Build();
 
                 yield return new FunctionOverloadBuilder("extensionResourceId")
@@ -499,6 +544,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("resourceId", LanguageConstants.String, "The resource ID for the resource that the extension resource is applied to")
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of the extension resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The extension resource name segment")
+                    .WithFlags(FunctionFlags.Pure)
                     .Build();
 
                 const string managementGroupResourceIdDescription = "Returns the unique identifier for a resource deployed at the management group level.";
@@ -507,6 +553,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithGenericDescription(managementGroupResourceIdDescription)
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsManagementGroupResourceIdCallPure)
                     .Build();
 
                 yield return new FunctionOverloadBuilder("managementGroupResourceId")
@@ -515,6 +562,7 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithRequiredParameter("managementGroupId", LanguageConstants.String, "The management group ID")
                     .WithRequiredParameter("resourceType", LanguageConstants.String, "Type of resource including resource provider namespace")
                     .WithVariableParameter("resourceName", LanguageConstants.String, minimumCount: 1, "The resource name segment")
+                    .WithIsPurePredicate(IsManagementGroupResourceIdCallPure)
                     .Build();
 
                 // Add roleDefinition function

--- a/src/Bicep.Core/Semantics/ParameterFileImportValidator.cs
+++ b/src/Bicep.Core/Semantics/ParameterFileImportValidator.cs
@@ -132,9 +132,11 @@ internal static class ParameterFileImportValidator
 
     private static bool CanEvaluateFunctionWhileBuildingParametersFile(SemanticModel model, FunctionSymbol functionSymbol, FunctionCallSyntaxBase functionCall)
     {
-        var flags = model.TypeManager.GetMatchedFunctionOverload(functionCall)?.Flags ?? functionSymbol.FunctionFlags;
+        var overload = model.TypeManager.GetMatchedFunctionOverload(functionCall);
+        var flags = overload?.Flags ?? functionSymbol.FunctionFlags;
 
-        return flags.HasFlag(FunctionFlags.Pure);
+        return flags.HasFlag(FunctionFlags.Pure) ||
+            overload?.IsPure?.Invoke(model, functionCall) is true;
     }
 
     private static IEnumerable<SyntaxBase> GetValueSyntaxes(DeclaredSymbol symbol) => symbol switch


### PR DESCRIPTION
## Summary

- add call-specific purity evaluation for built-in function overloads
- allow resource ID helpers in imported parameter-file declarations when their scope is explicit
- keep BCP452 for implicit-scope calls and nested or transitive deployment-context dependencies
- mark `tenantResourceId` and `extensionResourceId` as statically pure

## Context

#20063 added validation that rejects imported declarations depending on deployment-context functions. The validation treated function purity as a static property, so it also rejected `resourceId(subscriptionId, resourceGroupName, resourceType, resourceName)`, even though that form depends only on its arguments and can be evaluated while building the parameters file.

The resource ID overloads all use strings plus variadic resource-name arguments, so normal overload resolution cannot reliably distinguish the explicit-scope form. This change adds a call-aware purity predicate that identifies the resource-type argument and verifies that all required scope arguments precede it.

Fixes #20131

## Testing

- `ParameterFileTests`: 46 passed
- `NamespaceTests.FunctionsShouldHaveExpectedSignatures`: 2 passed
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20142)