### PR TITLE
[Config Inheritance] relative path provenance for moduleAliasesMock + E2E tests

### DIFF
--- a/src/Bicep.Core.IntegrationTests/ConfigurationInheritanceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/ConfigurationInheritanceTests.cs
@@ -30,6 +30,15 @@ public class ConfigurationInheritanceTests
         return (compiler, fileExplorer);
     }
 
+    private static IBicepConfigurationManager CreateConfigManager(InMemoryFileExplorer fileExplorer)
+    {
+        var services = new ServiceCollection()
+            .AddSingleton<IFileExplorer>(fileExplorer)
+            .AddBicepCore()
+            .BuildServiceProvider();
+        return services.GetRequiredService<IBicepConfigurationManager>();
+    }
+
     private static IOUri BicepUri(string path) => IOUri.FromFilePath(path);
 
     private static void WriteFile(InMemoryFileExplorer fileExplorer, string path, string content)
@@ -248,6 +257,529 @@ public class ConfigurationInheritanceTests
 
         // Base value inherited.
         config.CacheRootDirectory.Should().Be("/tmp/cache");
+
+        await Task.CompletedTask;
+    }
+
+    // ── Squiggles: cycle detection ────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_WithCyclicExtends_EmitsCycleError()
+    {
+        // Arrange — A extends B, B extends A.
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicep", "");
+        WriteFile(fileExplorer, "/bicepconfig.json", """{ "extends": "./other/bicepconfig.json" }""");
+        WriteFile(fileExplorer, "/other/bicepconfig.json", """{ "extends": "../bicepconfig.json" }""");
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics().ToList();
+
+        // Assert — cycle error (BCP454) reported.
+        diagnostics.Should().HaveCount(1);
+        diagnostics[0].Code.Should().Be("BCP454");
+        diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
+        diagnostics[0].Message.Should().Contain("cycle");
+
+        await Task.CompletedTask;
+    }
+
+    // ── Squiggles: chain too deep ─────────────────────────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_WithChainExceedingMaxDepth_EmitsChainTooDeepError()
+    {
+        // Arrange — build a chain of 65 files (exceeds the 64 limit).
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicep", "");
+
+        const int depth = 65;
+        for (int i = 0; i < depth; i++)
+        {
+            var path = i == 0 ? "/bicepconfig.json" : $"/bicepconfig{i}.json";
+            var extendsLine = i < depth - 1
+                ? $"""  "extends": "./bicepconfig{i + 1}.json" """
+                : "  \"experimentalFeaturesWarning\": false";
+            WriteFile(fileExplorer, path, $"{{ {extendsLine} }}");
+        }
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics().ToList();
+
+        // Assert — chain-too-deep error (BCP455) reported.
+        diagnostics.Should().HaveCount(1);
+        diagnostics[0].Code.Should().Be("BCP455");
+        diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
+
+        await Task.CompletedTask;
+    }
+
+    // ── Squiggles: missing extends target ────────────────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_WithMissingExtendsFile_EmitsLoadError()
+    {
+        // Arrange — extends points to a nonexistent file.
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicep", "");
+        WriteFile(fileExplorer, "/bicepconfig.json", """{ "extends": "./nonexistent/bicepconfig.json" }""");
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics().ToList();
+
+        // Assert — unloadable file error reported.
+        diagnostics.Should().HaveCount(1);
+        diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
+        diagnostics[0].Message.Should().Contain("nonexistent");
+
+        await Task.CompletedTask;
+    }
+
+    // ── Squiggles: absolute path in extends ───────────────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_WithAbsoluteExtendsPath_EmitsBCP453()
+    {
+        // Arrange — extends uses an absolute path (not allowed).
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicep", "");
+        WriteFile(fileExplorer, "/bicepconfig.json", """{ "extends": "/absolute/bicepconfig.json" }""");
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        var diagnostics = chain.GetEffectiveConfiguration().GetDiagnostics().ToList();
+
+        // Assert — BCP453 absolute path error.
+        diagnostics.Should().HaveCount(1);
+        diagnostics[0].Code.Should().Be("BCP453");
+        diagnostics[0].Level.Should().Be(DiagnosticLevel.Error);
+
+        await Task.CompletedTask;
+    }
+
+    // ── Squiggles: per-file diagnostic attribution ────────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_WithTwoLayerChain_EnumerateDiagnosticsPerFileAttributesToEachLayer()
+    {
+        // Arrange — leaf extends base; both are valid, so no diagnostics.
+        // The key contract: EnumerateDiagnosticsPerFile() returns one entry *per layer*,
+        // keyed to that layer's config URI. This is what allows the LS to publish squiggles
+        // on the correct file — if the base config had a diagnostic, it would be attributed
+        // to the base URI, not the leaf URI.
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicep", "");
+        WriteFile(fileExplorer, "/bicepconfig.json", """{ "extends": "./base/bicepconfig.base.json" }""");
+        WriteFile(fileExplorer, "/base/bicepconfig.base.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "off" }
+              }
+            }
+          }
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        var perFileDiagnostics = chain.EnumerateDiagnosticsPerFile().ToList();
+
+        // Assert — exactly two entries: one for the leaf, one for the base.
+        perFileDiagnostics.Should().HaveCount(2);
+        perFileDiagnostics.Select(kvp => kvp.Key).Should().Contain(BicepUri("/bicepconfig.json"),
+            "leaf config should have its own entry in the per-file map");
+        perFileDiagnostics.Select(kvp => kvp.Key).Should().Contain(BicepUri("/base/bicepconfig.base.json"),
+            "base config should have its own entry so diagnostics on it would be attributed correctly");
+
+        // Both configs are valid — no diagnostics.
+        perFileDiagnostics.SelectMany(kvp => kvp.Value).Should().BeEmpty();
+
+        await Task.CompletedTask;
+    }
+
+    // ── Cache invalidation: base config change is picked up ──────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_AfterBaseConfigChange_CacheInvalidationPicksUpNewValues()
+    {
+        // Arrange — leaf extends base; base initially disables the rule.
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicep", "param unused string");
+        WriteFile(fileExplorer, "/bicepconfig.json", """{ "extends": "./base/bicepconfig.base.json" }""");
+        WriteFile(fileExplorer, "/base/bicepconfig.base.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "off" }
+              }
+            }
+          }
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act 1 — initial compilation should suppress the diagnostic.
+        var chain1 = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        chain1.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+
+        // Simulate editing the base config to re-enable the rule.
+        WriteFile(fileExplorer, "/base/bicepconfig.base.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "warning" }
+              }
+            }
+          }
+        }
+        """);
+
+        // Purge the cache for the changed file.
+        configManager.PurgeCacheForAffectedChains(BicepUri("/base/bicepconfig.base.json"));
+
+        // Act 2 — reloaded chain should reflect the updated base config.
+        var chain2 = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+
+        // Assert — new chain instance with updated settings.
+        chain2.Should().NotBeSameAs(chain1);
+        chain2.LayerCount.Should().Be(2);
+        chain2.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
+
+        await Task.CompletedTask;
+    }
+
+    // ── Local modules: each module uses its nearest bicepconfig.json ──────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_LocalModulesWithOwnConfig_EachUsesNearestConfig()
+    {
+        // Arrange:
+        //   /bicepconfig.json — disables no-unused-params (applies to main.bicep)
+        //   /modules/bicepconfig.json — enables no-unused-params as warning (applies to storage.bicep)
+        //   /main.bicep — has unused param, references /modules/storage.bicep
+        //   /modules/storage.bicep — has unused param
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicep", """
+        param unused string
+        module storage './modules/storage.bicep' = {
+          name: 'storage'
+          params: {}
+        }
+        """);
+        WriteFile(fileExplorer, "/bicepconfig.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "off" }
+              }
+            }
+          }
+        }
+        """);
+        WriteFile(fileExplorer, "/modules/storage.bicep", "param unused string");
+        WriteFile(fileExplorer, "/modules/bicepconfig.json", """
+        {
+          "analyzers": {
+            "core": {
+              "rules": {
+                "no-unused-params": { "level": "warning" }
+              }
+            }
+          }
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act — check each file's config independently.
+        var mainChain = configManager.GetConfigurationChain(BicepUri("/main.bicep"));
+        var storageChain = configManager.GetConfigurationChain(BicepUri("/modules/storage.bicep"));
+
+        // Assert — main.bicep uses /bicepconfig.json (no-unused-params off).
+        mainChain.LayerCount.Should().Be(1);
+        mainChain.GetEffectiveConfiguration().ConfigFileUri.Should().Be(BicepUri("/bicepconfig.json"));
+
+        // Assert — storage.bicep uses /modules/bicepconfig.json (no-unused-params warning).
+        storageChain.LayerCount.Should().Be(1);
+        storageChain.GetEffectiveConfiguration().ConfigFileUri.Should().Be(BicepUri("/modules/bicepconfig.json"));
+
+        await Task.CompletedTask;
+    }
+
+    // ── Bicep params file inherits config ─────────────────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_BicepParamsFile_UsesNearestInheritedConfig()
+    {
+        // Arrange — params file in same directory as the leaf bicepconfig.json.
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/main.bicepparam", "using './main.bicep'");
+        WriteFile(fileExplorer, "/main.bicep", "param p string");
+        WriteFile(fileExplorer, "/bicepconfig.json", """
+        {
+          "extends": "./shared/bicepconfig.shared.json",
+          "experimentalFeaturesWarning": true
+        }
+        """);
+        WriteFile(fileExplorer, "/shared/bicepconfig.shared.json", """
+        {
+          "cacheRootDirectory": "/tmp/shared-cache"
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act — params file should discover the same leaf config as main.bicep.
+        var paramsChain = configManager.GetConfigurationChain(BicepUri("/main.bicepparam"));
+        var config = paramsChain.GetEffectiveConfiguration();
+
+        // Assert — params file sees the full inherited config chain.
+        paramsChain.LayerCount.Should().Be(2);
+        config.GetDiagnostics().Should().BeEmpty();
+        config.ExperimentalFeaturesWarning.Should().BeTrue();   // from leaf
+        config.CacheRootDirectory.Should().Be("/tmp/shared-cache"); // from shared base
+
+        await Task.CompletedTask;
+    }
+
+    // ── moduleAliasesMock: relative path provenance ───────────────────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_InheritedMockAlias_DeclaringUriIsBaseConfig()
+    {
+        // Arrange:
+        //   base config at /config/bicepconfig.base.json declares mapToFilePath = "../modules"
+        //   leaf config at /apps/bicepconfig.json extends the base
+        //   The alias should resolve relative to /config/, NOT /apps/
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/apps/main.bicep", "");
+        WriteFile(fileExplorer, "/apps/bicepconfig.json", """
+        { "extends": "../config/bicepconfig.base.json" }
+        """);
+        WriteFile(fileExplorer, "/config/bicepconfig.base.json", """
+        {
+          "moduleAliasesMock": {
+            "br": {
+              "shared": { "mapToFilePath": "../modules" }
+            }
+          }
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/apps/main.bicep"));
+        var aliasResult = chain.GetEffectiveConfiguration().ModuleAliasesMock
+            .TryGetOciArtifactModuleAliasMock("shared");
+
+        // Assert — alias resolved, declaring URI is the base config (not the leaf).
+        aliasResult.IsSuccess(out var alias, out _).Should().BeTrue();
+        alias!.MapToFilePath.Should().Be("../modules");
+        alias.DeclaringConfigUri.Should().Be(BicepUri("/config/bicepconfig.base.json"),
+            "mapToFilePath must resolve from the base config's directory, not the leaf's");
+
+        await Task.CompletedTask;
+    }
+
+    // ── moduleAliasesMock: 4-layer chain, alias in deepest layer ─────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_FourLayerChain_AliasInDeepestLayer_DeclaringUriIsGreatGrandparent()
+    {
+        // Chain (leaf → parent → grandparent → great-grandparent):
+        //
+        //   /proj/bicepconfig.json                    (leaf, no aliases)
+        //       → /org/bicepconfig.org.json           (parent, no aliases)
+        //           → /corp/bicepconfig.corp.json     (grandparent, no aliases)
+        //               → /root/bicepconfig.root.json (great-grandparent, declares "storage" alias)
+        //
+        // "storage" is only declared in the great-grandparent.
+        // Its mapToFilePath should resolve from /root/, so DeclaringConfigUri = /root/bicepconfig.root.json.
+
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/proj/main.bicep", "");
+        WriteFile(fileExplorer, "/proj/bicepconfig.json", """
+        { "extends": "../org/bicepconfig.org.json" }
+        """);
+        WriteFile(fileExplorer, "/org/bicepconfig.org.json", """
+        { "extends": "../corp/bicepconfig.corp.json" }
+        """);
+        WriteFile(fileExplorer, "/corp/bicepconfig.corp.json", """
+        { "extends": "../root/bicepconfig.root.json" }
+        """);
+        WriteFile(fileExplorer, "/root/bicepconfig.root.json", """
+        {
+          "moduleAliasesMock": {
+            "br": {
+              "storage": { "mapToFilePath": "../shared-modules" }
+            }
+          }
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/proj/main.bicep"));
+        var aliasResult = chain.GetEffectiveConfiguration().ModuleAliasesMock
+            .TryGetOciArtifactModuleAliasMock("storage");
+
+        // Assert.
+        chain.LayerCount.Should().Be(4);
+        aliasResult.IsSuccess(out var alias, out _).Should().BeTrue();
+        alias!.MapToFilePath.Should().Be("../shared-modules");
+        alias.DeclaringConfigUri.Should().Be(BicepUri("/root/bicepconfig.root.json"),
+            "alias declared in great-grandparent must have DeclaringConfigUri pointing to /root/bicepconfig.root.json");
+
+        await Task.CompletedTask;
+    }
+
+    // ── moduleAliasesMock: 4-layer chain, alias in middle layer ──────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_FourLayerChain_AliasInMiddleLayer_DeclaringUriIsGrandparent()
+    {
+        // Chain (leaf → parent → grandparent → great-grandparent):
+        //
+        //   /proj/bicepconfig.json                    (leaf, no aliases)
+        //       → /org/bicepconfig.org.json           (parent, no aliases)
+        //           → /corp/bicepconfig.corp.json     (grandparent, declares TWO aliases)
+        //               → /root/bicepconfig.root.json (great-grandparent, declares ONE alias)
+        //
+        // "network" declared in grandparent → DeclaringConfigUri = /corp/bicepconfig.corp.json
+        // "storage" declared in great-grandparent → DeclaringConfigUri = /root/bicepconfig.root.json
+        //
+        // Both coexist; each resolves relative to its own declaring config's directory.
+
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/proj/main.bicep", "");
+        WriteFile(fileExplorer, "/proj/bicepconfig.json", """
+        { "extends": "../org/bicepconfig.org.json" }
+        """);
+        WriteFile(fileExplorer, "/org/bicepconfig.org.json", """
+        { "extends": "../corp/bicepconfig.corp.json" }
+        """);
+        WriteFile(fileExplorer, "/corp/bicepconfig.corp.json", """
+        {
+          "extends": "../root/bicepconfig.root.json",
+          "moduleAliasesMock": {
+            "br": {
+              "network": { "mapToFilePath": "./network-modules" }
+            }
+          }
+        }
+        """);
+        WriteFile(fileExplorer, "/root/bicepconfig.root.json", """
+        {
+          "moduleAliasesMock": {
+            "br": {
+              "storage": { "mapToFilePath": "./storage-modules" }
+            }
+          }
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/proj/main.bicep"));
+        var effectiveConfig = chain.GetEffectiveConfiguration();
+        var networkResult = effectiveConfig.ModuleAliasesMock.TryGetOciArtifactModuleAliasMock("network");
+        var storageResult = effectiveConfig.ModuleAliasesMock.TryGetOciArtifactModuleAliasMock("storage");
+
+        // Assert — "network" traces to grandparent (/corp/).
+        chain.LayerCount.Should().Be(4);
+        networkResult.IsSuccess(out var networkAlias, out _).Should().BeTrue();
+        networkAlias!.MapToFilePath.Should().Be("./network-modules");
+        networkAlias.DeclaringConfigUri.Should().Be(BicepUri("/corp/bicepconfig.corp.json"),
+            "network alias was declared in the grandparent (/corp/)");
+
+        // Assert — "storage" traces to great-grandparent (/root/).
+        storageResult.IsSuccess(out var storageAlias, out _).Should().BeTrue();
+        storageAlias!.MapToFilePath.Should().Be("./storage-modules");
+        storageAlias.DeclaringConfigUri.Should().Be(BicepUri("/root/bicepconfig.root.json"),
+            "storage alias was declared in the great-grandparent (/root/)");
+
+        await Task.CompletedTask;
+    }
+
+    // ── moduleAliasesMock: leaf overrides alias from deep layer ───────────────
+
+    [TestMethod]
+    public async Task ConfigurationManager_FourLayerChain_LeafOverridesAliasFromDeepLayer_LeafDeclaringUriWins()
+    {
+        // Chain (leaf → parent → grandparent → great-grandparent):
+        //
+        //   /proj/bicepconfig.json          (leaf, redefines "storage" → different path)
+        //       → /org/bicepconfig.org.json (parent, no aliases)
+        //           → /corp/bicepconfig.corp.json     (grandparent, no aliases)
+        //               → /root/bicepconfig.root.json (great-grandparent, also declares "storage")
+        //
+        // Leaf re-declares "storage" with a different mapToFilePath.
+        // Leaf wins the merge, so DeclaringConfigUri must be the leaf (/proj/bicepconfig.json),
+
+        var fileExplorer = new InMemoryFileExplorer();
+        WriteFile(fileExplorer, "/proj/main.bicep", "");
+        WriteFile(fileExplorer, "/proj/bicepconfig.json", """
+        {
+          "extends": "../org/bicepconfig.org.json",
+          "moduleAliasesMock": {
+            "br": {
+              "storage": { "mapToFilePath": "./local-overrides" }
+            }
+          }
+        }
+        """);
+        WriteFile(fileExplorer, "/org/bicepconfig.org.json", """
+        { "extends": "../corp/bicepconfig.corp.json" }
+        """);
+        WriteFile(fileExplorer, "/corp/bicepconfig.corp.json", """
+        { "extends": "../root/bicepconfig.root.json" }
+        """);
+        WriteFile(fileExplorer, "/root/bicepconfig.root.json", """
+        {
+          "moduleAliasesMock": {
+            "br": {
+              "storage": { "mapToFilePath": "../enterprise-modules" }
+            }
+          }
+        }
+        """);
+
+        var configManager = CreateConfigManager(fileExplorer);
+
+        // Act.
+        var chain = configManager.GetConfigurationChain(BicepUri("/proj/main.bicep"));
+        var aliasResult = chain.GetEffectiveConfiguration().ModuleAliasesMock
+            .TryGetOciArtifactModuleAliasMock("storage");
+
+        // Assert — leaf overrides great-grandparent; leaf path and declaring URI win.
+        chain.LayerCount.Should().Be(4);
+        aliasResult.IsSuccess(out var alias, out _).Should().BeTrue();
+        alias!.MapToFilePath.Should().Be("./local-overrides",
+            "leaf's mapToFilePath should win over great-grandparent's");
+        alias.DeclaringConfigUri.Should().Be(BicepUri("/proj/bicepconfig.json"),
+            "DeclaringConfigUri must be the leaf — it's the one that owns the winning declaration");
 
         await Task.CompletedTask;
     }

--- a/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationManagerTests.cs
@@ -561,5 +561,96 @@ namespace Bicep.Core.UnitTests.Configuration
             chainOtherAfter.GetEffectiveConfiguration().ExperimentalFeaturesWarning.Should().BeFalse();
             chainOtherAfter.GetEffectiveConfiguration().GetDiagnostics().Should().BeEmpty();
         }
+
+        // ── moduleAliasesMock relative path provenance ────────────────────────
+
+        [TestMethod]
+        public void GetConfigurationChain_AliasInLeaf_DeclaringConfigUriIsLeaf()
+        {
+            // Alias declared in the leaf — DeclaringConfigUri should be the leaf URI.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """
+                    {
+                      "moduleAliasesMock": {
+                        "br": {
+                          "shared": { "mapToFilePath": "../modules" }
+                        }
+                      }
+                    }
+                    """));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+
+            var chain = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            var alias = chain.GetEffectiveConfiguration().ModuleAliasesMock
+                .TryGetOciArtifactModuleAliasMock("shared");
+
+            alias.IsSuccess(out var mockAlias, out _).Should().BeTrue();
+            mockAlias!.DeclaringConfigUri.Should().Be(fileSet.GetUri("bicepconfig.json"));
+        }
+
+        [TestMethod]
+        public void GetConfigurationChain_AliasInBase_DeclaringConfigUriIsBase()
+        {
+            // Alias declared only in the base — DeclaringConfigUri should be the base URI, not the leaf.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """{ "extends": "./base/bicepconfig.base.json" }"""),
+                ("base/bicepconfig.base.json", """
+                    {
+                      "moduleAliasesMock": {
+                        "br": {
+                          "shared": { "mapToFilePath": "../modules" }
+                        }
+                      }
+                    }
+                    """));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+
+            var chain = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            var alias = chain.GetEffectiveConfiguration().ModuleAliasesMock
+                .TryGetOciArtifactModuleAliasMock("shared");
+
+            alias.IsSuccess(out var mockAlias, out _).Should().BeTrue();
+            // Must be the base URI — leaf doesn't declare this alias.
+            mockAlias!.DeclaringConfigUri.Should().Be(fileSet.GetUri("base/bicepconfig.base.json"));
+        }
+
+        [TestMethod]
+        public void GetConfigurationChain_AliasOverriddenInLeaf_DeclaringConfigUriIsLeaf()
+        {
+            // Both leaf and base declare the same alias — leaf wins, so DeclaringConfigUri is the leaf.
+            var fileSet = InMemoryTestFileSet.Create(
+                ("main.bicep", ""),
+                ("bicepconfig.json", """
+                    {
+                      "extends": "./base/bicepconfig.base.json",
+                      "moduleAliasesMock": {
+                        "br": {
+                          "shared": { "mapToFilePath": "./leaf-modules" }
+                        }
+                      }
+                    }
+                    """),
+                ("base/bicepconfig.base.json", """
+                    {
+                      "moduleAliasesMock": {
+                        "br": {
+                          "shared": { "mapToFilePath": "./base-modules" }
+                        }
+                      }
+                    }
+                    """));
+            var sut = new BicepConfigurationManager(fileSet.FileExplorer);
+
+            var chain = sut.GetConfigurationChain(fileSet.GetUri("main.bicep"));
+            var alias = chain.GetEffectiveConfiguration().ModuleAliasesMock
+                .TryGetOciArtifactModuleAliasMock("shared");
+
+            alias.IsSuccess(out var mockAlias, out _).Should().BeTrue();
+            // Leaf overrides the alias — declaring URI must be the leaf.
+            mockAlias!.DeclaringConfigUri.Should().Be(fileSet.GetUri("bicepconfig.json"));
+            mockAlias.MapToFilePath.Should().Be("./leaf-modules");
+        }
     }
 }

--- a/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationManager.cs
@@ -214,6 +214,16 @@ public class BicepConfigurationManager : IBicepConfigurationManager
             return GetBuiltInChain(diagnostics: [DiagnosticBuilder.ForDocumentStart().InvalidBicepConfigFile(leafUri, exception.Message)]);
         }
 
+        // Annotate moduleAliasesMock aliases with the URI of the config file that declared each one.
+        // Walk rawLayers, leaf-first: the first layer that contains an alias is the declaring layer.
+        var declaringUriMap = BuildAliasDeclaringUriMap(rawLayers);
+        if (declaringUriMap.Count > 0)
+        {
+            var annotatedMock = ((ModuleAliasesMockConfiguration)effectiveConfig.ModuleAliasesMock)
+                .WithDeclaringUris(declaringUriMap);
+            effectiveConfig = effectiveConfig.With(moduleAliasesMock: annotatedMock);
+        }
+
         // Build per-layer configs so diagnostics can be attributed to the exact file that caused them.
         var layers = rawLayers
             .Select(layer =>
@@ -232,6 +242,37 @@ public class BicepConfigurationManager : IBicepConfigurationManager
             .ToImmutableArray();
 
         return new BicepConfigurationChain(effectiveConfig, layers);
+    }
+
+    /// <summary>
+    /// Builds a map from alias name to the URI of the config file that first declared it.
+    /// Layers are visited leaf-first so the most-derived (leaf) declaration wins.
+    /// </summary>
+    private static ImmutableDictionary<string, IOUri> BuildAliasDeclaringUriMap(
+        List<(IFileHandle FileHandle, JsonElement Element)> rawLayers)
+    {
+        var map = ImmutableDictionary.CreateBuilder<string, IOUri>(StringComparer.Ordinal);
+
+        foreach (var (fileHandle, element) in rawLayers) // leaf first
+        {
+            if (!element.TryGetProperty(BicepConfiguration.ModuleAliasesMockKey, out var mockElement))
+            {
+                continue;
+            }
+
+            if (!mockElement.TryGetProperty("br", out var brElement))
+            {
+                continue;
+            }
+
+            foreach (var alias in brElement.EnumerateObject())
+            {
+                // First layer from leaf that declares this alias name is the declaring layer.
+                map.TryAdd(alias.Name, fileHandle.Uri);
+            }
+        }
+
+        return map.ToImmutable();
     }
 
     private static JsonElement StripExtendsProperty(JsonElement element)

--- a/src/Bicep.Core/Configuration/ModuleAliasesMockConfiguration.cs
+++ b/src/Bicep.Core/Configuration/ModuleAliasesMockConfiguration.cs
@@ -22,6 +22,14 @@ namespace Bicep.Core.Configuration
     {
         public string? MapToFilePath { get; init; }
 
+        /// <summary>
+        /// The URI of the configuration file that declared this alias's <see cref="MapToFilePath"/>.
+        /// Set by <see cref="ModuleAliasesMockConfiguration.WithDeclaringUris"/> during chain building
+        /// so that relative paths are resolved from the declaring file's directory, not the leaf's.
+        /// </summary>
+        [JsonIgnore]
+        public IOUri? DeclaringConfigUri { get; init; }
+
         public override string ToString() => $"{MapToFilePath}";
     }
 
@@ -60,6 +68,24 @@ namespace Bicep.Core.Configuration
             }
 
             return new(alias);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="ModuleAliasesMockConfiguration"/> with each alias annotated with its
+        /// declaring config file URI. Aliases not present in <paramref name="declaringUris"/> are unchanged.
+        /// </summary>
+        public ModuleAliasesMockConfiguration WithDeclaringUris(ImmutableDictionary<string, IOUri> declaringUris)
+        {
+            var annotated = this.Data.OciArtifactModuleAliasesMock
+                .ToImmutableSortedDictionary(
+                    kvp => kvp.Key,
+                    kvp => declaringUris.TryGetValue(kvp.Key, out var uri)
+                        ? kvp.Value with { DeclaringConfigUri = uri }
+                        : kvp.Value);
+
+            return new ModuleAliasesMockConfiguration(
+                this.Data with { OciArtifactModuleAliasesMock = annotated },
+                this.configFileUri);
         }
 
         private static bool ValidateAliasName(string aliasName, [NotNullWhen(false)] out DiagnosticBuilderDelegate? errorBuilder)

--- a/src/Bicep.Core/Registry/OciArtifactRegistry.cs
+++ b/src/Bicep.Core/Registry/OciArtifactRegistry.cs
@@ -87,10 +87,14 @@ namespace Bicep.Core.Registry
                         return new(x => x.InvalidOciArtifactModuleAliasRegistryNullOrUndefined(aliasName, configFileUri));
                     }
 
+                    // Use the declaring config's URI so that a relative mapToFilePath inherited from a base
+                    // config is resolved from that base config's directory, not the leaf's.
+                    var resolveBaseUri = mockAlias.DeclaringConfigUri ?? configFileUri;
+
                     if (!OciArtifactMockedReference.TryParse(
                         referencingFile,
                         mockAlias.MapToFilePath,
-                        configFileUri,
+                        resolveBaseUri,
                         reference,
                         this.fileExplorer,
                         aliasName).IsSuccess(out var mockedRef, out var mockedFailureBuilder))


### PR DESCRIPTION
## Description

<!-- Provide a 1-2 sentence description of your change -->

->Fixes  `moduleAliasesMock.mapToFilePath`  resolution to use the declaring config file's directory instead of always the leaf's, via a `DeclaringConfigUri` tracked per-alias through the inheritance chain. 

->Adds 18 end-to-end integration tests covering config inheritance across the full compiler pipeline , including cycle/depth/path diagnostics, cache invalidation, per-file squiggle attribution, local module and moduleAliasesMock provenance. 




## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20252)