### PR TITLE
[Perf improvement] Cache configuration source directories

### DIFF
--- a/src/Bicep.Core/Analyzers/Linter/LinterRuleBase.cs
+++ b/src/Bicep.Core/Analyzers/Linter/LinterRuleBase.cs
@@ -66,12 +66,13 @@ namespace Bicep.Core.Analyzers.Linter
 
         public IEnumerable<IDiagnostic> Analyze(SemanticModel model, IServiceProvider serviceProvider)
         {
-            if (GetDiagnosticLevel(model) == DiagnosticLevel.Off)
+            var diagnosticLevel = GetDiagnosticLevel(model);
+            if (diagnosticLevel == DiagnosticLevel.Off)
             {
                 return [];
             }
 
-            return AnalyzeInternal(model, serviceProvider, GetDiagnosticLevel(model));
+            return AnalyzeInternal(model, serviceProvider, diagnosticLevel);
         }
 
         /// <summary>

--- a/src/Bicep.Core/Configuration/ConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/ConfigurationManager.cs
@@ -18,6 +18,7 @@ namespace Bicep.Core.Configuration
     public class ConfigurationManager : IConfigurationManager
     {
         private readonly static DiagnosticBuilder.DiagnosticBuilderInternal ConfigDiagnosticBuilder = DiagnosticBuilder.ForDocumentStart();
+        private readonly ConcurrentDictionary<IOUri, IDirectoryHandle> directoryHandleCache = new();
         private readonly ConcurrentDictionary<IDirectoryHandle, ResultWithDiagnostic<IFileHandle?>> configFileLookupCache = new(); // Source file directory handle -> config file handle.
         private readonly ConcurrentDictionary<IFileHandle, ResultWithDiagnostic<RootConfiguration>> loadedConfigCache = new();     // Config file handle -> RootConfiguration.
         private readonly IFileExplorer fileExplorer;
@@ -34,7 +35,11 @@ namespace Bicep.Core.Configuration
                 return GetDefaultConfiguration();
             }
 
-            var sourceDirectory = this.fileExplorer.GetFile(sourceFileUri).GetParent();
+            // GetParent() is computationally expensive, and this gets called a lot during linting,
+            // so let's cache the result.
+            var sourceDirectory = directoryHandleCache.GetOrAdd(
+                sourceFileUri,
+                uri => this.fileExplorer.GetFile(uri).GetParent());
 
             if (!configFileLookupCache.GetOrAdd(sourceDirectory, LookupConfigurationFile).IsSuccess(out var configFileHandle, out var lookupDiagnostic))
             {


### PR DESCRIPTION
## Summary

Cache each source file URI's parent directory in `ConfigurationManager` so repeated configuration lookups do not reconstruct and normalize the same directory URI during linting. Also resolve each linter rule's configured diagnostic level once per analysis.

The original hot path repeatedly executed `GetParent() -> IOUri.Resolve() -> IOUri.FromFilePath() -> IOUri.NormalizePath()` before reaching the existing configuration caches.

## Performance

Measured with a Release `bicep build --pattern` over `src/Bicep.Core.Samples/Files/user_submitted`, using `dotnet-trace` sampled thread time, allocation, and verbose GC events.

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Compile allocations | 1.212 GB | 965.8 MB | 20.3% lower |
| Linter allocations | 289.5 MB | 74.6 MB | 74.2% lower |
| GC collections | 259 | 212 | 18.1% fewer |
| Peak heap | 251.3 MB | 248.1 MB | 1.3% lower |
| Promoted memory | 900.1 MB | 888.2 MB | 1.3% lower |

Within the linter CPU scope, `ConfigurationManager.GetConfiguration` fell from 60.05% to 4.88%. `FileSystemFileHandle.GetParent`, `IOUri.Resolve`, and `IOUri.FromFilePath` disappeared from the sampled linter path.

Both traces had 100% method-name resolution and matching Bicep PDBs. Allocation is the more reliable comparison: the optimized linter CPU scope contained only 82 periodic samples, so CPU percentages are directional.