### PR TITLE
Add MegaLinter to community Bicep projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You can also get in touch with other users through the community-created [Azure 
 * [Bicep Language Service support in Neovim](https://github.com/Azure/bicep/issues/1141#issuecomment-749372637)
 * [Bicep PowerShell Module](https://github.com/PSBicep/PSBicep)
 * [Bicep Tasks extension for Azure Pipelines](https://marketplace.visualstudio.com/items?itemName=piraces.bicep-tasks)
+* [MegaLinter](https://megalinter.io/) - Open-source linters aggregator for CI that runs the [Bicep linter](https://megalinter.io/latest/descriptors/bicep_bicep_linter/) out of the box
 
 ## Alternatives
 


### PR DESCRIPTION
Hi Bicep team!

I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI pipelines. It ships the Bicep linter out of the box ([descriptor page](https://megalinter.io/latest/descriptors/bicep_bicep_linter/)), so folks can lint their .bicep files alongside the rest of their repo with a single step.

This PR just adds a one-line entry to the *Community Bicep projects* section of the README, in alphabetical order and matching the style of the other entries.

Thanks for the great tool!
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20157)