### PR TITLE
Enable compression for single-file CLI

### DIFF
--- a/src/Bicep.Cli/Bicep.Cli.csproj
+++ b/src/Bicep.Cli/Bicep.Cli.csproj
@@ -17,6 +17,7 @@
 
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <PublishSingleFile>true</PublishSingleFile>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
     <!-- restore pre-.net8 trim behavior https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/publishtrimmed -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>


### PR DESCRIPTION
## Summary

Enable compression for assemblies embedded in the self-contained single-file Bicep CLI executable.

## Size

A local `win-x64` self-contained Release publish produced:

| Variant | Size |
| --- | ---: |
| Uncompressed | 117.21 MiB |
| Compressed | 68.93 MiB |
| Reduction | **48.28 MiB (41.2%)** |

## Benchmark methodology

Environment:

- Windows 11 Enterprise 10.0.26200
- AMD Ryzen 7 5800X3D, 8 cores / 16 logical processors
- 31.9 GiB RAM
- .NET SDK 10.0.400

Both variants were otherwise identical trimmed, self-contained, single-file `win-x64` Release publishes. The benchmark used three workloads:

- Startup: `bicep --version`
- Small resource-heavy compilation: `Resources_CRLF/main.bicep`
- Large 85 KiB syntax-stress compilation: `LargeTemplate_Stress_LF/main.bicep`

Compilation used `--stdout --no-restore` to avoid network and output-file effects. Each combination received 3 warmup runs followed by 30 measured runs, for 180 timed processes. Compressed and uncompressed execution order was randomized within each iteration. Peak working set was measured separately with 10 runs per combination because it required polling the process while it was running.

These are warm filesystem-cache measurements. They do not measure first execution after installation or reboot.

## Elapsed time

| Workload | Variant | Median | Mean | P95 |
| --- | --- | ---: | ---: | ---: |
| Startup | Uncompressed | 423.94 ms | 477.26 ms | 748.91 ms |
| Startup | Compressed | 438.11 ms | 473.54 ms | 629.94 ms |
| Small compilation | Uncompressed | 3957.83 ms | 4028.66 ms | 4401.42 ms |
| Small compilation | Compressed | 3848.96 ms | 3891.56 ms | 4211.95 ms |
| Large compilation | Uncompressed | 3449.14 ms | 3401.18 ms | 3668.14 ms |
| Large compilation | Compressed | 3303.04 ms | 3320.22 ms | 3566.35 ms |

The paired startup mean difference was -3.71 ms, with a 95% confidence interval of -62.33 to +54.90 ms. The benchmark therefore did not detect a reliable wall-clock startup regression. The apparently lower compilation elapsed times should not be interpreted as compression improving compilation; CPU time below more directly shows the decompression cost.

## CPU time

| Workload | Uncompressed median | Compressed median | Difference |
| --- | ---: | ---: | ---: |
| Startup | 414.06 ms | 421.88 ms | **+7.82 ms (+1.9%)** |
| Small compilation | 3710.94 ms | 3750.00 ms | **+39.06 ms (+1.1%)** |
| Large compilation | 3179.69 ms | 3187.50 ms | **+7.81 ms (+0.25%)** |

## Peak working set

| Workload | Uncompressed median | Compressed median | Difference |
| --- | ---: | ---: | ---: |
| Startup | 35.41 MiB | 41.78 MiB | **+6.38 MiB (+18.0%)** |
| Small compilation | 193.88 MiB | 203.43 MiB | **+9.55 MiB (+4.9%)** |
| Large compilation | 183.71 MiB | 194.09 MiB | **+10.38 MiB (+5.6%)** |

## Correctness and validation

- All benchmark processes exited successfully
- Compressed and uncompressed variants produced identical SHA-256 output hashes for every workload
- Published the `win-x64` self-contained Release executable with the project setting enabled
- Verified `bicep --version`
- Compiled `Resources_CRLF/main.bicep` with `--stdout --no-restore`

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20251)