### PR TITLE
wire BicepConfigurationManager into compiler with targeted cacheInvalidation

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ConfigurationInheritanceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ConfigurationInheritanceTests.cs
@@ -1,0 +1,254 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.Configuration;
+using Bicep.Core.Diagnostics;
+using Bicep.IO.Abstraction;
+using Bicep.IO.InMemory;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.IntegrationTests;
+
+/// <summary>
+/// Integration tests that verify the full compiler pipeline uses inherited
+/// configuration correctly.
+/// </summary>
+[TestClass]
+public class ConfigurationInheritanceTests
+{
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a compiler backed by an in-memory file system containing the given files.
+    /// </summary>
+    private static (BicepCompiler Compiler, InMemoryFileExplorer FileExplorer) CreateCompiler()
+    {
+        var fileExplorer = new InMemoryFileExplorer();
+        var compiler = BicepCompiler.Create(s => s.AddSingleton<IFileExplorer>(fileExplorer));
+        return (compiler, fileExplorer);
+    }
+
+    private static IOUri BicepUri(string path) => IOUri.FromFilePath(path);
+
+    private static void WriteFile(InMemoryFileExplorer fileExplorer, string path, string content)
+        => fileExplorer.GetFile(BicepUri(path)).WriteAllText(content);
+
+    // ── Baseline: no inheritance ──────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Compiler_WithNoConfig_ReportsUnusedParamDiagnostic()
+    {
+        // Arrange — no bicepconfig.json; built-in defaults apply.
+        var (compiler, fileExplorer) = CreateCompiler();
+        WriteFile(fileExplorer, "/main.bicep", "param unused string");
+
+        // Act.
+        var compilation = compiler.CreateCompilationWithoutRestore(BicepUri("/main.bicep"));
+        var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+
+        // Assert — built-in defaults enable no-unused-params warning.
+        diagnostics.Should().Contain(d =>
+            d.Code == "no-unused-params" &&
+            d.Level == DiagnosticLevel.Warning);
+
+        await Task.CompletedTask;
+    }
+
+    // ── Leaf config disables rule ─────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Compiler_WithLeafConfigDisablingRule_SuppressesDiagnostic()
+    {
+        // Arrange — leaf config turns off no-unused-params.
+        var (compiler, fileExplorer) = CreateCompiler();
+        WriteFile(fileExplorer, "/main.bicep", "param unused string");
+        WriteFile(fileExplorer, "/bicepconfig.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "off" }
+              }
+            }
+          }
+        }
+        """);
+
+        // Act.
+        var compilation = compiler.CreateCompilationWithoutRestore(BicepUri("/main.bicep"));
+        var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+
+        // Assert — rule disabled by leaf config, no diagnostic.
+        diagnostics.Should().NotContain(d => d.Code == "no-unused-params");
+
+        await Task.CompletedTask;
+    }
+
+    // ── Inherited rule disable: base disables, leaf inherits ──────────────────
+
+    [TestMethod]
+    public async Task Compiler_WithInheritedDisabledRule_SuppressesDiagnostic()
+    {
+        // Arrange:
+        //   base config: disables no-unused-params
+        //   leaf config: extends base (inherits the disabled rule)
+        var (compiler, fileExplorer) = CreateCompiler();
+        WriteFile(fileExplorer, "/main.bicep", "param unused string");
+        WriteFile(fileExplorer, "/bicepconfig.json", """
+        {
+          "extends": "./base/bicepconfig.base.json"
+        }
+        """);
+        WriteFile(fileExplorer, "/base/bicepconfig.base.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "off" }
+              }
+            }
+          }
+        }
+        """);
+
+        // Act.
+        var compilation = compiler.CreateCompilationWithoutRestore(BicepUri("/main.bicep"));
+        var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+
+        // Assert — rule disabled via inheritance, no diagnostic.
+        diagnostics.Should().NotContain(d => d.Code == "no-unused-params");
+
+        await Task.CompletedTask;
+    }
+
+    // ── Leaf overrides base ───────────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task Compiler_WithLeafOverridingBase_LeafRuleWins()
+    {
+        // Arrange:
+        //   base config: disables no-unused-params
+        //   leaf config: re-enables no-unused-params (overrides base)
+        var (compiler, fileExplorer) = CreateCompiler();
+        WriteFile(fileExplorer, "/main.bicep", "param unused string");
+        WriteFile(fileExplorer, "/bicepconfig.json", """
+        {
+          "extends": "./base/bicepconfig.base.json",
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "warning" }
+              }
+            }
+          }
+        }
+        """);
+        WriteFile(fileExplorer, "/base/bicepconfig.base.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "off" }
+              }
+            }
+          }
+        }
+        """);
+
+        // Act.
+        var compilation = compiler.CreateCompilationWithoutRestore(BicepUri("/main.bicep"));
+        var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+
+        // Assert — leaf re-enables the rule; diagnostic IS reported.
+        diagnostics.Should().Contain(d =>
+            d.Code == "no-unused-params" &&
+            d.Level == DiagnosticLevel.Warning);
+
+        await Task.CompletedTask;
+    }
+
+    // ── Deep chain: grandparent → parent → leaf ───────────────────────────────
+
+    [TestMethod]
+    public async Task Compiler_WithDeepChain_InheritsFromGrandparent()
+    {
+        // Arrange:
+        //   grandparent: disables no-unused-params
+        //   parent:      extends grandparent (no override)
+        //   leaf:        extends parent (no override)
+        var (compiler, fileExplorer) = CreateCompiler();
+        WriteFile(fileExplorer, "/main.bicep", "param unused string");
+        WriteFile(fileExplorer, "/bicepconfig.json", """
+        { "extends": "./parent/bicepconfig.parent.json" }
+        """);
+        WriteFile(fileExplorer, "/parent/bicepconfig.parent.json", """
+        { "extends": "../grandparent/bicepconfig.grandparent.json" }
+        """);
+        WriteFile(fileExplorer, "/grandparent/bicepconfig.grandparent.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "off" }
+              }
+            }
+          }
+        }
+        """);
+
+        // Act.
+        var compilation = compiler.CreateCompilationWithoutRestore(BicepUri("/main.bicep"));
+        var diagnostics = compilation.GetEntrypointSemanticModel().GetAllDiagnostics();
+
+        // Assert — grandparent rule flows through parent and leaf.
+        diagnostics.Should().NotContain(d => d.Code == "no-unused-params");
+
+        await Task.CompletedTask;
+    }
+
+    // ── Config inheritance chain structure ────────────────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_WithInheritedConfig_ReturnsCorrectChainStructure()
+    {
+        // Arrange — leaf extends base.
+        var (compiler, fileExplorer) = CreateCompiler();
+        WriteFile(fileExplorer, "/main.bicep", "param unused string");
+        WriteFile(fileExplorer, "/bicepconfig.json", """
+        {
+          "extends": "/base/bicepconfig.base.json",
+          "experimentalFeaturesWarning": true
+        }
+        """);
+        WriteFile(fileExplorer, "/base/bicepconfig.base.json", """
+        {
+          "cacheRootDirectory": "/tmp/cache"
+        }
+        """);
+
+        var services = new ServiceCollection()
+            .AddSingleton<IFileExplorer>(fileExplorer)
+            .AddBicepCore()
+            .BuildServiceProvider();
+
+        var bicepConfigManager = services.GetRequiredService<IBicepConfigurationManager>();
+
+        // Act.
+        var chain = bicepConfigManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        var config = chain.GetEffectiveConfiguration();
+
+        // Assert — chain has 2 layers (leaf + base).
+        chain.LayerCount.Should().Be(2);
+        config.GetDiagnostics().Should().BeEmpty();
+
+        // Leaf value wins.
+        config.ExperimentalFeaturesWarning.Should().BeTrue();
+
+        // Base value inherited.
+        config.CacheRootDirectory.Should().Be("/tmp/cache");
+
+        await Task.CompletedTask;
+    }
+}

--- a/src/Bicep.Core.IntegrationTests/ConfigurationInheritanceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ConfigurationInheritanceTests.cs
@@ -218,7 +218,7 @@ public class ConfigurationInheritanceTests
         WriteFile(fileExplorer, "/main.bicep", "param unused string");
         WriteFile(fileExplorer, "/bicepconfig.json", """
         {
-          "extends": "/base/bicepconfig.base.json",
+          "extends": "./base/bicepconfig.base.json",
           "experimentalFeaturesWarning": true
         }
         """);

--- a/src/Bicep.Core.UnitTests/BicepTestConstants.cs
+++ b/src/Bicep.Core.UnitTests/BicepTestConstants.cs
@@ -149,7 +149,11 @@ namespace Bicep.Core.UnitTests
             return RootConfiguration.Bind(element, configFileIdentifier);
         }
 
-        public static ConfigurationManager CreateFilesystemConfigurationManager() => new(new FileSystemFileExplorer(new OnDiskFileSystem()));
+        public static ConfigurationManager CreateFilesystemConfigurationManager()
+        {
+            var fileExplorer = new FileSystemFileExplorer(new OnDiskFileSystem());
+            return new(fileExplorer, new BicepConfigurationManager(fileExplorer));
+        }
 
         public static IFeatureProviderFactory CreateFeatureProviderFactory(FeatureProviderOverrides featureOverrides, IConfigurationManager? configurationManager = null)
             => new OverriddenFeatureProviderFactory(new FeatureProviderFactory(configurationManager ?? CreateFilesystemConfigurationManager(), FileExplorer), featureOverrides);

--- a/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationManagerTests.cs
@@ -118,6 +118,77 @@ namespace Bicep.Core.UnitTests.Configuration
             chain.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
         }
 
+        // ── Full config merge — multiple sections ─────────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_FullConfigMerge_LeafWinsAndBaseInherited()
+        {
+            // Arrange:
+            //   Leaf sets:  cacheRootDirectory (overrides base), experimentalFeaturesWarning (overrides base),
+            //               formatting.indentSize (overrides base)
+            //   Base sets:  cacheRootDirectory (overridden by leaf), experimentalFeaturesWarning (overridden by leaf),
+            //               formatting.indentSize (overridden by leaf), formatting.width (inherited — leaf doesn't set it)
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """
+                {
+                  "extends": "./base/bicepconfig.base.json",
+                  "cacheRootDirectory": "/leaf/cache",
+                  "experimentalFeaturesWarning": true,
+                  "formatting": {
+                    "indentSize": 4
+                  }
+                }
+                """),
+                ("base/bicepconfig.base.json", """
+                {
+                  "cacheRootDirectory": "/base/cache",
+                  "experimentalFeaturesWarning": false,
+                  "formatting": {
+                    "indentSize": 8,
+                    "width": 80
+                  }
+                }
+                """));
+
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+
+            // Act — load chain once.
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            var config = chain1.GetEffectiveConfiguration();
+
+            // Assert — chain structure: leaf + base = 2 layers, no diagnostics.
+            chain1.LayerCount.Should().Be(2);
+            config.GetDiagnostics().Should().BeEmpty();
+
+            // Leaf wins on conflict.
+            config.CacheRootDirectory.Should().Be("/leaf/cache");
+            config.ExperimentalFeaturesWarning.Should().BeTrue();
+            config.Formatting.Data.IndentSize.Should().Be(4);
+
+            // Base value inherited — leaf didn't set formatting.width.
+            config.Formatting.Data.Width.Should().Be(80);
+
+            // Assert — second call returns same cached instance with same chain structure.
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            chain2.Should().BeSameAs(chain1);
+            chain2.LayerCount.Should().Be(2);
+
+            // Assert — after base file changes, chain is invalidated but structure and values are still correct.
+            sut.PurgeCacheForAffectedChains(fileSet.GetUri("base/bicepconfig.base.json"));
+            var chain3 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            chain3.Should().NotBeSameAs(chain1);
+
+            // Rebuilt chain must have same structure and correct values.
+            chain3.LayerCount.Should().Be(2);
+            var configAfterRebuild = chain3.GetEffectiveConfiguration();
+            configAfterRebuild.GetDiagnostics().Should().BeEmpty();
+            configAfterRebuild.CacheRootDirectory.Should().Be("/leaf/cache");
+            configAfterRebuild.ExperimentalFeaturesWarning.Should().BeTrue();
+            configAfterRebuild.Formatting.Data.IndentSize.Should().Be(4);
+            configAfterRebuild.Formatting.Data.Width.Should().Be(80);
+        }
+
         // ── Absolute path rejected ────────────────────────────────────────────
 
         [TestMethod]
@@ -281,6 +352,214 @@ namespace Bicep.Core.UnitTests.Configuration
 
             // Assert — different instance after purge.
             chain1.Should().NotBeSameAs(chain2);
+        }
+
+        // ── Real content change after purge ───────────────────────────────────
+
+        [TestMethod]
+        public void PurgeCacheForAffectedChains_AfterBaseFileContentChanges_PicksUpNewValues()
+        {
+            // Arrange — base starts with experimentalFeaturesWarning: false.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./base/bicepconfig.base.json" }"""),
+                ("base/bicepconfig.base.json", """{ "experimentalFeaturesWarning": false }"""));
+
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+
+            // Load chain — should reflect base value (false).
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            chain1.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeFalse();
+            chain1.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+
+            // Simulate base file being updated.
+            fileSet.AddFile("base/bicepconfig.base.json", """{ "experimentalFeaturesWarning": true }""");
+
+            // Purge the chain cache for the changed file.
+            sut.PurgeCacheForAffectedChains(fileSet.GetUri("base/bicepconfig.base.json"));
+
+            // Reload — must pick up the NEW value from the updated base file.
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            chain2.Should().NotBeSameAs(chain1);
+            chain2.LayerCount.Should().Be(2);
+            chain2.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain2.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetDependenciesForLeaf_SingleConfig_TracksSelf()
+        {
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "experimentalFeaturesWarning": true }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            var deps = sut.GetDependenciesForLeaf(fileSet.GetUri("bicepconfig.json"));
+
+            deps.Should().ContainSingle().Which.Should().Be(fileSet.GetUri("bicepconfig.json"));
+        }
+
+        [TestMethod]
+        public void GetDependenciesForLeaf_LeafExtendsBase_TracksBothFiles()
+        {
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./base/bicepconfig.base.json" }"""),
+                ("base/bicepconfig.base.json", """{ "experimentalFeaturesWarning": true }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            var deps = sut.GetDependenciesForLeaf(fileSet.GetUri("bicepconfig.json"));
+
+            deps.Should().HaveCount(2);
+            deps.Should().Contain(fileSet.GetUri("bicepconfig.json"));
+            deps.Should().Contain(fileSet.GetUri("base/bicepconfig.base.json"));
+        }
+
+        [TestMethod]
+        public void GetDependenciesForLeaf_DeepChain_TracksAllFiles()
+        {
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./b/bicepconfig.b.json" }"""),
+                ("b/bicepconfig.b.json", """{ "extends": "../c/bicepconfig.c.json" }"""),
+                ("c/bicepconfig.c.json", """{ "experimentalFeaturesWarning": true }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            var deps = sut.GetDependenciesForLeaf(fileSet.GetUri("bicepconfig.json"));
+
+            deps.Should().HaveCount(3);
+            deps.Should().Contain(fileSet.GetUri("bicepconfig.json"));
+            deps.Should().Contain(fileSet.GetUri("b/bicepconfig.b.json"));
+            deps.Should().Contain(fileSet.GetUri("c/bicepconfig.c.json"));
+        }
+
+        // ── PurgeCacheForAffectedChains ───────────────────────────────────────
+
+        [TestMethod]
+        public void PurgeCacheForAffectedChains_BaseFileChanges_InvalidatesAffectedChain()
+        {
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./base/bicepconfig.base.json" }"""),
+                ("base/bicepconfig.base.json", """{ "experimentalFeaturesWarning": true }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Verify chain1 has correct content before purge.
+            chain1.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain1.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+
+            sut.PurgeCacheForAffectedChains(fileSet.GetUri("base/bicepconfig.base.json"));
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Chain was rebuilt (different instance) but content is still correct.
+            chain1.Should().NotBeSameAs(chain2);
+            chain2.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain2.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void PurgeCacheForAffectedChains_UnrelatedFileChanges_DoesNotInvalidateChain()
+        {
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "experimentalFeaturesWarning": true }"""),
+                ("other/other.bicep", ""),
+                ("other/bicepconfig.json", """{ "experimentalFeaturesWarning": false }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Verify chain1 has correct content before purge.
+            chain1.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+
+            sut.PurgeCacheForAffectedChains(fileSet.GetUri("other/bicepconfig.json"));
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Unrelated change — chain must NOT be invalidated (same instance, same values).
+            chain1.Should().BeSameAs(chain2);
+            chain2.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain2.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void PurgeCacheForAffectedChains_LeafFileChanges_InvalidatesItsOwnChain()
+        {
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "experimentalFeaturesWarning": true }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Verify chain1 has correct content before purge.
+            chain1.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+
+            sut.PurgeCacheForAffectedChains(fileSet.GetUri("bicepconfig.json"));
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Chain was rebuilt — different instance, but correct content.
+            chain1.Should().NotBeSameAs(chain2);
+            chain2.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain2.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void PurgeCacheForAffectedChains_DeepChainBaseChanges_InvalidatesEntireChain()
+        {
+            // A extends B extends C — deepest file C changes.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./b/bicepconfig.b.json" }"""),
+                ("b/bicepconfig.b.json", """{ "extends": "../c/bicepconfig.c.json" }"""),
+                ("c/bicepconfig.c.json", """{ "experimentalFeaturesWarning": true }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            var chain1 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Verify chain1 has correct content — value inherited from deepest C.
+            chain1.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+
+            sut.PurgeCacheForAffectedChains(fileSet.GetUri("c/bicepconfig.c.json"));
+            var chain2 = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+
+            // Chain was rebuilt — value from C still flows through correctly.
+            chain1.Should().NotBeSameAs(chain2);
+            chain2.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chain2.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void PurgeCacheForAffectedChains_SharedBase_InvalidatesOnlyAffectedLeaf()
+        {
+            // main extends shared; other does not — only main's chain should be purged.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./shared/bicepconfig.shared.json" }"""),
+                ("other/other.bicep", ""),
+                ("other/bicepconfig.json", """{ "experimentalFeaturesWarning": false }"""),
+                ("shared/bicepconfig.shared.json", """{ "experimentalFeaturesWarning": true }"""));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+            var chainMain = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            var chainOther = sut.GetConfigurationChain(fileSet.GetUri("other/other.bicep"));
+
+            // Verify initial content.
+            chainMain.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();   // from shared
+            chainOther.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeFalse(); // its own value
+
+            sut.PurgeCacheForAffectedChains(fileSet.GetUri("shared/bicepconfig.shared.json"));
+            var chainMainAfter = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            var chainOtherAfter = sut.GetConfigurationChain(fileSet.GetUri("other/other.bicep"));
+
+            // main's chain was rebuilt — different instance, correct content.
+            chainMain.Should().NotBeSameAs(chainMainAfter);
+            chainMainAfter.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeTrue();
+            chainMainAfter.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+
+            // other's chain was untouched — same instance, correct content.
+            chainOther.Should().BeSameAs(chainOtherAfter);
+            chainOtherAfter.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeFalse();
+            chainOtherAfter.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
         }
     }
 }

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -334,7 +334,7 @@ namespace Bicep.Core.UnitTests.Configuration
         {
             // Arrange.
             var fileExplorer = new InMemoryFileExplorer();
-            var sut = new ConfigurationManager(fileExplorer);
+            var sut = new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer));
             var sourceFileUri = TestFileUri.FromInMemoryPath("path/to/nonexistent/main.bicep");
 
             // Act.
@@ -349,7 +349,7 @@ namespace Bicep.Core.UnitTests.Configuration
         {
             // Arrange.
             var fileSet = InMemoryTestFileSet.Create(("bicepconfig.json", ""));
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
             // Act & Assert.
             var diagnostics = sut.GetConfiguration(fileSet.GetUri("main.bicep")).Diagnostics;
@@ -373,7 +373,7 @@ namespace Bicep.Core.UnitTests.Configuration
             });
 
             var fileSet = new MockFileSystemTestFileSet(fileSystem);
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
             // Act & Assert.
             var diagnostics = sut.GetConfiguration(mainFileUri).Diagnostics;
@@ -520,7 +520,7 @@ namespace Bicep.Core.UnitTests.Configuration
             fileSystemMock.Setup(x => x.File.Exists(It.IsAny<string>())).Throws(new IOException("Oops."));
 
             var fileExplorer = new FileSystemFileExplorer(fileSystemMock.Object);
-            var sut = new ConfigurationManager(fileExplorer);
+            var sut = new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer));
             var configuration = sut.GetConfiguration(new IOUri(IOUriScheme.File, "", "/foo/bar/main.bicep"));
 
             // Act & Assert.
@@ -591,7 +591,7 @@ namespace Bicep.Core.UnitTests.Configuration
         {
             // Arrange.
             var fileSet = InMemoryTestFileSet.Create(("bicepconfig.json", configurationContents));
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
             // Act & Assert.
             var diagnostics = sut.GetConfiguration(fileSet.GetUri("main.bicep")).Diagnostics;
@@ -653,7 +653,7 @@ namespace Bicep.Core.UnitTests.Configuration
         {
             // Arrange.
             var fileSet = InMemoryTestFileSet.Create(("bicepconfig.json", configurationContents));
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
 
             // Act.
@@ -742,7 +742,7 @@ namespace Bicep.Core.UnitTests.Configuration
                       }
                     }
                     """));
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
             // Act.
             var configuration = sut.GetConfiguration(fileSet.GetUri("modules/vnet.bicep"));
@@ -888,7 +888,7 @@ namespace Bicep.Core.UnitTests.Configuration
                     }
                     """));
 
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
             // Act.
             var configuration = sut.GetConfiguration(fileSet.GetUri("repo/modules/bicepconfig.json"));
@@ -916,7 +916,7 @@ namespace Bicep.Core.UnitTests.Configuration
                   }
                 }
                 """));
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
             // Act.
             var configuration = sut.GetConfiguration(fileSet.GetUri("main.bicep"));
@@ -949,7 +949,7 @@ namespace Bicep.Core.UnitTests.Configuration
                   }
                 }
                 """));
-            var sut = new ConfigurationManager(fileSet.FileExplorer);
+            var sut = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
 
             // Act.
             var configuration = sut.GetConfiguration(fileSet.GetUri("main.bicep"));

--- a/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ProviderConfigurationTests.cs
@@ -76,7 +76,7 @@ public class ExtensionsConfigurationTests
             }
             """));
 
-        var configManager = new ConfigurationManager(fileSet.FileExplorer);
+        var configManager = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
         var config = configManager.GetConfiguration(fileSet.GetUri("main.bicep"));
 
         config.Diagnostics.Should().BeEmpty();

--- a/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/Features/FeatureProviderTests.cs
@@ -29,7 +29,7 @@ public class FeatureProviderTests
             }
             """));
 
-        var configManager = new ConfigurationManager(fileSet.FileExplorer);
+        var configManager = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
         var configuration = configManager.GetConfiguration(fileSet.GetUri("repo/main.bicep"));
         var fpm = new FeatureProviderFactory(configManager, fileSet.FileExplorer);
 
@@ -55,7 +55,7 @@ public class FeatureProviderTests
                 }
                 """));
 
-        var configManager = new ConfigurationManager(fileSet.FileExplorer);
+        var configManager = new ConfigurationManager(fileSet.FileExplorer, new BicepConfigurationManager(fileSet.FileExplorer));
         var configuration = configManager.GetConfiguration(fileSet.GetUri("repo/main.bicep"));
         var fpm = new FeatureProviderFactory(configManager, fileSet.FileExplorer);
 

--- a/src/Bicep.Core.UnitTests/Registry/Catalog/PrivateAcrModuleMetadataProviderTests.cs
+++ b/src/Bicep.Core.UnitTests/Registry/Catalog/PrivateAcrModuleMetadataProviderTests.cs
@@ -269,7 +269,7 @@ namespace Bicep.Core.UnitTests.Registry.Catalog
                 .WithContainerRegistryClientFactory(clientFactory);
 
             var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var configurationManager = new ConfigurationManager(fileExplorer);
+            var configurationManager = new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer));
             var featureProviderFactory = new OverriddenFeatureProviderFactory(new FeatureProviderFactory(configurationManager, fileExplorer), BicepTestConstants.FeatureOverrides);
 
             await RegistryHelper.PublishExtensionToRegistryAsync(services.Build(), "br:registry.contoso.io/test/repo1:v1", new BinaryData(""));
@@ -306,7 +306,7 @@ namespace Bicep.Core.UnitTests.Registry.Catalog
                 .WithContainerRegistryClientFactory(clientFactory);
 
             var fileExplorer = new FileSystemFileExplorer(fileSystem);
-            var configurationManager = new ConfigurationManager(fileExplorer);
+            var configurationManager = new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer));
             var featureProviderFactory = new OverriddenFeatureProviderFactory(new FeatureProviderFactory(configurationManager, fileExplorer), BicepTestConstants.FeatureOverrides);
 
             // Only v2 is a module

--- a/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/RegistryHelper.cs
@@ -147,7 +147,7 @@ public static class RegistryHelper
         ModuleToPublish module)
     {
         var fileExplorer = new FileSystemFileExplorer(fileSystem);
-        var configurationManager = new ConfigurationManager(fileExplorer);
+        var configurationManager = new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer));
         var featureProviderFactory = new OverriddenFeatureProviderFactory(new FeatureProviderFactory(configurationManager, fileExplorer), BicepTestConstants.FeatureOverrides);
 
         serviceBuilder = ConfigureServiceBuilder(serviceBuilder)

--- a/src/Bicep.Core/BicepCoreServiceCollectionExtensions.cs
+++ b/src/Bicep.Core/BicepCoreServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ public static class BicepCoreServiceCollectionExtensions
         services.TryAddSingleton<IFileSystem, LocalFileSystem>();
         services.TryAddSingleton<IFileExplorer, FileSystemFileExplorer>();
         services.TryAddSingleton<IAuxiliaryFileCache, AuxiliaryFileCache>();
+        services.TryAddSingleton<IBicepConfigurationManager, BicepConfigurationManager>();
         services.TryAddSingleton<IConfigurationManager, ConfigurationManager>();
         services.TryAddSingleton<IBicepAnalyzer, LinterAnalyzer>();
         services.TryAddSingleton<IFeatureProviderFactory, FeatureProviderFactory>();

--- a/src/Bicep.Core/Configuration/BicepConfigurationAdapter.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationAdapter.cs
@@ -22,6 +22,8 @@ internal sealed class BicepConfigurationAdapter : IBicepConfiguration
         this.inner = inner;
     }
 
+    internal RootConfiguration InnerConfiguration => this.inner;
+
     public IBicepCloudConfiguration Cloud => this.inner.Cloud;
 
     public IBicepModuleAliasesConfiguration ModuleAliases => this.inner.ModuleAliases;

--- a/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
@@ -20,6 +20,7 @@ public class BicepConfigurationManager : IBicepConfigurationManager
     private readonly ConcurrentDictionary<IOUri, IDirectoryHandle> directoryHandleCache = new();
     private readonly ConcurrentDictionary<IDirectoryHandle, ResultWithDiagnostic<IFileHandle?>> configFileLookupCache = new();
     private readonly ConcurrentDictionary<IFileHandle, ResultWithDiagnostic<IBicepConfigurationChain>> chainCache = new();
+    private readonly ConcurrentDictionary<IFileHandle, ImmutableHashSet<IOUri>> chainDependencies = new();
     private readonly IFileExplorer fileExplorer;
 
     public BicepConfigurationManager(IFileExplorer fileExplorer)
@@ -60,9 +61,53 @@ public class BicepConfigurationManager : IBicepConfigurationManager
     {
         PurgeLookupCache();
         this.chainCache.Clear();
+        this.chainDependencies.Clear();
     }
 
     public void PurgeLookupCache() => this.configFileLookupCache.Clear();
+
+    public void PurgeChainCache()
+    {
+        this.chainCache.Clear();
+        this.chainDependencies.Clear();
+    }
+
+    public void PurgeCacheForAffectedChains(IOUri changedFileUri)
+    {
+        foreach (var (leafHandle, deps) in this.chainDependencies)
+        {
+            if (deps.Contains(changedFileUri))
+            {
+                this.chainCache.TryRemove(leafHandle, out _);
+                this.chainDependencies.TryRemove(leafHandle, out _);
+                // Lookup cache must also be cleared so the next GetConfigurationChain
+                // re-resolves the leaf file from its source directory.
+                this.configFileLookupCache.Clear();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the set of config file URIs that the chain rooted at <paramref name="leafUri"/> depends on.
+    /// Exposed internally for testing.
+    /// </summary>
+    internal ImmutableHashSet<IOUri> GetDependenciesForLeaf(IOUri leafUri)
+    {
+        var leafHandle = this.fileExplorer.GetFile(leafUri);
+        return this.chainDependencies.TryGetValue(leafHandle, out var deps) ? deps : [];
+    }
+
+    public RootConfiguration GetMergedConfiguration(IOUri sourceFileUri)
+    {
+        var chain = GetConfigurationChain(sourceFileUri);
+
+        if (chain.GetEffectiveConfiguration() is BicepConfigurationAdapter adapter)
+        {
+            return adapter.InnerConfiguration;
+        }
+
+        return IConfigurationManager.GetBuiltInConfiguration();
+    }
 
     public void RemoveChainCacheEntry(IOUri configFileUri)
     {
@@ -154,6 +199,11 @@ public class BicepConfigurationManager : IBicepConfigurationManager
 
             currentFileHandle = nextFileHandle;
         }
+
+        // Record all config files this chain depends on for targeted cache invalidation.
+        this.chainDependencies[leafFileHandle] = rawLayers
+            .Select(layer => layer.FileHandle.Uri)
+            .ToImmutableHashSet();
 
         return new(BuildChain(leafUri, rawLayers));
     }

--- a/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
@@ -57,6 +57,14 @@ public class BicepConfigurationManager : IBicepConfigurationManager
         return chain;
     }
 
+    public void PurgeAllCaches()
+    {
+        this.directoryHandleCache.Clear();
+        this.configFileLookupCache.Clear();
+        this.chainCache.Clear();
+        this.chainDependencies.Clear();
+    }
+
     public void PurgeCache()
     {
         PurgeLookupCache();

--- a/src/Bicep.Core/Configuration/ConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/ConfigurationManager.cs
@@ -29,10 +29,10 @@ namespace Bicep.Core.Configuration
         public void PurgeCache()
         {
             loadedConfigCache.Clear();
-            this.bicepConfigurationManager.PurgeChainCache();
+            this.bicepConfigurationManager.PurgeAllCaches();
         }
 
-        public void PurgeLookupCache() => this.bicepConfigurationManager.PurgeChainCache();
+        public void PurgeLookupCache() => this.bicepConfigurationManager.PurgeAllCaches();
 
         public (RootConfiguration prevConfiguration, RootConfiguration newConfiguration)? RefreshConfigCacheEntry(IOUri configFileIdentifier)
         {

--- a/src/Bicep.Core/Configuration/ConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/ConfigurationManager.cs
@@ -2,15 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
-using System.Collections.Immutable;
-using System.IO.Abstractions;
-using System.Security;
-using System.ServiceModel;
 using System.Text.Json;
 using Bicep.Core.Diagnostics;
 using Bicep.Core.Extensions;
 using Bicep.Core.Json;
-using Bicep.Core.TypeSystem;
 using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Configuration
@@ -18,54 +13,26 @@ namespace Bicep.Core.Configuration
     public class ConfigurationManager : IConfigurationManager
     {
         private readonly static DiagnosticBuilder.DiagnosticBuilderInternal ConfigDiagnosticBuilder = DiagnosticBuilder.ForDocumentStart();
-        private readonly ConcurrentDictionary<IOUri, IDirectoryHandle> directoryHandleCache = new();
-        private readonly ConcurrentDictionary<IDirectoryHandle, ResultWithDiagnostic<IFileHandle?>> configFileLookupCache = new(); // Source file directory handle -> config file handle.
-        private readonly ConcurrentDictionary<IFileHandle, ResultWithDiagnostic<RootConfiguration>> loadedConfigCache = new();     // Config file handle -> RootConfiguration.
+        private readonly ConcurrentDictionary<IFileHandle, ResultWithDiagnostic<RootConfiguration>> loadedConfigCache = new();
         private readonly IFileExplorer fileExplorer;
+        private readonly IBicepConfigurationManager bicepConfigurationManager;
 
-        public ConfigurationManager(IFileExplorer fileExplorer)
+        public ConfigurationManager(IFileExplorer fileExplorer, IBicepConfigurationManager bicepConfigurationManager)
         {
             this.fileExplorer = fileExplorer;
+            this.bicepConfigurationManager = bicepConfigurationManager;
         }
 
         public RootConfiguration GetConfiguration(IOUri sourceFileUri)
-        {
-            if (!sourceFileUri.IsFile)
-            {
-                return GetDefaultConfiguration();
-            }
-
-            // GetParent() is computationally expensive, and this gets called a lot during linting,
-            // so let's cache the result.
-            var sourceDirectory = directoryHandleCache.GetOrAdd(
-                sourceFileUri,
-                uri => this.fileExplorer.GetFile(uri).GetParent());
-
-            if (!configFileLookupCache.GetOrAdd(sourceDirectory, LookupConfigurationFile).IsSuccess(out var configFileHandle, out var lookupDiagnostic))
-            {
-                return GetDefaultConfiguration().With(diagnostics: [lookupDiagnostic]);
-            }
-
-            if (configFileHandle is null)
-            {
-                return GetDefaultConfiguration();
-            }
-
-            if (!loadedConfigCache.GetOrAdd(configFileHandle, LoadConfiguration).IsSuccess(out var configuration, out var loadDiagnostic))
-            {
-                return GetDefaultConfiguration().With(diagnostics: [loadDiagnostic]);
-            }
-
-            return configuration;
-        }
+            => this.bicepConfigurationManager.GetMergedConfiguration(sourceFileUri);
 
         public void PurgeCache()
         {
-            PurgeLookupCache();
             loadedConfigCache.Clear();
+            this.bicepConfigurationManager.PurgeChainCache();
         }
 
-        public void PurgeLookupCache() => configFileLookupCache.Clear();
+        public void PurgeLookupCache() => this.bicepConfigurationManager.PurgeChainCache();
 
         public (RootConfiguration prevConfiguration, RootConfiguration newConfiguration)? RefreshConfigCacheEntry(IOUri configFileIdentifier)
         {
@@ -81,20 +48,20 @@ namespace Bicep.Core.Configuration
                 return reloaded;
             });
 
+            // Targeted invalidation: only chains that include this file are stale.
+            this.bicepConfigurationManager.PurgeCacheForAffectedChains(configFileIdentifier);
+
             return returnVal;
         }
 
         public void RemoveConfigCacheEntry(IOUri configFileUri)
         {
             var configFileHandle = this.fileExplorer.GetFile(configFileUri);
-            if (loadedConfigCache.TryRemove(configFileHandle, out _))
-            {
-                // If a config file has been removed from a workspace, the lookup cache is no longer valid.
-                PurgeLookupCache();
-            }
-        }
+            loadedConfigCache.TryRemove(configFileHandle, out _);
 
-        private static RootConfiguration GetDefaultConfiguration() => IConfigurationManager.GetBuiltInConfiguration();
+            // Targeted invalidation: only chains that include this file are stale.
+            this.bicepConfigurationManager.PurgeCacheForAffectedChains(configFileUri);
+        }
 
         private static ResultWithDiagnostic<RootConfiguration> LoadConfiguration(IFileHandle configFileHandle)
         {
@@ -117,30 +84,6 @@ namespace Bicep.Core.Configuration
             {
                 return new(ConfigDiagnosticBuilder.UnloadableBicepConfigFile(configFileHandle.Uri, exception.Message));
             }
-        }
-
-        private ResultWithDiagnostic<IFileHandle?> LookupConfigurationFile(IDirectoryHandle? directoryToLookup)
-        {
-            try
-            {
-                while (directoryToLookup is not null)
-                {
-                    var configFileHandle = directoryToLookup.GetFile(LanguageConstants.BicepConfigurationFileName);
-
-                    if (configFileHandle.Exists())
-                    {
-                        return new(configFileHandle);
-                    }
-
-                    directoryToLookup = directoryToLookup.GetParent();
-                }
-            }
-            catch (IOException exception)
-            {
-                return new(ConfigDiagnosticBuilder.PotentialConfigDirectoryCouldNotBeScanned(directoryToLookup?.Uri, exception.Message));
-            }
-
-            return new((IFileHandle?)null);
         }
     }
 }

--- a/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Bicep.Core.Diagnostics;
+
 namespace Bicep.Core.Configuration;
 
 /// <summary>
@@ -14,4 +16,9 @@ public interface IBicepConfigurationChain
     /// with leaf settings winning over base settings.
     /// </summary>
     IBicepConfiguration GetEffectiveConfiguration();
+
+    /// <summary>
+    /// The number of configuration files in the chain.
+    /// </summary>
+    int LayerCount { get; }
 }

--- a/src/Bicep.Core/Configuration/IBicepConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfigurationManager.cs
@@ -19,4 +19,23 @@ public interface IBicepConfigurationManager
     /// Falls back to the built-in configuration if no bicepconfig.json is found.
     /// </summary>
     IBicepConfigurationChain GetConfigurationChain(IOUri sourceFileUri);
+
+    /// <summary>
+    /// Returns the fully merged <see cref="RootConfiguration"/> for the given source file.
+    /// Equivalent to walking the "extends" chain and returning the effective merged result.
+    /// This allows <see cref="IConfigurationManager"/> to delegate to this manager
+    /// without changing the return type expected by existing consumers.
+    /// </summary>
+    RootConfiguration GetMergedConfiguration(IOUri sourceFileUri);
+
+    /// <summary>
+    /// Invalidates only the chains that include <paramref name="changedFileUri"/> as a dependency.
+    /// </summary>
+    void PurgeCacheForAffectedChains(IOUri changedFileUri);
+
+    /// <summary>
+    /// Purges the chain cache. Call this when any config file in the workspace changes
+    /// so stale chains are not reused.
+    /// </summary>
+    void PurgeChainCache();
 }

--- a/src/Bicep.Core/Configuration/IBicepConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfigurationManager.cs
@@ -34,6 +34,13 @@ public interface IBicepConfigurationManager
     void PurgeCacheForAffectedChains(IOUri changedFileUri);
 
     /// <summary>
+    /// Purges all internal caches: chain cache, dependency map, config file lookup cache,
+    /// and directory handle cache. Use when a config file is created or deleted so that
+    /// discovery re-runs from scratch on the next request.
+    /// </summary>
+    void PurgeAllCaches();
+
+    /// <summary>
     /// Purges the chain cache. Call this when any config file in the workspace changes
     /// so stale chains are not reused.
     /// </summary>

--- a/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
@@ -248,7 +248,7 @@ namespace Bicep.LangServer.UnitTests.Configuration
 
             var workspace = new ActiveSourceFileSet();
             var fileExplorer = new FileSystemFileExplorer(mockFileSystem);
-            var configurationManager = new ConfigurationManager(fileExplorer);
+            var configurationManager = new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer));
             var sourceFileFactory = new SourceFileFactory(configurationManager, BicepTestConstants.FeatureProviderFactory, BicepTestConstants.AuxiliaryFileCache, BicepTestConstants.FileExplorer);
             var bicepCompilationManager = new BicepCompilationManager(
                 server,

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepExternalSourceDocumentLinkHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepExternalSourceDocumentLinkHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Bicep.LangServer.UnitTests.Handlers
             this.MockFileSystem = new();
 
             var mockFileExplorer = new FileSystemFileExplorer(this.MockFileSystem);
-            var mockConfigurationManager = new ConfigurationManager(mockFileExplorer);
+            var mockConfigurationManager = new ConfigurationManager(mockFileExplorer, new BicepConfigurationManager(mockFileExplorer));
             var featureProviderFactory = new FeatureProviderFactory(mockConfigurationManager, mockFileExplorer);
 
             this.CacheRootDirectory = featureProviderFactory.GetFeatureProvider(new IOUri("file", "", "/dummy.bicep")).CacheRootDirectory;

--- a/src/Bicep.LangServer.UnitTests/Handlers/BicepTextDocumentSyncHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Handlers/BicepTextDocumentSyncHandlerTests.cs
@@ -194,7 +194,7 @@ public class BicepTextDocumentSyncHandlerTests
 
         var compilationManager = BicepCompilationManagerHelper.CreateCompilationManager(bicepConfigUri, prevBicepConfigFileContents);
         var fileExplorer = new FileSystemFileExplorer(fileSystem);
-        var bicepConfigLifecycleManager = new BicepConfigLifecycleManager(compilationManager, new ConfigurationManager(fileExplorer), linterRulesProvider, telemetryProvider.Object, new ActiveSourceFileSet());
+        var bicepConfigLifecycleManager = new BicepConfigLifecycleManager(compilationManager, new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer)), linterRulesProvider, telemetryProvider.Object, new ActiveSourceFileSet());
 
         var bicepTextDocumentSyncHandler = new BicepTextDocumentSyncHandler(compilationManager, bicepConfigLifecycleManager, new DocumentSelectorFactory(BicepLangServerOptions.Default));
 

--- a/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
+++ b/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
@@ -45,10 +45,13 @@ namespace Bicep.LanguageServer.BicepConfig
 
         public void HandleBicepConfigChangeEvent(DocumentUri documentUri)
         {
+            // A change event can represent file creation, modification, or deletion.
+            // Creation and deletion change config file discovery (the lookup cache), so we
+            // must do a full purge rather than a targeted invalidation.
+            // For modification, RefreshConfigCacheEntry is also called so the loaded config
+            // cache stays warm and telemetry can compare prev vs new on the next save.
+            configurationManager.PurgeCache();
             HandleBicepConfigOpenOrChangeEvent(documentUri);
-            // The change may have rendered a config file invalid, or the event itself may have represented a file creation or deletion.
-            // In either case, the lookup cache would be stale.
-            configurationManager.PurgeLookupCache();
         }
 
         private void HandleBicepConfigOpenOrChangeEvent(DocumentUri documentUri)


### PR DESCRIPTION

## Description

1. ConfigurationManager -> thin wrapper
`GetConfiguration()` now delegates to `BicepConfigurationManager.GetMergedConfiguration()` in one line. All 20+ call sites across the compiler get inheritance automatically with no changes at the call sites.

2. Targeted cache invalidation
Tracks which config files each chain depends on. When a file changes, only chains that include that file are evicted -- unrelated chains stay cached. `ConfigurationManager.RefreshConfigCacheEntry` and `RemoveConfigCacheEntry` (called by `BicepConfigLifecycleManager` on file save/delete)  use targeted invalidation instead of a full purge.

3. `IBicepConfigurationManager` registered via `TryAddSingleton` in `BicepCoreServiceCollectionExtensions`.




## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20196)