### PR TITLE
Expose Documentation section on IBicepConfiguration

### DIFF
--- a/src/Bicep.Core/Configuration/BicepConfiguration.cs
+++ b/src/Bicep.Core/Configuration/BicepConfiguration.cs
@@ -22,6 +22,7 @@ namespace Bicep.Core.Configuration
             IBicepImplicitExtensionsConfiguration implicitExtensions,
             IBicepAnalyzersConfiguration analyzers,
             IBicepFormattingConfiguration formatting,
+            IBicepDocumentationConfiguration documentation,
             ExperimentalFeaturesEnabled experimentalFeaturesEnabled,
             string? cacheRootDirectory,
             bool experimentalFeaturesWarning,
@@ -35,6 +36,7 @@ namespace Bicep.Core.Configuration
             ImplicitExtensions = implicitExtensions;
             Analyzers = analyzers;
             Formatting = formatting;
+            Documentation = documentation;
             ExperimentalFeaturesEnabled = experimentalFeaturesEnabled;
             CacheRootDirectory = ExpandCacheRootDirectory(cacheRootDirectory);
             ExperimentalFeaturesWarning = experimentalFeaturesWarning;
@@ -55,6 +57,8 @@ namespace Bicep.Core.Configuration
         public IBicepAnalyzersConfiguration Analyzers { get; }
 
         public IBicepFormattingConfiguration Formatting { get; }
+
+        public IBicepDocumentationConfiguration Documentation { get; }
 
         public ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled { get; }
 

--- a/src/Bicep.Core/Configuration/BicepConfigurationAdapter.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationAdapter.cs
@@ -38,6 +38,8 @@ internal sealed class BicepConfigurationAdapter : IBicepConfiguration
 
     public IBicepFormattingConfiguration Formatting => this.inner.Formatting;
 
+    public IBicepDocumentationConfiguration Documentation => this.inner.Documentation;
+
     public ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled => this.inner.ExperimentalFeaturesEnabled;
 
     public string? CacheRootDirectory => this.inner.CacheRootDirectory;

--- a/src/Bicep.Core/Configuration/DocumentationConfiguration.cs
+++ b/src/Bicep.Core/Configuration/DocumentationConfiguration.cs
@@ -149,7 +149,7 @@ public sealed record DocumentationPatternSet
 /// <summary>
 /// Provides the documentation section of a Bicep configuration.
 /// </summary>
-public sealed class DocumentationConfiguration : ConfigurationSection<Documentation>
+public sealed class DocumentationConfiguration : ConfigurationSection<Documentation>, IBicepDocumentationConfiguration
 {
     public DocumentationConfiguration(Documentation data)
         : base(data)

--- a/src/Bicep.Core/Configuration/IBicepConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfiguration.cs
@@ -28,6 +28,8 @@ namespace Bicep.Core.Configuration
 
         IBicepFormattingConfiguration Formatting { get; }
 
+        IBicepDocumentationConfiguration Documentation { get; }
+
         ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled { get; }
 
         string? CacheRootDirectory { get; }

--- a/src/Bicep.Core/Configuration/IBicepDocumentationConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepDocumentationConfiguration.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.Configuration
+{
+    public interface IBicepDocumentationConfiguration
+    {
+        Documentation Data { get; }
+    }
+}


### PR DESCRIPTION
## Description

<!-- Provide a 1-2 sentence description of your change -->
This PR adds a  `IBicepDocumentationConfiguration`  section interface (mirroring the other sections) and exposes `Documentation`  on  `IBicepConfiguration` , its concrete impl  BicepConfiguration , and  BicepConfigurationAdapter .
Purely additive, no behavior change.


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20216)