### PR TITLE
Introduce IBicepConfiguration interface layer for configuration inheritance

### DIFF
--- a/src/Bicep.Core/Configuration/AnalyzersConfiguration.cs
+++ b/src/Bicep.Core/Configuration/AnalyzersConfiguration.cs
@@ -7,7 +7,7 @@ using Bicep.Core.Json;
 
 namespace Bicep.Core.Configuration
 {
-    public class AnalyzersConfiguration : ConfigurationSection<JsonElement>
+    public class AnalyzersConfiguration : ConfigurationSection<JsonElement>, IBicepAnalyzersConfiguration
     {
         public AnalyzersConfiguration(JsonElement data) : base(data) { }
 

--- a/src/Bicep.Core/Configuration/BicepConfiguration.cs
+++ b/src/Bicep.Core/Configuration/BicepConfiguration.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+using Bicep.IO.Abstraction;
+
+namespace Bicep.Core.Configuration
+{
+    /// <summary>
+    /// Concrete implementation of <see cref="IBicepConfiguration"/>.
+    /// Holds the fully merged effective configuration for a source file,
+    /// constructed from section interfaces to support inheritance and testability.
+    /// </summary>
+    public class BicepConfiguration : IBicepConfiguration
+    {
+        public BicepConfiguration(
+            IBicepCloudConfiguration cloud,
+            IBicepModuleAliasesConfiguration moduleAliases,
+            IBicepModuleAliasesMockConfiguration moduleAliasesMock,
+            IBicepExtensionsConfiguration extensions,
+            IBicepImplicitExtensionsConfiguration implicitExtensions,
+            IBicepAnalyzersConfiguration analyzers,
+            IBicepFormattingConfiguration formatting,
+            ExperimentalFeaturesEnabled experimentalFeaturesEnabled,
+            string? cacheRootDirectory,
+            bool experimentalFeaturesWarning,
+            IOUri? configFileUri,
+            IEnumerable<IDiagnostic>? diagnostics)
+        {
+            Cloud = cloud;
+            ModuleAliases = moduleAliases;
+            ModuleAliasesMock = moduleAliasesMock;
+            Extensions = extensions;
+            ImplicitExtensions = implicitExtensions;
+            Analyzers = analyzers;
+            Formatting = formatting;
+            ExperimentalFeaturesEnabled = experimentalFeaturesEnabled;
+            CacheRootDirectory = ExpandCacheRootDirectory(cacheRootDirectory);
+            ExperimentalFeaturesWarning = experimentalFeaturesWarning;
+            ConfigFileUri = configFileUri;
+            Diagnostics = diagnostics?.ToImmutableArray() ?? [];
+        }
+
+        public IBicepCloudConfiguration Cloud { get; }
+
+        public IBicepModuleAliasesConfiguration ModuleAliases { get; }
+
+        public IBicepModuleAliasesMockConfiguration ModuleAliasesMock { get; }
+
+        public IBicepExtensionsConfiguration Extensions { get; }
+
+        public IBicepImplicitExtensionsConfiguration ImplicitExtensions { get; }
+
+        public IBicepAnalyzersConfiguration Analyzers { get; }
+
+        public IBicepFormattingConfiguration Formatting { get; }
+
+        public ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled { get; }
+
+        public string? CacheRootDirectory { get; }
+
+        public bool ExperimentalFeaturesWarning { get; }
+
+        public IOUri? ConfigFileUri { get; }
+
+        public bool IsBuiltIn => ConfigFileUri is null;
+
+        public ImmutableArray<IDiagnostic> Diagnostics { get; }
+
+        public IEnumerable<IDiagnostic> GetDiagnostics() => Diagnostics;
+
+        /// <summary>
+        /// Expands a leading '~' in the cache root directory path to the user's home directory.
+        /// </summary>
+        private static string? ExpandCacheRootDirectory(string? cacheRootDirectory)
+        {
+            if (string.IsNullOrEmpty(cacheRootDirectory) || cacheRootDirectory[0] != '~')
+            {
+                return cacheRootDirectory;
+            }
+
+            var homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            if (cacheRootDirectory.Length == 1)
+            {
+                return homeDirectory;
+            }
+
+            if (cacheRootDirectory[1] is '/' or '\\')
+            {
+                return $"{homeDirectory}{cacheRootDirectory[1..]}";
+            }
+
+            return cacheRootDirectory;
+        }
+    }
+}

--- a/src/Bicep.Core/Configuration/BicepConfigurationChain.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationChain.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+
+namespace Bicep.Core.Configuration;
+
+/// <summary>
+/// Represents a chain of Bicep configuration files linked via "extends".
+/// The chain is ordered from the leaf (most specific, e.g. closest bicepconfig.json)
+/// to the built-in defaults (last).
+///
+/// The primary purpose of keeping the full chain — rather than just the merged result —
+/// is to support accurate diagnostics: each <see cref="IBicepConfiguration"/> in the chain
+/// carries its own diagnostics, so errors can be
+/// attributed to the exact file that caused them.
+///
+/// </summary>
+public class BicepConfigurationChain : IBicepConfigurationChain
+{
+    // The fully merged effective configuration constructed by BicepConfigurationManager.
+    private readonly IBicepConfiguration effectiveConfiguration;
+
+    // All individual configurations in the chain, ordered leaf-first.
+    // Each carries its own diagnostics, enabling per-file error attribution.
+    private readonly ImmutableArray<IBicepConfiguration> layers;
+
+    // Lazily computed aggregation of diagnostics from all layers.
+    private ImmutableArray<IDiagnostic>? aggregatedDiagnostics;
+
+    /// <param name="effectiveConfiguration">
+    ///   The pre-merged configuration representing the combined settings of all layers.
+    ///   Produced by <c>BicepConfigurationManager</c>.
+    /// </param>
+    /// <param name="layers">
+    ///   Ordered collection of individual configurations, leaf first, built-in last.
+    ///   Used for diagnostic provenance tracking.
+    /// </param>
+    public BicepConfigurationChain(
+        IBicepConfiguration effectiveConfiguration,
+        IEnumerable<IBicepConfiguration> layers)
+    {
+        this.effectiveConfiguration = effectiveConfiguration;
+        this.layers = [.. layers];
+    }
+
+    /// <summary>
+    /// Returns the fully merged effective configuration.
+    /// The returned configuration's <see cref="IBicepConfiguration.GetDiagnostics"/>
+    /// aggregates diagnostics from every layer in the chain.
+    /// </summary>
+    public IBicepConfiguration GetEffectiveConfiguration() => this.effectiveConfiguration;
+
+    /// <summary>
+    /// Returns all diagnostics from every configuration file in the chain.
+    /// Each diagnostic already carries its source file URI via its message context,
+    /// so callers can attribute errors to the exact file that caused them.
+    /// </summary>
+    public IEnumerable<IDiagnostic> GetAllDiagnostics()
+    {
+        if (this.aggregatedDiagnostics is null)
+        {
+            this.aggregatedDiagnostics = this.layers
+                .SelectMany(layer => layer.GetDiagnostics())
+                .ToImmutableArray();
+        }
+
+        return this.aggregatedDiagnostics.Value;
+    }
+
+    /// <summary>
+    /// The number of configuration files in the chain, including the built-in defaults.
+    /// </summary>
+    public int LayerCount => this.layers.Length;
+}

--- a/src/Bicep.Core/Configuration/CloudConfiguration.cs
+++ b/src/Bicep.Core/Configuration/CloudConfiguration.cs
@@ -28,7 +28,7 @@ namespace Bicep.Core.Configuration
 
     public record ManagedIdentity(ManagedIdentityType Type, string? ClientId, string? ResourceId);
 
-    public class CloudConfiguration : ConfigurationSection<Cloud>, IEquatable<CloudConfiguration>
+    public class CloudConfiguration : ConfigurationSection<Cloud>, IBicepCloudConfiguration, IEquatable<CloudConfiguration>
     {
         public CloudConfiguration(Cloud data, Uri resourceManagerEndpointUri, Uri activeDirectoryAuthorityUri)
             : base(data)

--- a/src/Bicep.Core/Configuration/ExtensionsConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ExtensionsConfiguration.cs
@@ -26,7 +26,7 @@ public record ExtensionConfigEntry
         => Value;
 }
 
-public partial class ExtensionsConfiguration : ConfigurationSection<ImmutableDictionary<string, ExtensionConfigEntry>>
+public partial class ExtensionsConfiguration : ConfigurationSection<ImmutableDictionary<string, ExtensionConfigEntry>>, IBicepExtensionsConfiguration
 {
     private ExtensionsConfiguration(ImmutableDictionary<string, ExtensionConfigEntry> data) : base(data) { }
 

--- a/src/Bicep.Core/Configuration/FormattingConfiguration.cs
+++ b/src/Bicep.Core/Configuration/FormattingConfiguration.cs
@@ -7,7 +7,7 @@ using Bicep.Core.PrettyPrintV2;
 
 namespace Bicep.Core.Configuration
 {
-    public class FormattingConfiguration : ConfigurationSection<PrettyPrinterV2Options>
+    public class FormattingConfiguration : ConfigurationSection<PrettyPrinterV2Options>, IBicepFormattingConfiguration
     {
         public FormattingConfiguration(PrettyPrinterV2Options data)
             : base(data)

--- a/src/Bicep.Core/Configuration/IBicepAnalyzersConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepAnalyzersConfiguration.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepAnalyzersConfiguration
+    {
+        T GetValue<T>(string path, T defaultValue);
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepCloudConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepCloudConfiguration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepCloudConfiguration
+    {
+        ImmutableArray<CredentialType> CredentialPrecedence { get; }
+
+        CredentialOptions? CredentialOptions { get; }
+
+        Uri ResourceManagerEndpointUri { get; }
+
+        Uri ActiveDirectoryAuthorityUri { get; }
+
+        string AuthenticationScope { get; }
+
+        string ResourceManagerAudience { get; }
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfiguration.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+using Bicep.IO.Abstraction;
+
+namespace Bicep.Core.Configuration
+{
+    /// <summary>
+    /// Represents the effective Bicep configuration for a source file.
+    /// This is the result of merging all layers in a configuration chain
+    /// (built-in defaults, base configs, and the leaf config).
+    /// </summary>
+    public interface IBicepConfiguration
+    {
+        IBicepCloudConfiguration Cloud { get; }
+
+        IBicepModuleAliasesConfiguration ModuleAliases { get; }
+
+        IBicepModuleAliasesMockConfiguration ModuleAliasesMock { get; }
+
+        IBicepExtensionsConfiguration Extensions { get; }
+
+        IBicepImplicitExtensionsConfiguration ImplicitExtensions { get; }
+
+        IBicepAnalyzersConfiguration Analyzers { get; }
+
+        IBicepFormattingConfiguration Formatting { get; }
+
+        ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled { get; }
+
+        string? CacheRootDirectory { get; }
+
+        bool ExperimentalFeaturesWarning { get; }
+
+        /// <summary>
+        /// The URI of the leaf bicepconfig.json file that was discovered for this configuration.
+        /// Null when no user-defined config file was found and built-in defaults are in effect.
+        /// </summary>
+        IOUri? ConfigFileUri { get; }
+
+        /// <summary>
+        /// True when no user-defined bicepconfig.json was found and built-in defaults are in effect.
+        /// </summary>
+        bool IsBuiltIn { get; }
+
+        /// <summary>
+        /// Returns all diagnostics produced while loading this configuration.
+        /// For an inherited chain, this includes diagnostics from every file in the chain.
+        /// Each diagnostic's message already includes the source config file URI so callers
+        /// can report exactly which file caused the problem.
+        /// </summary>
+        IEnumerable<IDiagnostic> GetDiagnostics();
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Configuration;
+
+/// <summary>
+/// Represents a chain of Bicep configuration files linked via "extends".
+/// The chain goes from the leaf (most specific) file up to the built-in defaults.
+/// </summary>
+public interface IBicepConfigurationChain
+{
+    /// <summary>
+    /// Returns the effective configuration produced by merging all layers in the chain,
+    /// with leaf settings winning over base settings.
+    /// </summary>
+    IBicepConfiguration GetEffectiveConfiguration();
+}

--- a/src/Bicep.Core/Configuration/IBicepExtensionsConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepExtensionsConfiguration.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Diagnostics;
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepExtensionsConfiguration
+    {
+        ResultWithDiagnosticBuilder<ExtensionConfigEntry> TryGetExtensionSource(string extensionName);
+
+        bool IsSysOrBuiltIn(string extensionName);
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepFormattingConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepFormattingConfiguration.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.PrettyPrintV2;
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepFormattingConfiguration
+    {
+        PrettyPrinterV2Options Data { get; }
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepImplicitExtensionsConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepImplicitExtensionsConfiguration.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepImplicitExtensionsConfiguration
+    {
+        IEnumerable<string> GetImplicitExtensionNames();
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepModuleAliasesConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepModuleAliasesConfiguration.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepModuleAliasesConfiguration
+    {
+        ImmutableSortedDictionary<string, OciArtifactModuleAlias> GetOciArtifactModuleAliases();
+
+        ImmutableSortedDictionary<string, TemplateSpecModuleAlias> GetTemplateSpecModuleAliases();
+
+        ResultWithDiagnosticBuilder<OciArtifactModuleAlias> TryGetOciArtifactModuleAlias(string aliasName);
+
+        ResultWithDiagnosticBuilder<TemplateSpecModuleAlias> TryGetTemplateSpecModuleAlias(string aliasName);
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepModuleAliasesMockConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepModuleAliasesMockConfiguration.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepModuleAliasesMockConfiguration
+    {
+        ImmutableSortedDictionary<string, OciArtifactModuleAliasMock> GetOciArtifactModuleAliasesMock();
+
+        ResultWithDiagnosticBuilder<OciArtifactModuleAliasMock> TryGetOciArtifactModuleAliasMock(string aliasName);
+    }
+}

--- a/src/Bicep.Core/Configuration/ImplicitExtensionsConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ImplicitExtensionsConfiguration.cs
@@ -7,7 +7,7 @@ using Bicep.Core.Extensions;
 
 namespace Bicep.Core.Configuration;
 
-public partial class ImplicitExtensionsConfiguration : ConfigurationSection<ImmutableArray<string>>
+public partial class ImplicitExtensionsConfiguration : ConfigurationSection<ImmutableArray<string>>, IBicepImplicitExtensionsConfiguration
 {
     private ImplicitExtensionsConfiguration(ImmutableArray<string> data) : base(data) { }
 

--- a/src/Bicep.Core/Configuration/ModuleAliasesConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ModuleAliasesConfiguration.cs
@@ -42,7 +42,7 @@ namespace Bicep.Core.Configuration
                 : $"{Registry}";
     }
 
-    public partial class ModuleAliasesConfiguration : ConfigurationSection<ModuleAliases>
+    public partial class ModuleAliasesConfiguration : ConfigurationSection<ModuleAliases>, IBicepModuleAliasesConfiguration
     {
         private readonly IOUri? configFileUri;
 

--- a/src/Bicep.Core/Configuration/ModuleAliasesMockConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ModuleAliasesMockConfiguration.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.Configuration
         public override string ToString() => $"{MapToFilePath}";
     }
 
-    public partial class ModuleAliasesMockConfiguration : ConfigurationSection<ModuleAliasesMock>
+    public partial class ModuleAliasesMockConfiguration : ConfigurationSection<ModuleAliasesMock>, IBicepModuleAliasesMockConfiguration
     {
         private readonly IOUri? configFileUri;
 


### PR DESCRIPTION
## Description

<!-- Provide a 1-2 sentence description of your change -->

This PR introduces the interface foundation required to support configuration inheritance ( extends  in  bicepconfig.json ).

No existing behavior is changed.  RootConfiguration ,  ConfigurationManager , the compiler, and the language server are untouched. 

**Changes**

Interfaces ( IBicepCloudConfiguration ,  IBicepModuleAliasesConfiguration ,  IBicepModuleAliasesMockConfiguration ,  IBicepExtensionsConfiguration ,  IBicepImplicitExtensionsConfiguration ,  IBicepAnalyzersConfiguration ,  IBicepFormattingConfiguration )

->Each interface exposes only what consumers outside the configuration system actually need
-> Each existing concrete section class implements its corresponding interface 

 IBicepConfiguration  +  BicepConfiguration 
-> Top-level configuration interface and concrete implementation
-> Holds all 7 section interfaces and properties ( CacheRootDirectory ,  ExperimentalFeaturesEnabled , etc.)
-> Exposes GetDiagnostics()  so each config file in the chain can report its own errors

 IBicepConfigurationChain  +  BicepConfigurationChain 
-> Represents the ordered chain of config files linked via  extends  (leaf -> built-in)
-> Aggregates diagnostics across all layers for accurate error attribution (which file caused the error)



     

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20176)