### PR TITLE
Remove Mono dependency from CLI NuGet packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -482,16 +482,8 @@ jobs:
           name: bicep-nupkg-any
           path: ./src/Bicep.MSBuild.E2eTests/examples/local-packages
 
-      - name: Install mono (Mac)
-        if: runner.os == 'macOS'
-        run: brew install mono
-
-      - name: Install mono (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt update && sudo apt install mono-complete
-
       - name: Build CLI Package
-        run: dotnet build --configuration Release /p:RuntimeSuffix=${{ matrix.rid }} ./src/Bicep.Cli.Nuget/nuget.proj
+        run: dotnet pack --configuration Release /p:RuntimeSuffix=${{ matrix.rid }} ./src/Bicep.Cli.Nuget/nuget.proj
 
       - name: Upload CLI Package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/update-notices.yml
+++ b/.github/workflows/update-notices.yml
@@ -62,7 +62,7 @@ jobs:
         run:  mkdir ./src/Bicep.Cli.Nuget/tools && copy ./src/Bicep.Cli/obj/project.assets.json ./src/Bicep.Cli.Nuget/tools/ && copy ./src/Bicep.Cli/bin/Release/net10.0/bicep.* ./src/Bicep.Cli.Nuget/tools/
 
       - name: Build CLI Package
-        run: dotnet build --configuration Release /p:RuntimeSuffix=win-x64 ./src/Bicep.Cli.Nuget/nuget.proj
+        run: dotnet pack --configuration Release /p:RuntimeSuffix=win-x64 ./src/Bicep.Cli.Nuget/nuget.proj
 
       - name: VSIX Notice prerequisites
         run: |

--- a/scripts/SetupMsBuildTests.ps1
+++ b/scripts/SetupMsBuildTests.ps1
@@ -92,7 +92,7 @@ Write-Output "Preparing Bicep CLI package prerequisites...";
 CopyFilesToDirectory -sourceDir $bicepCliPublishDir -fileNameFilter 'bicep*' -destinationDir $bicepCliNugetProjectToolsDir;
 
 Write-Output "Creating Bicep CLI NuGet package...";
-dotnet build --configuration $Configuration /p:RuntimeSuffix=$RuntimeIdentifier $bicepCliNugetProjectFile
+dotnet pack --configuration $Configuration /p:RuntimeSuffix=$RuntimeIdentifier $bicepCliNugetProjectFile
 
 Write-Output "Setting up Bicep MSBuild E2E test prerequisites...";
 CopyFilesToDirectory -sourceDir $msbuildProjectOutputDir -fileNameFilter $msbuildNuGetFileGlob -destinationDir $e2eTestProjectPackageDir;

--- a/src/Bicep.Cli.Nuget/nuget.proj
+++ b/src/Bicep.Cli.Nuget/nuget.proj
@@ -13,9 +13,10 @@
     <!-- NoTargets SDK no longer sets Language, which is required by NerdBank.GitVersioning -->
     <Language>C#</Language>
 
-    <NugetExePath>$(PkgNuGet_CommandLine)\tools\NuGet.exe</NugetExePath>
-    <NugetExePath Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">mono $(NugetExePath)</NugetExePath>
-    <NugetExePath Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">mono $(NugetExePath)</NugetExePath>
+    <IsPackable>true</IsPackable>
+    <NuspecFile>Package.nuspec</NuspecFile>
+    <PackageOutputPath>$(MSBuildProjectDirectory)</PackageOutputPath>
+    <BeforePack>PrepareForPack</BeforePack>
 
     <BicepBinariesDirectory>$(MSBuildProjectDirectory)\tools</BicepBinariesDirectory>
     <BicepExePathWindows>$(BicepBinariesDirectory)\bicep.exe</BicepExePathWindows>
@@ -25,19 +26,11 @@
     <NoticeFileName>ThirdPartyNotices.txt</NoticeFileName>
     <GenerateNoticeLocalFilePath>$(MSBuildProjectDirectory)\local-tpn.txt</GenerateNoticeLocalFilePath>
 
-    <GenerateNoticeBeforeTargets>RunTool</GenerateNoticeBeforeTargets>
+    <GenerateNoticeBeforeTargets>PrepareForPack</GenerateNoticeBeforeTargets>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.CommandLine">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Azure.Deployments.Internal.GenerateNotice" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <NuSpec Include="Package.nuspec" />
   </ItemGroup>
 
   <ItemGroup>
@@ -54,12 +47,12 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="RunTool" AfterTargets="Build" DependsOnTargets="GetBuildVersion">
-    <Error Text="This project requires the RuntimeSuffix property (/p:RuntimeSuffix=rid in dotnet build) to set explicitly." Condition=" $(RuntimeSuffix) == '' " />
+  <Target Name="PrepareForPack" DependsOnTargets="GetBuildVersion">
+    <Error Text="This project requires the RuntimeSuffix property (/p:RuntimeSuffix=rid in dotnet pack) to set explicitly." Condition=" $(RuntimeSuffix) == '' " />
     <Error Text="Unexpected number of bicep executables found: @(BicepExecutable->Count())" Condition=" @(BicepExecutable->Count()) != 1 " />
-
-    <!-- the Properties parameter value must be enclosed in quotes to avoid build breaks on non-windows machines -->
-    <Exec Command="$(NugetExePath) pack @(NuSpec) -Version $(NuGetPackageVersion) -NonInteractive -Properties &quot;rid=$(RuntimeSuffix);NoticeFileName=$(NoticeFileName);Configuration=$(Configuration);TargetFramework=$(TargetFramework)&quot;"
-          WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <PropertyGroup>
+      <PackageVersion>$(NuGetPackageVersion)</PackageVersion>
+      <NuspecProperties>version=$(NuGetPackageVersion);rid=$(RuntimeSuffix);NoticeFileName=$(NoticeFileName);Configuration=$(Configuration);TargetFramework=$(TargetFramework)</NuspecProperties>
+    </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
## Summary

- migrate the CLI NuGet package from `NuGet.exe pack` to the .NET SDK's native `dotnet pack` target
- remove Mono installation from the cross-platform build workflow
- preserve Nerdbank.GitVersioning, custom `.nuspec` substitutions, input validation, and notice generation
- update CI, notice generation, and local MSBuild test setup to invoke `dotnet pack`

## Validation

- `./scripts/SetupMsBuildTests.ps1 -RuntimeIdentifier win-x64 -Configuration Release`
- `npm test` in `src/Bicep.MSBuild.E2eTests` (12 test files, 16 tests passed)
- compared packages from `NuGet.exe pack` and `dotnet pack`; all stable archive entries matched by path and SHA-256
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20199)