### PR TITLE
Support offline dotnet dependencies in VS Code E2E tests

### DIFF
--- a/src/vscode-bicep/tests/e2e/README.md
+++ b/src/vscode-bicep/tests/e2e/README.md
@@ -132,6 +132,20 @@ Both E2E commands run the suite against:
 Unit and E2E tests both use Vitest. Unit tests run in regular Node.js through `npm run test:unit`; only E2E tests
 need the custom Extension Host pool described here.
 
+## Network-Isolated Builds
+
+By default the runner installs the `ms-dotnettools.vscode-dotnet-runtime` extension dependency from the
+Marketplace, and that extension downloads a .NET runtime when the Bicep extension activates. Builds that run
+under network isolation cannot reach either endpoint, so two optional environment variables let them supply
+both locally:
+
+| Variable | Purpose |
+| --- | --- |
+| `BICEP_DOTNET_EXTENSION_VSIX_PATH` | Path to a pre-downloaded `.vsix` for the .NET Install Tool, installed instead of resolving the extension from the Marketplace. |
+| `BICEP_DOTNET_RUNTIME_PATH` | Path to an existing `dotnet` executable. The runner writes it to `dotnetAcquisitionExtension.existingDotnetPath` so the .NET Install Tool skips its download. |
+
+Both are unset for local development and public CI, which keep the default Marketplace and download behavior.
+
 ## Writing Tests
 
 - Put E2E tests under `tests/e2e/` with a `.test.ts` suffix.

--- a/src/vscode-bicep/tests/e2e/runner/launch.ts
+++ b/src/vscode-bicep/tests/e2e/runner/launch.ts
@@ -40,12 +40,26 @@ async function go() {
       // some of our builds run as root in a container, which requires passing
       // the user data folder relative path to vs code itself
       const userDataDir = "./.vscode-test/user-data";
-      const userDataArguments = isRoot ? ["--user-data-dir", userDataDir] : [];
+
+      // Network-isolated builds cannot reach the Marketplace or the dotnet CDN, so they provide a
+      // pre-downloaded VSIX and a pre-installed dotnet instead. Both overrides force the relative
+      // user data folder so the CLI and the test run share the settings written below.
+      const dotnetExtensionVsixPath = process.env.BICEP_DOTNET_EXTENSION_VSIX_PATH;
+      const dotnetRuntimePath = process.env.BICEP_DOTNET_RUNTIME_PATH;
+      const userDataArguments = isRoot || dotnetRuntimePath ? ["--user-data-dir", userDataDir] : [];
+
+      if (dotnetRuntimePath) {
+        configureExistingDotnetPath(userDataDir, dotnetRuntimePath);
+      }
+
+      const dotnetExtensionToInstall = dotnetExtensionVsixPath
+        ? requireFile(path.resolve(dotnetExtensionVsixPath), "set BICEP_DOTNET_EXTENSION_VSIX_PATH to an existing VSIX")
+        : "ms-dotnettools.vscode-dotnet-runtime";
 
       const extensionInstallArguments = [
         ...cliArguments,
         "--install-extension",
-        "ms-dotnettools.vscode-dotnet-runtime",
+        `"${dotnetExtensionToInstall}"`,
         ...userDataArguments,
       ];
       const extensionListArguments = [...cliArguments, "--list-extensions", ...userDataArguments];
@@ -58,6 +72,11 @@ async function go() {
         shell: true,
       });
       console.log(result.error ?? result.output?.filter((o) => !!o).join("\n"));
+      if (result.error || result.status !== 0) {
+        throw new Error(
+          `Failed to install '${dotnetExtensionToInstall}'. The Bicep extension declares it as an extension dependency, so the E2E tests cannot run without it.`,
+        );
+      }
 
       console.log("Installed extensions:");
       result = cp.spawnSync(cliPath, extensionListArguments, {
@@ -107,9 +126,32 @@ function getLocalServerEnvironment(extensionPath: string): NodeJS.ProcessEnv {
   };
 }
 
-function requireFile(filePath: string, buildCommand: string): string {
+// Points the .NET Install Tool at an already installed dotnet so it does not download one at test
+// time. The Bicep extension reads this setting through the 'dotnet.acquire' command it invokes.
+function configureExistingDotnetPath(userDataDir: string, dotnetRuntimePath: string): void {
+  const resolvedDotnetPath = requireFile(
+    path.resolve(dotnetRuntimePath),
+    "set BICEP_DOTNET_RUNTIME_PATH to an existing dotnet executable",
+  );
+
+  const settingsPath = path.resolve(userDataDir, "User/settings.json");
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+
+  const settings = fs.existsSync(settingsPath)
+    ? JSON.parse(fs.readFileSync(settingsPath, { encoding: "utf-8" }))
+    : {};
+
+  settings["dotnetAcquisitionExtension.existingDotnetPath"] = [
+    { extensionId: "ms-azuretools.vscode-bicep", path: resolvedDotnetPath },
+  ];
+
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  console.log(`Configured existing dotnet path '${resolvedDotnetPath}' in '${settingsPath}'.`);
+}
+
+function requireFile(filePath: string, remediation: string): string {
   if (!fs.existsSync(filePath)) {
-    throw new Error(`Required local server does not exist at '${filePath}'. Run: ${buildCommand}`);
+    throw new Error(`Required file does not exist at '${filePath}'. Run: ${remediation}`);
   }
 
   return filePath;


### PR DESCRIPTION
## Summary

The VS Code E2E runner installs the `ms-dotnettools.vscode-dotnet-runtime` extension dependency from the Marketplace, and that extension then downloads a .NET runtime when the Bicep extension activates. Builds that run under network isolation cannot reach either endpoint, so the E2E job fails at extension install time with a socket-level `EPERM`.

This adds two optional environment variables so such builds can supply both artifacts locally. Local development and public CI set neither and keep the existing Marketplace + download behavior.

| Variable | Purpose |
| --- | --- |
| `BICEP_DOTNET_EXTENSION_VSIX_PATH` | Installs a pre-downloaded `.vsix` instead of resolving the extension from the Marketplace. |
| `BICEP_DOTNET_RUNTIME_PATH` | Written to the .NET Install Tool's `dotnetAcquisitionExtension.existingDotnetPath` setting so it skips its runtime download. |

The runner already had a precedent for this style of override in `BICEP_LANGUAGE_SERVER_PATH` / `BICEP_MCP_SERVER_PATH`, and `ensureDotnetRuntimeInstalled` already reads and logs the `existingDotnetPath` setting, so no product code changes were needed.

## Additional fix

The extension install result was previously only logged — only the subsequent `--list-extensions` call was checked for errors. A failed install therefore surfaced later as a confusing activation error rather than naming the missing dependency. The runner now fails fast with an explicit message.

## Testing

- `npm run build:e2e` and `eslint` pass.
- Verified the failure path: a non-existent `BICEP_DOTNET_EXTENSION_VSIX_PATH` produces a clear, actionable error.
- Verified the success path end to end with a real VSIX: the extension installed from disk, appeared in `--list-extensions`, and activation proceeded past `ensureDotnetRuntimeInstalled` using the pre-installed dotnet. The generated `settings.json` had the expected shape.
- Confirmed default behavior is unchanged when neither variable is set.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20250)