### PR TITLE
Fix CLI live test branch gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -791,7 +791,7 @@ jobs:
     name: Check secret access
     runs-on: ubuntu-latest
     outputs:
-      access_verified: ${{ steps.check-access.outputs.verified && (github.base_ref == 'refs/head/main' || github.ref == 'refs/head/main') }}
+      access_verified: ${{ steps.check-access.outputs.verified && (github.base_ref == 'main' || github.ref == 'refs/heads/main') }}
 
     steps:
       - id: check-access


### PR DESCRIPTION
## Description

Correct the GitHub ref values used by the secret-access gate so CLI live tests run for pull requests targeting `main` and for workflow runs on `main`. Fairfax tests remain disabled by the existing `[prod]` matrices.

## Checklist

- [ ] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20177)