### PR TITLE
add 'extends' schema support and surface config chain diagnostics in VSCode

### DIFF
--- a/src/Bicep.Core/Configuration/BicepConfigurationChain.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationChain.cs
@@ -74,7 +74,7 @@ public class BicepConfigurationChain : IBicepConfigurationChain
     /// Returns diagnostics grouped by the config file URI they originated from.
     /// Built-in default layers (no <see cref="IBicepConfiguration.ConfigFileUri"/>) are excluded.
     /// </summary>
-    public DiagnosticsPerFile GetDiagnosticsByConfigFile()
+    public DiagnosticsPerFile EnumerateDiagnosticsPerFile()
         => this.layers
             .Where(layer => !layer.IsBuiltIn)
             .Select(layer => new KeyValuePair<IOUri, ImmutableArray<IDiagnostic>>(

--- a/src/Bicep.Core/Configuration/BicepConfigurationChain.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationChain.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Bicep.Core.Diagnostics;
+using Bicep.IO.Abstraction;
 
 namespace Bicep.Core.Configuration;
 
@@ -68,6 +69,17 @@ public class BicepConfigurationChain : IBicepConfigurationChain
 
         return this.aggregatedDiagnostics.Value;
     }
+
+    /// <summary>
+    /// Returns diagnostics grouped by the config file URI they originated from.
+    /// Built-in default layers (no <see cref="IBicepConfiguration.ConfigFileUri"/>) are excluded.
+    /// </summary>
+    public DiagnosticsPerFile GetDiagnosticsByConfigFile()
+        => this.layers
+            .Where(layer => !layer.IsBuiltIn)
+            .Select(layer => new KeyValuePair<IOUri, ImmutableArray<IDiagnostic>>(
+                layer.ConfigFileUri!,
+                layer.GetDiagnostics().ToImmutableArray()));
 
     /// <summary>
     /// The number of configuration files in the chain, including the built-in defaults.

--- a/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
@@ -21,7 +21,7 @@ public interface IBicepConfigurationChain
     /// Returns diagnostics grouped by the config file URI they originated from.
     /// Only user-defined config files are included (built-in defaults are excluded).
     /// </summary>
-    DiagnosticsPerFile GetDiagnosticsByConfigFile();
+    DiagnosticsPerFile EnumerateDiagnosticsPerFile();
 
     /// <summary>
     /// The number of configuration files in the chain.

--- a/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfigurationChain.cs
@@ -18,6 +18,12 @@ public interface IBicepConfigurationChain
     IBicepConfiguration GetEffectiveConfiguration();
 
     /// <summary>
+    /// Returns diagnostics grouped by the config file URI they originated from.
+    /// Only user-defined config files are included (built-in defaults are excluded).
+    /// </summary>
+    DiagnosticsPerFile GetDiagnosticsByConfigFile();
+
+    /// <summary>
     /// The number of configuration files in the chain.
     /// </summary>
     int LayerCount { get; }

--- a/src/Bicep.Core/Diagnostics/GlobalUsings.cs
+++ b/src/Bicep.Core/Diagnostics/GlobalUsings.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+global using DiagnosticsPerFile =
+    System.Collections.Generic.IEnumerable<
+        System.Collections.Generic.KeyValuePair<
+            Bicep.IO.Abstraction.IOUri,
+            System.Collections.Immutable.ImmutableArray<Bicep.Core.Diagnostics.IDiagnostic>>>;

--- a/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
@@ -246,7 +246,8 @@ namespace Bicep.LangServer.UnitTests.Configuration
 
             var workspace = new ActiveSourceFileSet();
             var fileExplorer = new FileSystemFileExplorer(mockFileSystem);
-            var configurationManager = new ConfigurationManager(fileExplorer, new BicepConfigurationManager(fileExplorer));
+            var bicepConfigManager = new BicepConfigurationManager(fileExplorer);
+            var configurationManager = new ConfigurationManager(fileExplorer, bicepConfigManager);
             var sourceFileFactory = new SourceFileFactory(configurationManager, BicepTestConstants.FeatureProviderFactory, BicepTestConstants.AuxiliaryFileCache, BicepTestConstants.FileExplorer);
             var bicepCompilationManager = new BicepCompilationManager(
                 server,
@@ -259,7 +260,9 @@ namespace Bicep.LangServer.UnitTests.Configuration
 
             var bicepConfigLifecycleManager = new BicepConfigLifecycleManager(
                 bicepCompilationManager,
-                configurationManager);
+                configurationManager,
+                bicepConfigManager,
+                server);
 
             bicepConfigLifecycleManager.RefreshCompilationOfSourceFilesInWorkspace();
 

--- a/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Configuration/BicepConfigChangeHandlerTests.cs
@@ -195,6 +195,42 @@ namespace Bicep.LangServer.UnitTests.Configuration
         }
 
         [TestMethod]
+        public void HandleBicepConfigOpenEvent_WithCyclicExtends_PublishesBCP454ToConfigFileUri()
+        {
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.AddFile("/a/bicepconfig.json", """{ "extends": "./b/bicepconfig.json" }""");
+            mockFileSystem.AddFile("/a/b/bicepconfig.json", """{ "extends": "../bicepconfig.json" }""");
+
+            PublishDiagnosticsParams? receivedParams = null;
+            var document = BicepCompilationManagerHelper.CreateMockDocument(p => receivedParams = p);
+            ILanguageServerFacade server = BicepCompilationManagerHelper.CreateMockServer(document).Object;
+
+            var fileExplorer = new FileSystemFileExplorer(mockFileSystem);
+            var bicepConfigManager = new BicepConfigurationManager(fileExplorer);
+            var configurationManager = new ConfigurationManager(fileExplorer, bicepConfigManager);
+            var workspace = new ActiveSourceFileSet();
+            var bicepCompilationManager = new BicepCompilationManager(
+                server,
+                BicepCompilationManagerHelper.CreateEmptyCompilationProvider(configurationManager),
+                workspace,
+                BicepCompilationManagerHelper.CreateMockScheduler().Object,
+                new SourceFileFactory(configurationManager, BicepTestConstants.FeatureProviderFactory, BicepTestConstants.AuxiliaryFileCache, BicepTestConstants.FileExplorer),
+                BicepTestConstants.AuxiliaryFileCache);
+
+            var lifecycleManager = new BicepConfigLifecycleManager(
+                bicepCompilationManager,
+                configurationManager,
+                bicepConfigManager,
+                server);
+
+            var configUri = DocumentUri.From(InMemoryFileResolver.GetFileUri("/a/bicepconfig.json"));
+            lifecycleManager.HandleBicepConfigOpenEvent(configUri);
+
+            receivedParams.Should().NotBeNull();
+            receivedParams!.Diagnostics.Should().ContainSingle(d => d.Code!.Value.String == "BCP454");
+        }
+
+        [TestMethod]
         public void RefreshCompilationOfSourceFilesInWorkspace_WithoutBicepConfigFile_ShouldUseDefaultConfigAndRefreshCompilation()
         {
             var bicepFileContents = "param storageAccountName string = 'testAccount'";

--- a/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
+++ b/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
@@ -77,38 +77,22 @@ namespace Bicep.LanguageServer.BicepConfig
         private void PublishConfigDiagnostics(DocumentUri documentUri)
         {
             var chain = bicepConfigurationManager.GetConfigurationChain(documentUri.ToIOUri());
-            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics().ToList();
+            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics();
 
-            if (diagnostics.Count == 0)
+            var lspDiagnostics = diagnostics.Select(d => new LspDiagnostic
             {
-                // Clear any stale squiggles on the active file.
-                server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
-                {
-                    Uri = documentUri,
-                    Diagnostics = new Container<LspDiagnostic>()
-                });
-                return;
-            }
+                Severity = ToLspSeverity(d.Level),
+                Code = new DiagnosticCode(d.Code),
+                Message = d.Message,
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
+                Source = "bicep"
+            });
 
-            // Group by IDiagnostic.Uri so each bicepconfig.json in the chain gets its own
-            // PublishDiagnostics call — squiggles appear on the specific file that has the
-            // error, not always on the leaf.
-            // Diagnostics without a URI fall back to the active documentUri.
-            foreach (var group in diagnostics.GroupBy(d => d.Uri is { } u ? DocumentUri.From(u) : documentUri))
+            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
             {
-                server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
-                {
-                    Uri = group.Key,
-                    Diagnostics = new Container<LspDiagnostic>(group.Select(d => new LspDiagnostic
-                    {
-                        Severity = ToLspSeverity(d.Level),
-                        Code = new DiagnosticCode(d.Code),
-                        Message = d.Message,
-                        Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
-                        Source = "bicep"
-                    }))
-                });
-            }
+                Uri = documentUri,
+                Diagnostics = new Container<LspDiagnostic>(lspDiagnostics)
+            });
         }
 
         private static DiagnosticSeverity ToLspSeverity(DiagnosticLevel level) => level switch

--- a/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
+++ b/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
@@ -2,8 +2,14 @@
 // Licensed under the MIT License.
 
 using Bicep.Core.Configuration;
+using Bicep.Core.Diagnostics;
 using Bicep.LanguageServer.Compilation;
+using Bicep.LanguageServer.Extensions;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
 
 namespace Bicep.LanguageServer.BicepConfig
 {
@@ -11,12 +17,18 @@ namespace Bicep.LanguageServer.BicepConfig
     {
         private readonly ICompilationManager compilationManager;
         private readonly ConfigurationManager configurationManager;
+        private readonly IBicepConfigurationManager bicepConfigurationManager;
+        private readonly ILanguageServerFacade server;
 
         public BicepConfigLifecycleManager(ICompilationManager compilationManager,
-                           ConfigurationManager configurationManager)
+                           ConfigurationManager configurationManager,
+                           IBicepConfigurationManager bicepConfigurationManager,
+                           ILanguageServerFacade server)
         {
             this.compilationManager = compilationManager;
             this.configurationManager = configurationManager;
+            this.bicepConfigurationManager = bicepConfigurationManager;
+            this.server = server;
         }
 
         public void RefreshCompilationOfSourceFilesInWorkspace()
@@ -29,6 +41,7 @@ namespace Bicep.LanguageServer.BicepConfig
         public void HandleBicepConfigOpenEvent(DocumentUri documentUri)
         {
             HandleBicepConfigOpenOrChangeEvent(documentUri);
+            PublishConfigDiagnostics(documentUri);
         }
 
         public void HandleBicepConfigChangeEvent(DocumentUri documentUri)
@@ -38,15 +51,178 @@ namespace Bicep.LanguageServer.BicepConfig
             // must do a full purge rather than a targeted invalidation.
             configurationManager.PurgeCache();
             HandleBicepConfigOpenOrChangeEvent(documentUri);
+            PublishConfigDiagnostics(documentUri);
         }
 
         private void HandleBicepConfigOpenOrChangeEvent(DocumentUri documentUri)
             => configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri());
 
         public void HandleBicepConfigSaveEvent(DocumentUri documentUri)
-            => configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri());
+        {
+            configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri());
+            PublishConfigDiagnostics(documentUri);
+        }
 
         public void HandleBicepConfigCloseEvent(DocumentUri documentUri)
-            => configurationManager.RemoveConfigCacheEntry(documentUri.ToIOUri());
+        {
+            configurationManager.RemoveConfigCacheEntry(documentUri.ToIOUri());
+
+            // Clear squiggles when the file is closed.
+            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            {
+                Uri = documentUri,
+                Diagnostics = new Container<LspDiagnostic>()
+            });
+        }
+
+        private void PublishConfigDiagnostics(DocumentUri documentUri)
+        {
+            var chain = bicepConfigurationManager.GetConfigurationChain(documentUri.ToIOUri());
+            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics();
+
+            var lspDiagnostics = diagnostics.Select(d => new LspDiagnostic
+            {
+                Severity = ToLspSeverity(d.Level),
+                Code = new DiagnosticCode(d.Code),
+                Message = d.Message,
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
+                Source = "bicep"
+            });
+
+            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            {
+                Uri = documentUri,
+                Diagnostics = new Container<LspDiagnostic>(lspDiagnostics)
+            });
+        }
+
+        private static DiagnosticSeverity ToLspSeverity(DiagnosticLevel level) => level switch
+        {
+            DiagnosticLevel.Error => DiagnosticSeverity.Error,
+            DiagnosticLevel.Warning => DiagnosticSeverity.Warning,
+            DiagnosticLevel.Info => DiagnosticSeverity.Information,
+            _ => DiagnosticSeverity.Hint
+        };
+    }
+}
+
+namespace Bicep.LanguageServer.BicepConfig
+{
+    public class BicepConfigLifecycleManager : IBicepConfigLifecycleManager
+    {
+        private readonly ICompilationManager compilationManager;
+        private readonly ConfigurationManager configurationManager;
+<<<<<<< HEAD
+
+        public BicepConfigLifecycleManager(ICompilationManager compilationManager,
+                           ConfigurationManager configurationManager)
+        {
+            this.compilationManager = compilationManager;
+            this.configurationManager = configurationManager;
+=======
+        private readonly IBicepConfigurationManager bicepConfigurationManager;
+        private readonly ILanguageServerFacade server;
+        private readonly ILinterRulesProvider linterRulesProvider;
+        private readonly ITelemetryProvider telemetryProvider;
+        private readonly IActiveSourceFileSet workspace;
+
+        public BicepConfigLifecycleManager(ICompilationManager compilationManager,
+                           ConfigurationManager configurationManager,
+                           IBicepConfigurationManager bicepConfigurationManager,
+                           ILanguageServerFacade server,
+                           ILinterRulesProvider linterRulesProvider,
+                           ITelemetryProvider telemetryProvider,
+                           IActiveSourceFileSet workspace)
+        {
+            this.compilationManager = compilationManager;
+            this.configurationManager = configurationManager;
+            this.bicepConfigurationManager = bicepConfigurationManager;
+            this.server = server;
+            this.linterRulesProvider = linterRulesProvider;
+            this.telemetryProvider = telemetryProvider;
+            this.workspace = workspace;
+>>>>>>> af7513a9a (add 'extends' schema support and surface config chain diagnostics in VS Code)
+        }
+
+        public void RefreshCompilationOfSourceFilesInWorkspace()
+        {
+            configurationManager.PurgeCache();
+            // We shouldn't need to reload auxiliary files if a configuration file has changed.
+            compilationManager.RefreshAllActiveCompilations(forceReloadAuxiliaryFiles: false);
+        }
+
+        public void HandleBicepConfigOpenEvent(DocumentUri documentUri)
+        {
+            HandleBicepConfigOpenOrChangeEvent(documentUri);
+            PublishConfigDiagnostics(documentUri);
+        }
+
+        public void HandleBicepConfigChangeEvent(DocumentUri documentUri)
+        {
+            // A change event can represent file creation, modification, or deletion.
+            // Creation and deletion change config file discovery (the lookup cache), so we
+            // must do a full purge rather than a targeted invalidation.
+            configurationManager.PurgeCache();
+            HandleBicepConfigOpenOrChangeEvent(documentUri);
+            PublishConfigDiagnostics(documentUri);
+        }
+
+        private void HandleBicepConfigOpenOrChangeEvent(DocumentUri documentUri)
+            => configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri());
+
+        public void HandleBicepConfigSaveEvent(DocumentUri documentUri)
+<<<<<<< HEAD
+            => configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri());
+=======
+        {
+            if (configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri()) is { } update)
+            {
+                TelemetryHelper.SendTelemetryOnBicepConfigChange(update.prevConfiguration, update.newConfiguration, linterRulesProvider, telemetryProvider);
+            }
+
+            PublishConfigDiagnostics(documentUri);
+        }
+>>>>>>> af7513a9a (add 'extends' schema support and surface config chain diagnostics in VS Code)
+
+        public void HandleBicepConfigCloseEvent(DocumentUri documentUri)
+        {
+            configurationManager.RemoveConfigCacheEntry(documentUri.ToIOUri());
+
+            // Clear squiggles when the file is closed.
+            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            {
+                Uri = documentUri,
+                Diagnostics = new Container<LspDiagnostic>()
+            });
+        }
+
+        private void PublishConfigDiagnostics(DocumentUri documentUri)
+        {
+            var chain = bicepConfigurationManager.GetConfigurationChain(documentUri.ToIOUri());
+            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics();
+
+            var lspDiagnostics = diagnostics.Select(d => new LspDiagnostic
+            {
+                Severity = ToLspSeverity(d.Level),
+                Code = new DiagnosticCode(d.Code),
+                Message = d.Message,
+                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
+                Source = "bicep"
+            });
+
+            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            {
+                Uri = documentUri,
+                Diagnostics = new Container<LspDiagnostic>(lspDiagnostics)
+            });
+        }
+
+        private static DiagnosticSeverity ToLspSeverity(DiagnosticLevel level) => level switch
+        {
+            DiagnosticLevel.Error => DiagnosticSeverity.Error,
+            DiagnosticLevel.Warning => DiagnosticSeverity.Warning,
+            DiagnosticLevel.Info => DiagnosticSeverity.Information,
+            _ => DiagnosticSeverity.Hint
+        };
     }
 }

--- a/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
+++ b/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
@@ -51,7 +51,6 @@ namespace Bicep.LanguageServer.BicepConfig
             // must do a full purge rather than a targeted invalidation.
             configurationManager.PurgeCache();
             HandleBicepConfigOpenOrChangeEvent(documentUri);
-            PublishConfigDiagnostics(documentUri);
         }
 
         private void HandleBicepConfigOpenOrChangeEvent(DocumentUri documentUri)

--- a/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
+++ b/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
@@ -77,24 +77,27 @@ namespace Bicep.LanguageServer.BicepConfig
         private void PublishConfigDiagnostics(DocumentUri documentUri)
         {
             var chain = bicepConfigurationManager.GetConfigurationChain(documentUri.ToIOUri());
-            var diagnosticsByFile = chain.GetDiagnosticsByConfigFile().ToList();
 
-            if (diagnosticsByFile.All(kvp => kvp.Value.IsEmpty))
+            // Always publish to documentUri first — covers chain-level errors (cycle, too deep)
+            // stored on the built-in fallback layer, and clears stale squiggles on the active file.
+            var effectiveDiagnostics = chain.GetEffectiveConfiguration().GetDiagnostics();
+            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
             {
-                // No diagnostics in any layer — clear stale squiggles on the active file.
-                server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+                Uri = documentUri,
+                Diagnostics = new Container<LspDiagnostic>(effectiveDiagnostics.Select(d => new LspDiagnostic
                 {
-                    Uri = documentUri,
-                    Diagnostics = new Container<LspDiagnostic>()
-                });
-                return;
-            }
+                    Severity = ToLspSeverity(d.Level),
+                    Code = new DiagnosticCode(d.Code),
+                    Message = d.Message,
+                    Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
+                    Source = "bicep"
+                }))
+            });
 
-            // Publish squiggles to each config file that has diagnostics.
-            foreach (var (fileUri, diagnostics) in diagnosticsByFile)
+            // Publish diagnostics for every user-layer config file in the chain — including empty
+            // arrays so the client clears stale squiggles for files that no longer have errors.
+            foreach (var (fileUri, diagnostics) in chain.EnumerateDiagnosticsPerFile())
             {
-                if (diagnostics.IsEmpty) { continue; }
-
                 server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
                 {
                     Uri = DocumentUri.From(fileUri.ToUri()),
@@ -108,127 +111,6 @@ namespace Bicep.LanguageServer.BicepConfig
                     }))
                 });
             }
-        }
-
-        private static DiagnosticSeverity ToLspSeverity(DiagnosticLevel level) => level switch
-        {
-            DiagnosticLevel.Error => DiagnosticSeverity.Error,
-            DiagnosticLevel.Warning => DiagnosticSeverity.Warning,
-            DiagnosticLevel.Info => DiagnosticSeverity.Information,
-            _ => DiagnosticSeverity.Hint
-        };
-    }
-}
-
-namespace Bicep.LanguageServer.BicepConfig
-{
-    public class BicepConfigLifecycleManager : IBicepConfigLifecycleManager
-    {
-        private readonly ICompilationManager compilationManager;
-        private readonly ConfigurationManager configurationManager;
-<<<<<<< HEAD
-
-        public BicepConfigLifecycleManager(ICompilationManager compilationManager,
-                           ConfigurationManager configurationManager)
-        {
-            this.compilationManager = compilationManager;
-            this.configurationManager = configurationManager;
-=======
-        private readonly IBicepConfigurationManager bicepConfigurationManager;
-        private readonly ILanguageServerFacade server;
-        private readonly ILinterRulesProvider linterRulesProvider;
-        private readonly ITelemetryProvider telemetryProvider;
-        private readonly IActiveSourceFileSet workspace;
-
-        public BicepConfigLifecycleManager(ICompilationManager compilationManager,
-                           ConfigurationManager configurationManager,
-                           IBicepConfigurationManager bicepConfigurationManager,
-                           ILanguageServerFacade server,
-                           ILinterRulesProvider linterRulesProvider,
-                           ITelemetryProvider telemetryProvider,
-                           IActiveSourceFileSet workspace)
-        {
-            this.compilationManager = compilationManager;
-            this.configurationManager = configurationManager;
-            this.bicepConfigurationManager = bicepConfigurationManager;
-            this.server = server;
-            this.linterRulesProvider = linterRulesProvider;
-            this.telemetryProvider = telemetryProvider;
-            this.workspace = workspace;
->>>>>>> af7513a9a (add 'extends' schema support and surface config chain diagnostics in VS Code)
-        }
-
-        public void RefreshCompilationOfSourceFilesInWorkspace()
-        {
-            configurationManager.PurgeCache();
-            // We shouldn't need to reload auxiliary files if a configuration file has changed.
-            compilationManager.RefreshAllActiveCompilations(forceReloadAuxiliaryFiles: false);
-        }
-
-        public void HandleBicepConfigOpenEvent(DocumentUri documentUri)
-        {
-            HandleBicepConfigOpenOrChangeEvent(documentUri);
-            PublishConfigDiagnostics(documentUri);
-        }
-
-        public void HandleBicepConfigChangeEvent(DocumentUri documentUri)
-        {
-            // A change event can represent file creation, modification, or deletion.
-            // Creation and deletion change config file discovery (the lookup cache), so we
-            // must do a full purge rather than a targeted invalidation.
-            configurationManager.PurgeCache();
-            HandleBicepConfigOpenOrChangeEvent(documentUri);
-            PublishConfigDiagnostics(documentUri);
-        }
-
-        private void HandleBicepConfigOpenOrChangeEvent(DocumentUri documentUri)
-            => configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri());
-
-        public void HandleBicepConfigSaveEvent(DocumentUri documentUri)
-<<<<<<< HEAD
-            => configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri());
-=======
-        {
-            if (configurationManager.RefreshConfigCacheEntry(documentUri.ToIOUri()) is { } update)
-            {
-                TelemetryHelper.SendTelemetryOnBicepConfigChange(update.prevConfiguration, update.newConfiguration, linterRulesProvider, telemetryProvider);
-            }
-
-            PublishConfigDiagnostics(documentUri);
-        }
->>>>>>> af7513a9a (add 'extends' schema support and surface config chain diagnostics in VS Code)
-
-        public void HandleBicepConfigCloseEvent(DocumentUri documentUri)
-        {
-            configurationManager.RemoveConfigCacheEntry(documentUri.ToIOUri());
-
-            // Clear squiggles when the file is closed.
-            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
-            {
-                Uri = documentUri,
-                Diagnostics = new Container<LspDiagnostic>()
-            });
-        }
-
-        private void PublishConfigDiagnostics(DocumentUri documentUri)
-        {
-            var chain = bicepConfigurationManager.GetConfigurationChain(documentUri.ToIOUri());
-            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics();
-
-            var lspDiagnostics = diagnostics.Select(d => new LspDiagnostic
-            {
-                Severity = ToLspSeverity(d.Level),
-                Code = new DiagnosticCode(d.Code),
-                Message = d.Message,
-                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
-                Source = "bicep"
-            });
-
-            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
-            {
-                Uri = documentUri,
-                Diagnostics = new Container<LspDiagnostic>(lspDiagnostics)
-            });
         }
 
         private static DiagnosticSeverity ToLspSeverity(DiagnosticLevel level) => level switch

--- a/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
+++ b/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
@@ -77,22 +77,37 @@ namespace Bicep.LanguageServer.BicepConfig
         private void PublishConfigDiagnostics(DocumentUri documentUri)
         {
             var chain = bicepConfigurationManager.GetConfigurationChain(documentUri.ToIOUri());
-            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics();
+            var diagnosticsByFile = chain.GetDiagnosticsByConfigFile().ToList();
 
-            var lspDiagnostics = diagnostics.Select(d => new LspDiagnostic
+            if (diagnosticsByFile.All(kvp => kvp.Value.IsEmpty))
             {
-                Severity = ToLspSeverity(d.Level),
-                Code = new DiagnosticCode(d.Code),
-                Message = d.Message,
-                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
-                Source = "bicep"
-            });
+                // No diagnostics in any layer — clear stale squiggles on the active file.
+                server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+                {
+                    Uri = documentUri,
+                    Diagnostics = new Container<LspDiagnostic>()
+                });
+                return;
+            }
 
-            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            // Publish squiggles to each config file that has diagnostics.
+            foreach (var (fileUri, diagnostics) in diagnosticsByFile)
             {
-                Uri = documentUri,
-                Diagnostics = new Container<LspDiagnostic>(lspDiagnostics)
-            });
+                if (diagnostics.IsEmpty) { continue; }
+
+                server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+                {
+                    Uri = DocumentUri.From(fileUri.ToUri()),
+                    Diagnostics = new Container<LspDiagnostic>(diagnostics.Select(d => new LspDiagnostic
+                    {
+                        Severity = ToLspSeverity(d.Level),
+                        Code = new DiagnosticCode(d.Code),
+                        Message = d.Message,
+                        Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
+                        Source = "bicep"
+                    }))
+                });
+            }
         }
 
         private static DiagnosticSeverity ToLspSeverity(DiagnosticLevel level) => level switch

--- a/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
+++ b/src/Bicep.LangServer/BicepConfig/BicepConfigLifecycleManager.cs
@@ -77,22 +77,38 @@ namespace Bicep.LanguageServer.BicepConfig
         private void PublishConfigDiagnostics(DocumentUri documentUri)
         {
             var chain = bicepConfigurationManager.GetConfigurationChain(documentUri.ToIOUri());
-            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics();
+            var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics().ToList();
 
-            var lspDiagnostics = diagnostics.Select(d => new LspDiagnostic
+            if (diagnostics.Count == 0)
             {
-                Severity = ToLspSeverity(d.Level),
-                Code = new DiagnosticCode(d.Code),
-                Message = d.Message,
-                Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
-                Source = "bicep"
-            });
+                // Clear any stale squiggles on the active file.
+                server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+                {
+                    Uri = documentUri,
+                    Diagnostics = new Container<LspDiagnostic>()
+                });
+                return;
+            }
 
-            server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+            // Group by IDiagnostic.Uri so each bicepconfig.json in the chain gets its own
+            // PublishDiagnostics call — squiggles appear on the specific file that has the
+            // error, not always on the leaf.
+            // Diagnostics without a URI fall back to the active documentUri.
+            foreach (var group in diagnostics.GroupBy(d => d.Uri is { } u ? DocumentUri.From(u) : documentUri))
             {
-                Uri = documentUri,
-                Diagnostics = new Container<LspDiagnostic>(lspDiagnostics)
-            });
+                server.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+                {
+                    Uri = group.Key,
+                    Diagnostics = new Container<LspDiagnostic>(group.Select(d => new LspDiagnostic
+                    {
+                        Severity = ToLspSeverity(d.Level),
+                        Code = new DiagnosticCode(d.Code),
+                        Message = d.Message,
+                        Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 0, 0),
+                        Source = "bicep"
+                    }))
+                });
+            }
         }
 
         private static DiagnosticSeverity ToLspSeverity(DiagnosticLevel level) => level switch

--- a/src/Bicep.LangServer/IServiceCollectionExtensions.cs
+++ b/src/Bicep.LangServer/IServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ public static class IServiceCollectionExtensions
         .AddSingleton<IModuleRestoreScheduler, ModuleRestoreScheduler>()
         .AddSingleton<IAzResourceProvider, AzResourceProvider>()
         .AddSingleton<IBicepConfigLifecycleManager, BicepConfigLifecycleManager>()
+        .AddSingleton<IBicepConfigurationManager, BicepConfigurationManager>()
         .AddSingleton<IDeploymentCollectionProvider, DeploymentCollectionProvider>()
         .AddSingleton<IDeploymentOperationsCache, DeploymentOperationsCache>()
         .AddSingleton<IDeploymentFileCompilationCache, DeploymentFileCompilationCache>()

--- a/src/vscode-bicep/resources/configuration/bicepconfig.schema.json
+++ b/src/vscode-bicep/resources/configuration/bicepconfig.schema.json
@@ -157,6 +157,11 @@
   "type": "object",
   "default": {},
   "properties": {
+    "extends": {
+      "title": "Extends",
+      "description": "Relative path to a base bicepconfig.json to inherit settings from. Absolute paths are not allowed.",
+      "type": "string"
+    },
     "cloud": {
       "title": "Cloud",
       "type": "object",


### PR DESCRIPTION
## Description

<!-- Provide a 1-2 sentence description of your change -->

Builds on the BicepConfigurationManager chain engine (PR3- https://github.com/Azure/bicep/pull/20196)  to give users immediate  feedback in the editor when their bicepconfig.json has a bad "extends" value.

## Changes

### Schema
- Added `"extends"` property to `bicepconfig.schema.json`
- Enables VS Code IntelliSense, autocomplete, and hover docs for the `"extends"` key

### Squiggles 
- `BicepConfigLifecycleManager` now receives `IBicepConfigurationManager` and 
  `ILanguageServerFacade` via constructor injection
- Added `PublishConfigDiagnostics()` -- calls `GetConfigurationChain()` and publishes 
  any BCP453/454/455 diagnostics as squiggles on the `bicepconfig.json` file
- Squiggles fire on open, change, and save, cleared on close


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20198)