### PR TITLE
feat: add parameter to specify bicepconfig.json file

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/LintCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/LintCommandTests.cs
@@ -257,6 +257,81 @@ param notUsedParm = 'string'
     }
 
     [TestMethod]
+    public async Task Lint_with_config_option_should_override_discovered_configuration()
+    {
+        var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+        var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicep", """
+    param unusedParam string
+    """, outputPath);
+
+        // This config will be discovered automatically and should produce a warning.
+        FileHelper.SaveResultFile(TestContext, "bicepconfig.json", """
+    {
+    "analyzers": {
+        "core": {
+        "rules": {
+            "no-unused-params": {
+            "level": "warning"
+            }
+        }
+        }
+    }
+    }
+    """, outputPath);
+
+        // This config is supplied explicitly and disables the rule.
+        var overrideConfig = FileHelper.SaveResultFile(TestContext, "override.json", """
+    {
+    "analyzers": {
+        "core": {
+        "rules": {
+            "no-unused-params": {
+            "level": "off"
+            }
+        }
+        }
+    }
+    }
+    """, outputPath);
+
+        var (output, error, result) = await Bicep(
+            "lint",
+            inputFile,
+            "--config",
+            overrideConfig);
+
+        result.Should().Be(0);
+        output.Should().BeEmpty();
+
+        // Rule should NOT fire because override.json was used.
+        error.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Lint_with_missing_config_should_report_configuration_error()
+    {
+        var outputPath = FileHelper.GetUniqueTestOutputPath(TestContext);
+
+        var inputFile = FileHelper.SaveResultFile(TestContext, "main.bicep", """
+    param foo string
+    """, outputPath);
+
+        var missingConfig = Path.Combine(outputPath, "doesnotexist.json");
+
+        var (output, error, result) = await Bicep(
+            "lint",
+            inputFile,
+            "--config",
+            missingConfig);
+
+        result.Should().Be(1);
+        output.Should().BeEmpty();
+
+        error.Should().Contain("doesnotexist.json");
+    }
+
+    [TestMethod]
     public async Task Lint_with_sarif_diagnostics_format_should_output_valid_sarif()
     {
         var inputFile = FileHelper.SaveResultFile(this.TestContext, "main.bicep", @"param storageAccountName string = 'test'");

--- a/src/Bicep.Cli/Arguments/LintArguments.cs
+++ b/src/Bicep.Cli/Arguments/LintArguments.cs
@@ -7,4 +7,5 @@ public record LintArguments(
     string? InputFile,
     string? FilePattern,
     DiagnosticsFormat? DiagnosticsFormat,
-    bool NoRestore) : IFilePatternInputArguments;
+    bool NoRestore,
+    string? Config) : IFilePatternInputArguments;

--- a/src/Bicep.Cli/Commands/LintCommand.cs
+++ b/src/Bicep.Cli/Commands/LintCommand.cs
@@ -7,6 +7,7 @@ using Bicep.Cli.Constants;
 using Bicep.Cli.Helpers;
 using Bicep.Cli.Logging;
 using Bicep.Core;
+using Bicep.Core.Configuration;
 using Bicep.Core.Features;
 using Bicep.Core.Utils;
 using Bicep.IO.Abstraction;
@@ -20,7 +21,8 @@ public class LintCommand(
     ILogger logger,
     DiagnosticLogger diagnosticLogger,
     BicepCompiler compiler,
-    InputOutputArgumentsResolver inputOutputArgumentsResolver) : ICommand
+    InputOutputArgumentsResolver inputOutputArgumentsResolver,
+    IConfigurationManager configurationManager) : ICommand
 {
     public async Task<int> RunAsync(LintArguments args)
     {
@@ -30,16 +32,20 @@ public class LintCommand(
         {
             ArgumentHelper.ValidateBicepOrBicepParamFile(inputUri);
 
-            var result = await Lint(inputUri, args.NoRestore, args.DiagnosticsFormat);
+            var result = await Lint(inputUri, args.NoRestore, args.DiagnosticsFormat, args.Config);
             hasErrors |= result.HasErrors;
         }
 
         return CommandHelper.GetExitCode(new(hasErrors));
     }
 
-    private async Task<DiagnosticSummary> Lint(IOUri inputUri, bool noRestore, DiagnosticsFormat? diagnosticsFormat)
+    private async Task<DiagnosticSummary> Lint(IOUri inputUri, bool noRestore, DiagnosticsFormat? diagnosticsFormat, string? config)
     {
-        var compilation = await compiler.CreateCompilation(inputUri, skipRestore: noRestore);
+
+        var lintCompiler = GetCompiler(config);
+
+        var compilation = await lintCompiler.CreateCompilation(inputUri, skipRestore: noRestore);
+
         CommandHelper.LogExperimentalWarning(logger, compilation);
 
         var summary = diagnosticLogger.LogDiagnostics(ArgumentHelper.GetDiagnosticOptions(diagnosticsFormat) with { SarifToStdout = true }, compilation);
@@ -68,11 +74,16 @@ public class LintCommand(
         {
             Description = "Sets the diagnostics format. Valid values are (Default, SARIF).",
         };
+        var configOption = new System.CommandLine.Option<string?>(Option.Config)
+        {
+            Description = "Specifies the path to a bicepconfig.json file to use.",
+        };
 
         command.Add(inputFileArgument);
         command.Add(filePatternOption);
         command.Add(noRestoreOption);
         command.Add(diagnosticsFormatOption);
+        command.Add(configOption);
         command.Validators.Add((System.CommandLine.Parsing.CommandResult result) => CommandLineBuilderContext.ValidatePositionalArgument(result, inputFileArgument));
 
         command.SetAction((result, ct) => context.RunCommandAsync(async () =>
@@ -82,11 +93,30 @@ public class LintCommand(
                 result.GetValue(inputFileArgument),
                 result.GetValue(filePatternOption),
                 diagnosticsFormat,
-                result.GetValue(noRestoreOption));
+                result.GetValue(noRestoreOption),
+                result.GetValue(configOption));
 
             return await context.GetCommand<LintCommand>().RunAsync(args);
         }));
 
         return command;
+    }
+
+    private BicepCompiler GetCompiler(string? config)
+    {
+        if (config is null)
+        {
+            return compiler;
+        }
+
+        var configUri = IOUri.FromFilePath(config);
+
+        var configuration = configurationManager.LoadConfiguration(configUri);
+
+        return BicepCompiler.Create(services =>
+        {
+            services.AddSingleton<IConfigurationManager>(
+                IConfigurationManager.WithStaticConfiguration(configuration));
+        });
     }
 }

--- a/src/Bicep.Cli/Constants/CliConstants.cs
+++ b/src/Bicep.Cli/Constants/CliConstants.cs
@@ -63,6 +63,9 @@ namespace Bicep.Cli.Constants
         public const string IndentSize = "--indent-size";
         public const string InsertFinalNewline = "--insert-final-newline";
 
+        // Lint
+        public const string Config = "--config";
+
         // Publish
         public const string Target = "--target";
         public const string DocumentationUri = "--documentation-uri";

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -958,5 +958,45 @@ namespace Bicep.Core.UnitTests.Configuration
             configuration.ModuleAliases.TryGetOciArtifactModuleAlias("myAlias").IsSuccess(out var alias).Should().BeTrue();
             alias!.Registry.Should().Be("real.azurecr.io");
         }
+
+        [TestMethod]
+        public void LoadConfiguration_LoadsExplicitConfigFile()
+        {
+            // Arrange.
+            var fileExplorer = new InMemoryFileExplorer();
+            var configFileUri = TestFileUri.FromInMemoryPath("path/to/bicepconfig.json");
+
+            var configFile = fileExplorer.GetFile(configFileUri);
+
+            using (var stream = configFile.OpenWrite())
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.Write("{}");
+            }
+
+            var sut = new ConfigurationManager(fileExplorer);
+
+            // Act.
+            var configuration = sut.LoadConfiguration(configFileUri);
+
+            // Assert.
+            configuration.Should().NotBeNull();
+        }
+
+        [TestMethod]
+        public void LoadConfiguration_MissingFileReturnsDiagnostic()
+        {
+            // Arrange.
+            var fileExplorer = new InMemoryFileExplorer();
+            var sut = new ConfigurationManager(fileExplorer);
+
+            var configFileUri = TestFileUri.FromInMemoryPath("path/to/missing/bicepconfig.json");
+
+            // Act.
+            var configuration = sut.LoadConfiguration(configFileUri);
+
+            // Assert.
+            configuration.Diagnostics.Should().NotBeEmpty();
+        }
     }
 }

--- a/src/Bicep.Core.UnitTests/Configuration/PatchingConfigurationManager.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/PatchingConfigurationManager.cs
@@ -18,4 +18,6 @@ public class PatchingConfigurationManager : IConfigurationManager
     }
 
     public RootConfiguration GetConfiguration(IOUri sourceFileUri) => patchFunc(configurationManager.GetConfiguration(sourceFileUri));
+
+    public RootConfiguration LoadConfiguration(IOUri configFileUri) => patchFunc(configurationManager.LoadConfiguration(configFileUri));
 }

--- a/src/Bicep.Core/Configuration/ConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/ConfigurationManager.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
-using System.IO.Abstractions;
-using System.Security;
-using System.ServiceModel;
 using System.Text.Json;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
@@ -46,12 +42,35 @@ namespace Bicep.Core.Configuration
                 return GetDefaultConfiguration();
             }
 
-            if (!loadedConfigCache.GetOrAdd(configFileHandle, LoadConfiguration).IsSuccess(out var configuration, out var loadDiagnostic))
+            if (!loadedConfigCache.GetOrAdd(configFileHandle, LoadConfigurationInternal).IsSuccess(out var configuration, out var diagnostic))
             {
-                return GetDefaultConfiguration().With(diagnostics: [loadDiagnostic]);
+                return GetDefaultConfiguration()
+                    .With(diagnostics: [diagnostic]);
             }
 
-            return configuration;
+            return configuration!;
+        }
+
+        public RootConfiguration LoadConfiguration(IOUri configFileUri)
+        {
+            var configFileHandle = this.fileExplorer.GetFile(configFileUri);
+
+            if (!configFileHandle.Exists())
+            {
+                return GetDefaultConfiguration()
+                    .With(diagnostics:
+                    [
+                        ConfigDiagnosticBuilder.ConfigurationFileNotFound(configFileHandle.Uri)
+                    ]);
+            }
+
+            if (!loadedConfigCache.GetOrAdd(configFileHandle, LoadConfigurationInternal).IsSuccess(out var configuration, out var diagnostic))
+            {
+                return GetDefaultConfiguration()
+                    .With(diagnostics: [diagnostic]);
+            }
+
+            return configuration!;
         }
 
         public void PurgeCache()
@@ -66,13 +85,14 @@ namespace Bicep.Core.Configuration
         {
             (RootConfiguration, RootConfiguration)? returnVal = null;
             var configFileHandle = this.fileExplorer.GetFile(configFileIdentifier);
-            loadedConfigCache.AddOrUpdate(configFileHandle, LoadConfiguration, (handle, prev) =>
+            loadedConfigCache.AddOrUpdate(configFileHandle, LoadConfigurationInternal, (handle, prev) =>
             {
-                var reloaded = LoadConfiguration(handle);
+                var reloaded = LoadConfigurationInternal(handle);
                 if (prev.IsSuccess(out var prevConfig) && reloaded.IsSuccess(out var newConfig))
                 {
                     returnVal = (prevConfig, newConfig);
                 }
+
                 return reloaded;
             });
 
@@ -91,7 +111,7 @@ namespace Bicep.Core.Configuration
 
         private static RootConfiguration GetDefaultConfiguration() => IConfigurationManager.GetBuiltInConfiguration();
 
-        private static ResultWithDiagnostic<RootConfiguration> LoadConfiguration(IFileHandle configFileHandle)
+        private static ResultWithDiagnostic<RootConfiguration> LoadConfigurationInternal(IFileHandle configFileHandle)
         {
             try
             {

--- a/src/Bicep.Core/Configuration/IConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/IConfigurationManager.cs
@@ -21,6 +21,14 @@ namespace Bicep.Core.Configuration
         RootConfiguration GetConfiguration(IOUri sourceFileUri);
 
         /// <summary>
+        /// Gets the configuration from the specified configuration file.
+        /// If the configuration file cannot be loaded, the built-in configuration is returned with diagnostics.
+        /// </summary>
+        /// <param name="configFileUri">The URI of the configuration file to load.</param>
+        /// <returns>The configuration loaded from the specified file.</returns>
+        RootConfiguration LoadConfiguration(IOUri configFileUri);
+
+        /// <summary>
         /// Gets the built-in configuration.
         /// </summary>
         /// <returns>The built-in configuration.</returns>
@@ -56,6 +64,8 @@ namespace Bicep.Core.Configuration
             }
 
             public RootConfiguration GetConfiguration(IOUri sourceFileUri) => configuration;
+
+            public RootConfiguration LoadConfiguration(IOUri configFileUri) => configuration;
         }
     }
 }


### PR DESCRIPTION
## Description

Add an optional parameter to specify an bicepconfig.json file that will override the default config file and the normal [file resolution process](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config#understand-the-file-resolution-process)
- add a new, optional '--config' parameter to specify a specific bicepconfig.json
- update unit tests
- add fallback logic

## Example Usage

`bicep lint main.bicep --config /foo-bar/override.json`

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20149)