### PR TITLE
[Perf improvement] Cache regex pattern validation results

### DIFF
--- a/src/Bicep.Core/TypeSystem/TypeHelper.cs
+++ b/src/Bicep.Core/TypeSystem/TypeHelper.cs
@@ -23,6 +23,9 @@ namespace Bicep.Core.TypeSystem
     {
         private static TypeComparer typeComparer = new();
 
+        // Constructing a non-backtracking Regex is expensive, and the same patterns recur constantly across resource types.
+        private static readonly ConcurrentDictionary<string, string?> RegexValidationCache = new();
+
         /// <summary>
         /// Try to collapse multiple types into a single (non-union) type. Returns null if this is not possible.
         /// </summary>
@@ -748,7 +751,7 @@ namespace Bicep.Core.TypeSystem
         /// <returns>The pattern string iff it can be used with the non-backtracking engine.</returns>
         public static string? AsOptionalValidFiniteRegexPattern(string? pattern)
         {
-            if (pattern is not null && TryGetRegularExpressionValidationException(pattern) is null)
+            if (pattern is not null && TryGetRegularExpressionValidationError(pattern) is null)
             {
                 return pattern;
             }
@@ -762,18 +765,19 @@ namespace Bicep.Core.TypeSystem
         /// </summary>
         /// <param name="pattern">The regular expression pattern</param>
         /// <returns>The exception raised by <see cref="Regex.Regex(string, RegexOptions)"/>, if any.</returns>
-        public static Exception? TryGetRegularExpressionValidationException(string pattern)
-        {
-            try
+        public static string? TryGetRegularExpressionValidationError(string pattern)
+            => RegexValidationCache.GetOrAdd(pattern, static pattern =>
             {
-                var _ = new Regex(pattern, RegexOptions.NonBacktracking);
-                return null;
-            }
-            catch (Exception e)
-            {
-                return e;
-            }
-        }
+                try
+                {
+                    var _ = new Regex(pattern, RegexOptions.NonBacktracking);
+                    return null;
+                }
+                catch (Exception e)
+                {
+                    return e.Message;
+                }
+            });
 
         public static bool MatchesPattern(string pattern, string value)
             => Regex.IsMatch(value, pattern, RegexOptions.NonBacktracking);

--- a/src/Bicep.Core/TypeSystem/Types/StringType.cs
+++ b/src/Bicep.Core/TypeSystem/Types/StringType.cs
@@ -8,9 +8,9 @@ public class StringType : TypeSymbol
     internal StringType(long? minLength, long? maxLength, string? pattern, TypeSymbolValidationFlags validationFlags)
         : base(LanguageConstants.TypeNameString)
     {
-        if (pattern is not null && TypeHelper.TryGetRegularExpressionValidationException(pattern) is { } error)
+        if (pattern is not null && TypeHelper.TryGetRegularExpressionValidationError(pattern) is { } error)
         {
-            throw new ArgumentException($"The supplied regular expression pattern /{pattern}/ is not valid", error);
+            throw new ArgumentException($"The supplied regular expression pattern /{pattern}/ is not valid: {error}");
         }
 
         ValidationFlags = validationFlags;


### PR DESCRIPTION
## Summary

`TypeHelper.TryGetRegularExpressionValidationException` constructed a brand-new non-backtracking `Regex` on every call, purely to find out whether the pattern was valid, then threw the instance away. This showed up as one of the largest single allocation sources in a batch compile.

This PR caches the validation verdict keyed by pattern string.

## Measured impact

Captured with `dotnet-trace` over a 225-file corpus (`src/Bicep.Core.Samples/Files/user_submitted`), same corpus before and after:

| Metric | Before | After | Delta |
|---|---|---|---|
| Allocations under `TryGetRegularExpressionValidationException` | 136.83 MB | 6.22 MB | **−95.5%** |
| CPU samples (inclusive) | 184 (3.42% of compile scope) | 2 | **−98.9%** |
| Total process allocations | 1.72 GB | 1.588 GB | **−7.7%** |
| GC total pause | 1.22 s | 0.90 s | **−26%** |
| GC count / gen2 | 277 / 6 | 260 / 5 | −17 / −1 |
| Peak heap | 266 MB | 251.9 MB | −5.3% |
| Promoted bytes | 920 MB | 892.8 MB | −3.0% |

## On the cache being unbounded

Left unbounded, matching the existing convention across `Bicep.Core` (`DeclaredTypeManager`, `ResourceTypeCache`, `AzApiVersionProvider`, `Binder` and ~18 other files all use plain `ConcurrentDictionary` caches).

The growth path worth naming is the language server, where each keystroke inside a `@pattern('...')` literal produces a distinct key. An entry is a string reference plus a `null`, so even 10k entries over a long session is on the order of 1 MB, and the Azure type patterns that dominate the hit rate are a fixed, small set. Happy to add a capacity guard if reviewers would prefer one — flagging it explicitly rather than leaving it implicit.