### PR TITLE
Emit GA Language Version for NullableExisting and ThisNamespace

### DIFF
--- a/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
+++ b/src/Bicep.Core.IntegrationTests/NullableExistingResourceTests.cs
@@ -405,9 +405,8 @@ output accountLocation string? = storageAccount.?location
         }
 
         [TestMethod]
-        public void NullableExisting_NestedChildResource_ShouldEmitExperimentalLanguageVersion()
+        public void NullableExisting_NestedChildResource_ShouldEmitLanguageVersion20()
         {
-            // @nullIfNotFound on a nested existing child resource should still trigger the experimental language version
             var (template, diagnostics, _) = CompilationHelper.Compile(@"
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   name: 'testStorage'
@@ -429,8 +428,7 @@ output blobServiceId string? = storageAccount::blobService.?id
             {
                 diagnostics.ExcludingLinterDiagnostics().Should().BeEmpty();
                 template.Should().NotBeNull();
-                // Verify the experimental language version is used (required for @nullIfNotFound)
-                template.Should().HaveValueAtPath("$.languageVersion", "2.1-experimental");
+                template.Should().HaveValueAtPath("$.languageVersion", "2.0");
                 // Verify the nested existing resource has the correct options
                 template.Should().HaveValueAtPath("$.resources['storageAccount::blobService'].existing", true);
                 template.Should().HaveValueAtPath("$.resources['storageAccount::blobService']['@options'].nullIfNotFound", new JArray());

--- a/src/Bicep.Core.UnitTests/Semantics/Namespaces/ThisNamespaceTests.cs
+++ b/src/Bicep.Core.UnitTests/Semantics/Namespaces/ThisNamespaceTests.cs
@@ -90,6 +90,7 @@ resource testResource 'Microsoft.Storage/storageAccounts@2021-04-01' = {
 
                 // Check that this.exists() is compiled to not(empty(target('full')))
                 template.Should().HaveValueAtPath("$.resources.testResource.properties.allowBlobPublicAccess", "[not(empty(target('full')))]");
+                template.Should().HaveValueAtPath("$.languageVersion", "2.0");
             }
         }
 

--- a/src/Bicep.Core/Emit/EmitterSettings.cs
+++ b/src/Bicep.Core/Emit/EmitterSettings.cs
@@ -13,20 +13,7 @@ namespace Bicep.Core.Emit
         public EmitterSettings(SemanticModel model)
         {
             FileKind = model.SourceFileKind;
-            UseExperimentalTemplateLanguageVersion = model.Features.EnabledFeatureMetadata.Any(feature => feature.usesExperimentalArmEngineFeature) ||
-                // @nullIfNotFound and this namespace are GA'd Bicep features but still require the experimental ARM engine language version.
-                model.DeclaredResources.Any(r => SemanticModelHelper.TryGetDecoratorInNamespace(
-                    model,
-                    r.Symbol.DeclaringResource,
-                    SystemNamespaceType.BuiltInName,
-                    LanguageConstants.NullIfNotFoundDecoratorName) is not null) ||
-                SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,
-                    seed: false,
-                    function: (found, syntax) => found ||
-                        (syntax is InstanceFunctionCallSyntax ifcs &&
-                         model.Binder.GetSymbolInfo(ifcs.BaseExpression) is LocalThisNamespaceSymbol),
-                    resultSelector: result => result,
-                    continuationFunction: (result, syntax) => !result);
+            UseExperimentalTemplateLanguageVersion = model.Features.EnabledFeatureMetadata.Any(feature => feature.usesExperimentalArmEngineFeature);
 
             // Symbolic names are used if (evaluated in increasing order of computational cost):
             EnableSymbolicNames =
@@ -74,7 +61,15 @@ namespace Bicep.Core.Emit
                         (syntax is ResourceDeclarationSyntax rds && ResourceRequiresSymbolicNames(model, rds)),
                     resultSelector: result => result,
                     continuationFunction: (result, syntax) => !result) ||
-                model.Root.ResourceDeclarations.Any(resource => resource.TryGetDecorator(model, SystemNamespaceType.BuiltInName, LanguageConstants.RetryOnPropertyName) is not null);
+                model.Root.ResourceDeclarations.Any(resource => resource.TryGetDecorator(model, SystemNamespaceType.BuiltInName, LanguageConstants.RetryOnPropertyName) is not null) ||
+                model.Root.ResourceDeclarations.Any(resource => resource.TryGetDecorator(model, SystemNamespaceType.BuiltInName, LanguageConstants.NullIfNotFoundDecoratorName) is not null) ||
+                SyntaxAggregator.Aggregate(model.SourceFile.ProgramSyntax,
+                    seed: false,
+                    function: (found, syntax) => found ||
+                        (syntax is InstanceFunctionCallSyntax ifcs &&
+                         model.Binder.GetSymbolInfo(ifcs.BaseExpression) is LocalThisNamespaceSymbol),
+                    resultSelector: result => result,
+                    continuationFunction: (result, syntax) => !result);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Update ThisNamespace and NullableExisting to emit GA language version as backend has been fully deployed.


## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20258)