### PR TITLE
Fix blockquote formatting in resource and module hovers

### DIFF
--- a/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/HoverTests.cs
@@ -333,7 +333,7 @@ resource test|Output string = 'str'
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my module  \n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my param  \n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my var  \n"),
-                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my\nmultiline\nresource  \n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/discriminatortests?pivots=deployment-language-bicep)  \n"),
+                h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my\nmultiline\nresource\n\n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/discriminatortests?pivots=deployment-language-bicep)  \n"),
                 h => h!.Contents.MarkupContent!.Value.Should().EndWith("```  \nthis is my output  \n  \n"));
         }
 
@@ -447,7 +447,7 @@ output o1 string = mod|1.name
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
-            var expectedHover = "```bicep\nmodule mod1 './mod.bicep'\n```  \nthis is mod1  \nthis\nis\na description  \n";
+            var expectedHover = "```bicep\nmodule mod1 './mod.bicep'\n```  \nthis is mod1\n\nthis\nis\na description  \n";
             hovers.Should().SatisfyRespectively(
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover),
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover)
@@ -495,7 +495,7 @@ output o1 string = mod|1.name
 
             var hovers = await RequestHovers(client, bicepFile, cursors);
 
-            var expectedHover = $"```bicep\nmodule mod1 './mod.{extension}'\n```  \nthis is mod1  \nthis\nis\na description  \n";
+            var expectedHover = $"```bicep\nmodule mod1 './mod.{extension}'\n```  \nthis is mod1\n\nthis\nis\na description  \n";
             hovers.Should().SatisfyRespectively(
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover),
                 h => h!.Contents.MarkupContent!.Value.Should().Be(expectedHover)
@@ -543,7 +543,8 @@ resource foo 'Test.Rp/basicTests@2020-01-01'
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource bar 'Test.Rp/basicTests@2020-01-01'
 ```  " + @"
-This resource also has a description!  " + @"
+This resource also has a description!" + @"
+
 [View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/basictests?pivots=deployment-language-bicep)  " + @"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
@@ -551,6 +552,20 @@ resource madeUp 'Test.MadeUp/nonExistentResourceType@2020-01-01'
 ```  " + @"
   " + @"
 "));
+        }
+
+        [TestMethod]
+        public async Task Resource_hover_documentation_link_is_separated_from_trailing_blockquote()
+        {
+            var hovers = await RequestHoversAtCursorLocations(@"
+@description('''A resource description.
+
+> Note: name must be globally unique.''')
+resource sto|rage 'Test.Rp/basicTests@2020-01-01' = {}
+",
+                '|');
+
+            hovers.Single()!.Contents.MarkupContent!.Value.Should().Be("```bicep\nresource storage 'Test.Rp/basicTests@2020-01-01'\n```  \nA resource description.\n\n> Note: name must be globally unique.\n\n[View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/basictests?pivots=deployment-language-bicep)  \n");
         }
 
         [TestMethod]
@@ -577,7 +592,8 @@ resource foo 'Test.Rp/basicTests@2020-01-01'
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
 resource bar 'Test.Rp/basicTests@2020-01-01'
 ```  " + @"
-This resource also has a description!  " + @"
+This resource also has a description!" + @"
+
 [View Documentation](https://learn.microsoft.com/azure/templates/test.rp/2020-01-01/basictests?pivots=deployment-language-bicep)  " + @"
 "),
                 h => h!.Contents.MarkupContent!.Value.Should().BeEquivalentToIgnoringNewlines(@"```bicep
@@ -834,7 +850,16 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             "sha256:0000000000000000000000000000000000000000000000000000000000000000",
             null,
             "my description", // description
-             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage@sha256:0000000000000000000000000000000000000000000000000000000000000000'\n```  \nmy description  \n[View Documentation](http://test.com)  \n")]
+             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage@sha256:0000000000000000000000000000000000000000000000000000000000000000'\n```  \nmy description\n\n[View Documentation](http://test.com)  \n")]
+        [DataRow(
+            "http://test.com",
+            "br:test.azurecr.io/bicep/modules/storage@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "test.azurecr.io",
+            "bicep/modules/storage",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            null,
+            "> Note: The resource does not auto-generate the key for you.", // description
+             "```bicep\nmodule test 'br:test.azurecr.io/bicep/modules/storage@sha256:0000000000000000000000000000000000000000000000000000000000000000'\n```  \n> Note: The resource does not auto-generate the key for you.\n\n[View Documentation](http://test.com)  \n")]
         public async Task Verify_Hover_ContainerRegistry(string? documentationUri, string repositoryAndTag, string registry, string repository, string? digest, string? tag, string? description, string expectedHoverContent)
         {
             var fileWithCursors = $$"""
@@ -862,6 +887,36 @@ resource testRes 'Test.Rp/discriminatorTests@2020-01-01' = {
             var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
 
             hovers.Single()!.Contents.MarkupContent!.Value.Should().Be(expectedHoverContent);
+        }
+
+        [TestMethod]
+        public async Task Module_hover_descriptions_are_separated_by_blank_lines()
+        {
+            const string moduleReference = "br:test.azurecr.io/bicep/modules/storage@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+            var (bicepFileContents, cursors) = ParserHelper.GetFileWithCursors($$"""
+                @description('''> note''')
+                module |test '{{moduleReference}}' = {
+                  name: 'abc'
+                }
+                """, '|');
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.AddFile("input.bicep", bicepFileContents);
+
+            SaveManifestFileToModuleRegistryCache(
+                mockFileSystem,
+                "test.azurecr.io",
+                "bicep/modules/storage",
+                GetManifestFileContents("http://test.com", "registry description"),
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                null);
+
+            var helper = await GetLanguageClientAsync(mockFileSystem);
+            var bicepFile = new LanguageClientFile(mockFileSystem.Path.GetFullPath("input.bicep"), bicepFileContents);
+
+            await helper.OpenFileOnceAsync(TestContext, bicepFile.Text, bicepFile.Uri);
+            var hovers = await RequestHovers(helper.Client, bicepFile, cursors);
+
+            hovers.Single()!.Contents.MarkupContent!.Value.Should().Be($"```bicep\nmodule test '{moduleReference}'\n```  \n> note\n\nregistry description\n\n[View Documentation](http://test.com)  \n");
         }
 
         private static void SaveManifestFileToModuleRegistryCache(

--- a/src/Bicep.LangServer/Features/Language/Hover/BicepHoverHandler.cs
+++ b/src/Bicep.LangServer/Features/Language/Hover/BicepHoverHandler.cs
@@ -3,7 +3,6 @@
 
 using System.Text;
 using Bicep.Core;
-using Bicep.Core.Extensions;
 using Bicep.Core.Navigation;
 using Bicep.Core.Parsing;
 using Bicep.Core.Registry;
@@ -152,10 +151,13 @@ namespace Bicep.LanguageServer.Features.Language.Hover
                 case ResourceSymbol resource:
                     var docsSuffix = TryGetTypeDocumentationLink(resource) is { } typeDocsLink ? MarkdownHelper.GetDocumentationLink(typeDocsLink) : "";
                     var description = TryGetDescription(result, resource);
+                    var descriptionWithDocs = string.IsNullOrEmpty(docsSuffix)
+                        ? MarkdownHelper.AppendNewline(description)
+                        : MarkdownHelper.JoinWithBlankLine([description, docsSuffix]);
 
                     return AsMarkdown(MarkdownHelper.CodeBlockWithDescription(
                         $"resource {resource.Name} {(resource.Type is ResourceType ? $"'{resource.Type}'" : resource.Type)}",
-                        $"{MarkdownHelper.AppendNewline(description)}{docsSuffix}"));
+                        descriptionWithDocs));
 
                 case ModuleSymbol module:
                     return await GetModuleMarkdown(request, result, moduleDispatcher, moduleRegistryProvider, module);
@@ -255,7 +257,7 @@ namespace Bicep.LanguageServer.Features.Language.Hover
                 }
             }
 
-            var descriptions = MarkdownHelper.JoinWithNewlines(descriptionLines.WhereNotNull());
+            var descriptions = MarkdownHelper.JoinWithBlankLine(descriptionLines);
             return AsMarkdown(MarkdownHelper.CodeBlockWithDescription($"module {module.Name} '{filePath}'", descriptions));
         }
 

--- a/src/Bicep.LangServer/Utils/MarkdownHelper.cs
+++ b/src/Bicep.LangServer/Utils/MarkdownHelper.cs
@@ -23,8 +23,8 @@ public static class MarkdownHelper
     public static string AppendNewline(string? input)
         => input is null ? string.Empty : $"{input}{MarkdownNewLine}";
 
-    public static string JoinWithNewlines(IEnumerable<string> inputs)
-        => string.Join(MarkdownNewLine, inputs);
+    public static string JoinWithBlankLine(IEnumerable<string?> parts)
+        => string.Join("\n\n", parts.Where(part => !string.IsNullOrEmpty(part)));
 
     public static string? GetDocumentationLink(string? documentationUri)
         => documentationUri is null ? null : $"[View Documentation]({documentationUri})";


### PR DESCRIPTION
## Description

When a resource or module hover description ends in a Markdown blockquote, the following documentation link or module description can be rendered inside that quote. Add blank lines between those sections, with regression coverage for resource and module hovers.

Fixes #12756

## Example Usage

### Registry module documentation link

Hover over `modSshPublicKey` after the module has restored:

```bicep
module modSshPublicKey 'br/public:avm/res/compute/ssh-public-key:0.2.2' = {
  name: 'modSshPublicKey'
  params: {
    name: 'sshPublicKey'
  }
}
```

Before: the documentation link appears inside the registry description's final blockquote.
After: the note remains quoted, and the documentation link appears in a separate paragraph outside the quote.

**Before**

<img width="1370" height="372" alt="1" src="https://github.com/user-attachments/assets/61455206-2ece-45eb-bcc2-e561b3379d80" />

**After**

<img width="1370" height="372" alt="4" src="https://github.com/user-attachments/assets/ca2b73af-b4da-4e16-8d45-780369ca839b" />

### Resource documentation link

Hover over `storage`. The same result should also hold when hovering over the resource type string:

```bicep
@description('''A storage account.

> Note: The account name must be globally unique.''')
resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
  name: 'hoverexample'
}

output storageId string = storage.id
```

Before: the documentation link appears inside the quoted note.
After: the link appears outside the quote.

**Before**

<img width="1370" height="372" alt="2" src="https://github.com/user-attachments/assets/179c2435-9494-4ca8-8870-2f08c285169f" />

**After**

<img width="1370" height="372" alt="5" src="https://github.com/user-attachments/assets/7e9b6397-869c-4a15-b1ae-4e94b9b5d8af" />

### Separate module descriptions

Save these two files in the same directory and hover over `example` in `03-module-descriptions.bicep`.

`03-module-descriptions.bicep`:

```bicep
@description('''> This description comes from the module declaration.''')
module example './child.bicep' = {
  name: 'hover-example'
}

output message string = example.outputs.message
```

`child.bicep`:

```bicep
metadata description = 'This description comes from the module file.'

output message string = 'Hello'
```

Before: the child module's metadata description is included in the declaration's blockquote.
After: the declaration description remains quoted, and the module metadata description appears as a separate normal paragraph.

**Before**

<img width="1370" height="372" alt="3" src="https://github.com/user-attachments/assets/6e6020fa-55f3-4320-a2da-5182214b4a1e" />

**After**

<img width="1370" height="372" alt="6" src="https://github.com/user-attachments/assets/5f352dbe-7f19-46d8-85ef-9279deecd0e3" />

## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20281)