### PR TITLE
Improve Bicep CLI cold-start performance

### DIFF
--- a/src/Bicep.Cli/Bicep.Cli.csproj
+++ b/src/Bicep.Cli/Bicep.Cli.csproj
@@ -19,6 +19,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
+    <PublishReadyToRun>true</PublishReadyToRun>
     <!-- restore pre-.net8 trim behavior https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/publishtrimmed -->
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>

--- a/src/Bicep.Core.UnitTests/Mock/FakeResourceTypes.cs
+++ b/src/Bicep.Core.UnitTests/Mock/FakeResourceTypes.cs
@@ -6351,6 +6351,8 @@ Fake.Web/publishingCredentials@2415-08-01";
                     new ObjectType(tr.FormatName(), TypeSymbolValidationFlags.Default, [], new TypeProperty(LanguageConstants.Any))));
 
             typesLoader.Setup(m => m.GetAvailableTypes()).Returns(fakeResourceTypeReferences);
+            typesLoader.Setup(m => m.HasType(It.IsAny<ResourceTypeReference>()))
+                .Returns<ResourceTypeReference>(fakeResourceTypeReferences.Contains);
             return typesLoader;
         }
 

--- a/src/Bicep.Core.UnitTests/Resource/ResourceTypeReferenceTests.cs
+++ b/src/Bicep.Core.UnitTests/Resource/ResourceTypeReferenceTests.cs
@@ -18,6 +18,12 @@ namespace Bicep.Core.UnitTests.Resource
         [DataRow("@2020-01-01")]
         [DataRow("-@2020-01-01")]
         [DataRow("abc@+")]
+        [DataRow("abc@a")]
+        [DataRow("abc@@2020-01-01")]
+        [DataRow("abc//def@2020-01-01")]
+        [DataRow("abc/def/@2020-01-01")]
+        [DataRow("abc/_def@2020-01-01")]
+        [DataRow("abc/def@2020_01_01")]
         public void InvalidType_ShouldBeRejected(string value)
         {
             ResourceTypeReference.TryParse(value).Should().BeNull();
@@ -51,6 +57,16 @@ namespace Bicep.Core.UnitTests.Resource
 
             actual.Should().NotBeNull();
             actual!.FormatType().Should().Be(expectedFullyQualifiedType);
+        }
+
+        [TestMethod]
+        public void Parse_reuses_the_input_string_as_the_formatted_name()
+        {
+            var value = new string("Microsoft.Compute/virtualMachines@2019-06-01".ToCharArray());
+
+            var actual = ResourceTypeReference.Parse(value);
+
+            actual.FormatName().Should().BeSameAs(value);
         }
 
         [DataTestMethod]
@@ -109,4 +125,3 @@ namespace Bicep.Core.UnitTests.Resource
         }
     }
 }
-

--- a/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
+++ b/src/Bicep.Core.UnitTests/Utils/TestTypeHelper.cs
@@ -33,6 +33,9 @@ namespace Bicep.Core.UnitTests.Utils
 
             public IEnumerable<ResourceTypeReference> GetAvailableTypes()
                 => resourceTypes.Keys;
+
+            public bool HasType(ResourceTypeReference reference)
+                => resourceTypes.ContainsKey(reference);
         }
 
         public static IResourceTypeProvider CreateAzResourceTypeProviderWithTypes(IEnumerable<ResourceTypeComponents> resourceTypes)

--- a/src/Bicep.Core/Resources/ResourceTypeReference.cs
+++ b/src/Bicep.Core/Resources/ResourceTypeReference.cs
@@ -5,26 +5,49 @@ using System.Text.RegularExpressions;
 
 namespace Bicep.Core.Resources
 {
-    public partial class ResourceTypeReference
+    public partial class ResourceTypeReference : IEquatable<ResourceTypeReference>
     {
+        private readonly int hashCode;
+        private ImmutableArray<string> typeSegments;
+
         public ResourceTypeReference(string type, string? version)
+            : this(version is null ? type : $"{type}@{version}", type, version)
+        {
+        }
+
+        private ResourceTypeReference(string name, string type, string? version)
         {
             if (type.Length <= 0)
             {
                 throw new ArgumentException("Type must be non-empty.");
             }
 
-            Name = version is null ? type : $"{type}@{version}";
+            Name = name;
             Type = type;
-            TypeSegments = [.. type.Split('/')];
             ApiVersion = version;
+            hashCode = HashCode.Combine(
+                LanguageConstants.ResourceTypeComparer.GetHashCode(type),
+                version is null ? 0 : LanguageConstants.ResourceTypeComparer.GetHashCode(version));
         }
 
         public string FormatName() => Name;
 
         public string FormatType() => Type;
 
-        public ImmutableArray<string> TypeSegments { get; }
+        public ImmutableArray<string> TypeSegments
+        {
+            get
+            {
+                if (typeSegments.IsDefault)
+                {
+                    ImmutableInterlocked.InterlockedInitialize(
+                        ref typeSegments,
+                        SplitTypeSegments(Type));
+                }
+
+                return typeSegments;
+            }
+        }
 
         public string Name { get; }
 
@@ -34,29 +57,46 @@ namespace Bicep.Core.Resources
 
         public bool IsParentOf(ResourceTypeReference other)
         {
-            // Parent should have N types, child should have N+1, first N types should be equal
-            return
-                this.TypeSegments.Length + 1 == other.TypeSegments.Length &&
-                Enumerable.SequenceEqual(this.TypeSegments, other.TypeSegments.Take(this.TypeSegments.Length), StringComparer.OrdinalIgnoreCase);
+            if (this.TypeSegments.Length + 1 != other.TypeSegments.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < this.TypeSegments.Length; i++)
+            {
+                if (!StringComparer.OrdinalIgnoreCase.Equals(this.TypeSegments[i], other.TypeSegments[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public static ResourceTypeReference? TryParse(string resourceType)
         {
-            var match = ResourceTypePattern().Match(resourceType);
-            if (match.Success == false)
+            var separatorIndex = resourceType.IndexOf('@');
+            var typeSpan = separatorIndex < 0 ? resourceType.AsSpan() : resourceType.AsSpan(0, separatorIndex);
+            if (!IsValidType(typeSpan))
             {
                 return null;
             }
 
-            var types = match.Groups["types"].Value;
-            var version = match.Groups["version"].Value;
-
-            if (string.IsNullOrEmpty(version))
+            if (separatorIndex < 0)
             {
-                return new ResourceTypeReference(types, null);
+                return new ResourceTypeReference(resourceType, null);
             }
 
-            return new ResourceTypeReference(types, version);
+            var versionSpan = resourceType.AsSpan(separatorIndex + 1);
+            if (!IsValidVersion(versionSpan))
+            {
+                return null;
+            }
+
+            return new ResourceTypeReference(
+                resourceType,
+                resourceType[..separatorIndex],
+                resourceType[(separatorIndex + 1)..]);
         }
 
         public static ResourceTypeReference Combine(ResourceTypeReference baseType, ResourceTypeReference nestedType)
@@ -75,26 +115,73 @@ namespace Bicep.Core.Resources
         public override string ToString()
             => this.FormatName();
 
-        public override bool Equals(object? other)
+        public override bool Equals(object? other) => Equals(other as ResourceTypeReference);
+
+        public bool Equals(ResourceTypeReference? other)
+            => other is not null &&
+            LanguageConstants.ResourceTypeComparer.Equals(this.Type, other.Type) &&
+            LanguageConstants.ResourceTypeComparer.Equals(this.ApiVersion, other.ApiVersion);
+
+        public override int GetHashCode()
+            => hashCode;
+
+        private static bool IsValidType(ReadOnlySpan<char> type)
         {
-            if (other is not ResourceTypeReference otherReference)
+            var segmentStart = true;
+            foreach (var character in type)
+            {
+                if (segmentStart)
+                {
+                    if (!char.IsAsciiLetterOrDigit(character))
+                    {
+                        return false;
+                    }
+
+                    segmentStart = false;
+                }
+                else if (character == '/')
+                {
+                    segmentStart = true;
+                }
+                else if (!char.IsAsciiLetterOrDigit(character) && character is not '-' and not '.')
+                {
+                    return false;
+                }
+            }
+
+            return !segmentStart;
+        }
+
+        private static bool IsValidVersion(ReadOnlySpan<char> version)
+        {
+            if (version.Length < 2 || !char.IsAsciiLetterOrDigit(version[0]))
             {
                 return false;
             }
 
-            return Enumerable.SequenceEqual(this.TypeSegments, otherReference.TypeSegments, LanguageConstants.ResourceTypeComparer) &&
-                LanguageConstants.ResourceTypeComparer.Equals(this.ApiVersion, otherReference.ApiVersion);
+            foreach (var character in version[1..])
+            {
+                if (!char.IsAsciiLetterOrDigit(character) && character is not '-' and not '.')
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-        public override int GetHashCode()
-            => HashCode.Combine(
-                Enumerable.Select(this.TypeSegments, x => LanguageConstants.ResourceTypeComparer.GetHashCode(x)).Aggregate((a, b) => a ^ b),
-                (this.ApiVersion is null ? 0 : LanguageConstants.ResourceTypeComparer.GetHashCode(this.ApiVersion)));
+        private static ImmutableArray<string> SplitTypeSegments(string type)
+        {
+            var builder = ImmutableArray.CreateBuilder<string>(type.AsSpan().Count('/') + 1);
+            foreach (var range in type.AsSpan().Split('/'))
+            {
+                builder.Add(type[range]);
+            }
+
+            return builder.MoveToImmutable();
+        }
 
         [GeneratedRegex("^(?<types>[a-z0-9][a-z0-9-.]*(/[a-z0-9][a-z0-9-.]*)*)@", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
         private static partial Regex ResourceTypePrefixPattern();
-
-        [GeneratedRegex(@"^(?<types>[a-z0-9][a-z0-9-.]*(/[a-z0-9][a-z0-9-.]*)*)(@(?<version>[a-z0-9][a-z0-9-\.]+))?$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
-        private static partial Regex ResourceTypePattern();
     }
 }

--- a/src/Bicep.Core/TypeSystem/Providers/Az/AzResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Az/AzResourceTypeProvider.cs
@@ -214,7 +214,7 @@ namespace Bicep.Core.TypeSystem.Providers.Az
         }
 
         public AzResourceTypeProvider(IResourceTypeLoader resourceTypeLoader)
-            : base([.. resourceTypeLoader.GetAvailableTypes()])
+            : base(resourceTypeLoader.GetAvailableTypes())
         {
             this.resourceTypeLoader = resourceTypeLoader;
             definedTypeCache = new ResourceTypeCache();
@@ -508,7 +508,7 @@ namespace Bicep.Core.TypeSystem.Providers.Az
         }
 
         public bool HasDefinedType(ResourceTypeReference typeReference)
-            => availableResourceTypes.Contains(typeReference);
+            => resourceTypeLoader.HasType(typeReference);
 
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableResourceTypes;

--- a/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeLoader.cs
@@ -39,6 +39,9 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableTypes.Keys;
 
+        public bool HasType(ResourceTypeReference reference)
+            => availableTypes.ContainsKey(reference);
+
         public ResourceTypeComponents LoadType(ResourceTypeReference reference)
         {
             var typeLocation = availableTypes[reference];

--- a/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/Extensibility/ExtensionResourceTypeProvider.cs
@@ -17,7 +17,7 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
         private readonly ResourceTypeCache generatedTypeCache;
 
         public ExtensionResourceTypeProvider(ExtensionResourceTypeLoader resourceTypeLoader)
-            : base([.. resourceTypeLoader.GetAvailableTypes()])
+            : base(resourceTypeLoader.GetAvailableTypes())
         {
             this.resourceTypeLoader = resourceTypeLoader;
             definedTypeCache = new ResourceTypeCache();
@@ -214,7 +214,7 @@ namespace Bicep.Core.TypeSystem.Providers.Extensibility
         }
 
         public bool HasDefinedType(ResourceTypeReference typeReference)
-            => availableResourceTypes.Contains(typeReference);
+            => resourceTypeLoader.HasType(typeReference);
 
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableResourceTypes;

--- a/src/Bicep.Core/TypeSystem/Providers/IResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/IResourceTypeLoader.cs
@@ -11,5 +11,7 @@ namespace Bicep.Core.TypeSystem.Providers
         ResourceTypeComponents LoadType(ResourceTypeReference reference);
 
         IEnumerable<ResourceTypeReference> GetAvailableTypes();
+
+        bool HasType(ResourceTypeReference reference);
     }
 }

--- a/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeLoader.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeLoader.cs
@@ -28,6 +28,9 @@ namespace Bicep.Core.TypeSystem.Providers.K8s
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableTypes.Keys;
 
+        public bool HasType(ResourceTypeReference reference)
+            => availableTypes.ContainsKey(reference);
+
         public ResourceTypeComponents LoadType(ResourceTypeReference reference)
         {
             var typeLocation = availableTypes[reference];

--- a/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeProvider.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/K8s/K8sResourceTypeProvider.cs
@@ -25,7 +25,7 @@ namespace Bicep.Core.TypeSystem.Providers.K8s
         ]);
 
         public K8sResourceTypeProvider(K8sResourceTypeLoader resourceTypeLoader)
-            : base([.. resourceTypeLoader.GetAvailableTypes()])
+            : base(resourceTypeLoader.GetAvailableTypes())
         {
             this.resourceTypeLoader = resourceTypeLoader;
             definedTypeCache = new ResourceTypeCache();
@@ -173,7 +173,7 @@ namespace Bicep.Core.TypeSystem.Providers.K8s
         }
 
         public bool HasDefinedType(ResourceTypeReference typeReference)
-            => availableResourceTypes.Contains(typeReference);
+            => resourceTypeLoader.HasType(typeReference);
 
         public IEnumerable<ResourceTypeReference> GetAvailableTypes()
             => availableResourceTypes;

--- a/src/Bicep.Core/TypeSystem/Providers/ResourceTypeProviderBase.cs
+++ b/src/Bicep.Core/TypeSystem/Providers/ResourceTypeProviderBase.cs
@@ -7,12 +7,12 @@ namespace Bicep.Core.TypeSystem.Providers;
 
 public abstract class ResourceTypeProviderBase
 {
-    protected readonly ImmutableHashSet<ResourceTypeReference> availableResourceTypes;
+    protected readonly IEnumerable<ResourceTypeReference> availableResourceTypes;
     protected readonly Lazy<ImmutableDictionary<string, ImmutableArray<ResourceTypeReference>>> typeReferencesByTypeLazy;
 
     public ImmutableDictionary<string, ImmutableArray<ResourceTypeReference>> TypeReferencesByType => typeReferencesByTypeLazy.Value;
 
-    protected ResourceTypeProviderBase(ImmutableHashSet<ResourceTypeReference> availableResourceTypes)
+    protected ResourceTypeProviderBase(IEnumerable<ResourceTypeReference> availableResourceTypes)
     {
         this.availableResourceTypes = availableResourceTypes;
         typeReferencesByTypeLazy = new(() => availableResourceTypes

--- a/src/Bicep.Testing/Fakes/TypeSystem/FakeResourceTypeLoader.cs
+++ b/src/Bicep.Testing/Fakes/TypeSystem/FakeResourceTypeLoader.cs
@@ -19,6 +19,8 @@ namespace Bicep.Testing.Fakes.TypeSystem
 
         public IEnumerable<ResourceTypeReference> GetAvailableTypes() => this.resourceTypesByReference.Keys;
 
+        public bool HasType(ResourceTypeReference reference) => this.resourceTypesByReference.ContainsKey(reference);
+
         public ResourceTypeComponents LoadType(ResourceTypeReference reference) => this.resourceTypesByReference[reference];
     }
 }


### PR DESCRIPTION
## Description

Improves one-shot Bicep CLI build performance by removing redundant work from Azure resource type initialization and enabling compressed ReadyToRun publishing.

The regression investigation found that the .NET 10 migration changed Roslyn's lowering of `[.. type.Split('/')]` from a span-based path to `Enumerable.ToArray -> ICollectionToArray -> SZArrayHelper.CopyTo -> Array.Copy`. This expression runs for every entry in the Azure type index. The implementation now uses allocation-conscious span parsing, lazily materializes type segments, reuses the parsed input as the formatted name, caches the immutable resource type hash, and avoids copying loader keys into a second provider hash set. Resource type providers now delegate membership checks to their loader's existing dictionary.

The CLI also enables compressed ReadyToRun publishing. This retains the current single-file and compression behavior while precompiling eligible methods to reduce JIT work during startup and first compilation.

## Benchmarks

All timings are randomized, interleaved, cold-process Windows x64 runs after warmup. Absolute timings varied between sessions, so only binaries measured in the same session are compared.

### Resource initialization optimizations

| Comparison | Runs per binary | Before median | After median | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Initial parsing/segment optimization | 20 | 4,127.24 ms | 3,730.28 ms | 396.96 ms (9.6%) |
| Name/hash/provider-index follow-up | 25 | 3,735.46 ms | 3,555.89 ms | 179.57 ms (4.8%) |
| Original vs fully optimized code | 25 | 3,917.95 ms | 3,562.59 ms | 355.36 ms (9.1%) |

Trace confirmation after the follow-up changes:

- `AzResourceTypeProvider` construction decreased from 65 samples to 2 samples.
- The duplicate provider `ImmutableHashSet` construction disappeared.
- `ResourceTypeReference.GetHashCode` had no standalone samples after caching.

### Compressed ReadyToRun

| Publish mode | Build median | `--version` median | Executable size |
| --- | ---: | ---: | ---: |
| Compressed JIT/default | 3,608.89 ms | 812.93 ms | 68.93 MiB |
| Compressed ReadyToRun | 1,251.02 ms | 705.28 ms | 115.62 MiB |
| Change | 65.3% faster | 13.2% faster | 67.7% larger |

Single-file compression was enabled only one day earlier by commit `0da0a29a` / PR 20251. Before that change, the v0.46.1 `bicep-win-x64.exe` release asset was 112.23 MiB. The compressed ReadyToRun binary is 115.62 MiB, only 3.39 MiB (3.0%) larger than that previous release. Therefore ReadyToRun plus compression delivers the large startup and first-build gain while keeping the executable in roughly the same size range users already downloaded in prior releases.

A second compressed-R2R session measured a 1,227.18 ms build median. An uncompressed ReadyToRun experiment reached 887.03 ms but produced a 229.58 MiB executable, so this PR retains compression as the better size/startup tradeoff.

ReadyToRun and default publishes produced byte-identical ARM JSON for the benchmark input. A normal project publish with the new property produced the same binary size and output as the explicit `-p:PublishReadyToRun=true` experiment.

## Validation

- All 7,030 `Bicep.Core.UnitTests` tests pass.
- Release build succeeds with zero warnings and errors.
- ReadyToRun and JIT/default benchmark outputs are byte-identical.
- `git diff --check` passes.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20255)