### PR TITLE
Refresh setup, testing, and debugging instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ The Bicep solution is comprised of the following main components:
   * From repo root folder: `dotnet build`
   * From src\vscode-bicep:
     * `npm i`
-    * `npm run testlocal:e2e` or run launch vscode from src\vscode-bicep and run "Launch Tests: E2E (dev)"
+    * `node ./scripts/run-e2e-tests.mjs` or run launch vscode from src\vscode-bicep and run "Launch Tests: E2E (dev)"
 
 ### Updating test baselines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ The Bicep solution is comprised of the following main components:
   * From repo root folder: `dotnet build`
   * From src\vscode-bicep:
     * `npm i`
-    * `node ./scripts/run-e2e-tests.mjs` or run launch vscode from src\vscode-bicep and run "Launch Tests: E2E (dev)"
+    * `node ./scripts/run-e2e-tests.mjs` or launch VS Code from src\vscode-bicep and run "Launch Tests: E2E (dev)"
 
 ### Updating test baselines
 


### PR DESCRIPTION
## Description

Update `CONTRIBUTING.md` to replace the removed `testlocal:e2e` command with `node ./scripts/run-e2e-tests.mjs` and document `setup-development.mjs` for installing extension/UI dependencies and building the UI and local servers. Also align the Node.js recommendation with CI's Node 24, correct the unit-test and CLI launch configuration names, remove the obsolete WSL symlink step, and clarify C# debugger attachment and integration dataset placement.

Fixes #20284

## Checklist

- [X] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20285)