### PR TITLE
[Version Pinning Task 2] Add bicep.version configuration section

### DIFF
--- a/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationTests.cs
@@ -31,7 +31,6 @@ public class BicepConfigurationTests
     [TestMethod]
     public void Built_in_compiler_configuration_has_no_version_constraint()
     {
-        BicepTestConstants.BuiltInConfiguration.Compiler.Data.Version.Should().BeNull();
         BicepTestConstants.BuiltInConfiguration.Compiler.Version.Should().BeNull();
     }
 
@@ -49,7 +48,6 @@ public class BicepConfigurationTests
 
         var configuration = BicepConfiguration.Bind(element);
 
-        configuration.Compiler.Data.Version.Should().Be("1.2.3");
         configuration.Compiler.Version!.ToString().Should().Be(VersionRange.Parse("1.2.3").ToString());
         configuration.ToUtf8Json().Should().ContainAll(
             "\"bicep\"",

--- a/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/BicepConfigurationTests.cs
@@ -5,6 +5,7 @@
 using Bicep.Core.Configuration;
 using Bicep.Core.Extensions;
 using Bicep.Core.Json;
+using Bicep.Core.SemanticVersioning;
 using Bicep.IO.Abstraction;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -25,6 +26,68 @@ public class BicepConfigurationTests
         documentation.Template.Values.Should().BeEmpty();
         documentation.Examples.Sources.Should().HaveCount(2);
         documentation.Examples.Reassignments.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void Built_in_compiler_configuration_has_no_version_constraint()
+    {
+        BicepTestConstants.BuiltInConfiguration.Compiler.Data.Version.Should().BeNull();
+        BicepTestConstants.BuiltInConfiguration.Compiler.Version.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Bind_and_serialize_preserve_compiler_configuration()
+    {
+        var element = BicepConfiguration.BuiltInConfigurationElement.Merge(
+            JsonElementFactory.CreateElement("""
+                {
+                  "bicep": {
+                    "version": "1.2.3"
+                  }
+                }
+                """));
+
+        var configuration = BicepConfiguration.Bind(element);
+
+        configuration.Compiler.Data.Version.Should().Be("1.2.3");
+        configuration.Compiler.Version!.ToString().Should().Be(VersionRange.Parse("1.2.3").ToString());
+        configuration.ToUtf8Json().Should().ContainAll(
+            "\"bicep\"",
+            "\"version\": \"1.2.3\"");
+    }
+
+    [DataTestMethod]
+    [DataRow("1.2.3")]
+    [DataRow(">=1.0.0")]
+    [DataRow(">=1.0.0, <2.0.0")]
+    public void Compiler_configuration_binds_valid_version_values(string version)
+    {
+        var configuration = CompilerConfiguration.Bind(JsonElementFactory.CreateElement($$"""{ "version": "{{version}}" }"""));
+
+        configuration.Data.Version.Should().Be(version);
+        configuration.Version!.ToString().Should().Be(VersionRange.Parse(version).ToString());
+    }
+
+    [TestMethod]
+    public void Compiler_configuration_defaults_to_null_version_when_omitted()
+    {
+        var configuration = CompilerConfiguration.Bind(JsonElementFactory.CreateElement("{}"));
+
+        configuration.Data.Version.Should().BeNull();
+        configuration.Version.Should().BeNull();
+    }
+
+    [DataTestMethod]
+    [DataRow("not-a-version")]
+    [DataRow("*")]
+    [DataRow("1.*")]
+    [DataRow("")]
+    public void Compiler_configuration_rejects_invalid_version_values(string version)
+    {
+        FluentActions.Invoking(() =>
+                CompilerConfiguration.Bind(JsonElementFactory.CreateElement($$"""{ "version": "{{version}}" }""")))
+            .Should().Throw<ConfigurationException>()
+            .WithMessage("*is not a valid Bicep version or version range*");
     }
 
     [TestMethod]

--- a/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/src/Bicep.Core.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -148,7 +148,8 @@ namespace Bicep.Core.UnitTests.Configuration
             ],
             "reassignments": []
           }
-        }
+        },
+        "bicep": {}
       }
       """);
         }
@@ -255,7 +256,8 @@ namespace Bicep.Core.UnitTests.Configuration
             ],
             "reassignments": []
           }
-        }
+        },
+        "bicep": {}
       }
       """);
         }
@@ -384,7 +386,8 @@ namespace Bicep.Core.UnitTests.Configuration
             ],
             "reassignments": []
           }
-        }
+        },
+        "bicep": {}
       }
       """);
         }
@@ -580,7 +583,8 @@ namespace Bicep.Core.UnitTests.Configuration
                     ],
                     "reassignments": []
                 }
-            }
+            },
+            "bicep": {}
             }
             """);
         }
@@ -957,7 +961,8 @@ namespace Bicep.Core.UnitTests.Configuration
                       ],
                       "reassignments": []
                     }
-                  }
+                  },
+                  "bicep": {}
                 }
                 """);
         }

--- a/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
+++ b/src/Bicep.Core.UnitTests/Diagnostics/LinterRuleTests/UseRecentApiVersionRuleTests.cs
@@ -130,6 +130,7 @@ namespace Bicep.Core.UnitTests.Diagnostics.LinterRuleTests
                             .Replace("<GRACE_PERIOD_PROP>", gracePeriodInDays.HasValue ? $", \"gracePeriodInDays\": {gracePeriodInDays}" : ""))),
                 original.Formatting,
                 original.Documentation,
+                original.Compiler,
                 original.ExperimentalFeaturesEnabled with
                 {
                     SymbolicNameCodegen = true,

--- a/src/Bicep.Core/Configuration/BicepConfiguration.cs
+++ b/src/Bicep.Core/Configuration/BicepConfiguration.cs
@@ -39,6 +39,8 @@ namespace Bicep.Core.Configuration
 
         public const string DocumentationKey = "documentation";
 
+        public const string CompilerKey = "bicep";
+
         public const string BuiltInConfigurationResourceName = "Bicep.Core.Configuration.bicepconfig.json";
 
         public static IBicepConfiguration BuiltIn => BuiltInLazy.Value;
@@ -68,6 +70,7 @@ namespace Bicep.Core.Configuration
             IBicepAnalyzersConfiguration analyzers,
             IBicepFormattingConfiguration formatting,
             IBicepDocumentationConfiguration documentation,
+            IBicepCompilerConfiguration compiler,
             ExperimentalFeaturesEnabled experimentalFeaturesEnabled,
             string? cacheRootDirectory,
             bool experimentalFeaturesWarning,
@@ -82,6 +85,7 @@ namespace Bicep.Core.Configuration
             Analyzers = analyzers;
             Formatting = formatting;
             Documentation = documentation;
+            Compiler = compiler;
             ExperimentalFeaturesEnabled = experimentalFeaturesEnabled;
             CacheRootDirectory = ExpandCacheRootDirectory(cacheRootDirectory);
             ExperimentalFeaturesWarning = experimentalFeaturesWarning;
@@ -108,6 +112,9 @@ namespace Bicep.Core.Configuration
             var documentation = element.TryGetProperty(DocumentationKey, out var documentationElement)
                 ? DocumentationConfiguration.Bind(documentationElement)
                 : new DocumentationConfiguration(new());
+            var compiler = element.TryGetProperty(CompilerKey, out var compilerElement)
+                ? CompilerConfiguration.Bind(compilerElement)
+                : new CompilerConfiguration(new(), null);
 
             var extensions = ExtensionsConfiguration.Bind(element.GetProperty(ExtensionsKey));
             var implicitExtensions = ImplicitExtensionsConfiguration.Bind(element.GetProperty(ImplicitExtensionsKey));
@@ -121,6 +128,7 @@ namespace Bicep.Core.Configuration
                 analyzers: analyzers,
                 formatting: formatting,
                 documentation: documentation,
+                compiler: compiler,
                 experimentalFeaturesEnabled: experimentalFeaturesEnabled,
                 cacheRootDirectory: cacheRootDirectory,
                 experimentalFeaturesWarning: experimentalFeaturesWarning,
@@ -143,6 +151,8 @@ namespace Bicep.Core.Configuration
         public IBicepFormattingConfiguration Formatting { get; }
 
         public IBicepDocumentationConfiguration Documentation { get; }
+
+        public IBicepCompilerConfiguration Compiler { get; }
 
         public ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled { get; }
 

--- a/src/Bicep.Core/Configuration/BicepConfigurationExtensions.cs
+++ b/src/Bicep.Core/Configuration/BicepConfigurationExtensions.cs
@@ -28,6 +28,7 @@ namespace Bicep.Core.Configuration
             ExperimentalFeaturesEnabled? experimentalFeaturesEnabled = null,
             IBicepFormattingConfiguration? formatting = null,
             IBicepDocumentationConfiguration? documentation = null,
+            IBicepCompilerConfiguration? compiler = null,
             IOUri? configFileIdentifier = null,
             IEnumerable<IDiagnostic>? diagnostics = null)
         {
@@ -40,6 +41,7 @@ namespace Bicep.Core.Configuration
                 analyzers: analyzers ?? configuration.Analyzers,
                 formatting: formatting ?? configuration.Formatting,
                 documentation: documentation ?? configuration.Documentation,
+                compiler: compiler ?? configuration.Compiler,
                 experimentalFeaturesEnabled: experimentalFeaturesEnabled ?? configuration.ExperimentalFeaturesEnabled,
                 cacheRootDirectory: cacheRootDirectory ?? configuration.CacheRootDirectory,
                 experimentalFeaturesWarning: experimentalFeaturesWarning ?? configuration.ExperimentalFeaturesWarning,
@@ -90,6 +92,9 @@ namespace Bicep.Core.Configuration
 
                 writer.WritePropertyName(BicepConfiguration.DocumentationKey);
                 ((IWritableConfigurationSection)configuration.Documentation).WriteTo(writer);
+
+                writer.WritePropertyName(BicepConfiguration.CompilerKey);
+                ((IWritableConfigurationSection)configuration.Compiler).WriteTo(writer);
 
                 writer.WriteEndObject();
             }

--- a/src/Bicep.Core/Configuration/CompilerConfiguration.cs
+++ b/src/Bicep.Core/Configuration/CompilerConfiguration.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Bicep.Core.Extensions;
+using Bicep.Core.SemanticVersioning;
+
+namespace Bicep.Core.Configuration;
+
+/// <summary>
+/// Configures the Bicep compiler itself.
+/// </summary>
+public sealed record CompilerOptions
+{
+    /// <summary>
+    /// Gets the raw, unparsed accepted Bicep compiler version or version range, or null if unspecified.
+    /// </summary>
+    public string? Version { get; init; }
+}
+
+/// <summary>
+/// Provides the "bicep" section of a Bicep configuration.
+/// </summary>
+public sealed class CompilerConfiguration : ConfigurationSection<CompilerOptions>, IBicepCompilerConfiguration
+{
+    public CompilerConfiguration(CompilerOptions data, VersionRange? version)
+        : base(data)
+    {
+        Version = version;
+    }
+
+    public VersionRange? Version { get; }
+
+    public static CompilerConfiguration Bind(JsonElement element)
+    {
+        var data = element.ToNonNullObject<CompilerOptions>();
+
+        VersionRange? version = null;
+        if (data.Version is { } versionString)
+        {
+            if (!VersionRange.TryParse(versionString, out version))
+            {
+                throw new ConfigurationException($"The bicep.version property \"{versionString}\" is not a valid Bicep version or version range.");
+            }
+        }
+
+        return new(data, version);
+    }
+}

--- a/src/Bicep.Core/Configuration/IBicepCompilerConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepCompilerConfiguration.cs
@@ -7,8 +7,6 @@ namespace Bicep.Core.Configuration;
 
 public interface IBicepCompilerConfiguration
 {
-    CompilerOptions Data { get; }
-
     /// <summary>
     /// Gets the accepted Bicep compiler version range, or null if no constraint was specified.
     /// </summary>

--- a/src/Bicep.Core/Configuration/IBicepCompilerConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepCompilerConfiguration.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Bicep.Core.SemanticVersioning;
+
+namespace Bicep.Core.Configuration;
+
+public interface IBicepCompilerConfiguration
+{
+    CompilerOptions Data { get; }
+
+    /// <summary>
+    /// Gets the accepted Bicep compiler version range, or null if no constraint was specified.
+    /// </summary>
+    VersionRange? Version { get; }
+}

--- a/src/Bicep.Core/Configuration/IBicepConfiguration.cs
+++ b/src/Bicep.Core/Configuration/IBicepConfiguration.cs
@@ -30,6 +30,8 @@ namespace Bicep.Core.Configuration
 
         IBicepDocumentationConfiguration Documentation { get; }
 
+        IBicepCompilerConfiguration Compiler { get; }
+
         ExperimentalFeaturesEnabled ExperimentalFeaturesEnabled { get; }
 
         string? CacheRootDirectory { get; }

--- a/src/vscode-bicep/resources/configuration/bicepconfig.schema.json
+++ b/src/vscode-bicep/resources/configuration/bicepconfig.schema.json
@@ -1190,6 +1190,17 @@
           }
         }
       }
+    },
+    "bicep": {
+      "type": "object",
+      "description": "Settings for the Bicep compiler itself.",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The version or version range of the Bicep compiler required to compile this file, e.g. \"0.31.92\" or \">=0.31.0, <1.0.0\". If omitted, no version constraint is enforced."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Provide a 1-2 sentence description of your change -->

This PR adds a new optional  bicep.version  config section to  bicepconfig.json , letting users specify an accepted Bicep compiler(only parses and stores the setting, no enforcement yet)

1)Added support for a new optional  bicep.version setting in bicepconfig.json , allowing users to specify an accepted Bicep compiler version or version range (>=1.0.0 <2.0.0 ). The value is parsed and validated at config-bind time using the version parser, with a clear error thrown on invalid syntax.
2)Includes VS Code schema/IntelliSense support and unit test coverage.


## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20282)