### PR TITLE
[Version Pinning] Add version constraint parser and evaluator

### DIFF
--- a/src/Bicep.Core.UnitTests/SemanticVersioning/SemanticVersionTests.cs
+++ b/src/Bicep.Core.UnitTests/SemanticVersioning/SemanticVersionTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.SemanticVersioning;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.SemanticVersioning;
+
+[TestClass]
+public class SemanticVersionTests
+{
+    [DataTestMethod]
+    [DataRow("1.2.3", 1, 2, 3)]
+    [DataRow("0.0.0", 0, 0, 0)]
+    [DataRow("0.47.12", 0, 47, 12)]
+    // Omitted components default to zero.
+    [DataRow("1.2", 1, 2, 0)]
+    [DataRow("1", 1, 0, 0)]
+    [DataRow("0", 0, 0, 0)]
+    // Each component may be any non-negative number that fits in an int.
+    [DataRow("10.200.3000", 10, 200, 3000)]
+    [DataRow("2147483647.0.0", 2147483647, 0, 0)]
+    public void TryParse_ValidVersion_ReturnsTrueAndParsedComponents(string value, int major, int minor, int patch)
+    {
+        var result = SemanticVersion.TryParse(value, out var version);
+
+        result.Should().BeTrue();
+        version.Should().NotBeNull();
+        version!.Major.Should().Be(major);
+        version.Minor.Should().Be(minor);
+        version.Patch.Should().Be(patch);
+    }
+
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow("whatever")]
+    // Whitespace is trimmed by the comparator, not by the version itself.
+    [DataRow(" 1.2.3")]
+    [DataRow("1.2.3 ")]
+    // Leading zeros are not permitted.
+    [DataRow("01.2.3")]
+    [DataRow("1.02.3")]
+    [DataRow("1.2.03")]
+    // Malformed component lists.
+    [DataRow("1.2.3.4")]
+    [DataRow("1.")]
+    [DataRow("1..2")]
+    [DataRow(".1.2")]
+    [DataRow("1.2.")]
+    [DataRow("-1.2.3")]
+    [DataRow("+1.2.3")]
+    // Prerelease labels and build metadata are not supported.
+    [DataRow("1.2.3-preview")]
+    [DataRow("1.2.3-rc.1")]
+    [DataRow("1.2.3+abc123")]
+    [DataRow("1.2.3-rc.1+abc123")]
+    // Release tags carry a leading "v", but the version syntax does not.
+    [DataRow("v1.2.3")]
+    [DataRow("V1.2.3")]
+    // A component too large to represent is rejected rather than silently wrapping.
+    [DataRow("2147483648.0.0")]
+    [DataRow("99999999999999999999.0.0")]
+    // Only ASCII digits are accepted; "\d" would otherwise match these and differ between implementations.
+    [DataRow("١.٢.٣")]
+    public void TryParse_InvalidVersion_ReturnsFalseAndNull(string value)
+    {
+        var result = SemanticVersion.TryParse(value, out var version);
+
+        result.Should().BeFalse();
+        version.Should().BeNull();
+    }
+
+    [DataTestMethod]
+    [DataRow("1.2.3", "1.2.3", 0)]
+    // Major takes precedence over minor and patch.
+    [DataRow("2.0.0", "1.99.99", 1)]
+    [DataRow("1.99.99", "2.0.0", -1)]
+    // Then minor.
+    [DataRow("1.3.0", "1.2.99", 1)]
+    [DataRow("1.2.99", "1.3.0", -1)]
+    // Then patch.
+    [DataRow("1.2.4", "1.2.3", 1)]
+    [DataRow("1.2.3", "1.2.4", -1)]
+    // Components are compared as numbers, not as text.
+    [DataRow("1.10.0", "1.9.0", 1)]
+    [DataRow("0.47.12", "0.47.2", 1)]
+    public void CompareTo_OrdersByMajorThenMinorThenPatch(string left, string right, int expectedSign)
+    {
+        var comparison = SemanticVersion.Parse(left).CompareTo(SemanticVersion.Parse(right));
+
+        Math.Sign(comparison).Should().Be(expectedSign);
+    }
+
+    [TestMethod]
+    public void CompareTo_Null_ReturnsPositive()
+    {
+        SemanticVersion.Parse("1.2.3").CompareTo(null).Should().BePositive();
+    }
+
+    [DataTestMethod]
+    [DataRow("1.2.3", "1.2.3")]
+    [DataRow("1.2", "1.2.0")]
+    [DataRow("1", "1.0.0")]
+    public void ToString_RendersAllThreeComponents(string value, string expected)
+    {
+        SemanticVersion.Parse(value).ToString().Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void Equality_ComparesComponents()
+    {
+        SemanticVersion.Parse("1.2.3").Should().Be(SemanticVersion.Parse("1.2.3"));
+        SemanticVersion.Parse("1.2").Should().Be(SemanticVersion.Parse("1.2.0"));
+        SemanticVersion.Parse("1.2.3").Should().NotBe(SemanticVersion.Parse("1.2.4"));
+    }
+
+    [TestMethod]
+    public void Parse_InvalidVersion_ThrowsFormatException()
+    {
+        var action = () => SemanticVersion.Parse("not-a-version");
+
+        action.Should().Throw<FormatException>().WithMessage("The provided value 'not-a-version' is not a valid version.");
+    }
+}

--- a/src/Bicep.Core.UnitTests/SemanticVersioning/VersionComparatorTests.cs
+++ b/src/Bicep.Core.UnitTests/SemanticVersioning/VersionComparatorTests.cs
@@ -18,12 +18,8 @@ public class VersionComparatorTests
     [DataRow("<1.2.3", VersionComparatorOperator.LessThan, "1.2.3")]
     [DataRow("<=1.2.3", VersionComparatorOperator.LessThanOrEqual, "1.2.3")]
     [DataRow("  >=  1.2.3  ", VersionComparatorOperator.GreaterThanOrEqual, "1.2.3")]
-    [DataRow("v1.2.3", VersionComparatorOperator.Equal, "1.2.3")]
-    [DataRow(">=V1.2.3", VersionComparatorOperator.GreaterThanOrEqual, "1.2.3")]
     [DataRow(">=1.2", VersionComparatorOperator.GreaterThanOrEqual, "1.2.0")]
     [DataRow(">=1", VersionComparatorOperator.GreaterThanOrEqual, "1.0.0")]
-    [DataRow("1.2.3-preview", VersionComparatorOperator.Equal, "1.2.3-preview")]
-    [DataRow("1.2.3+abc123", VersionComparatorOperator.Equal, "1.2.3+abc123")]
     public void TryParse_ValidComparator_ReturnsTrueAndParsedComparator(string value, VersionComparatorOperator expectedOperator, string expectedVersion)
     {
         var result = VersionComparator.TryParse(value, out var comparator);
@@ -43,6 +39,10 @@ public class VersionComparatorTests
     [DataRow("whatever")]
     [DataRow("1.2.3.4")]
     [DataRow("01.2.3")]
+    [DataRow("v1.2.3")]
+    [DataRow(">=V1.2.3")]
+    [DataRow("1.2.3-preview")]
+    [DataRow("1.2.3+abc123")]
     [DataRow("^1.2.3")]
     [DataRow("~1.2.3")]
     [DataRow("*")]
@@ -74,7 +74,6 @@ public class VersionComparatorTests
     [DataTestMethod]
     [DataRow("1.2.3", "1.2.3")]
     [DataRow("=1.2.3", "1.2.3")]
-    [DataRow("v1.2.3", "1.2.3")]
     [DataRow(">=1.2", ">=1.2.0")]
     [DataRow("  <  1.2.3", "<1.2.3")]
     public void ToString_NormalizesTheComparator(string value, string expected)

--- a/src/Bicep.Core.UnitTests/SemanticVersioning/VersionComparatorTests.cs
+++ b/src/Bicep.Core.UnitTests/SemanticVersioning/VersionComparatorTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.SemanticVersioning;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bicep.Core.UnitTests.SemanticVersioning;
+
+[TestClass]
+public class VersionComparatorTests
+{
+    [DataTestMethod]
+    [DataRow("1.2.3", VersionComparatorOperator.Equal, "1.2.3")]
+    [DataRow("=1.2.3", VersionComparatorOperator.Equal, "1.2.3")]
+    [DataRow(">1.2.3", VersionComparatorOperator.GreaterThan, "1.2.3")]
+    [DataRow(">=1.2.3", VersionComparatorOperator.GreaterThanOrEqual, "1.2.3")]
+    [DataRow("<1.2.3", VersionComparatorOperator.LessThan, "1.2.3")]
+    [DataRow("<=1.2.3", VersionComparatorOperator.LessThanOrEqual, "1.2.3")]
+    [DataRow("  >=  1.2.3  ", VersionComparatorOperator.GreaterThanOrEqual, "1.2.3")]
+    [DataRow("v1.2.3", VersionComparatorOperator.Equal, "1.2.3")]
+    [DataRow(">=V1.2.3", VersionComparatorOperator.GreaterThanOrEqual, "1.2.3")]
+    [DataRow(">=1.2", VersionComparatorOperator.GreaterThanOrEqual, "1.2.0")]
+    [DataRow(">=1", VersionComparatorOperator.GreaterThanOrEqual, "1.0.0")]
+    [DataRow("1.2.3-preview", VersionComparatorOperator.Equal, "1.2.3-preview")]
+    [DataRow("1.2.3+abc123", VersionComparatorOperator.Equal, "1.2.3+abc123")]
+    public void TryParse_ValidComparator_ReturnsTrueAndParsedComparator(string value, VersionComparatorOperator expectedOperator, string expectedVersion)
+    {
+        var result = VersionComparator.TryParse(value, out var comparator);
+
+        result.Should().BeTrue();
+        comparator.Should().NotBeNull();
+        comparator!.Operator.Should().Be(expectedOperator);
+        comparator.Version.ToString().Should().Be(expectedVersion);
+    }
+
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow(">=")]
+    [DataRow(">")]
+    [DataRow("=")]
+    [DataRow("whatever")]
+    [DataRow("1.2.3.4")]
+    [DataRow("01.2.3")]
+    [DataRow("^1.2.3")]
+    [DataRow("~1.2.3")]
+    [DataRow("*")]
+    [DataRow("=>1.2.3")]
+    [DataRow("(>=1.2.3)")]
+    public void TryParse_InvalidComparator_ReturnsFalseAndNull(string value)
+    {
+        var result = VersionComparator.TryParse(value, out var comparator);
+
+        result.Should().BeFalse();
+        comparator.Should().BeNull();
+    }
+
+    [DataTestMethod]
+    [DataRow("1.2.3", false, false, true)]
+    [DataRow(">1.2.3", true, false, false)]
+    [DataRow(">=1.2.3", true, false, true)]
+    [DataRow("<1.2.3", false, true, false)]
+    [DataRow("<=1.2.3", false, true, true)]
+    public void BoundProperties_ReturnExpectedValues(string value, bool isLowerBound, bool isUpperBound, bool isInclusive)
+    {
+        var comparator = ParseComparator(value);
+
+        comparator.IsLowerBound.Should().Be(isLowerBound);
+        comparator.IsUpperBound.Should().Be(isUpperBound);
+        comparator.IsInclusive.Should().Be(isInclusive);
+    }
+
+    [DataTestMethod]
+    [DataRow("1.2.3", "1.2.3")]
+    [DataRow("=1.2.3", "1.2.3")]
+    [DataRow("v1.2.3", "1.2.3")]
+    [DataRow(">=1.2", ">=1.2.0")]
+    [DataRow("  <  1.2.3", "<1.2.3")]
+    public void ToString_NormalizesTheComparator(string value, string expected)
+    {
+        ParseComparator(value).ToString().Should().Be(expected);
+    }
+
+    private static VersionComparator ParseComparator(string value)
+    {
+        VersionComparator.TryParse(value, out var comparator).Should().BeTrue();
+
+        return comparator!;
+    }
+}

--- a/src/Bicep.Core.UnitTests/SemanticVersioning/VersionRangeTests.cs
+++ b/src/Bicep.Core.UnitTests/SemanticVersioning/VersionRangeTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.SemanticVersioning;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Semver;
+
+namespace Bicep.Core.UnitTests.SemanticVersioning;
+
+[TestClass]
+public class VersionRangeTests
+{
+    [DataTestMethod]
+    // Exact versions.
+    [DataRow("1.2.3", "1.2.3")]
+    [DataRow("=0.31.0", "0.31.0")]
+    [DataRow("v1.2.3", "1.2.3")]
+    [DataRow("1.2.3-preview", "1.2.3-preview")]
+    // Single comparators.
+    [DataRow(">=0.31.0", ">=0.31.0")]
+    [DataRow("<0.31.0", "<0.31.0")]
+    [DataRow(">0.31.0", ">0.31.0")]
+    [DataRow("<=0.31.0", "<=0.31.0")]
+    // Omitted minor and patch components are filled in with zeroes.
+    [DataRow(">=1.2", ">=1.2.0")]
+    [DataRow(">=1", ">=1.0.0")]
+    // Ranges, including whitespace handling and bound reordering.
+    [DataRow(">=0.31.0, <1.0.0", ">=0.31.0, <1.0.0")]
+    [DataRow(">=0.31.0,<1.0.0", ">=0.31.0, <1.0.0")]
+    [DataRow("   >=0.31.0   ,   <1.0.0   ", ">=0.31.0, <1.0.0")]
+    [DataRow("<1.0.0, >=0.31.0", ">=0.31.0, <1.0.0")]
+    [DataRow(">0.31.0, <=1.0.0", ">0.31.0, <=1.0.0")]
+    public void TryParse_ValidConstraint_ReturnsTrueAndNormalizedRange(string value, string expected)
+    {
+        var result = VersionRange.TryParse(value, out var range);
+
+        result.Should().BeTrue();
+        range.Should().NotBeNull();
+        range!.ToString().Should().Be(expected);
+    }
+
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow("whatever")]
+    [DataRow(">=")]
+    // More than two comparators are not supported.
+    [DataRow(">=1.0.0, <2.0.0, <3.0.0")]
+    // Empty comparators.
+    [DataRow(">=1.0.0,")]
+    [DataRow(",<2.0.0")]
+    [DataRow(",")]
+    // A range must pair exactly one lower bound with one upper bound.
+    [DataRow(">=1.0.0, >=2.0.0")]
+    [DataRow("<1.0.0, <2.0.0")]
+    [DataRow("=1.0.0, <2.0.0")]
+    [DataRow("1.0.0, 2.0.0")]
+    // Range syntax is not wrapped in parentheses when used in bicepconfig.json.
+    [DataRow("(>=1.0.0, <2.0.0)")]
+    // npm-style advanced range syntax is intentionally unsupported.
+    [DataRow("^1.0.0")]
+    [DataRow("~1.0.0")]
+    [DataRow("1.x")]
+    public void TryParse_InvalidConstraint_ReturnsFalseAndNull(string value)
+    {
+        var result = VersionRange.TryParse(value, out var range);
+
+        result.Should().BeFalse();
+        range.Should().BeNull();
+    }
+
+    [DataTestMethod]
+    [DataRow(">=0.31.0", "0.31.0", true)]
+    [DataRow(">=0.31.0", "0.31.1", true)]
+    [DataRow(">=0.31.0", "1.0.0", true)]
+    [DataRow(">=0.31.0", "0.30.9", false)]
+    [DataRow(">0.31.0", "0.31.0", false)]
+    [DataRow("<0.31.0", "0.30.0", true)]
+    [DataRow("<0.31.0", "0.31.0", false)]
+    [DataRow("<=0.31.0", "0.31.0", true)]
+    [DataRow("0.31.0", "0.31.0", true)]
+    [DataRow("0.31.0", "0.31.1", false)]
+    [DataRow("=0.31.0", "0.31.0", true)]
+    [DataRow(">=1.2", "1.2.0", true)]
+    [DataRow(">=1", "1.0.0", true)]
+    [DataRow(">=1", "0.9.9", false)]
+    // Ranges.
+    [DataRow(">=0.31.0, <1.0.0", "0.31.0", true)]
+    [DataRow(">=0.31.0, <1.0.0", "0.99.99", true)]
+    [DataRow(">=0.31.0, <1.0.0", "1.0.0", false)]
+    [DataRow(">=0.31.0, <1.0.0", "0.30.0", false)]
+    // A prerelease sorts below its own release.
+    [DataRow(">=1.0.0", "1.0.0-preview", false)]
+    [DataRow("<1.0.0", "1.0.0-preview", true)]
+    [DataRow(">=1.0.0-alpha, <2.0.0", "1.0.0-beta", true)]
+    // Build metadata does not affect precedence.
+    [DataRow("=1.0.0", "1.0.0+abc123", true)]
+    [DataRow(">=1.0.0", "1.0.0+abc123", true)]
+    public void Satisfies_ReturnsExpectedResult(string constraint, string version, bool expected)
+    {
+        var range = VersionRange.Parse(constraint);
+
+        range.Satisfies(SemVersion.Parse(version, SemVersionStyles.Strict)).Should().Be(expected);
+    }
+
+    [DataTestMethod]
+    [DataRow("1.0.0", true)]
+    [DataRow(">=1.0.0", true)]
+    [DataRow(">=1.0.0, <2.0.0", true)]
+    [DataRow(">=1.0.0, <=1.0.0", true)]
+    [DataRow(">=2.0.0, <1.0.0", false)]
+    [DataRow(">=1.0.0, <1.0.0", false)]
+    [DataRow(">1.0.0, <=1.0.0", false)]
+    public void IsSatisfiable_ReturnsExpectedResult(string constraint, bool expected)
+    {
+        VersionRange.Parse(constraint).IsSatisfiable.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void Parse_InvalidConstraint_ThrowsFormatException()
+    {
+        var action = () => VersionRange.Parse("not-a-version");
+
+        action.Should().Throw<FormatException>().WithMessage("The provided value 'not-a-version' is not a valid version constraint.");
+    }
+
+    [TestMethod]
+    public void LowerBoundAndUpperBound_ExposeTheCorrespondingComparators()
+    {
+        var range = VersionRange.Parse(">=0.31.0, <1.0.0");
+
+        range.LowerBound.Should().NotBeNull();
+        range.LowerBound!.ToString().Should().Be(">=0.31.0");
+        range.UpperBound.Should().NotBeNull();
+        range.UpperBound!.ToString().Should().Be("<1.0.0");
+    }
+
+    [TestMethod]
+    public void LowerBoundAndUpperBound_AreNullForAnExactVersion()
+    {
+        var range = VersionRange.Parse("0.31.0");
+
+        range.LowerBound.Should().BeNull();
+        range.UpperBound.Should().BeNull();
+    }
+}

--- a/src/Bicep.Core.UnitTests/SemanticVersioning/VersionRangeTests.cs
+++ b/src/Bicep.Core.UnitTests/SemanticVersioning/VersionRangeTests.cs
@@ -4,7 +4,6 @@
 using Bicep.Core.SemanticVersioning;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Semver;
 
 namespace Bicep.Core.UnitTests.SemanticVersioning;
 
@@ -15,8 +14,8 @@ public class VersionRangeTests
     // Exact versions.
     [DataRow("1.2.3", "1.2.3")]
     [DataRow("=0.31.0", "0.31.0")]
-    [DataRow("v1.2.3", "1.2.3")]
-    [DataRow("1.2.3-preview", "1.2.3-preview")]
+    // An exact version is held as a pair of inclusive bounds, so the two spellings normalize to the same constraint.
+    [DataRow(">=1.2.3, <=1.2.3", "1.2.3")]
     // Single comparators.
     [DataRow(">=0.31.0", ">=0.31.0")]
     [DataRow("<0.31.0", "<0.31.0")]
@@ -51,11 +50,18 @@ public class VersionRangeTests
     [DataRow(">=1.0.0,")]
     [DataRow(",<2.0.0")]
     [DataRow(",")]
-    // A range must pair exactly one lower bound with one upper bound.
+    // A range must pair at most one lower bound with one upper bound.
     [DataRow(">=1.0.0, >=2.0.0")]
     [DataRow("<1.0.0, <2.0.0")]
     [DataRow("=1.0.0, <2.0.0")]
     [DataRow("1.0.0, 2.0.0")]
+    // A leading "v" is not part of the constraint syntax, even though release tags carry one.
+    [DataRow("v1.2.3")]
+    [DataRow(">=v1.0.0, <v2.0.0")]
+    // Prerelease labels and build metadata are not supported.
+    [DataRow("1.2.3-preview")]
+    [DataRow(">=1.0.0-rc.1")]
+    [DataRow("1.2.3+abc123")]
     // Range syntax is not wrapped in parentheses when used in bicepconfig.json.
     [DataRow("(>=1.0.0, <2.0.0)")]
     // npm-style advanced range syntax is intentionally unsupported.
@@ -82,26 +88,23 @@ public class VersionRangeTests
     [DataRow("0.31.0", "0.31.0", true)]
     [DataRow("0.31.0", "0.31.1", false)]
     [DataRow("=0.31.0", "0.31.0", true)]
-    [DataRow(">=1.2", "1.2.0", true)]
     [DataRow(">=1", "1.0.0", true)]
     [DataRow(">=1", "0.9.9", false)]
+    // Omitting the patch component pins that exact version; it does not match the whole minor version line.
+    [DataRow("1.2", "1.2.0", true)]
+    [DataRow("1.2", "1.2.5", false)]
+    [DataRow(">=1.2", "1.2.0", true)]
     // Ranges.
     [DataRow(">=0.31.0, <1.0.0", "0.31.0", true)]
     [DataRow(">=0.31.0, <1.0.0", "0.99.99", true)]
     [DataRow(">=0.31.0, <1.0.0", "1.0.0", false)]
     [DataRow(">=0.31.0, <1.0.0", "0.30.0", false)]
-    // A prerelease sorts below its own release.
-    [DataRow(">=1.0.0", "1.0.0-preview", false)]
-    [DataRow("<1.0.0", "1.0.0-preview", true)]
-    [DataRow(">=1.0.0-alpha, <2.0.0", "1.0.0-beta", true)]
-    // Build metadata does not affect precedence.
-    [DataRow("=1.0.0", "1.0.0+abc123", true)]
-    [DataRow(">=1.0.0", "1.0.0+abc123", true)]
+    [DataRow(">=0.31.0", "0.47.12", true)]
     public void Satisfies_ReturnsExpectedResult(string constraint, string version, bool expected)
     {
         var range = VersionRange.Parse(constraint);
 
-        range.Satisfies(SemVersion.Parse(version, SemVersionStyles.Strict)).Should().Be(expected);
+        range.IsSatisfiedBy(SemanticVersion.Parse(version)).Should().Be(expected);
     }
 
     [DataTestMethod]
@@ -112,9 +115,27 @@ public class VersionRangeTests
     [DataRow(">=2.0.0, <1.0.0", false)]
     [DataRow(">=1.0.0, <1.0.0", false)]
     [DataRow(">1.0.0, <=1.0.0", false)]
+    [DataRow(">=1.0.0, <1.0.1", true)]
+    [DataRow(">1.0.0, <1.0.2", true)]
+    // Exclusive bounds exactly one patch version apart admit no version, since there is nothing between them.
+    [DataRow(">1.2.3, <1.2.4", false)]
+    [DataRow(">1.2.4, <1.2.5", false)]
     public void IsSatisfiable_ReturnsExpectedResult(string constraint, bool expected)
     {
         VersionRange.Parse(constraint).IsSatisfiable.Should().Be(expected);
+    }
+
+    [DataTestMethod]
+    [DataRow("1.2.3", true)]
+    [DataRow("=1.2.3", true)]
+    [DataRow(">=1.2.3, <=1.2.3", true)]
+    [DataRow(">=1.2.3", false)]
+    [DataRow("<=1.2.3", false)]
+    [DataRow(">=1.0.0, <2.0.0", false)]
+    [DataRow(">1.2.3, <1.2.3", false)]
+    public void IsExactVersion_ReturnsExpectedResult(string constraint, bool expected)
+    {
+        VersionRange.Parse(constraint).IsExactVersion.Should().Be(expected);
     }
 
     [TestMethod]
@@ -137,11 +158,22 @@ public class VersionRangeTests
     }
 
     [TestMethod]
-    public void LowerBoundAndUpperBound_AreNullForAnExactVersion()
+    public void LowerBoundAndUpperBound_AreBothSetForAnExactVersion()
     {
         var range = VersionRange.Parse("0.31.0");
 
-        range.LowerBound.Should().BeNull();
+        range.LowerBound.Should().NotBeNull();
+        range.LowerBound!.ToString().Should().Be(">=0.31.0");
+        range.UpperBound.Should().NotBeNull();
+        range.UpperBound!.ToString().Should().Be("<=0.31.0");
+    }
+
+    [TestMethod]
+    public void LowerBoundAndUpperBound_AreNullWhenTheConstraintIsOpenEnded()
+    {
+        var range = VersionRange.Parse(">=0.31.0");
+
+        range.LowerBound.Should().NotBeNull();
         range.UpperBound.Should().BeNull();
     }
 }

--- a/src/Bicep.Core/SemanticVersioning/SemanticVersion.cs
+++ b/src/Bicep.Core/SemanticVersioning/SemanticVersion.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Bicep.Core.SemanticVersioning;
+
+/// <summary>
+/// A version made up of a major, minor and patch number, as published for Bicep releases.
+/// </summary>
+public sealed partial record SemanticVersion(int Major, int Minor, int Patch) : IComparable<SemanticVersion>
+{
+    /// <summary>
+    /// Parses a version, where the minor and patch components may be omitted ("1.2" is equivalent to "1.2.0", and
+    /// "1" to "1.0.0").
+    /// </summary>
+    public static bool TryParse(string value, [NotNullWhen(true)] out SemanticVersion? result)
+    {
+        result = null;
+
+        if (VersionPattern().Match(value) is not { Success: true } match)
+        {
+            return false;
+        }
+
+        // A component that is present but too large to represent fails to parse rather than silently wrapping.
+        if (!TryParseComponent(match.Groups["major"], out var major) ||
+            !TryParseComponent(match.Groups["minor"], out var minor) ||
+            !TryParseComponent(match.Groups["patch"], out var patch))
+        {
+            return false;
+        }
+
+        result = new SemanticVersion(major, minor, patch);
+        return true;
+    }
+
+    public static SemanticVersion Parse(string value)
+        => TryParse(value, out var result)
+            ? result
+            : throw new FormatException($"The provided value '{value}' is not a valid version.");
+
+    /// <summary>
+    /// Orders two versions by major, then minor, then patch. Returns a negative number when this version is lower
+    /// than the other, zero when they are equal, and a positive number when it is higher.
+    /// </summary>
+    public int CompareTo(SemanticVersion? other)
+    {
+        if (other is null)
+        {
+            return 1;
+        }
+
+        if (this.Major != other.Major)
+        {
+            return this.Major.CompareTo(other.Major);
+        }
+
+        if (this.Minor != other.Minor)
+        {
+            return this.Minor.CompareTo(other.Minor);
+        }
+
+        return this.Patch.CompareTo(other.Patch);
+    }
+
+    public override string ToString() => $"{this.Major}.{this.Minor}.{this.Patch}";
+
+    /// <summary>
+    /// An omitted component defaults to zero. Digits are matched explicitly as "[0-9]".
+    /// </summary>
+    private static bool TryParseComponent(Group group, out int result)
+    {
+        if (!group.Success)
+        {
+            result = 0;
+            return true;
+        }
+
+        return int.TryParse(group.ValueSpan, NumberStyles.None, CultureInfo.InvariantCulture, out result);
+    }
+
+    [GeneratedRegex(@"^(?<major>0|[1-9][0-9]*)(?:\.(?<minor>0|[1-9][0-9]*)(?:\.(?<patch>0|[1-9][0-9]*))?)?$", RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
+    private static partial Regex VersionPattern();
+}

--- a/src/Bicep.Core/SemanticVersioning/VersionComparator.cs
+++ b/src/Bicep.Core/SemanticVersioning/VersionComparator.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Semver;
+
+namespace Bicep.Core.SemanticVersioning;
+
+/// <summary>
+/// A single component of a version constraint, A bare version such as "1.2.0"
+/// is equivalent to "=1.2.0".
+/// </summary>
+public sealed record VersionComparator(VersionComparatorOperator Operator, SemVersion Version)
+{
+    /// <summary>
+    /// The version styles accepted within a constraint. A leading "v" is allowed and the minor and patch components may
+    /// be omitted (">=1.2" is equivalent to ">=1.2.0", and ">=1" to ">=1.0.0").
+    /// </summary>
+    private const SemVersionStyles VersionStyles = SemVersionStyles.AllowV | SemVersionStyles.OptionalMinorPatch;
+
+    /// <summary>
+    /// The recognized operator tokens. Two-character tokens must be tested first so that ">=" is not
+    /// mistaken for ">" followed by a version starting with "=".
+    /// </summary>
+    private static readonly ImmutableArray<(string Token, VersionComparatorOperator Operator)> OperatorTokens =
+    [
+        (">=", VersionComparatorOperator.GreaterThanOrEqual),
+        ("<=", VersionComparatorOperator.LessThanOrEqual),
+        (">", VersionComparatorOperator.GreaterThan),
+        ("<", VersionComparatorOperator.LessThan),
+        ("=", VersionComparatorOperator.Equal),
+    ];
+
+    /// <summary>
+    /// Whether this comparator constrains how low a version may go.
+    /// </summary>
+    public bool IsLowerBound => this.Operator is VersionComparatorOperator.GreaterThan or VersionComparatorOperator.GreaterThanOrEqual;
+
+    /// <summary>
+    /// Whether this comparator constrains how high a version may go.
+    /// </summary>
+    public bool IsUpperBound => this.Operator is VersionComparatorOperator.LessThan or VersionComparatorOperator.LessThanOrEqual;
+
+    /// <summary>
+    /// Whether the bound itself is an accepted version.
+    /// </summary>
+    public bool IsInclusive => this.Operator is not (VersionComparatorOperator.GreaterThan or VersionComparatorOperator.LessThan);
+
+    /// <summary>
+    /// Determines whether the supplied version satisfies this comparator. Comparison follows semantic version precedence.
+    /// </summary>
+    public bool Satisfies(SemVersion version)
+    {
+        var comparison = version.ComparePrecedenceTo(this.Version);
+
+        return this.Operator switch
+        {
+            VersionComparatorOperator.Equal => comparison == 0,
+            VersionComparatorOperator.GreaterThan => comparison > 0,
+            VersionComparatorOperator.GreaterThanOrEqual => comparison >= 0,
+            VersionComparatorOperator.LessThan => comparison < 0,
+            VersionComparatorOperator.LessThanOrEqual => comparison <= 0,
+            _ => throw new UnreachableException($"Unrecognized {nameof(VersionComparatorOperator)}: {this.Operator}."),
+        };
+    }
+
+    public static bool TryParse(string value, [NotNullWhen(true)] out VersionComparator? result)
+    {
+        var remainder = value.Trim();
+        var @operator = VersionComparatorOperator.Equal;
+
+        foreach (var (token, candidate) in OperatorTokens)
+        {
+            if (remainder.StartsWith(token, StringComparison.Ordinal))
+            {
+                @operator = candidate;
+                remainder = remainder[token.Length..].TrimStart();
+                break;
+            }
+        }
+
+        if (!SemVersion.TryParse(remainder, VersionStyles, out var version))
+        {
+            result = null;
+            return false;
+        }
+
+        result = new VersionComparator(@operator, version);
+        return true;
+    }
+
+    public override string ToString() => this.Operator switch
+    {
+        // An exact constraint is rendered without an operator, matching the syntax users are expected to write.
+        VersionComparatorOperator.Equal => this.Version.ToString(),
+        VersionComparatorOperator.GreaterThan => $">{this.Version}",
+        VersionComparatorOperator.GreaterThanOrEqual => $">={this.Version}",
+        VersionComparatorOperator.LessThan => $"<{this.Version}",
+        VersionComparatorOperator.LessThanOrEqual => $"<={this.Version}",
+        _ => throw new UnreachableException($"Unrecognized {nameof(VersionComparatorOperator)}: {this.Operator}."),
+    };
+}

--- a/src/Bicep.Core/SemanticVersioning/VersionComparator.cs
+++ b/src/Bicep.Core/SemanticVersioning/VersionComparator.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Semver;
 
 namespace Bicep.Core.SemanticVersioning;
 
@@ -12,14 +11,8 @@ namespace Bicep.Core.SemanticVersioning;
 /// A single component of a version constraint, A bare version such as "1.2.0"
 /// is equivalent to "=1.2.0".
 /// </summary>
-public sealed record VersionComparator(VersionComparatorOperator Operator, SemVersion Version)
+public sealed record VersionComparator(VersionComparatorOperator Operator, SemanticVersion Version)
 {
-    /// <summary>
-    /// The version styles accepted within a constraint. A leading "v" is allowed and the minor and patch components may
-    /// be omitted (">=1.2" is equivalent to ">=1.2.0", and ">=1" to ">=1.0.0").
-    /// </summary>
-    private const SemVersionStyles VersionStyles = SemVersionStyles.AllowV | SemVersionStyles.OptionalMinorPatch;
-
     /// <summary>
     /// The recognized operator tokens. Two-character tokens must be tested first so that ">=" is not
     /// mistaken for ">" followed by a version starting with "=".
@@ -51,9 +44,9 @@ public sealed record VersionComparator(VersionComparatorOperator Operator, SemVe
     /// <summary>
     /// Determines whether the supplied version satisfies this comparator. Comparison follows semantic version precedence.
     /// </summary>
-    public bool Satisfies(SemVersion version)
+    public bool IsSatisfiedBy(SemanticVersion version)
     {
-        var comparison = version.ComparePrecedenceTo(this.Version);
+        var comparison = version.CompareTo(this.Version);
 
         return this.Operator switch
         {
@@ -81,7 +74,7 @@ public sealed record VersionComparator(VersionComparatorOperator Operator, SemVe
             }
         }
 
-        if (!SemVersion.TryParse(remainder, VersionStyles, out var version))
+        if (!SemanticVersion.TryParse(remainder, out var version))
         {
             result = null;
             return false;

--- a/src/Bicep.Core/SemanticVersioning/VersionComparatorOperator.cs
+++ b/src/Bicep.Core/SemanticVersioning/VersionComparatorOperator.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Bicep.Core.SemanticVersioning;
+
+/// <summary>
+/// The comparison operators supported in a version constraint.
+/// </summary>
+public enum VersionComparatorOperator
+{
+    Equal,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+}

--- a/src/Bicep.Core/SemanticVersioning/VersionRange.cs
+++ b/src/Bicep.Core/SemanticVersioning/VersionRange.cs
@@ -14,7 +14,7 @@ public sealed class VersionRange
     /// <summary>
     /// A range may pair at most one lower bound with one upper bound.
     /// </summary>
-    public const int MaxComparatorCount = 2;
+    private const int MaxComparatorCount = 2;
 
     private const char ComparatorSeparator = ',';
 

--- a/src/Bicep.Core/SemanticVersioning/VersionRange.cs
+++ b/src/Bicep.Core/SemanticVersioning/VersionRange.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Semver;
+
+namespace Bicep.Core.SemanticVersioning;
+
+/// <summary>
+/// A version constraint, expressed either as an exact version ("1.2.3") or as a range of up to two
+/// comparators separated by a comma ("&gt;=1.2.3, &lt;2.0.0"). Whitespace around comparators is ignored.
+/// </summary>
+public sealed class VersionRange
+{
+    /// <summary>
+    /// A range may pair at most one lower bound with one upper bound.
+    /// </summary>
+    public const int MaxComparatorCount = 2;
+
+    private const char ComparatorSeparator = ',';
+
+    private VersionRange(ImmutableArray<VersionComparator> comparators)
+    {
+        this.Comparators = comparators;
+    }
+
+    /// <summary>
+    /// The comparators making up this range. When two are present, the lower bound is always first.
+    /// </summary>
+    public ImmutableArray<VersionComparator> Comparators { get; }
+
+    public VersionComparator? LowerBound => this.Comparators.FirstOrDefault(comparator => comparator.IsLowerBound);
+
+    public VersionComparator? UpperBound => this.Comparators.FirstOrDefault(comparator => comparator.IsUpperBound);
+
+    /// <summary>
+    /// Whether any version at all can satisfy this range. A range such as "&gt;=2.0.0, &lt;1.0.0" parses
+    /// successfully but can never be satisfied.
+    /// </summary>
+    public bool IsSatisfiable
+    {
+        get
+        {
+            if (this.LowerBound is not { } lower || this.UpperBound is not { } upper)
+            {
+                return true;
+            }
+
+            return lower.Version.ComparePrecedenceTo(upper.Version) switch
+            {
+                < 0 => true,
+                // The bounds coincide, so the range describes a single version only if both ends include it.
+                0 => lower.IsInclusive && upper.IsInclusive,
+                _ => false,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the supplied version satisfies every comparator in this range.
+    /// </summary>
+    public bool Satisfies(SemVersion version) => this.Comparators.All(comparator => comparator.Satisfies(version));
+
+    public static VersionRange Parse(string value)
+        => TryParse(value, out var result)
+            ? result
+            : throw new FormatException($"The provided value '{value}' is not a valid version constraint.");
+
+    public static bool TryParse(string value, [NotNullWhen(true)] out VersionRange? result)
+    {
+        result = null;
+
+        var parts = value.Split(ComparatorSeparator);
+
+        if (parts.Length > MaxComparatorCount)
+        {
+            return false;
+        }
+
+        var comparators = new VersionComparator[parts.Length];
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (!VersionComparator.TryParse(parts[i], out var comparator))
+            {
+                return false;
+            }
+
+            comparators[i] = comparator;
+        }
+
+        if (comparators.Length == MaxComparatorCount)
+        {
+            var (first, second) = (comparators[0], comparators[1]);
+
+            // A two-part range must pair one lower bound with one upper bound. This rejects redundant ranges
+            // such as ">=1.0.0, >=2.0.0" as well as any range combining an exact version with a bound.
+            if (first.IsUpperBound && second.IsLowerBound)
+            {
+                // Normalize so that the lower bound always comes first.
+                comparators = [second, first];
+            }
+            else if (!first.IsLowerBound || !second.IsUpperBound)
+            {
+                return false;
+            }
+        }
+
+        result = new VersionRange([.. comparators]);
+        return true;
+    }
+
+    public override string ToString() => string.Join($"{ComparatorSeparator} ", this.Comparators);
+}

--- a/src/Bicep.Core/SemanticVersioning/VersionRange.cs
+++ b/src/Bicep.Core/SemanticVersioning/VersionRange.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using Semver;
 
 namespace Bicep.Core.SemanticVersioning;
 
 /// <summary>
-/// A version constraint, expressed either as an exact version ("1.2.3") or as a range of up to two
-/// comparators separated by a comma ("&gt;=1.2.3, &lt;2.0.0"). Whitespace around comparators is ignored.
+/// A version constraint, expressed either as an exact version ("1.2.3") or as a range pairing a lower bound with an
+/// upper bound . Whitespace around comparators is ignored.
 /// </summary>
 public sealed class VersionRange
 {
@@ -20,23 +18,35 @@ public sealed class VersionRange
 
     private const char ComparatorSeparator = ',';
 
-    private VersionRange(ImmutableArray<VersionComparator> comparators)
+    private VersionRange(VersionComparator? lowerBound, VersionComparator? upperBound)
     {
-        this.Comparators = comparators;
+        this.LowerBound = lowerBound;
+        this.UpperBound = upperBound;
     }
 
     /// <summary>
-    /// The comparators making up this range. When two are present, the lower bound is always first.
+    /// The lower end of the range, if the constraint has one.
     /// </summary>
-    public ImmutableArray<VersionComparator> Comparators { get; }
-
-    public VersionComparator? LowerBound => this.Comparators.FirstOrDefault(comparator => comparator.IsLowerBound);
-
-    public VersionComparator? UpperBound => this.Comparators.FirstOrDefault(comparator => comparator.IsUpperBound);
+    public VersionComparator? LowerBound { get; }
 
     /// <summary>
-    /// Whether any version at all can satisfy this range. A range such as "&gt;=2.0.0, &lt;1.0.0" parses
-    /// successfully but can never be satisfied.
+    /// The upper end of the range, if the constraint has one.
+    /// </summary>
+    public VersionComparator? UpperBound { get; }
+
+    /// <summary>
+    /// Whether this constraint accepts a single version only. An exact version is held as a pair of inclusive bounds.
+    /// </summary>
+    public bool IsExactVersion
+        => this.LowerBound is { IsInclusive: true } lower &&
+           this.UpperBound is { IsInclusive: true } upper &&
+           lower.Version == upper.Version;
+
+    /// <summary>
+    /// Whether the bounds are ordered such that a version could fall between them. A range such as
+    /// "&gt;=2.0.0, &lt;1.0.0" parses successfully but can never be satisfied. Because versions are discrete
+    /// (there is no version between "1.2.3" and "1.2.4"), a range such as "&gt;1.2.3, &lt;1.2.4" is also
+    /// unsatisfiable even though its bounds are correctly ordered.
     /// </summary>
     public bool IsSatisfiable
     {
@@ -47,9 +57,9 @@ public sealed class VersionRange
                 return true;
             }
 
-            return lower.Version.ComparePrecedenceTo(upper.Version) switch
+            return lower.Version.CompareTo(upper.Version) switch
             {
-                < 0 => true,
+                < 0 => !AreAdjacentExclusiveBounds(lower, upper),
                 // The bounds coincide, so the range describes a single version only if both ends include it.
                 0 => lower.IsInclusive && upper.IsInclusive,
                 _ => false,
@@ -58,9 +68,24 @@ public sealed class VersionRange
     }
 
     /// <summary>
-    /// Determines whether the supplied version satisfies every comparator in this range.
+    /// Whether the lower and upper bounds are both exclusive and exactly one patch version apart, e.g.
+    /// "&gt;1.2.3, &lt;1.2.4". No version can satisfy such a pair, since patch numbers are whole integers and
+    /// there is nothing strictly between them. The comparison uses <see langword="long"/> so that a patch value
+    /// of <see cref="int.MaxValue"/> cannot overflow and mask a genuine adjacency.
     /// </summary>
-    public bool Satisfies(SemVersion version) => this.Comparators.All(comparator => comparator.Satisfies(version));
+    private static bool AreAdjacentExclusiveBounds(VersionComparator lower, VersionComparator upper)
+        => !lower.IsInclusive &&
+           !upper.IsInclusive &&
+           lower.Version.Major == upper.Version.Major &&
+           lower.Version.Minor == upper.Version.Minor &&
+           (long)lower.Version.Patch + 1 == upper.Version.Patch;
+
+    /// <summary>
+    /// Determines whether the supplied version satisfies both ends of this range.
+    /// </summary>
+    public bool IsSatisfiedBy(SemanticVersion version)
+        => (this.LowerBound?.IsSatisfiedBy(version) ?? true) &&
+           (this.UpperBound?.IsSatisfiedBy(version) ?? true);
 
     public static VersionRange Parse(string value)
         => TryParse(value, out var result)
@@ -78,38 +103,60 @@ public sealed class VersionRange
             return false;
         }
 
-        var comparators = new VersionComparator[parts.Length];
+        VersionComparator? lowerBound = null;
+        VersionComparator? upperBound = null;
 
-        for (var i = 0; i < parts.Length; i++)
+        // Assigning each comparator to the end of the range it constrains rejects redundant constraints such as
+        // ">=1.0.0, >=2.0.0", and makes the order the parts were written in irrelevant.
+        foreach (var part in parts)
         {
-            if (!VersionComparator.TryParse(parts[i], out var comparator))
+            if (!VersionComparator.TryParse(part, out var comparator))
             {
                 return false;
             }
 
-            comparators[i] = comparator;
+            if (comparator.Operator is VersionComparatorOperator.Equal)
+            {
+                // An exact version is the degenerate range that admits only itself, so it occupies both ends. This
+                // also rejects any constraint combining an exact version with a bound, such as "=1.0.0, <2.0.0".
+                if (lowerBound is not null || upperBound is not null)
+                {
+                    return false;
+                }
+
+                lowerBound = comparator with { Operator = VersionComparatorOperator.GreaterThanOrEqual };
+                upperBound = comparator with { Operator = VersionComparatorOperator.LessThanOrEqual };
+            }
+            else if (comparator.IsLowerBound)
+            {
+                if (lowerBound is not null)
+                {
+                    return false;
+                }
+
+                lowerBound = comparator;
+            }
+            else
+            {
+                if (upperBound is not null)
+                {
+                    return false;
+                }
+
+                upperBound = comparator;
+            }
         }
 
-        if (comparators.Length == MaxComparatorCount)
-        {
-            var (first, second) = (comparators[0], comparators[1]);
-
-            // A two-part range must pair one lower bound with one upper bound. This rejects redundant ranges
-            // such as ">=1.0.0, >=2.0.0" as well as any range combining an exact version with a bound.
-            if (first.IsUpperBound && second.IsLowerBound)
-            {
-                // Normalize so that the lower bound always comes first.
-                comparators = [second, first];
-            }
-            else if (!first.IsLowerBound || !second.IsUpperBound)
-            {
-                return false;
-            }
-        }
-
-        result = new VersionRange([.. comparators]);
+        result = new VersionRange(lowerBound, upperBound);
         return true;
     }
 
-    public override string ToString() => string.Join($"{ComparatorSeparator} ", this.Comparators);
+    /// <summary>
+    /// Renders the constraint in its normalized form. Diagnostics should report constraints through this method, so
+    /// that an exact version is shown the way a user would write it rather than as a pair of bounds.
+    /// </summary>
+    public override string ToString()
+        => this.IsExactVersion && this.LowerBound is { } exact
+            ? exact.Version.ToString()
+            : string.Join($"{ComparatorSeparator} ", new[] { this.LowerBound, this.UpperBound }.OfType<VersionComparator>());
 }


### PR DESCRIPTION
## Description

<!-- Provide a 1-2 sentence description of your change -->

Part 1 of the Bicep version pinning REP. Adds a parser and evaluator that takes a version constraint (`1.2.3`, `>=0.31.0`, `>=0.31.0, <1.0.0`, `v` prefixes, partial versions) and answers whether a given version satisfies it. Comparison is done by our custom parser.

Nothing is consuming this yet will be wired up in follow-up PRs. 
Tests added in `VersionRangeTests.cs` and `VersionComparatorTests.cs`.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20256)