### PR TITLE
Make apiVersion optional in the Azure resource schema MCP tool

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -8,7 +8,7 @@ We have built a Bicep MCP server with agentic tools to support Bicep code genera
 
 - `get_bicep_best_practices`: Lists up-to-date recommended Bicep best-practices for authoring templates. These practices help improve maintainability, security, and reliability of your Bicep files. This is helpful additional context if you've been asked to generate Bicep code.
 - `list_azure_resource_types`: Lists all available Azure resource types and their API versions for a specific Azure resource provider namespace. Data is sourced from Azure Resource Provider APIs.
-- `get_azure_resource_type_schema`: Gets the schema for a specific Azure resource type and API version. Data is sourced from Azure Resource Provider APIs.
+- `get_azure_resource_type_schema`: Gets the schema for a specific Azure resource type from Bicep's bundled Azure resource type catalog. The optional `apiVersion` defaults to the newest version by date, including preview versions, with stable preferred on the same date. Pass `latest-stable` to select only stable versions, or an explicit version to pin the schema.
 - `list_extension_resource_types`: Lists all available resource types for a Bicep extension. Accepts a canonical OCI artifact reference (e.g., `br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:1.0.0`).
 - `get_extension_resource_type_schema`: Gets the schema for a specific extension resource type. Accepts a canonical OCI artifact reference, resource type, and API version.
 - `list_well_known_extensions`: Lists well-known Bicep extensions (e.g., Microsoft Graph) with their dynamically-discovered version tags from MCR. This is not an exhaustive list; other extensions may exist. Use this to discover extensions and their versions for use with the extension resource type tools.
@@ -19,6 +19,34 @@ We have built a Bicep MCP server with agentic tools to support Bicep code genera
 - `decompile_arm_template_file`: Converts an ARM template JSON file into Bicep syntax (`.bicep`). Accepts files with `.json`, `.jsonc`, or `.arm` extensions.
 - `decompile_arm_parameters_file`: Converts an ARM template parameters JSON file into Bicep parameters syntax (`.bicepparam`). Accepts files with `.json`, `.jsonc`, or `.arm` extensions.
 - `get_deployment_snapshot`: Creates a deployment snapshot from a Bicep parameters file (`.bicepparam`) by compiling and pre-expanding the ARM template, allowing you to preview predicted resources without running a deployment.
+
+### Azure resource schema versions
+
+Call `get_azure_resource_type_schema` with only a resource type to select the newest API version by date in the bundled catalog, whether stable or preview. Stable versions take precedence when the dates are the same:
+
+```json
+{ "resourceType": "Microsoft.KeyVault/vaults" }
+```
+
+Passing `"apiVersion": null` has the same behavior as omitting it. Preview includes other prerelease versions recognized by Bicep, not just versions ending in `-preview`.
+
+To select the newest stable version only, pass `latest-stable` (case-insensitive). This returns an error if the resource type has no stable versions; it does not fall back to preview:
+
+```json
+{ "resourceType": "Microsoft.KeyVault/vaults", "apiVersion": "latest-stable" }
+```
+
+For reproducible results, supply an explicit version:
+
+```json
+{ "resourceType": "Microsoft.KeyVault/vaults", "apiVersion": "2024-11-01" }
+```
+
+The schema's `title` contains the selected resource type and API version, including when `excludeDescriptions` or `excludeReadOnlyProperties` is enabled.
+
+Unsupported API versions and unavailable selections return an error listing all valid API version options for the resource type. The list contains all available explicit versions, plus `null` (latest) and `latest-stable` only when those selections can resolve successfully. Unknown resource types return a resource-type-not-found error, with no API version options to list. Empty or whitespace versions and the literals `"latest"` and `"latest-preview"` are invalid; they do not trigger default selection.
+
+The catalog is bundled with Bicep, not queried live from Azure. The default and `latest-stable` versions may change when Bicep's bundled types are updated and do not guarantee availability in a particular cloud, region, or subscription.
 
 ## Transport
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -8,7 +8,7 @@ We have built a Bicep MCP server with agentic tools to support Bicep code genera
 
 - `get_bicep_best_practices`: Lists up-to-date recommended Bicep best-practices for authoring templates. These practices help improve maintainability, security, and reliability of your Bicep files. This is helpful additional context if you've been asked to generate Bicep code.
 - `list_azure_resource_types`: Lists all available Azure resource types and their API versions for a specific Azure resource provider namespace. Data is sourced from Azure Resource Provider APIs.
-- `get_azure_resource_type_schema`: Gets the schema for a specific Azure resource type from Bicep's bundled Azure resource type catalog. The optional `apiVersion` defaults to the newest version by date, including preview versions, with stable preferred on the same date. Pass `latest-stable` to select only stable versions, or an explicit version to pin the schema.
+- `get_azure_resource_type_schema`: Gets the schema for a specific Azure resource type from Bicep's bundled Azure resource type catalog. The optional `apiVersion` defaults to the newest version by date, including preview versions, with stable preferred on the same date. Set `includePreview` to `false` for stable-only automatic selection, or supply an explicit version to pin the schema.
 - `list_extension_resource_types`: Lists all available resource types for a Bicep extension. Accepts a canonical OCI artifact reference (e.g., `br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:1.0.0`).
 - `get_extension_resource_type_schema`: Gets the schema for a specific extension resource type. Accepts a canonical OCI artifact reference, resource type, and API version.
 - `list_well_known_extensions`: Lists well-known Bicep extensions (e.g., Microsoft Graph) with their dynamically-discovered version tags from MCR. This is not an exhaustive list; other extensions may exist. Use this to discover extensions and their versions for use with the extension resource type tools.
@@ -28,15 +28,15 @@ Call `get_azure_resource_type_schema` with only a resource type to select the ne
 { "resourceType": "Microsoft.KeyVault/vaults" }
 ```
 
-Passing `"apiVersion": null` has the same behavior as omitting it. Preview includes other prerelease versions recognized by Bicep, not just versions ending in `-preview`.
+Passing `"apiVersion": null` has the same behavior as omitting it. The `includePreview` flag defaults to `true`. Preview includes other prerelease versions recognized by Bicep, not just versions ending in `-preview`.
 
-To select the newest stable version only, pass `latest-stable` (case-insensitive). This returns an error if the resource type has no stable versions; it does not fall back to preview:
+To select the newest stable version only, omit `apiVersion` or pass `null` and set `includePreview` to `false`. This returns an error if the resource type has no stable versions; it does not fall back to preview:
 
 ```json
-{ "resourceType": "Microsoft.KeyVault/vaults", "apiVersion": "latest-stable" }
+{ "resourceType": "Microsoft.KeyVault/vaults", "includePreview": false }
 ```
 
-For reproducible results, supply an explicit version:
+For reproducible results, supply an explicit version. Explicit versions override `includePreview`, so an explicit preview version is honored even when `includePreview` is `false`:
 
 ```json
 { "resourceType": "Microsoft.KeyVault/vaults", "apiVersion": "2024-11-01" }
@@ -44,9 +44,9 @@ For reproducible results, supply an explicit version:
 
 The schema's `title` contains the selected resource type and API version, including when `excludeDescriptions` or `excludeReadOnlyProperties` is enabled.
 
-Unsupported API versions and unavailable selections return an error listing all valid API version options for the resource type. The list contains all available explicit versions, plus `null` (latest) and `latest-stable` only when those selections can resolve successfully. Unknown resource types return a resource-type-not-found error, with no API version options to list. Empty or whitespace versions and the literals `"latest"` and `"latest-preview"` are invalid; they do not trigger default selection.
+Unsupported API versions and unavailable selections return an error listing all valid API version options for the resource type. The list contains all available explicit versions, plus the combinations of `apiVersion = null` with `includePreview = true` (latest) or `includePreview = false` (latest stable) only when those selections can resolve successfully. Unknown resource types return a resource-type-not-found error, with no API version options to list. Empty or whitespace versions and the literals `"latest"`, `"latest-preview"`, and `"latest-stable"` are invalid; they do not trigger automatic selection.
 
-The catalog is bundled with Bicep, not queried live from Azure. The default and `latest-stable` versions may change when Bicep's bundled types are updated and do not guarantee availability in a particular cloud, region, or subscription.
+The catalog is bundled with Bicep, not queried live from Azure. Automatically selected versions may change when Bicep's bundled types are updated and do not guarantee availability in a particular cloud, region, or subscription.
 
 ## Transport
 

--- a/src/Bicep.McpServer.Core/BicepTools.cs
+++ b/src/Bicep.McpServer.Core/BicepTools.cs
@@ -101,17 +101,18 @@ public sealed class BicepTools(
     The returned JSON schema includes resource type definitions, nested complex types, resource function signatures (like list* operations), and property constraints.
     Data comes from Bicep's bundled Azure resource type catalog, not a live Azure API query.
     Specify the resource type (e.g., Microsoft.KeyVault/vaults). Omit apiVersion or pass null to select the newest API version by date, including preview versions; stable versions win same-date ties.
-    Pass latest-stable (case-insensitive) to select only the newest stable version, or an explicit API version (e.g., 2024-11-01 or 2024-12-01-preview) to pin the schema.
+    Set includePreview to false to select only the newest stable version, with no preview fallback. An explicit API version (e.g., 2024-11-01 or 2024-12-01-preview) pins the schema and overrides includePreview.
     Preview includes other prerelease versions recognized by Bicep. Unknown resource types return an error. Unsupported API versions or unavailable selections return an error listing all valid API version options for the resource type.
     The schema title includes the selected resource type and API version, even when read-only properties are excluded.
     """)]
     public ResourceTypeSchemaResult GetAzureResourceTypeSchema(
         [Description("The resource type of the Azure resource; e.g. Microsoft.KeyVault/vaults")] string resourceType,
-        [Description("The API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview. Omit or pass null for the newest version by date in Bicep's bundled catalog, including prereleases, with stable preferred on the same date. Pass latest-stable (case-insensitive) for the newest stable version only; an error lists valid options if no stable version exists or the requested version is unsupported.")] string? apiVersion = null,
+        [Description("The explicit API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview. Omit or pass null for the newest version by date in Bicep's bundled catalog, subject to includePreview, with stable preferred on the same date. An explicit version overrides includePreview. Errors list valid options.")] string? apiVersion = null,
         [Description("When true, omits description fields from the schema to reduce payload size. Default: false")] bool excludeDescriptions = false,
-        [Description("When true, omits read-only properties from the schema to reduce payload size. Default: false")] bool excludeReadOnlyProperties = false)
+        [Description("When true, omits read-only properties from the schema to reduce payload size. Default: false")] bool excludeReadOnlyProperties = false,
+        [Description("When apiVersion is omitted or null, includes preview and other Bicep-recognized prerelease versions in automatic selection. Set to false for the newest stable version only; returns an error if none exists. Ignored for explicit API versions. Default: true")] bool includePreview = true)
     {
-        apiVersion = ResolveApiVersion(resourceType, apiVersion);
+        apiVersion = ResolveApiVersion(resourceType, apiVersion, includePreview);
         TypesDefinitionResult typesDefinition = resourceVisitor.LoadSingleResourceType(resourceType, apiVersion, excludeReadOnlyProperties);
         var options = new JsonSchemaWriterOptions(excludeDescriptions);
 
@@ -241,7 +242,7 @@ public sealed class BicepTools(
         return new WellKnownExtensionsResult([.. extensions]);
     }
 
-    private string ResolveApiVersion(string resourceType, string? apiVersion)
+    private string ResolveApiVersion(string resourceType, string? apiVersion, bool includePreview)
     {
         var resourceTypes = azResourceTypeLoader.GetAvailableTypes()
             .Where(type => type.FormatType().Equals(resourceType, StringComparison.OrdinalIgnoreCase))
@@ -252,8 +253,7 @@ public sealed class BicepTools(
             throw new InvalidDataException($"Resource type {resourceType} not found in Bicep's bundled Azure resource type catalog.");
         }
 
-        var stableOnly = string.Equals(apiVersion, "latest-stable", StringComparison.OrdinalIgnoreCase);
-        if (apiVersion is not null && !stableOnly && resourceTypes.Any(type => string.Equals(type.ApiVersion, apiVersion, StringComparison.OrdinalIgnoreCase)))
+        if (apiVersion is not null && resourceTypes.Any(type => string.Equals(type.ApiVersion, apiVersion, StringComparison.OrdinalIgnoreCase)))
         {
             return apiVersion;
         }
@@ -274,10 +274,10 @@ public sealed class BicepTools(
             .ThenBy(version => version.ApiVersion, StringComparer.Ordinal)
             .ToArray();
 
-        if (apiVersion is null || stableOnly)
+        if (apiVersion is null)
         {
             var selectedVersion = orderedVersions.FirstOrDefault(version =>
-                version.ParsedVersion is { } parsedVersion && (!stableOnly || parsedVersion.IsStable)).ApiVersion;
+                version.ParsedVersion is { } parsedVersion && (includePreview || parsedVersion.IsStable)).ApiVersion;
             if (selectedVersion is not null)
             {
                 return selectedVersion;
@@ -287,21 +287,21 @@ public sealed class BicepTools(
         var validOptions = new List<string>();
         if (orderedVersions.Any(version => version.ParsedVersion is not null))
         {
-            validOptions.Add("null (latest)");
+            validOptions.Add("apiVersion = null with includePreview = true (latest)");
         }
         if (orderedVersions.Any(version => version.ParsedVersion is { IsStable: true }))
         {
-            validOptions.Add("\"latest-stable\"");
+            validOptions.Add("apiVersion = null with includePreview = false (latest stable)");
         }
         validOptions.AddRange(orderedVersions.Select(version => version.ApiVersion)
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Select(version => $"\"{version}\""));
+            .Select(version => $"apiVersion = \"{version}\""));
 
         var error = apiVersion is null
-            ? $"No supported API versions found for resource type {resourceType} in Bicep's bundled Azure resource type catalog."
-            : stableOnly
-                ? $"No stable API versions found for resource type {resourceType} in Bicep's bundled Azure resource type catalog."
-                : $"Resource type {resourceType} with API version {apiVersion} not found.";
+            ? includePreview
+                ? $"No supported API versions found for resource type {resourceType} in Bicep's bundled Azure resource type catalog."
+                : $"No stable API versions found for resource type {resourceType} in Bicep's bundled Azure resource type catalog."
+            : $"Resource type {resourceType} with API version {apiVersion} not found.";
         throw new InvalidDataException($"{error} Valid options: {(validOptions.Count > 0 ? string.Join(", ", validOptions) : "none")}.");
     }
 }

--- a/src/Bicep.McpServer.Core/BicepTools.cs
+++ b/src/Bicep.McpServer.Core/BicepTools.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.ComponentModel;
+using Bicep.Core.Analyzers.Linter.ApiVersions;
 using Bicep.Core.Registry.Catalog.Implementation.PublicRegistries;
 using Bicep.Core.TypeSystem.Providers.Az;
 using Bicep.Core.TypeSystem.Providers.Extensibility;
@@ -98,15 +99,19 @@ public sealed class BicepTools(
     - Find available resource functions and their signatures
     - Generate accurate Bicep code with proper property names and types
     The returned JSON schema includes resource type definitions, nested complex types, resource function signatures (like list* operations), and property constraints.
-    Data is sourced directly from Azure Resource Provider APIs, ensuring the most accurate and up-to-date schema information.
-    Specify the resource type (e.g., Microsoft.KeyVault/vaults) and API version (e.g., 2024-11-01 or 2024-12-01-preview).
+    Data comes from Bicep's bundled Azure resource type catalog, not a live Azure API query.
+    Specify the resource type (e.g., Microsoft.KeyVault/vaults). Omit apiVersion or pass null to select the newest API version by date, including preview versions; stable versions win same-date ties.
+    Pass latest-stable (case-insensitive) to select only the newest stable version, or an explicit API version (e.g., 2024-11-01 or 2024-12-01-preview) to pin the schema.
+    Preview includes other prerelease versions recognized by Bicep. Unknown resource types return an error. Unsupported API versions or unavailable selections return an error listing all valid API version options for the resource type.
+    The schema title includes the selected resource type and API version, even when read-only properties are excluded.
     """)]
     public ResourceTypeSchemaResult GetAzureResourceTypeSchema(
         [Description("The resource type of the Azure resource; e.g. Microsoft.KeyVault/vaults")] string resourceType,
-        [Description("The API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview")] string apiVersion,
+        [Description("The API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview. Omit or pass null for the newest version by date in Bicep's bundled catalog, including prereleases, with stable preferred on the same date. Pass latest-stable (case-insensitive) for the newest stable version only; an error lists valid options if no stable version exists or the requested version is unsupported.")] string? apiVersion = null,
         [Description("When true, omits description fields from the schema to reduce payload size. Default: false")] bool excludeDescriptions = false,
         [Description("When true, omits read-only properties from the schema to reduce payload size. Default: false")] bool excludeReadOnlyProperties = false)
     {
+        apiVersion = ResolveApiVersion(resourceType, apiVersion);
         TypesDefinitionResult typesDefinition = resourceVisitor.LoadSingleResourceType(resourceType, apiVersion, excludeReadOnlyProperties);
         var options = new JsonSchemaWriterOptions(excludeDescriptions);
 
@@ -234,5 +239,69 @@ public sealed class BicepTools(
         }
 
         return new WellKnownExtensionsResult([.. extensions]);
+    }
+
+    private string ResolveApiVersion(string resourceType, string? apiVersion)
+    {
+        var resourceTypes = azResourceTypeLoader.GetAvailableTypes()
+            .Where(type => type.FormatType().Equals(resourceType, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (resourceTypes.Length == 0)
+        {
+            throw new InvalidDataException($"Resource type {resourceType} not found in Bicep's bundled Azure resource type catalog.");
+        }
+
+        var stableOnly = string.Equals(apiVersion, "latest-stable", StringComparison.OrdinalIgnoreCase);
+        if (apiVersion is not null && !stableOnly && resourceTypes.Any(type => string.Equals(type.ApiVersion, apiVersion, StringComparison.OrdinalIgnoreCase)))
+        {
+            return apiVersion;
+        }
+
+        var versions = new List<(string ApiVersion, AzureResourceApiVersion? ParsedVersion)>();
+        foreach (var type in resourceTypes)
+        {
+            if (type.ApiVersion is { } version)
+            {
+                versions.Add((version, AzureResourceApiVersion.TryParse(version, out var parsedVersion) ? parsedVersion : null));
+            }
+        }
+
+        var orderedVersions = versions
+            .OrderByDescending(version => version.ParsedVersion?.Date)
+            .ThenByDescending(version => version.ParsedVersion?.IsStable)
+            .ThenBy(version => version.ParsedVersion?.Suffix, StringComparer.Ordinal)
+            .ThenBy(version => version.ApiVersion, StringComparer.Ordinal)
+            .ToArray();
+
+        if (apiVersion is null || stableOnly)
+        {
+            var selectedVersion = orderedVersions.FirstOrDefault(version =>
+                version.ParsedVersion is { } parsedVersion && (!stableOnly || parsedVersion.IsStable)).ApiVersion;
+            if (selectedVersion is not null)
+            {
+                return selectedVersion;
+            }
+        }
+
+        var validOptions = new List<string>();
+        if (orderedVersions.Any(version => version.ParsedVersion is not null))
+        {
+            validOptions.Add("null (latest)");
+        }
+        if (orderedVersions.Any(version => version.ParsedVersion is { IsStable: true }))
+        {
+            validOptions.Add("\"latest-stable\"");
+        }
+        validOptions.AddRange(orderedVersions.Select(version => version.ApiVersion)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(version => $"\"{version}\""));
+
+        var error = apiVersion is null
+            ? $"No supported API versions found for resource type {resourceType} in Bicep's bundled Azure resource type catalog."
+            : stableOnly
+                ? $"No stable API versions found for resource type {resourceType} in Bicep's bundled Azure resource type catalog."
+                : $"Resource type {resourceType} with API version {apiVersion} not found.";
+        throw new InvalidDataException($"{error} Valid options: {(validOptions.Count > 0 ? string.Join(", ", validOptions) : "none")}.");
     }
 }

--- a/src/Bicep.McpServer.UnitTests/AzureResourceSchemaServerTests.cs
+++ b/src/Bicep.McpServer.UnitTests/AzureResourceSchemaServerTests.cs
@@ -18,11 +18,11 @@ public class AzureResourceSchemaServerTests
     public TestContext? TestContext { get; set; }
 
     [TestMethod]
-    [DataRow(false, null, "2025-01-01-preview")]
-    [DataRow(true, null, "2025-01-01-preview")]
-    [DataRow(true, "latest-stable", "2024-01-01")]
-    [DataRow(true, "2023-01-01", "2023-01-01")]
-    public async Task GetAzureResourceTypeSchema_accepts_optional_api_version(bool includeApiVersion, string? apiVersion, string expectedVersion)
+    [DataRow(false, null, null, "2025-01-01-preview")]
+    [DataRow(true, null, true, "2025-01-01-preview")]
+    [DataRow(true, null, false, "2024-01-01")]
+    [DataRow(true, "2025-01-01-preview", false, "2025-01-01-preview")]
+    public async Task GetAzureResourceTypeSchema_accepts_optional_api_version(bool includeApiVersion, string? apiVersion, bool? includePreview, string expectedVersion)
     {
         await using var helper = await McpServerHelper.StartServer(TestContext, services =>
             services.AddSingleton(ResourceTypeCatalogHelper.CreateTypeLoader(
@@ -36,6 +36,10 @@ public class AzureResourceSchemaServerTests
         if (includeApiVersion)
         {
             arguments["apiVersion"] = apiVersion;
+        }
+        if (includePreview is { } includePreviewValue)
+        {
+            arguments["includePreview"] = includePreviewValue;
         }
 
         var response = await helper.Client.CallToolAsync("get_azure_resource_type_schema", arguments);
@@ -70,7 +74,8 @@ public class AzureResourceSchemaServerTests
         response.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>()
             .Which.Text.Should().Be(resourceType != "Test.Rp/widgets"
                 ? $"Error: Resource type {resourceType} not found in Bicep's bundled Azure resource type catalog."
-                : $"Error: Resource type {resourceType} with API version {apiVersion} not found. Valid options: null (latest), \"latest-stable\", \"2024-01-01\".");
+                : $"Error: Resource type {resourceType} with API version {apiVersion} not found. " +
+                    "Valid options: apiVersion = null with includePreview = true (latest), apiVersion = null with includePreview = false (latest stable), apiVersion = \"2024-01-01\".");
     }
 
     [TestMethod]
@@ -82,12 +87,12 @@ public class AzureResourceSchemaServerTests
         var response = await helper.Client.CallToolAsync("get_azure_resource_type_schema", new Dictionary<string, object?>
         {
             ["resourceType"] = "Test.Rp/widgets",
-            ["apiVersion"] = "latest-stable",
+            ["includePreview"] = false,
         });
 
         response.IsError.Should().BeTrue();
         response.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>()
             .Which.Text.Should().Be("Error: No stable API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog. " +
-                "Valid options: null (latest), \"2024-01-01-preview\".");
+                "Valid options: apiVersion = null with includePreview = true (latest), apiVersion = \"2024-01-01-preview\".");
     }
 }

--- a/src/Bicep.McpServer.UnitTests/AzureResourceSchemaServerTests.cs
+++ b/src/Bicep.McpServer.UnitTests/AzureResourceSchemaServerTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Bicep.McpServer.UnitTests.Helpers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace Bicep.McpServer.UnitTests;
+
+[TestClass]
+public class AzureResourceSchemaServerTests
+{
+    [NotNull]
+    public TestContext? TestContext { get; set; }
+
+    [TestMethod]
+    [DataRow(false, null, "2025-01-01-preview")]
+    [DataRow(true, null, "2025-01-01-preview")]
+    [DataRow(true, "latest-stable", "2024-01-01")]
+    [DataRow(true, "2023-01-01", "2023-01-01")]
+    public async Task GetAzureResourceTypeSchema_accepts_optional_api_version(bool includeApiVersion, string? apiVersion, string expectedVersion)
+    {
+        await using var helper = await McpServerHelper.StartServer(TestContext, services =>
+            services.AddSingleton(ResourceTypeCatalogHelper.CreateTypeLoader(
+                "Test.Rp/widgets@2023-01-01",
+                "Test.Rp/widgets@2024-01-01",
+                "Test.Rp/widgets@2025-01-01-preview")));
+        var arguments = new Dictionary<string, object?>
+        {
+            ["resourceType"] = "Test.Rp/widgets",
+        };
+        if (includeApiVersion)
+        {
+            arguments["apiVersion"] = apiVersion;
+        }
+
+        var response = await helper.Client.CallToolAsync("get_azure_resource_type_schema", arguments);
+
+        response.IsError.Should().NotBe(true);
+        response.StructuredContent.Should().NotBeNull();
+        var content = response.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>().Subject;
+        using var result = JsonDocument.Parse(content.Text);
+        using var schema = JsonDocument.Parse(result.RootElement.GetProperty("schema").GetString()!);
+        schema.RootElement.GetProperty("title").GetString().Should().Be($"Test.Rp/widgets@{expectedVersion}");
+    }
+
+    [TestMethod]
+    [DataRow("Test.Rp/missing", null)]
+    [DataRow("Test.Rp/widgets", "2099-01-01")]
+    public async Task GetAzureResourceTypeSchema_returns_error_for_invalid_inputs(string resourceType, string? apiVersion)
+    {
+        await using var helper = await McpServerHelper.StartServer(TestContext, services =>
+            services.AddSingleton(ResourceTypeCatalogHelper.CreateTypeLoader("Test.Rp/widgets@2024-01-01")));
+        var arguments = new Dictionary<string, object?>
+        {
+            ["resourceType"] = resourceType,
+        };
+        if (apiVersion is not null)
+        {
+            arguments["apiVersion"] = apiVersion;
+        }
+
+        var response = await helper.Client.CallToolAsync("get_azure_resource_type_schema", arguments);
+
+        response.IsError.Should().BeTrue();
+        response.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>()
+            .Which.Text.Should().Be(resourceType != "Test.Rp/widgets"
+                ? $"Error: Resource type {resourceType} not found in Bicep's bundled Azure resource type catalog."
+                : $"Error: Resource type {resourceType} with API version {apiVersion} not found. Valid options: null (latest), \"latest-stable\", \"2024-01-01\".");
+    }
+
+    [TestMethod]
+    public async Task GetAzureResourceTypeSchema_returns_error_when_no_stable_version_exists()
+    {
+        await using var helper = await McpServerHelper.StartServer(TestContext, services =>
+            services.AddSingleton(ResourceTypeCatalogHelper.CreateTypeLoader("Test.Rp/widgets@2024-01-01-preview")));
+
+        var response = await helper.Client.CallToolAsync("get_azure_resource_type_schema", new Dictionary<string, object?>
+        {
+            ["resourceType"] = "Test.Rp/widgets",
+            ["apiVersion"] = "latest-stable",
+        });
+
+        response.IsError.Should().BeTrue();
+        response.Content.Should().ContainSingle().Which.Should().BeOfType<TextContentBlock>()
+            .Which.Text.Should().Be("Error: No stable API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog. " +
+                "Valid options: null (latest), \"2024-01-01-preview\".");
+    }
+}

--- a/src/Bicep.McpServer.UnitTests/BicepToolsTests.cs
+++ b/src/Bicep.McpServer.UnitTests/BicepToolsTests.cs
@@ -3,10 +3,14 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Bicep.Core;
+using Bicep.Core.Analyzers.Linter.ApiVersions;
+using Bicep.Core.Resources;
 using Bicep.Core.UnitTests.Assertions;
 using Bicep.Core.UnitTests.Baselines;
 using Bicep.McpServer.Core;
+using Bicep.McpServer.UnitTests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,6 +32,11 @@ public class BicepToolsTests
     }
 
     private readonly BicepTools tools = GetServiceProvider().GetRequiredService<BicepTools>();
+
+    private static ServiceProvider GetServiceProviderWithResourceTypes(params string[] resourceTypes) => new ServiceCollection()
+        .AddBicepMcpServer().Services
+        .AddSingleton(ResourceTypeCatalogHelper.CreateTypeLoader(resourceTypes))
+        .BuildServiceProvider();
 
     [TestMethod]
     public void ListAzureResourceTypes_returns_list_of_resource_types()
@@ -77,6 +86,225 @@ public class BicepToolsTests
 
         baselineFile.WriteToOutputFolder(response.Schema);
         baselineFile.ShouldHaveExpectedJsonValue();
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("latest-stable")]
+    public void GetAzureResourceTypeSchema_resolves_versions_from_bundled_catalog(string? apiVersion)
+    {
+        const string resourceType = "Microsoft.KeyVault/vaults";
+
+        var response = tools.GetAzureResourceTypeSchema(resourceType, apiVersion);
+
+        using var schema = JsonDocument.Parse(response.Schema);
+        var selectedResourceType = ResourceTypeReference.Parse(schema.RootElement.GetProperty("title").GetString()!);
+        selectedResourceType.FormatType().Should().Be(resourceType);
+        selectedResourceType.ApiVersion.Should().NotBeNullOrEmpty();
+        tools.ListAzureResourceTypes("Microsoft.KeyVault").ResourceTypes.Should().Contain(selectedResourceType.FormatName());
+        response.Schema.Should().Be(tools.GetAzureResourceTypeSchema(resourceType, selectedResourceType.ApiVersion).Schema);
+
+        if (apiVersion == "latest-stable")
+        {
+            AzureResourceApiVersion.Parse(selectedResourceType.ApiVersion!).IsStable.Should().BeTrue();
+        }
+    }
+
+    [TestMethod]
+    [DataRow("2025-01-01-preview", new[] { "2023-01-01", "2024-01-01", "2025-01-01-preview" })]
+    [DataRow("2025-01-01-preview", new[] { "2025-01-01-preview", "2024-01-01", "2023-01-01" })]
+    [DataRow("2025-01-01", new[] { "2024-01-01-preview", "2025-01-01" })]
+    [DataRow("2025-01-01", new[] { "2025-01-01", "2024-01-01" })]
+    [DataRow("2024-01-01", new[] { "2024-01-01-preview", "2024-01-01" })]
+    [DataRow("2024-01-01", new[] { "2024-01-01", "2024-01-01-preview" })]
+    [DataRow("2025-01-01-alpha", new[] { "2024-01-01", "2025-01-01-alpha" })]
+    [DataRow("2025-01-01-privatepreview", new[] { "2024-01-01", "2025-01-01-privatepreview" })]
+    [DataRow("2025-01-01-preview", new[] { "2024-01-01-preview", "2025-01-01-preview" })]
+    [DataRow("2025-01-01-alpha", new[] { "2025-01-01-preview", "2025-01-01-beta", "2025-01-01-alpha" })]
+    [DataRow("2025-01-01-PREVIEW", new[] { "2024-01-01-preview", "2025-01-01-PREVIEW" })]
+    [DataRow("2024-01-01", new[] { "v1.0", "2024-01-01" })]
+    public void GetAzureResourceTypeSchema_selects_latest_version(string expectedVersion, string[] versions)
+    {
+        using var services = GetServiceProviderWithResourceTypes([.. versions.Select(version => $"Test.Rp/widgets@{version}")]);
+        var catalogTools = services.GetRequiredService<BicepTools>();
+
+        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets");
+
+        response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", expectedVersion).Schema);
+        response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", null).Schema);
+        using var schema = JsonDocument.Parse(response.Schema);
+        schema.RootElement.GetProperty("title").GetString().Should().Be($"Test.Rp/widgets@{expectedVersion}");
+        schema.RootElement.GetProperty("x-bicep-resource-functions").EnumerateArray().Should()
+            .ContainSingle().Which.GetProperty("apiVersion").GetString().Should().Be(expectedVersion);
+    }
+
+    [TestMethod]
+    [DataRow("latest-stable", "2024-01-01", new[] { "2023-01-01", "2024-01-01", "2025-01-01-preview" })]
+    [DataRow("LATEST-STABLE", "2024-01-01", new[] { "2025-01-01-privatepreview", "2024-01-01", "2025-01-01-alpha" })]
+    [DataRow("Latest-Stable", "2024-01-01", new[] { "2024-01-01-preview", "2024-01-01", "v1.0" })]
+    [DataRow("latest-stable", "2025-01-01", new[] { "2024-01-01", "2025-01-01" })]
+    public void GetAzureResourceTypeSchema_selects_latest_stable_version(string selector, string expectedVersion, string[] versions)
+    {
+        using var services = GetServiceProviderWithResourceTypes([.. versions.Select(version => $"Test.Rp/widgets@{version}")]);
+        var catalogTools = services.GetRequiredService<BicepTools>();
+
+        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", selector);
+
+        response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", expectedVersion).Schema);
+        using var schema = JsonDocument.Parse(response.Schema);
+        schema.RootElement.GetProperty("title").GetString().Should().Be($"Test.Rp/widgets@{expectedVersion}");
+        schema.RootElement.GetProperty("x-bicep-resource-functions").EnumerateArray().Should()
+            .ContainSingle().Which.GetProperty("apiVersion").GetString().Should().Be(expectedVersion);
+    }
+
+    [TestMethod]
+    [DataRow("2023-01-01")]
+    [DataRow("2025-01-01-preview")]
+    [DataRow("v1.0")]
+    public void GetAzureResourceTypeSchema_honors_explicit_version(string apiVersion)
+    {
+        using var services = GetServiceProviderWithResourceTypes(
+            "Test.Rp/widgets@2023-01-01",
+            "Test.Rp/widgets@2024-01-01",
+            "Test.Rp/widgets@2025-01-01-preview",
+            "Test.Rp/widgets@v1.0");
+        var catalogTools = services.GetRequiredService<BicepTools>();
+
+        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion);
+
+        using var schema = JsonDocument.Parse(response.Schema);
+        schema.RootElement.GetProperty("title").GetString().Should().Be($"Test.Rp/widgets@{apiVersion}");
+        schema.RootElement.GetProperty("x-bicep-resource-functions").EnumerateArray().Should()
+            .ContainSingle().Which.GetProperty("apiVersion").GetString().Should().Be(apiVersion);
+    }
+
+    [TestMethod]
+    [DataRow("test.rp/WIDGETS", null, "Test.Rp/widgets@2024-01-01")]
+    [DataRow("test.rp/WIDGETS", "latest-stable", "Test.Rp/widgets@2024-01-01")]
+    [DataRow("test.rp/WIDGETS", "2024-01-01", "Test.Rp/widgets@2024-01-01")]
+    [DataRow("Test.Rp/widgets/children", null, "Test.Rp/widgets/children@2025-01-01")]
+    [DataRow("Test.Rp/widgets/children", "latest-stable", "Test.Rp/widgets/children@2025-01-01")]
+    public void GetAzureResourceTypeSchema_matches_full_type_case_insensitively(string resourceType, string? apiVersion, string expectedTitle)
+    {
+        using var services = GetServiceProviderWithResourceTypes(
+            "Test.Rp/widgets@2024-01-01",
+            "Test.Rp/widgets/children@2025-01-01",
+            "Test.Rp/widgetsOther@2026-01-01",
+            "Other.Rp/widgets@2027-01-01");
+
+        var response = services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema(resourceType, apiVersion);
+
+        using var schema = JsonDocument.Parse(response.Schema);
+        schema.RootElement.GetProperty("title").GetString().Should().Be(expectedTitle);
+    }
+
+    [TestMethod]
+    [DataRow("Unknown.Rp/widgets")]
+    [DataRow("Test.Rp/missing")]
+    [DataRow("Test.Rp/widget")]
+    [DataRow("Test.Rp")]
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow("Test.Rp//widgets")]
+    [DataRow("Test.Rp/widgets@2024-01-01")]
+    public void GetAzureResourceTypeSchema_rejects_invalid_resource_type(string resourceType)
+    {
+        using var services = GetServiceProviderWithResourceTypes("Test.Rp/widgets@2024-01-01");
+        var catalogTools = services.GetRequiredService<BicepTools>();
+
+        var defaultVersionAction = () => catalogTools.GetAzureResourceTypeSchema(resourceType);
+        var stableVersionAction = () => catalogTools.GetAzureResourceTypeSchema(resourceType, "latest-stable");
+        var explicitVersionAction = () => catalogTools.GetAzureResourceTypeSchema(resourceType, "2024-01-01");
+
+        defaultVersionAction.Should().Throw<InvalidDataException>()
+            .WithMessage($"Resource type {resourceType} not found in Bicep's bundled Azure resource type catalog.");
+        stableVersionAction.Should().Throw<InvalidDataException>()
+            .WithMessage($"Resource type {resourceType} not found in Bicep's bundled Azure resource type catalog.");
+        explicitVersionAction.Should().Throw<InvalidDataException>()
+            .WithMessage($"Resource type {resourceType} not found in Bicep's bundled Azure resource type catalog.");
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow("latest")]
+    [DataRow("latest-preview")]
+    [DataRow("latest-stable ")]
+    [DataRow("2099-01-01")]
+    [DataRow("2024-01-01 ")]
+    public void GetAzureResourceTypeSchema_rejects_unsupported_explicit_version(string apiVersion)
+    {
+        using var services = GetServiceProviderWithResourceTypes(
+            "Test.Rp/widgets@2023-01-01",
+            "Test.Rp/widgets@2024-01-01-preview",
+            "Test.Rp/widgets@v1.0",
+            "Test.Rp/widgets@2025-01-01-preview",
+            "Test.Rp/widgets@2024-01-01",
+            "Test.Rp/widgets/children@2026-01-01",
+            "Other.Rp/widgets@2027-01-01");
+
+        var action = () => services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion);
+
+        action.Should().Throw<InvalidDataException>()
+            .WithMessage($"Resource type Test.Rp/widgets with API version {apiVersion} not found. " +
+                "Valid options: null (latest), \"latest-stable\", \"2025-01-01-preview\", \"2024-01-01\", \"2024-01-01-preview\", \"2023-01-01\", \"v1.0\".");
+    }
+
+    [TestMethod]
+    [DataRow("latest-stable", "No stable API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog.")]
+    [DataRow("LATEST-STABLE", "No stable API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog.")]
+    [DataRow("latest-preview", "Resource type Test.Rp/widgets with API version latest-preview not found.")]
+    public void GetAzureResourceTypeSchema_lists_only_usable_options_for_preview_only_resources(string apiVersion, string expectedError)
+    {
+        using var services = GetServiceProviderWithResourceTypes(
+            "Test.Rp/widgets@2024-01-01-preview",
+            "Test.Rp/widgets@2025-01-01-privatepreview",
+            "Test.Rp/widgets@2025-01-01-alpha",
+            "Test.Rp/widgets/children@2026-01-01");
+
+        var action = () => services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion);
+
+        action.Should().Throw<InvalidDataException>()
+            .WithMessage($"{expectedError} Valid options: null (latest), \"2025-01-01-alpha\", \"2025-01-01-privatepreview\", \"2024-01-01-preview\".");
+    }
+
+    [TestMethod]
+    [DataRow("Test.Rp/widgets@v1.0", null, "supported", "\"v1.0\"")]
+    [DataRow("Test.Rp/widgets@v1.0", "latest-stable", "stable", "\"v1.0\"")]
+    [DataRow("Test.Rp/widgets", null, "supported", "none")]
+    [DataRow("Test.Rp/widgets", "latest-stable", "stable", "none")]
+    public void GetAzureResourceTypeSchema_rejects_catalog_without_usable_versions(string resourceTypeName, string? apiVersion, string versionKind, string expectedOptions)
+    {
+        using var services = GetServiceProviderWithResourceTypes(resourceTypeName);
+
+        var action = () => services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion);
+
+        action.Should().Throw<InvalidDataException>()
+            .WithMessage($"No {versionKind} API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog. Valid options: {expectedOptions}.");
+    }
+
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(true, true)]
+    public void GetAzureResourceTypeSchema_preserves_trim_options_with_default_version(bool excludeDescriptions, bool excludeReadOnlyProperties)
+    {
+        using var services = GetServiceProviderWithResourceTypes("Test.Rp/widgets@2024-01-01");
+        var catalogTools = services.GetRequiredService<BicepTools>();
+
+        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets",
+            excludeDescriptions: excludeDescriptions, excludeReadOnlyProperties: excludeReadOnlyProperties);
+
+        response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema(
+            "Test.Rp/widgets", "2024-01-01", excludeDescriptions, excludeReadOnlyProperties).Schema);
+        response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema(
+            "Test.Rp/widgets", "latest-stable", excludeDescriptions, excludeReadOnlyProperties).Schema);
+        using var schema = JsonDocument.Parse(response.Schema);
+        schema.RootElement.GetProperty("title").GetString().Should().Be("Test.Rp/widgets@2024-01-01");
+        var properties = schema.RootElement.GetProperty("properties");
+        properties.TryGetProperty("id", out _).Should().Be(!excludeReadOnlyProperties);
+        properties.GetProperty("name").TryGetProperty("description", out _).Should().Be(!excludeDescriptions);
     }
 
     [TestMethod]

--- a/src/Bicep.McpServer.UnitTests/BicepToolsTests.cs
+++ b/src/Bicep.McpServer.UnitTests/BicepToolsTests.cs
@@ -89,13 +89,13 @@ public class BicepToolsTests
     }
 
     [TestMethod]
-    [DataRow(null)]
-    [DataRow("latest-stable")]
-    public void GetAzureResourceTypeSchema_resolves_versions_from_bundled_catalog(string? apiVersion)
+    [DataRow(true)]
+    [DataRow(false)]
+    public void GetAzureResourceTypeSchema_resolves_versions_from_bundled_catalog(bool includePreview)
     {
         const string resourceType = "Microsoft.KeyVault/vaults";
 
-        var response = tools.GetAzureResourceTypeSchema(resourceType, apiVersion);
+        var response = tools.GetAzureResourceTypeSchema(resourceType, includePreview: includePreview);
 
         using var schema = JsonDocument.Parse(response.Schema);
         var selectedResourceType = ResourceTypeReference.Parse(schema.RootElement.GetProperty("title").GetString()!);
@@ -104,7 +104,7 @@ public class BicepToolsTests
         tools.ListAzureResourceTypes("Microsoft.KeyVault").ResourceTypes.Should().Contain(selectedResourceType.FormatName());
         response.Schema.Should().Be(tools.GetAzureResourceTypeSchema(resourceType, selectedResourceType.ApiVersion).Schema);
 
-        if (apiVersion == "latest-stable")
+        if (!includePreview)
         {
             AzureResourceApiVersion.Parse(selectedResourceType.ApiVersion!).IsStable.Should().BeTrue();
         }
@@ -132,6 +132,7 @@ public class BicepToolsTests
 
         response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", expectedVersion).Schema);
         response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", null).Schema);
+        response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", includePreview: true).Schema);
         using var schema = JsonDocument.Parse(response.Schema);
         schema.RootElement.GetProperty("title").GetString().Should().Be($"Test.Rp/widgets@{expectedVersion}");
         schema.RootElement.GetProperty("x-bicep-resource-functions").EnumerateArray().Should()
@@ -139,18 +140,19 @@ public class BicepToolsTests
     }
 
     [TestMethod]
-    [DataRow("latest-stable", "2024-01-01", new[] { "2023-01-01", "2024-01-01", "2025-01-01-preview" })]
-    [DataRow("LATEST-STABLE", "2024-01-01", new[] { "2025-01-01-privatepreview", "2024-01-01", "2025-01-01-alpha" })]
-    [DataRow("Latest-Stable", "2024-01-01", new[] { "2024-01-01-preview", "2024-01-01", "v1.0" })]
-    [DataRow("latest-stable", "2025-01-01", new[] { "2024-01-01", "2025-01-01" })]
-    public void GetAzureResourceTypeSchema_selects_latest_stable_version(string selector, string expectedVersion, string[] versions)
+    [DataRow("2024-01-01", new[] { "2023-01-01", "2024-01-01", "2025-01-01-preview" })]
+    [DataRow("2024-01-01", new[] { "2025-01-01-privatepreview", "2024-01-01", "2025-01-01-alpha" })]
+    [DataRow("2024-01-01", new[] { "2024-01-01-preview", "2024-01-01", "v1.0" })]
+    [DataRow("2025-01-01", new[] { "2024-01-01", "2025-01-01" })]
+    public void GetAzureResourceTypeSchema_selects_latest_stable_version(string expectedVersion, string[] versions)
     {
         using var services = GetServiceProviderWithResourceTypes([.. versions.Select(version => $"Test.Rp/widgets@{version}")]);
         var catalogTools = services.GetRequiredService<BicepTools>();
 
-        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", selector);
+        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", includePreview: false);
 
         response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", expectedVersion).Schema);
+        response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", null, includePreview: false).Schema);
         using var schema = JsonDocument.Parse(response.Schema);
         schema.RootElement.GetProperty("title").GetString().Should().Be($"Test.Rp/widgets@{expectedVersion}");
         schema.RootElement.GetProperty("x-bicep-resource-functions").EnumerateArray().Should()
@@ -158,10 +160,13 @@ public class BicepToolsTests
     }
 
     [TestMethod]
-    [DataRow("2023-01-01")]
-    [DataRow("2025-01-01-preview")]
-    [DataRow("v1.0")]
-    public void GetAzureResourceTypeSchema_honors_explicit_version(string apiVersion)
+    [DataRow("2023-01-01", true)]
+    [DataRow("2023-01-01", false)]
+    [DataRow("2025-01-01-preview", true)]
+    [DataRow("2025-01-01-preview", false)]
+    [DataRow("v1.0", true)]
+    [DataRow("v1.0", false)]
+    public void GetAzureResourceTypeSchema_honors_explicit_version(string apiVersion, bool includePreview)
     {
         using var services = GetServiceProviderWithResourceTypes(
             "Test.Rp/widgets@2023-01-01",
@@ -170,7 +175,7 @@ public class BicepToolsTests
             "Test.Rp/widgets@v1.0");
         var catalogTools = services.GetRequiredService<BicepTools>();
 
-        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion);
+        var response = catalogTools.GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion, includePreview: includePreview);
 
         using var schema = JsonDocument.Parse(response.Schema);
         schema.RootElement.GetProperty("title").GetString().Should().Be($"Test.Rp/widgets@{apiVersion}");
@@ -179,12 +184,12 @@ public class BicepToolsTests
     }
 
     [TestMethod]
-    [DataRow("test.rp/WIDGETS", null, "Test.Rp/widgets@2024-01-01")]
-    [DataRow("test.rp/WIDGETS", "latest-stable", "Test.Rp/widgets@2024-01-01")]
-    [DataRow("test.rp/WIDGETS", "2024-01-01", "Test.Rp/widgets@2024-01-01")]
-    [DataRow("Test.Rp/widgets/children", null, "Test.Rp/widgets/children@2025-01-01")]
-    [DataRow("Test.Rp/widgets/children", "latest-stable", "Test.Rp/widgets/children@2025-01-01")]
-    public void GetAzureResourceTypeSchema_matches_full_type_case_insensitively(string resourceType, string? apiVersion, string expectedTitle)
+    [DataRow("test.rp/WIDGETS", null, true, "Test.Rp/widgets@2024-01-01")]
+    [DataRow("test.rp/WIDGETS", null, false, "Test.Rp/widgets@2024-01-01")]
+    [DataRow("test.rp/WIDGETS", "2024-01-01", false, "Test.Rp/widgets@2024-01-01")]
+    [DataRow("Test.Rp/widgets/children", null, true, "Test.Rp/widgets/children@2025-01-01")]
+    [DataRow("Test.Rp/widgets/children", null, false, "Test.Rp/widgets/children@2025-01-01")]
+    public void GetAzureResourceTypeSchema_matches_full_type_case_insensitively(string resourceType, string? apiVersion, bool includePreview, string expectedTitle)
     {
         using var services = GetServiceProviderWithResourceTypes(
             "Test.Rp/widgets@2024-01-01",
@@ -192,7 +197,7 @@ public class BicepToolsTests
             "Test.Rp/widgetsOther@2026-01-01",
             "Other.Rp/widgets@2027-01-01");
 
-        var response = services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema(resourceType, apiVersion);
+        var response = services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema(resourceType, apiVersion, includePreview: includePreview);
 
         using var schema = JsonDocument.Parse(response.Schema);
         schema.RootElement.GetProperty("title").GetString().Should().Be(expectedTitle);
@@ -213,7 +218,7 @@ public class BicepToolsTests
         var catalogTools = services.GetRequiredService<BicepTools>();
 
         var defaultVersionAction = () => catalogTools.GetAzureResourceTypeSchema(resourceType);
-        var stableVersionAction = () => catalogTools.GetAzureResourceTypeSchema(resourceType, "latest-stable");
+        var stableVersionAction = () => catalogTools.GetAzureResourceTypeSchema(resourceType, includePreview: false);
         var explicitVersionAction = () => catalogTools.GetAzureResourceTypeSchema(resourceType, "2024-01-01");
 
         defaultVersionAction.Should().Throw<InvalidDataException>()
@@ -229,6 +234,8 @@ public class BicepToolsTests
     [DataRow(" ")]
     [DataRow("latest")]
     [DataRow("latest-preview")]
+    [DataRow("latest-stable")]
+    [DataRow("LATEST-STABLE")]
     [DataRow("latest-stable ")]
     [DataRow("2099-01-01")]
     [DataRow("2024-01-01 ")]
@@ -247,14 +254,15 @@ public class BicepToolsTests
 
         action.Should().Throw<InvalidDataException>()
             .WithMessage($"Resource type Test.Rp/widgets with API version {apiVersion} not found. " +
-                "Valid options: null (latest), \"latest-stable\", \"2025-01-01-preview\", \"2024-01-01\", \"2024-01-01-preview\", \"2023-01-01\", \"v1.0\".");
+                "Valid options: apiVersion = null with includePreview = true (latest), apiVersion = null with includePreview = false (latest stable), " +
+                "apiVersion = \"2025-01-01-preview\", apiVersion = \"2024-01-01\", apiVersion = \"2024-01-01-preview\", apiVersion = \"2023-01-01\", apiVersion = \"v1.0\".");
     }
 
     [TestMethod]
-    [DataRow("latest-stable", "No stable API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog.")]
-    [DataRow("LATEST-STABLE", "No stable API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog.")]
-    [DataRow("latest-preview", "Resource type Test.Rp/widgets with API version latest-preview not found.")]
-    public void GetAzureResourceTypeSchema_lists_only_usable_options_for_preview_only_resources(string apiVersion, string expectedError)
+    [DataRow(null, false, "No stable API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog.")]
+    [DataRow("latest-stable", true, "Resource type Test.Rp/widgets with API version latest-stable not found.")]
+    [DataRow("latest-preview", false, "Resource type Test.Rp/widgets with API version latest-preview not found.")]
+    public void GetAzureResourceTypeSchema_lists_only_usable_options_for_preview_only_resources(string? apiVersion, bool includePreview, string expectedError)
     {
         using var services = GetServiceProviderWithResourceTypes(
             "Test.Rp/widgets@2024-01-01-preview",
@@ -262,22 +270,23 @@ public class BicepToolsTests
             "Test.Rp/widgets@2025-01-01-alpha",
             "Test.Rp/widgets/children@2026-01-01");
 
-        var action = () => services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion);
+        var action = () => services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion, includePreview: includePreview);
 
         action.Should().Throw<InvalidDataException>()
-            .WithMessage($"{expectedError} Valid options: null (latest), \"2025-01-01-alpha\", \"2025-01-01-privatepreview\", \"2024-01-01-preview\".");
+            .WithMessage($"{expectedError} Valid options: apiVersion = null with includePreview = true (latest), " +
+                "apiVersion = \"2025-01-01-alpha\", apiVersion = \"2025-01-01-privatepreview\", apiVersion = \"2024-01-01-preview\".");
     }
 
     [TestMethod]
-    [DataRow("Test.Rp/widgets@v1.0", null, "supported", "\"v1.0\"")]
-    [DataRow("Test.Rp/widgets@v1.0", "latest-stable", "stable", "\"v1.0\"")]
-    [DataRow("Test.Rp/widgets", null, "supported", "none")]
-    [DataRow("Test.Rp/widgets", "latest-stable", "stable", "none")]
-    public void GetAzureResourceTypeSchema_rejects_catalog_without_usable_versions(string resourceTypeName, string? apiVersion, string versionKind, string expectedOptions)
+    [DataRow("Test.Rp/widgets@v1.0", true, "supported", "apiVersion = \"v1.0\"")]
+    [DataRow("Test.Rp/widgets@v1.0", false, "stable", "apiVersion = \"v1.0\"")]
+    [DataRow("Test.Rp/widgets", true, "supported", "none")]
+    [DataRow("Test.Rp/widgets", false, "stable", "none")]
+    public void GetAzureResourceTypeSchema_rejects_catalog_without_usable_versions(string resourceTypeName, bool includePreview, string versionKind, string expectedOptions)
     {
         using var services = GetServiceProviderWithResourceTypes(resourceTypeName);
 
-        var action = () => services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema("Test.Rp/widgets", apiVersion);
+        var action = () => services.GetRequiredService<BicepTools>().GetAzureResourceTypeSchema("Test.Rp/widgets", includePreview: includePreview);
 
         action.Should().Throw<InvalidDataException>()
             .WithMessage($"No {versionKind} API versions found for resource type Test.Rp/widgets in Bicep's bundled Azure resource type catalog. Valid options: {expectedOptions}.");
@@ -299,7 +308,7 @@ public class BicepToolsTests
         response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema(
             "Test.Rp/widgets", "2024-01-01", excludeDescriptions, excludeReadOnlyProperties).Schema);
         response.Schema.Should().Be(catalogTools.GetAzureResourceTypeSchema(
-            "Test.Rp/widgets", "latest-stable", excludeDescriptions, excludeReadOnlyProperties).Schema);
+            "Test.Rp/widgets", null, excludeDescriptions, excludeReadOnlyProperties, includePreview: false).Schema);
         using var schema = JsonDocument.Parse(response.Schema);
         schema.RootElement.GetProperty("title").GetString().Should().Be("Test.Rp/widgets@2024-01-01");
         var properties = schema.RootElement.GetProperty("properties");

--- a/src/Bicep.McpServer.UnitTests/Files/ServerTests/tools.json
+++ b/src/Bicep.McpServer.UnitTests/Files/ServerTests/tools.json
@@ -287,7 +287,7 @@
   },
   {
     "name": "get_azure_resource_type_schema",
-    "description": "Retrieves the complete JSON schema definition for a specific Azure resource type and API version, including all properties, nested types, and constraints.\nUse this tool to:\n- Understand what properties are available on an Azure resource\n- Learn about required vs optional properties, their types, and allowed values\n- Discover nested resource types and their schemas\n- Find available resource functions and their signatures\n- Generate accurate Bicep code with proper property names and types\nThe returned JSON schema includes resource type definitions, nested complex types, resource function signatures (like list* operations), and property constraints.\nData is sourced directly from Azure Resource Provider APIs, ensuring the most accurate and up-to-date schema information.\nSpecify the resource type (e.g., Microsoft.KeyVault/vaults) and API version (e.g., 2024-11-01 or 2024-12-01-preview).",
+    "description": "Retrieves the complete JSON schema definition for a specific Azure resource type and API version, including all properties, nested types, and constraints.\nUse this tool to:\n- Understand what properties are available on an Azure resource\n- Learn about required vs optional properties, their types, and allowed values\n- Discover nested resource types and their schemas\n- Find available resource functions and their signatures\n- Generate accurate Bicep code with proper property names and types\nThe returned JSON schema includes resource type definitions, nested complex types, resource function signatures (like list* operations), and property constraints.\nData comes from Bicep's bundled Azure resource type catalog, not a live Azure API query.\nSpecify the resource type (e.g., Microsoft.KeyVault/vaults). Omit apiVersion or pass null to select the newest API version by date, including preview versions; stable versions win same-date ties.\nPass latest-stable (case-insensitive) to select only the newest stable version, or an explicit API version (e.g., 2024-11-01 or 2024-12-01-preview) to pin the schema.\nPreview includes other prerelease versions recognized by Bicep. Unknown resource types return an error. Unsupported API versions or unavailable selections return an error listing all valid API version options for the resource type.\nThe schema title includes the selected resource type and API version, even when read-only properties are excluded.",
     "jsonSchema": {
       "type": "object",
       "properties": {
@@ -296,8 +296,12 @@
           "type": "string"
         },
         "apiVersion": {
-          "description": "The API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview",
-          "type": "string"
+          "description": "The API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview. Omit or pass null for the newest version by date in Bicep's bundled catalog, including prereleases, with stable preferred on the same date. Pass latest-stable (case-insensitive) for the newest stable version only; an error lists valid options if no stable version exists or the requested version is unsupported.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         },
         "excludeDescriptions": {
           "description": "When true, omits description fields from the schema to reduce payload size. Default: false",
@@ -311,8 +315,7 @@
         }
       },
       "required": [
-        "resourceType",
-        "apiVersion"
+        "resourceType"
       ]
     },
     "returnJsonSchema": {

--- a/src/Bicep.McpServer.UnitTests/Files/ServerTests/tools.json
+++ b/src/Bicep.McpServer.UnitTests/Files/ServerTests/tools.json
@@ -287,7 +287,7 @@
   },
   {
     "name": "get_azure_resource_type_schema",
-    "description": "Retrieves the complete JSON schema definition for a specific Azure resource type and API version, including all properties, nested types, and constraints.\nUse this tool to:\n- Understand what properties are available on an Azure resource\n- Learn about required vs optional properties, their types, and allowed values\n- Discover nested resource types and their schemas\n- Find available resource functions and their signatures\n- Generate accurate Bicep code with proper property names and types\nThe returned JSON schema includes resource type definitions, nested complex types, resource function signatures (like list* operations), and property constraints.\nData comes from Bicep's bundled Azure resource type catalog, not a live Azure API query.\nSpecify the resource type (e.g., Microsoft.KeyVault/vaults). Omit apiVersion or pass null to select the newest API version by date, including preview versions; stable versions win same-date ties.\nPass latest-stable (case-insensitive) to select only the newest stable version, or an explicit API version (e.g., 2024-11-01 or 2024-12-01-preview) to pin the schema.\nPreview includes other prerelease versions recognized by Bicep. Unknown resource types return an error. Unsupported API versions or unavailable selections return an error listing all valid API version options for the resource type.\nThe schema title includes the selected resource type and API version, even when read-only properties are excluded.",
+    "description": "Retrieves the complete JSON schema definition for a specific Azure resource type and API version, including all properties, nested types, and constraints.\nUse this tool to:\n- Understand what properties are available on an Azure resource\n- Learn about required vs optional properties, their types, and allowed values\n- Discover nested resource types and their schemas\n- Find available resource functions and their signatures\n- Generate accurate Bicep code with proper property names and types\nThe returned JSON schema includes resource type definitions, nested complex types, resource function signatures (like list* operations), and property constraints.\nData comes from Bicep's bundled Azure resource type catalog, not a live Azure API query.\nSpecify the resource type (e.g., Microsoft.KeyVault/vaults). Omit apiVersion or pass null to select the newest API version by date, including preview versions; stable versions win same-date ties.\nSet includePreview to false to select only the newest stable version, with no preview fallback. An explicit API version (e.g., 2024-11-01 or 2024-12-01-preview) pins the schema and overrides includePreview.\nPreview includes other prerelease versions recognized by Bicep. Unknown resource types return an error. Unsupported API versions or unavailable selections return an error listing all valid API version options for the resource type.\nThe schema title includes the selected resource type and API version, even when read-only properties are excluded.",
     "jsonSchema": {
       "type": "object",
       "properties": {
@@ -296,7 +296,7 @@
           "type": "string"
         },
         "apiVersion": {
-          "description": "The API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview. Omit or pass null for the newest version by date in Bicep's bundled catalog, including prereleases, with stable preferred on the same date. Pass latest-stable (case-insensitive) for the newest stable version only; an error lists valid options if no stable version exists or the requested version is unsupported.",
+          "description": "The explicit API version of the resource type; e.g. 2024-11-01 or 2024-12-01-preview. Omit or pass null for the newest version by date in Bicep's bundled catalog, subject to includePreview, with stable preferred on the same date. An explicit version overrides includePreview. Errors list valid options.",
           "type": [
             "string",
             "null"
@@ -312,6 +312,11 @@
           "description": "When true, omits read-only properties from the schema to reduce payload size. Default: false",
           "type": "boolean",
           "default": false
+        },
+        "includePreview": {
+          "description": "When apiVersion is omitted or null, includes preview and other Bicep-recognized prerelease versions in automatic selection. Set to false for the newest stable version only; returns an error if none exists. Ignored for explicit API versions. Default: true",
+          "type": "boolean",
+          "default": true
         }
       },
       "required": [

--- a/src/Bicep.McpServer.UnitTests/Helpers/ResourceTypeCatalogHelper.cs
+++ b/src/Bicep.McpServer.UnitTests/Helpers/ResourceTypeCatalogHelper.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.Bicep.Types;
+using Azure.Bicep.Types.Concrete;
+using Azure.Bicep.Types.Index;
+using Bicep.Core.Resources;
+using Bicep.Core.UnitTests.Mock;
+
+namespace Bicep.McpServer.UnitTests.Helpers;
+
+public static class ResourceTypeCatalogHelper
+{
+    public static ITypeLoader CreateTypeLoader(params string[] resourceTypeNames)
+    {
+        var factory = new TypeFactory([]);
+        var stringType = factory.Create(() => new StringType());
+        var bodyType = factory.Create(() => new ObjectType(
+            "TestResourceBody",
+            new Dictionary<string, ObjectTypeProperty>
+            {
+                ["name"] = new(factory.GetReference(stringType), ObjectTypePropertyFlags.Required | ObjectTypePropertyFlags.Identifier, "Resource name"),
+                ["id"] = new(factory.GetReference(stringType), ObjectTypePropertyFlags.ReadOnly, "Resource ID"),
+            },
+            null,
+            null));
+
+        var typeLoader = StrictMock.Of<ITypeLoader>();
+        var resources = new Dictionary<string, CrossFileTypeReference>();
+        var resourceFunctions = new Dictionary<string, Dictionary<string, IReadOnlyList<CrossFileTypeReference>>>();
+
+        foreach (var resourceTypeName in resourceTypeNames)
+        {
+            var reference = ResourceTypeReference.Parse(resourceTypeName);
+            var resourceType = factory.Create(() => new ResourceType(
+                resourceTypeName,
+                factory.GetReference(bodyType),
+                functions: null,
+                writableScopes_in: ScopeType.ResourceGroup,
+                readableScopes_in: ScopeType.ResourceGroup,
+                scopeType: null,
+                readOnlyScopes: null,
+                flags: null));
+            var resourceReference = new CrossFileTypeReference("types.json", factory.GetIndex(resourceType));
+            resources.Add(resourceTypeName, resourceReference);
+            typeLoader.Setup(loader => loader.LoadResourceType(resourceReference)).Returns(resourceType);
+
+            if (reference.ApiVersion is { } apiVersion)
+            {
+                var functionType = factory.Create(() => new ResourceFunctionType(
+                    "listSecrets",
+                    reference.FormatType(),
+                    apiVersion,
+                    factory.GetReference(stringType),
+                    factory.GetReference(stringType)));
+                var functionReference = new CrossFileTypeReference("types.json", factory.GetIndex(functionType));
+                if (!resourceFunctions.TryGetValue(reference.FormatType(), out var functionsByVersion))
+                {
+                    functionsByVersion = new Dictionary<string, IReadOnlyList<CrossFileTypeReference>>();
+                    resourceFunctions.Add(reference.FormatType(), functionsByVersion);
+                }
+
+                functionsByVersion.Add(apiVersion, [functionReference]);
+                typeLoader.Setup(loader => loader.LoadResourceFunctionType(functionReference)).Returns(functionType);
+            }
+        }
+
+        var index = new TypeIndex(
+            resources: resources,
+            resourceFunctions: resourceFunctions.ToDictionary(
+                entry => entry.Key,
+                entry => (IReadOnlyDictionary<string, IReadOnlyList<CrossFileTypeReference>>)entry.Value),
+            namespaceFunctions: [],
+            settings: null,
+            fallbackResourceType: null);
+        typeLoader.Setup(loader => loader.LoadTypeIndex()).Returns(index);
+
+        return typeLoader.Object;
+    }
+}


### PR DESCRIPTION
## Description

Update the `get_azure_resource_type_schema` mcp tool to make `apiVersion` optional. In cases where clients want to use the latest API version, this saves an extra call to the `list_azure_resource_types` tool.

- Default omitted/null `apiVersion` to the newest bundled version, including prereleases, with stable preferred on same-date ties.
- Add `latest-stable` selection while preserving explicit-version support.
- Return errors for unknown resource types and list valid options for unsupported versions.
- Update documentation, MCP metadata, and tests, including real-catalog smoke coverage.

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20292)