### PR TITLE
Fix Bicep console rendering for wrapped input

### DIFF
--- a/src/Bicep.Cli.UnitTests/Helpers/Repl/PrintHelperTests.cs
+++ b/src/Bicep.Cli.UnitTests/Helpers/Repl/PrintHelperTests.cs
@@ -38,6 +38,25 @@ public class PrintHelperTests
     }
 
     [TestMethod]
+    public void PrintInputLine_repositions_cursor_across_wrapped_rows()
+    {
+        var input = "012345678901234567890123456789";
+
+        var result = PrintHelper.PrintInputLine("> ", input, 10, terminalWidth: 20, previousCursorOffset: input.Length);
+
+        AnsiHelper.ReplaceCodes(result).Should().Be(string.Concat(
+            "[HideCursor]",
+            "[MoveCursorUp(1)]",
+            "[MoveCursorToLineStart]",
+            "[ClearToEndOfScreen]",
+            "[Gray]> [Reset]012345678901234567890123456789",
+            "[MoveCursorToLineStart]",
+            "[MoveCursorUp(1)]",
+            "[MoveCursorRight(12)]",
+            "[ShowCursor]"));
+    }
+
+    [TestMethod]
     public void PrintWithSyntaxHighlighting_returns_expected_output()
     {
         var compilation = CompilationHelper.Compile("""

--- a/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
+++ b/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
@@ -155,7 +155,7 @@ public class ReplEnvironmentTests
     }
 
     [TestMethod]
-    public void Expression_evaluation_handles_nested_collection_lambdas()
+    public void Long_expressions_over_terminal_width_are_printed_correctly()
     {
         var outputs = EvaluateInputs([
             """

--- a/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
+++ b/src/Bicep.Cli.UnitTests/Services/ReplEnvironmentTests.cs
@@ -155,6 +155,22 @@ public class ReplEnvironmentTests
     }
 
     [TestMethod]
+    public void Expression_evaluation_handles_nested_collection_lambdas()
+    {
+        var outputs = EvaluateInputs([
+            """
+            join(map(sort(filter(range(1, 50), x => x % 3 == 0 && x % 5 != 0), (a, b) => b < a), x => '${x}:${padLeft(string(x * x), 4, '0')}'), '|')
+            """
+        ]);
+
+        outputs.Should().ContainSingle()
+            .Which.Should().BeEquivalentToIgnoringNewlines("""
+                [Orange]'48:2304|42:1764|39:1521|36:1296|33:1089|27:0729|24:0576|21:0441|18:0324|12:0144|9:0081|6:0036|3:0009'[Reset]
+
+                """);
+    }
+
+    [TestMethod]
     public void Expression_evaluation_succeeds_issue_18316()
     {
         // https://github.com/Azure/bicep/issues/18316

--- a/src/Bicep.Cli/Commands/ConsoleCommand.cs
+++ b/src/Bicep.Cli/Commands/ConsoleCommand.cs
@@ -219,7 +219,7 @@ public class ConsoleCommand(
 
     private readonly record struct InputLine(string Text, bool StartedWithBufferedInput, bool HasBufferedInputAfterEnter);
 
-    private async Task<bool> PrintHistory(StringBuilder buffer, LineEditor editor, bool backwards)
+    private async Task<bool> PrintHistory(StringBuilder buffer, LineEditor editor, bool backwards, int previousCursorOffset)
     {
         if (replEnvironment.TryGetHistory(backwards) is not { } history)
         {
@@ -235,7 +235,7 @@ public class ConsoleCommand(
         buffer.Append(history[..lineStart]);
         editor.Reset(GetRunes(history[lineStart..]));
 
-        var output = replEnvironment.HighlightInputLine(FirstLinePrefix, buffer.ToString(), editor.Buffer, editor.Cursor, printPrevLines: true);
+        var output = replEnvironment.HighlightInputLine(FirstLinePrefix, buffer.ToString(), editor.Buffer, editor.Cursor, printPrevLines: true, Console.WindowWidth, previousCursorOffset);
         await io.Output.Writer.WriteAsync(PrintHelper.MoveCursorUp(prevBufferLineCount));
         await io.Output.Writer.WriteAsync(output);
         return true;
@@ -254,12 +254,13 @@ public class ConsoleCommand(
         while (true)
         {
             var keyInfo = Console.ReadKey(intercept: true);
+            var previousCursorOffset = editor.Buffer.Take(editor.Cursor).Sum(rune => rune.Utf16SequenceLength);
 
             switch ((keyInfo.Modifiers, keyInfo.Key))
             {
                 case (_, UpArrow) or (_, DownArrow):
                     // History navigation re-renders the whole line itself, so skip the redraw below when it handled the key.
-                    if (await PrintHistory(buffer, editor, backwards: keyInfo.Key == UpArrow))
+                    if (await PrintHistory(buffer, editor, backwards: keyInfo.Key == UpArrow, previousCursorOffset))
                     {
                         continue;
                     }
@@ -333,7 +334,7 @@ public class ConsoleCommand(
             editor.Track();
 
             await io.Output.Writer.WriteAsync(
-                replEnvironment.HighlightInputLine(GetPrefix(buffer), buffer.ToString(), editor.Buffer, editor.Cursor, printPrevLines: false));
+                replEnvironment.HighlightInputLine(GetPrefix(buffer), buffer.ToString(), editor.Buffer, editor.Cursor, printPrevLines: false, Console.WindowWidth, previousCursorOffset));
         }
     }
 }

--- a/src/Bicep.Cli/Helpers/AnsiHelper.cs
+++ b/src/Bicep.Cli/Helpers/AnsiHelper.cs
@@ -30,6 +30,7 @@ public static class AnsiHelper
     private static readonly ImmutableDictionary<string, string> escapeCodeRegexByName = new Dictionary<string, string>
     {
         [nameof(PrintHelper.MoveCursorRight)] = "\u001b\\[(\\d+)C",
+        [nameof(PrintHelper.MoveCursorUp)] = "\u001b\\[(\\d+)A",
     }.ToImmutableDictionary();
 
     [return: NotNullIfNotNull(nameof(input))]

--- a/src/Bicep.Cli/Helpers/Repl/PrintHelper.cs
+++ b/src/Bicep.Cli/Helpers/Repl/PrintHelper.cs
@@ -142,12 +142,15 @@ public class PrintHelper
         return outputSb.ToString();
     }
 
-    public static string PrintInputLine(string prefix, string content, int cursorOffset)
+    public static string PrintInputLine(string prefix, string content, int cursorOffset, int terminalWidth = int.MaxValue, int? previousCursorOffset = null)
     {
         var output = new StringBuilder();
 
         output.Append(HideCursor);
 
+        // Return to the first physical row occupied by the previous rendering before clearing and repainting.
+        var previousCursorPosition = prefix.Length + (previousCursorOffset ?? cursorOffset);
+        output.Append(MoveCursorUp(previousCursorPosition / terminalWidth));
         output.Append(MoveCursorToLineStart);
         output.Append(ClearToEndOfScreen);
 
@@ -157,9 +160,27 @@ public class PrintHelper
         output.Append(MoveCursorToLineStart);
         if (!content.Contains('\n'))
         {
-            output.Append(MoveCursorRight(prefix.Length));
+            // Repainting leaves the cursor on the final wrapped row, so move up before restoring an earlier cursor position.
+            var contentLength = AnsiHelper.RemoveCodes(content).Length;
+            var endRow = (prefix.Length + contentLength) / terminalWidth;
+            var cursorPosition = prefix.Length + cursorOffset;
+            var cursorRow = cursorPosition / terminalWidth;
+
+            if (endRow == 0)
+            {
+                output.Append(MoveCursorRight(prefix.Length));
+                output.Append(MoveCursorRight(cursorOffset));
+            }
+            else
+            {
+                output.Append(MoveCursorUp(endRow - cursorRow));
+                output.Append(MoveCursorRight(cursorPosition % terminalWidth));
+            }
         }
-        output.Append(MoveCursorRight(cursorOffset));
+        else
+        {
+            output.Append(MoveCursorRight(cursorOffset));
+        }
 
         output.Append(ShowCursor);
 

--- a/src/Bicep.Cli/Services/ReplEnvironment.cs
+++ b/src/Bicep.Cli/Services/ReplEnvironment.cs
@@ -47,7 +47,7 @@ public class ReplEnvironment
         this.auxiliaryDirectory = auxiliaryFileExplorer.GetDirectory(IOUri.FromFilePath(auxiliaryFileSystem.Directory.GetCurrentDirectory()));
     }
 
-    public string HighlightInputLine(string prefix, string prevLines, IReadOnlyList<Rune> lineBuffer, int cursorOffset, bool printPrevLines)
+    public string HighlightInputLine(string prefix, string prevLines, IReadOnlyList<Rune> lineBuffer, int cursorOffset, bool printPrevLines, int terminalWidth = int.MaxValue, int? previousCursorOffset = null)
     {
         var currentLine = string.Concat(lineBuffer);
         var fullContent = $"{prevLines}{currentLine}";
@@ -61,12 +61,12 @@ public class ReplEnvironment
         {
             var historyHighlighted = PrintHelper.PrintWithSyntaxHighlighting(model, fullContent, 0);
 
-            return PrintHelper.PrintInputLine(prefix, historyHighlighted, width);
+            return PrintHelper.PrintInputLine(prefix, historyHighlighted, width, terminalWidth, previousCursorOffset);
         }
 
         var highlighted = PrintHelper.PrintWithSyntaxHighlighting(model, fullContent, lineStart);
 
-        return PrintHelper.PrintInputLine(prefix, highlighted, width);
+        return PrintHelper.PrintInputLine(prefix, highlighted, width, terminalWidth, previousCursorOffset);
     }
 
     public string HighlightSyntax(SyntaxBase syntax)


### PR DESCRIPTION
## Summary

For #20153.

Fixes interactive Bicep console rendering when an input line exceeds the terminal width.

Previously, each keypress repainted from the cursor's current wrapped row instead of returning to the first physical row occupied by the input. This left duplicate partial lines in the terminal and could restore the cursor to the wrong row or column.

The fix:

- tracks the cursor offset before each edit
- moves back to the first physical row before clearing and repainting
- accounts for terminal width when restoring the updated cursor position
- preserves the existing behavior for unwrapped and multiline input

## Reproduction

Enter the following expression in `bicep console` in a terminal narrow enough for it to wrap:

```bicep
join(map(sort(filter(range(1, 50), x => x % 3 == 0 && x % 5 != 0), (a, b) => b < a), x => '${x}:${padLeft(string(x * x), 4, '0')}'), '|')
```

Before this change, typing the expression produced repeated partial rows. After this change, the expression is rendered once and evaluates normally.

## Testing

- Added coverage for repositioning the cursor across wrapped terminal rows.
- Added a regression test for the nested collection-lambda expression above.
- Ran `dotnet test ./src/Bicep.Cli.UnitTests/Bicep.Cli.UnitTests.csproj --no-restore` (72 passed).
- Verified the exact expression interactively against the rebuilt CLI in a real terminal.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20154)