### PR TITLE
Add BicepConfigurationManager with 'extends' chain and cycle detection

### DIFF
--- a/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationManagerTests.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Configuration;
+using Bicep.Core.Diagnostics;
+using Bicep.IO.Abstraction;
+using Bicep.Testing;
+using Bicep.Testing.IO;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.Configuration
+{
+    [TestClass]
+    public class BicepConfigurationManagerTests
+    {
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        private static IBicepConfigurationChain GetChain(TestFileSet fileSet, string sourceFile = "main.bicep")
+        {
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            return sut.GetConfigurationChain(fileSet.GetUri(sourceFile));
+        }
+
+        private static IDiagnostic GetSingleDiagnostic(IBicepConfigurationChain chain)
+        {
+            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics().ToList();
+            diagnostics.Should().HaveCount(1);
+            return diagnostics[0];
+        }
+
+        // ── No config file ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_NoConfigFile_ReturnsBuiltInChain()
+        {
+            // Arrange — source file with no bicepconfig.json anywhere nearby.
+            var fileSet = InMemoryTestFileSet.Create(("main.bicep", ""));
+
+            // Act.
+            var chain = GetChain(fileSet);
+
+            // Assert — effective config is the built-in.
+            chain.GetEffectiveConfiguration().IsBuiltIn.Should().BeTrue();
+            chain.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        // ── Single config, no extends ─────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_SingleConfigNoExtends_ReturnsConfigWithNoErrors()
+        {
+            // Arrange.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "experimentalFeaturesWarning": true }"""));
+
+            // Act.
+            var chain = GetChain(fileSet);
+
+            // Assert.
+            chain.GetEffectiveConfiguration().IsBuiltIn.Should().BeFalse();
+            chain.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        // ── Simple two-level extends ──────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_LeafExtendsBase_LeafWinsOnConflict()
+        {
+            // Arrange — leaf overrides experimentalFeaturesWarning from base.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """
+                {
+                  "extends": "./base/bicepconfig.base.json",
+                  "experimentalFeaturesWarning": true
+                }
+                """),
+                ("base/bicepconfig.base.json", """
+                {
+                  "experimentalFeaturesWarning": false
+                }
+                """));
+
+            // Act.
+            var chain = GetChain(fileSet);
+
+            // Assert — leaf value (true) wins over base value (false).
+            chain.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetConfigurationChain_LeafExtendsBase_InheritsBaseValuesNotOverridden()
+        {
+            // Arrange — leaf does not set cacheRootDirectory; base does.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """
+                {
+                  "extends": "./base/bicepconfig.base.json",
+                  "experimentalFeaturesWarning": true
+                }
+                """),
+                ("base/bicepconfig.base.json", """
+                {
+                  "cacheRootDirectory": "/tmp/cache"
+                }
+                """));
+
+            // Act.
+            var chain = GetChain(fileSet);
+
+            // Assert — base value is inherited.
+            chain.GetEffectiveConfiguration().CacheRootDirectory.Should().Be("/tmp/cache");
+            chain.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        // ── Absolute path rejected ────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_ExtendsAbsolutePath_EmitsBCP453()
+        {
+            // Arrange.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "/absolute/path/bicepconfig.json" }"""));
+
+            // Act.
+            var chain = GetChain(fileSet);
+            var diagnostic = GetSingleDiagnostic(chain);
+
+            // Assert.
+            diagnostic.Code.Should().Be("BCP453");
+            diagnostic.Level.Should().Be(DiagnosticLevel.Error);
+        }
+
+        // ── Cycle detection ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_DirectCycle_EmitsBCP454()
+        {
+            // Arrange — A extends B, B extends A.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./other/bicepconfig.json" }"""),
+                ("other/bicepconfig.json", """{ "extends": "../bicepconfig.json" }"""));
+
+            // Act.
+            var chain = GetChain(fileSet);
+            var diagnostic = GetSingleDiagnostic(chain);
+
+            // Assert.
+            diagnostic.Code.Should().Be("BCP454");
+            diagnostic.Level.Should().Be(DiagnosticLevel.Error);
+        }
+
+        // ── File not found ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_ExtendsFileMissing_EmitsUnloadableDiagnostic()
+        {
+            // Arrange — extends points to a file that doesn't exist.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./nonexistent/bicepconfig.json" }"""));
+
+            // Act.
+            var chain = GetChain(fileSet);
+            var diagnostic = GetSingleDiagnostic(chain);
+
+            // Assert.
+            diagnostic.Code.Should().Be("BCP272");
+            diagnostic.Level.Should().Be(DiagnosticLevel.Error);
+            diagnostic.Message.Should().Contain("File not found");
+        }
+
+        // ── Invalid JSON ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_InvalidJson_EmitsUnparsableDiagnostic()
+        {
+            // Arrange.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", "not json at all"));
+
+            // Act.
+            var chain = GetChain(fileSet);
+            var diagnostic = GetSingleDiagnostic(chain);
+
+            // Assert.
+            diagnostic.Code.Should().Be("BCP271");
+            diagnostic.Level.Should().Be(DiagnosticLevel.Error);
+        }
+
+        // ── Depth limit ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_ChainExceedsMaxDepth_EmitsBCP455()
+        {
+            // Arrange — build a flat chain of 65 files all in the same directory.
+            // Each extends the next: bicepconfig.json -> bicepconfig1.json -> ... -> bicepconfig64.json
+            const int depth = 65;
+            var files = new List<(string, string)> { ("main.bicep", "") };
+
+            for (int i = 0; i < depth; i++)
+            {
+                var path = i == 0 ? "bicepconfig.json" : $"bicepconfig{i}.json";
+                var extendsLine = i < depth - 1
+                    ? $"""  "extends": "./bicepconfig{i + 1}.json" """
+                    : "";
+                files.Add((path, $$"""{ {{extendsLine}} }"""));
+            }
+
+            var fileSet = InMemoryTestFileSet.Create([.. files]);
+
+            // Act.
+            var chain = GetChain(fileSet);
+            var diagnostic = GetSingleDiagnostic(chain);
+
+            // Assert.
+            diagnostic.Code.Should().Be("BCP455");
+            diagnostic.Level.Should().Be(DiagnosticLevel.Error);
+        }
+
+        // ── Non-file URI ──────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_NonFileUri_ReturnsBuiltInChain()
+        {
+            // Arrange — source file is a remote URI (e.g. from a registry).
+            var fileSet = InMemoryTestFileSet.Create();
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            var remoteUri = new IOUri(new IOUriScheme("https"), "management.azure.com", "/bicep/main.bicep");
+
+            // Act.
+            var chain = sut.GetConfigurationChain(remoteUri);
+
+            // Assert.
+            chain.GetEffectiveConfiguration().IsBuiltIn.Should().BeTrue();
+            chain.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        // ── Caching ───────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_CalledTwiceForSameSource_ReturnsSameChainInstance()
+        {
+            // Arrange.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "experimentalFeaturesWarning": true }"""));
+
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+
+            // Act.
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Assert — same instance returned from cache.
+            chain1.Should().BeSameAs(chain2);
+        }
+
+        [TestMethod]
+        public void GetConfigurationChain_AfterPurgeCache_ReturnsNewInstance()
+        {
+            // Arrange.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "experimentalFeaturesWarning": true }"""));
+
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+
+            // Act.
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            sut.PurgeCache();
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Assert — different instance after purge.
+            chain1.Should().NotBeSameAs(chain2);
+        }
+    }
+}

--- a/src/Bicep.Core/Configuration/BicepConfigurationAdapter.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationAdapter.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Bicep.Core.Diagnostics;
+using Bicep.IO.Abstraction;
+
+namespace Bicep.Core.Configuration;
+
+/// <summary>
+/// Adapts the existing <see cref="RootConfiguration"/> to the <see cref="IBicepConfiguration"/> interface.
+/// This allows <see cref="BicepConfigurationManager"/> to return <see cref="IBicepConfiguration"/> instances
+/// backed by the existing configuration loading infrastructure, without requiring <see cref="RootConfiguration"/>
+/// to directly implement the interface.
+/// </summary>
+internal sealed class BicepConfigurationAdapter : IBicepConfiguration
+{
+    private readonly RootConfiguration inner;
+
+    public BicepConfigurationAdapter(RootConfiguration inner)
+    {
+        this.inner = inner;
+    }
+
+    public IBicepCloudConfiguration Cloud => this.inner.Cloud;
+
+    public IBicepModuleAliasesConfiguration ModuleAliases => this.inner.ModuleAliases;
+
+    public IBicepModuleAliasesMockConfiguration ModuleAliasesMock => this.inner.ModuleAliasesMock;
+
+    public IBicepExtensionsConfiguration Extensions => this.inner.Extensions;
+
+    public IBicepImplicitExtensionsConfiguration ImplicitExtensions => this.inner.ImplicitExtensions;
+
+    public IBicepAnalyzersConfiguration Analyzers => this.inner.Analyzers;
+
+    public IBicepFormattingConfiguration Formatting => this.inner.Formatting;
+
+    public ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled => this.inner.ExperimentalFeaturesEnabled;
+
+    public string? CacheRootDirectory => this.inner.CacheRootDirectory;
+
+    public bool ExperimentalFeaturesWarning => this.inner.ExperimentalFeaturesWarning;
+
+    public IOUri? ConfigFileUri => this.inner.ConfigFileUri;
+
+    public bool IsBuiltIn => this.inner.IsBuiltIn;
+
+    public IEnumerable<IDiagnostic> GetDiagnostics() => this.inner.Diagnostics;
+}

--- a/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Text.Json;
+using Bicep.Core.Diagnostics;
+using Bicep.Core.Extensions;
+using Bicep.Core.Json;
+using Bicep.IO.Abstraction;
+
+namespace Bicep.Core.Configuration;
+
+public class BicepConfigurationManager : IBicepConfigurationManager
+{
+    private const int MaxChainDepth = 64;
+
+    private static readonly DiagnosticBuilder.DiagnosticBuilderInternal ConfigDiagnosticBuilder = DiagnosticBuilder.ForDocumentStart();
+
+    private readonly ConcurrentDictionary<IOUri, IDirectoryHandle> directoryHandleCache = new();
+    private readonly ConcurrentDictionary<IDirectoryHandle, ResultWithDiagnostic<IFileHandle?>> configFileLookupCache = new();
+    private readonly ConcurrentDictionary<IFileHandle, ResultWithDiagnostic<IBicepConfigurationChain>> chainCache = new();
+    private readonly IFileExplorer fileExplorer;
+
+    public BicepConfigurationManager(IFileExplorer fileExplorer)
+    {
+        this.fileExplorer = fileExplorer;
+    }
+
+    public IBicepConfigurationChain GetConfigurationChain(IOUri sourceFileUri)
+    {
+        if (!sourceFileUri.IsFile)
+        {
+            return GetBuiltInChain();
+        }
+
+        var sourceDirectory = this.directoryHandleCache.GetOrAdd(
+            sourceFileUri,
+            uri => this.fileExplorer.GetFile(uri).GetParent());
+
+        if (!this.configFileLookupCache.GetOrAdd(sourceDirectory, LookupConfigurationFile).IsSuccess(out var configFileHandle, out var lookupDiagnostic))
+        {
+            return GetBuiltInChain(diagnostics: [lookupDiagnostic]);
+        }
+
+        if (configFileHandle is null)
+        {
+            return GetBuiltInChain();
+        }
+
+        if (!this.chainCache.GetOrAdd(configFileHandle, LoadChain).IsSuccess(out var chain, out var loadDiagnostic))
+        {
+            return GetBuiltInChain(diagnostics: [loadDiagnostic]);
+        }
+
+        return chain;
+    }
+
+    public void PurgeCache()
+    {
+        PurgeLookupCache();
+        this.chainCache.Clear();
+    }
+
+    public void PurgeLookupCache() => this.configFileLookupCache.Clear();
+
+    public void RemoveChainCacheEntry(IOUri configFileUri)
+    {
+        var configFileHandle = this.fileExplorer.GetFile(configFileUri);
+
+        if (this.chainCache.TryRemove(configFileHandle, out _))
+        {
+            PurgeLookupCache();
+        }
+    }
+
+    private static IBicepConfigurationChain GetBuiltInChain(IEnumerable<IDiagnostic>? diagnostics = null)
+    {
+        var builtInConfig = GetBuiltInRootConfiguration(diagnostics);
+
+        return new BicepConfigurationChain(new BicepConfigurationAdapter(builtInConfig), [new BicepConfigurationAdapter(builtInConfig)]);
+    }
+
+    private static RootConfiguration GetBuiltInRootConfiguration(IEnumerable<IDiagnostic>? diagnostics = null) =>
+        diagnostics is null
+            ? IConfigurationManager.GetBuiltInConfiguration()
+            : IConfigurationManager.GetBuiltInConfiguration().With(diagnostics: diagnostics);
+
+    private ResultWithDiagnostic<IBicepConfigurationChain> LoadChain(IFileHandle leafFileHandle)
+    {
+        var leafUri = leafFileHandle.Uri;
+        var rawLayers = new List<(IFileHandle FileHandle, JsonElement Element)>();
+        var visited = new HashSet<IOUri>();
+        var currentFileHandle = leafFileHandle;
+
+        while (true)
+        {
+            JsonElement currentElement;
+            try
+            {
+                using var stream = currentFileHandle.OpenRead();
+                currentElement = JsonElementFactory.CreateElementFromStream(stream);
+            }
+            catch (JsonException exception)
+            {
+                return new(ConfigDiagnosticBuilder.UnparsableBicepConfigFile(currentFileHandle.Uri, exception.Message));
+            }
+            catch (Exception exception)
+            {
+                return new(ConfigDiagnosticBuilder.UnloadableBicepConfigFile(currentFileHandle.Uri, exception.Message));
+            }
+
+            rawLayers.Add((currentFileHandle, currentElement));
+            visited.Add(currentFileHandle.Uri);
+
+            if (!currentElement.TryGetProperty("extends", out var extendsElement) ||
+                extendsElement.ValueKind == JsonValueKind.Null)
+            {
+                break;
+            }
+
+            var extendsPath = extendsElement.GetString();
+
+            if (string.IsNullOrWhiteSpace(extendsPath))
+            {
+                break;
+            }
+
+            if (IOUri.IsAbsoluteFilePath(extendsPath))
+            {
+                return new(ConfigDiagnosticBuilder.BicepConfigExtendsAbsolutePath(currentFileHandle.Uri));
+            }
+
+            var nextUri = currentFileHandle.Uri.Resolve(extendsPath);
+
+            if (visited.Contains(nextUri))
+            {
+                var cycleDisplay = string.Join(" -> ", visited.Select(u => u.ToString())) + " -> " + nextUri;
+
+                return new(ConfigDiagnosticBuilder.BicepConfigExtendsCycle(leafUri, cycleDisplay));
+            }
+
+            if (rawLayers.Count >= MaxChainDepth)
+            {
+                return new(ConfigDiagnosticBuilder.BicepConfigExtendsChainTooDeep(leafUri));
+            }
+
+            var nextFileHandle = this.fileExplorer.GetFile(nextUri);
+
+            if (!nextFileHandle.Exists())
+            {
+                return new(ConfigDiagnosticBuilder.UnloadableBicepConfigFile(nextUri, "File not found."));
+            }
+
+            currentFileHandle = nextFileHandle;
+        }
+
+        return new(BuildChain(leafUri, rawLayers));
+    }
+
+    private static IBicepConfigurationChain BuildChain(IOUri leafUri, List<(IFileHandle FileHandle, JsonElement Element)> rawLayers)
+    {
+        // Merge: built-in first, then base configs in reverse order, leaf last (leaf wins).
+        var accumulated = IConfigurationManager.BuiltInConfigurationElement;
+
+        foreach (var (_, element) in Enumerable.Reverse(rawLayers))
+        {
+            accumulated = accumulated.Merge(StripExtendsProperty(element));
+        }
+
+        RootConfiguration effectiveRootConfig;
+        try
+        {
+            effectiveRootConfig = RootConfiguration.Bind(accumulated, leafUri);
+        }
+        catch (ConfigurationException exception)
+        {
+            return GetBuiltInChain(diagnostics: [DiagnosticBuilder.ForDocumentStart().InvalidBicepConfigFile(leafUri, exception.Message)]);
+        }
+
+        // Build per-layer configs so diagnostics can be attributed to the exact file that caused them.
+        var layers = rawLayers
+            .Select(layer =>
+            {
+                try
+                {
+                    var merged = IConfigurationManager.BuiltInConfigurationElement.Merge(StripExtendsProperty(layer.Element));
+
+                    return (IBicepConfiguration)new BicepConfigurationAdapter(RootConfiguration.Bind(merged, layer.FileHandle.Uri));
+                }
+                catch (ConfigurationException)
+                {
+                    return (IBicepConfiguration)new BicepConfigurationAdapter(
+                        IConfigurationManager.GetBuiltInConfiguration().With(configFileIdentifier: layer.FileHandle.Uri));
+                }
+            })
+            .ToImmutableArray();
+
+        return new BicepConfigurationChain(new BicepConfigurationAdapter(effectiveRootConfig), layers);
+    }
+
+    private static JsonElement StripExtendsProperty(JsonElement element)
+    {
+        if (!element.TryGetProperty("extends", out _))
+        {
+            return element;
+        }
+
+        var bufferWriter = new System.Buffers.ArrayBufferWriter<byte>();
+        using var writer = new Utf8JsonWriter(bufferWriter);
+
+        writer.WriteStartObject();
+        foreach (var property in element.EnumerateObject())
+        {
+            if (!string.Equals(property.Name, "extends", StringComparison.Ordinal))
+            {
+                property.WriteTo(writer);
+            }
+        }
+        writer.WriteEndObject();
+        writer.Flush();
+
+        return JsonElementFactory.CreateElement(bufferWriter.WrittenMemory);
+    }
+
+    private ResultWithDiagnostic<IFileHandle?> LookupConfigurationFile(IDirectoryHandle? directoryToLookup)
+    {
+        try
+        {
+            while (directoryToLookup is not null)
+            {
+                var configFileHandle = directoryToLookup.GetFile(LanguageConstants.BicepConfigurationFileName);
+
+                if (configFileHandle.Exists())
+                {
+                    return new(configFileHandle);
+                }
+
+                directoryToLookup = directoryToLookup.GetParent();
+            }
+        }
+        catch (IOException exception)
+        {
+            return new(ConfigDiagnosticBuilder.PotentialConfigDirectoryCouldNotBeScanned(directoryToLookup?.Uri, exception.Message));
+        }
+
+        return new((IFileHandle?)null);
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfigurationManager.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.IO.Abstraction;
+
+namespace Bicep.Core.Configuration;
+
+/// <summary>
+/// Manages loading and caching of Bicep configuration chains.
+/// A chain is the ordered sequence of configuration files linked via "extends",
+/// from the leaf (nearest bicepconfig.json) up to the built-in defaults.
+/// </summary>
+public interface IBicepConfigurationManager
+{
+    /// <summary>
+    /// Returns the configuration chain for the given source file.
+    /// Walks the "extends" chain starting from the nearest bicepconfig.json,
+    /// detects cycles, enforces depth limits, and merges all layers.
+    /// Falls back to the built-in configuration if no bicepconfig.json is found.
+    /// </summary>
+    IBicepConfigurationChain GetConfigurationChain(IOUri sourceFileUri);
+}

--- a/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
+++ b/src/Bicep.Core/Diagnostics/DiagnosticBuilder.cs
@@ -2072,6 +2072,18 @@ namespace Bicep.Core.Diagnostics
             public Diagnostic ImportedSymbolDependsOnDeploymentContextFunctions(string symbolName, IEnumerable<string> functionNames) => CoreError(
                 "BCP452",
                 @$"The imported symbol ""{symbolName}"" cannot be used in a {LanguageConstants.ParamsFileExtension} file because it depends on deployment-context functions: {ToQuotedString(functionNames)}. Imported declarations may only use functions that can be evaluated while building the parameters file.");
+
+            public Diagnostic BicepConfigExtendsAbsolutePath(IOUri configFileUri) => CoreError(
+                "BCP453",
+                $"The \"extends\" value in the Bicep configuration file \"{configFileUri}\" must be a relative path. Absolute paths are not allowed.");
+
+            public Diagnostic BicepConfigExtendsCycle(IOUri configFileUri, string cycle) => CoreError(
+                "BCP454",
+                $"A cycle was detected in the Bicep configuration \"extends\" chain starting from \"{configFileUri}\": {cycle}.");
+
+            public Diagnostic BicepConfigExtendsChainTooDeep(IOUri configFileUri) => CoreError(
+                "BCP455",
+                $"The Bicep configuration \"extends\" chain starting from \"{configFileUri}\" exceeds the maximum allowed depth of 64.");
         }
 
         public static DiagnosticBuilderInternal ForPosition(TextSpan span)


### PR DESCRIPTION
## Description
This is the second PR in the incremental implementation of Bicep Config Inheritance.

**PR 1** (https://github.com/Azure/bicep/pull/20176) introduced the foundational interfaces:
- Section interfaces (`IBicepCloudConfiguration`, `IBicepAnalyzersConfiguration`, etc.)
- `IBicepConfiguration` / `BicepConfiguration`
- `IBicepConfigurationChain` / `BicepConfigurationChain`

**This PR 2** implements the inheritance engine.

## What This PR Does

### New Files
- **`IBicepConfigurationManager.cs`** — Interface for the config chain loader
- **`BicepConfigurationManager.cs`** — Core engine that
  - Reads `bicepconfig.json` files and detects the `"extends"` property
  - Walks the inheritance chain
  - Detects cycles and enforces a max depth of 64
  - Merges JSON layers 
  - Builds a `BicepConfigurationChain` with per-layer diagnostics
  - Caches chains by leaf config URI for performance
- **`BicepConfigurationAdapter.cs`** -- Internal adapter wrapping `RootConfiguration` 
  into `IBicepConfiguration` (temporary bridge during gradual migration)

### Modified Files
- **`DiagnosticBuilder.cs`** -- Added three new diagnostic codes:
  - `BCP453` -- `extends` value must be a relative path (absolute paths rejected)
  - `BCP454` -- Cycle detected in `extends` chain
  - `BCP455` --- `extends` chain exceeds maximum depth (64)

- `BicepConfigurationManager` is **not yet wired** into the compiler or language server
- No changes to existing `ConfigurationManager.cs` behavior
- No `"extends"` IntelliSense in `bicepconfig.schema.json` yet
- Language server file watching for chain invalidation not yet implemented


### BCP453/454/455 are currently  CoreError . Should these be downgraded to  CoreWarning?

## For Follow-up PRs
PR 3 to Wire `BicepConfigurationManager` into `BicepConfigLifecycleManager` -- watch all files in the chain for changes, invalidate chain cache when any layer changes .
PR 4 to add `"extends"` property to `bicepconfig.schema.json` for VS Code IntelliSense/autocomplete.
PR 5 to Migrate `RootConfiguration` to implement `IBicepConfiguration` directly.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20181)