### PR TITLE
Implement `getRoleAssignmentName()` function

### DIFF
--- a/src/Bicep.Core.IntegrationTests/EvaluationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/EvaluationTests.cs
@@ -1010,6 +1010,63 @@ param param2 = union(param1, { reference: 'param2' })
     }
 
     [TestMethod]
+    public void Az_getRoleAssignmentName_functions_are_evaluated_successfully()
+    {
+        var (template, diagnostics, _) = CompilationHelper.Compile(@"
+output resourceGroupScope string = az.getRoleAssignmentName({
+  scope: '/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/myRg'
+  principalId: '22222222-2222-2222-2222-222222222222'
+  roleDefinitionId: '/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333'
+})
+output resourceGroupScopeTenantRoleDefinition string = az.getRoleAssignmentName({
+  scope: '/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/myRg'
+  principalId: '22222222-2222-2222-2222-222222222222'
+  roleDefinitionId: '/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333'
+})
+output resourceGroupScopeManagementGroupRoleDefinition string = az.getRoleAssignmentName({
+  scope: '/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/myRg'
+  principalId: '22222222-2222-2222-2222-222222222222'
+  roleDefinitionId: '/providers/Microsoft.Management/managementGroups/myMg/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333'
+})
+output upperCasedInputs string = az.getRoleAssignmentName({
+  scope: '/SUBSCRIPTIONS/11111111-1111-1111-1111-111111111111/RESOURCEGROUPS/MYRG'
+  principalId: '22222222-2222-2222-2222-222222222222'
+  roleDefinitionId: '/SUBSCRIPTIONS/11111111-1111-1111-1111-111111111111/PROVIDERS/MICROSOFT.AUTHORIZATION/ROLEDEFINITIONS/33333333-3333-3333-3333-333333333333'
+})
+output tenantScope string = az.getRoleAssignmentName({
+  scope: '/'
+  principalId: '22222222-2222-2222-2222-222222222222'
+  roleDefinitionId: '/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333'
+})
+output managementGroupScope string = az.getRoleAssignmentName({
+  scope: '/providers/Microsoft.Management/managementGroups/myMg'
+  principalId: '22222222-2222-2222-2222-222222222222'
+  roleDefinitionId: '/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333'
+})
+output subscriptionScopeDifferentPrincipal string = az.getRoleAssignmentName({
+  scope: '/subscriptions/11111111-1111-1111-1111-111111111111'
+  principalId: '99999999-9999-9999-9999-999999999999'
+  roleDefinitionId: '/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333'
+})
+");
+
+        using (new AssertionScope())
+        {
+            diagnostics.Should().NotHaveAnyDiagnostics();
+
+            var evaluated = TemplateEvaluator.Evaluate(template).ToJToken();
+
+            evaluated.Should().HaveValueAtPath("$.outputs['resourceGroupScope'].value", "eec47c62-a9a9-54dd-b8d8-f9e2839fab35");
+            evaluated.Should().HaveValueAtPath("$.outputs['resourceGroupScopeTenantRoleDefinition'].value", "eec47c62-a9a9-54dd-b8d8-f9e2839fab35");
+            evaluated.Should().HaveValueAtPath("$.outputs['resourceGroupScopeManagementGroupRoleDefinition'].value", "eec47c62-a9a9-54dd-b8d8-f9e2839fab35");
+            evaluated.Should().HaveValueAtPath("$.outputs['upperCasedInputs'].value", "eec47c62-a9a9-54dd-b8d8-f9e2839fab35");
+            evaluated.Should().HaveValueAtPath("$.outputs['tenantScope'].value", "c095807d-5244-5404-8bce-e0e762e70618");
+            evaluated.Should().HaveValueAtPath("$.outputs['managementGroupScope'].value", "6aab5ec9-d102-539e-8b65-b053c060e64f");
+            evaluated.Should().HaveValueAtPath("$.outputs['subscriptionScopeDifferentPrincipal'].value", "54e40269-cc30-57bd-8031-5ca4efc75fd5");
+        }
+        }
+
+    [TestMethod]
     public void Az_getsecret_params_cannot_be_dereferenced()
     {
         var bicepTemplateText = @"

--- a/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions/az.json
@@ -62,6 +62,25 @@
     ]
   },
   {
+    "name": "getRoleAssignmentName",
+    "description": "Returns a deterministic name for a role assignment.",
+    "fixedParameters": [
+      {
+        "name": "inputs",
+        "description": "The role assignment inputs",
+        "type": "inputs",
+        "required": true
+      }
+    ],
+    "minimumArgumentCount": 1,
+    "maximumArgumentCount": 1,
+    "flags": "pure",
+    "typeSignature": "(inputs: inputs): string",
+    "parameterTypeSignatures": [
+      "inputs: inputs"
+    ]
+  },
+  {
     "name": "managementGroup",
     "description": "Returns the scope for a named management group.",
     "fixedParameters": [

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.bicep
@@ -55,3 +55,8 @@ output likewildcardtest6 bool = like('aXbYa', 'a*b*a')
 output distinctTest array = distinct(['a','b','a','c','b'])
 output distinctTest2 array = distinct([1,2,3,1,2,4])
 output distinctTest3 array = distinct([{a:1}, {a:1}, {b:2}])
+output roleAssignmentName string = getRoleAssignmentName({
+  scope: resourceGroup().id
+  principalId: '00000000-0000-0000-0000-000000000000'
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+})

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.diagnostics.bicep
@@ -67,4 +67,9 @@ output distinctTest2 array = distinct([1,2,3,1,2,4])
 //@[21:26) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-user-defined-types) |array|
 output distinctTest3 array = distinct([{a:1}, {a:1}, {b:2}])
 //@[21:26) [use-user-defined-types (Warning)] Use user-defined types instead of 'object' or 'array'. (bicep core linter https://aka.ms/bicep/linter-diagnostics#use-user-defined-types) |array|
+output roleAssignmentName string = getRoleAssignmentName({
+  scope: resourceGroup().id
+  principalId: '00000000-0000-0000-0000-000000000000'
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+})
 

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.formatted.bicep
@@ -55,3 +55,8 @@ output likewildcardtest6 bool = like('aXbYa', 'a*b*a')
 output distinctTest array = distinct(['a', 'b', 'a', 'c', 'b'])
 output distinctTest2 array = distinct([1, 2, 3, 1, 2, 4])
 output distinctTest3 array = distinct([{ a: 1 }, { a: 1 }, { b: 2 }])
+output roleAssignmentName string = getRoleAssignmentName({
+  scope: resourceGroup().id
+  principalId: '00000000-0000-0000-0000-000000000000'
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+})

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.ir.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.ir.bicep
@@ -1,5 +1,5 @@
 func buildUrl(https bool, hostname string, path string) string => '${https ? 'https' : 'http'}://${hostname}${empty(path) ? '' : '/${path}'}'
-//@[000:2050) ProgramExpression
+//@[000:2253) ProgramExpression
 //@[000:0141) ├─DeclaredFunctionExpression { Name = buildUrl }
 //@[013:0141) | └─LambdaExpression
 //@[020:0024) |   ├─AmbientTypeReferenceExpression { Name = bool }
@@ -250,20 +250,39 @@ output distinctTest2 array = distinct([1,2,3,1,2,4])
 //@[047:0048) |     ├─IntegerLiteralExpression { Value = 2 }
 //@[049:0050) |     └─IntegerLiteralExpression { Value = 4 }
 output distinctTest3 array = distinct([{a:1}, {a:1}, {b:2}])
-//@[000:0060) └─DeclaredOutputExpression { Name = distinctTest3 }
-//@[021:0026)   ├─AmbientTypeReferenceExpression { Name = array }
-//@[029:0060)   └─FunctionCallExpression { Name = distinct }
-//@[038:0059)     └─ArrayExpression
-//@[039:0044)       ├─ObjectExpression
-//@[040:0043)       | └─ObjectPropertyExpression
-//@[040:0041)       |   ├─StringLiteralExpression { Value = a }
-//@[042:0043)       |   └─IntegerLiteralExpression { Value = 1 }
-//@[046:0051)       ├─ObjectExpression
-//@[047:0050)       | └─ObjectPropertyExpression
-//@[047:0048)       |   ├─StringLiteralExpression { Value = a }
-//@[049:0050)       |   └─IntegerLiteralExpression { Value = 1 }
-//@[053:0058)       └─ObjectExpression
-//@[054:0057)         └─ObjectPropertyExpression
-//@[054:0055)           ├─StringLiteralExpression { Value = b }
-//@[056:0057)           └─IntegerLiteralExpression { Value = 2 }
+//@[000:0060) ├─DeclaredOutputExpression { Name = distinctTest3 }
+//@[021:0026) | ├─AmbientTypeReferenceExpression { Name = array }
+//@[029:0060) | └─FunctionCallExpression { Name = distinct }
+//@[038:0059) |   └─ArrayExpression
+//@[039:0044) |     ├─ObjectExpression
+//@[040:0043) |     | └─ObjectPropertyExpression
+//@[040:0041) |     |   ├─StringLiteralExpression { Value = a }
+//@[042:0043) |     |   └─IntegerLiteralExpression { Value = 1 }
+//@[046:0051) |     ├─ObjectExpression
+//@[047:0050) |     | └─ObjectPropertyExpression
+//@[047:0048) |     |   ├─StringLiteralExpression { Value = a }
+//@[049:0050) |     |   └─IntegerLiteralExpression { Value = 1 }
+//@[053:0058) |     └─ObjectExpression
+//@[054:0057) |       └─ObjectPropertyExpression
+//@[054:0055) |         ├─StringLiteralExpression { Value = b }
+//@[056:0057) |         └─IntegerLiteralExpression { Value = 2 }
+output roleAssignmentName string = getRoleAssignmentName({
+//@[000:0202) └─DeclaredOutputExpression { Name = roleAssignmentName }
+//@[026:0032)   ├─AmbientTypeReferenceExpression { Name = string }
+//@[035:0202)   └─FunctionCallExpression { Name = getRoleAssignmentName }
+//@[057:0201)     └─ObjectExpression
+  scope: resourceGroup().id
+//@[002:0027)       ├─ObjectPropertyExpression
+//@[002:0007)       | ├─StringLiteralExpression { Value = scope }
+//@[009:0027)       | └─PropertyAccessExpression { PropertyName = id }
+//@[009:0024)       |   └─FunctionCallExpression { Name = resourceGroup }
+  principalId: '00000000-0000-0000-0000-000000000000'
+//@[002:0053)       ├─ObjectPropertyExpression
+//@[002:0013)       | ├─StringLiteralExpression { Value = principalId }
+//@[015:0053)       | └─StringLiteralExpression { Value = 00000000-0000-0000-0000-000000000000 }
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+//@[002:0058)       └─ObjectPropertyExpression
+//@[002:0018)         ├─StringLiteralExpression { Value = roleDefinitionId }
+//@[020:0058)         └─StringLiteralExpression { Value = 00000000-0000-0000-0000-000000000001 }
+})
 

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16013494690126396150"
+      "templateHash": "14070404464161621587"
     }
   },
   "definitions": {
@@ -270,6 +270,10 @@
     "distinctTest3": {
       "type": "array",
       "value": "[distinct(createArray(createObject('a', 1), createObject('a', 1), createObject('b', 2)))]"
+    },
+    "roleAssignmentName": {
+      "type": "string",
+      "value": "[getRoleAssignmentName(createObject('scope', resourceGroup().id, 'principalId', '00000000-0000-0000-0000-000000000000', 'roleDefinitionId', '00000000-0000-0000-0000-000000000001'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.sourcemap.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.sourcemap.bicep
@@ -305,5 +305,14 @@ output distinctTest3 array = distinct([{a:1}, {a:1}, {b:2}])
 //@    "distinctTest3": {
 //@      "type": "array",
 //@      "value": "[distinct(createArray(createObject('a', 1), createObject('a', 1), createObject('b', 2)))]"
+//@    },
+output roleAssignmentName string = getRoleAssignmentName({
+//@    "roleAssignmentName": {
+//@      "type": "string",
+//@      "value": "[getRoleAssignmentName(createObject('scope', resourceGroup().id, 'principalId', '00000000-0000-0000-0000-000000000000', 'roleDefinitionId', '00000000-0000-0000-0000-000000000001'))]"
 //@    }
+  scope: resourceGroup().id
+  principalId: '00000000-0000-0000-0000-000000000000'
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+})
 

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.symbolicnames.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.symbolicnames.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "dev",
-      "templateHash": "16013494690126396150"
+      "templateHash": "14070404464161621587"
     }
   },
   "definitions": {
@@ -270,6 +270,10 @@
     "distinctTest3": {
       "type": "array",
       "value": "[distinct(createArray(createObject('a', 1), createObject('a', 1), createObject('b', 2)))]"
+    },
+    "roleAssignmentName": {
+      "type": "string",
+      "value": "[getRoleAssignmentName(createObject('scope', resourceGroup().id, 'principalId', '00000000-0000-0000-0000-000000000000', 'roleDefinitionId', '00000000-0000-0000-0000-000000000001'))]"
     }
   }
 }

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.symbols.bicep
@@ -103,4 +103,10 @@ output distinctTest2 array = distinct([1,2,3,1,2,4])
 //@[07:020) Output distinctTest2. Type: array. Declaration start char: 0, length: 52
 output distinctTest3 array = distinct([{a:1}, {a:1}, {b:2}])
 //@[07:020) Output distinctTest3. Type: array. Declaration start char: 0, length: 60
+output roleAssignmentName string = getRoleAssignmentName({
+//@[07:025) Output roleAssignmentName. Type: string. Declaration start char: 0, length: 202
+  scope: resourceGroup().id
+  principalId: '00000000-0000-0000-0000-000000000000'
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+})
 

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.syntax.bicep
@@ -1,5 +1,5 @@
 func buildUrl(https bool, hostname string, path string) string => '${https ? 'https' : 'http'}://${hostname}${empty(path) ? '' : '/${path}'}'
-//@[000:2050) ProgramSyntax
+//@[000:2253) ProgramSyntax
 //@[000:0141) ├─FunctionDeclarationSyntax
 //@[000:0004) | ├─Token(Identifier) |func|
 //@[005:0013) | ├─IdentifierSyntax
@@ -957,5 +957,57 @@ output distinctTest3 array = distinct([{a:1}, {a:1}, {b:2}])
 //@[058:0059) |   |   └─Token(RightSquare) |]|
 //@[059:0060) |   └─Token(RightParen) |)|
 //@[060:0061) ├─Token(NewLine) |\n|
+output roleAssignmentName string = getRoleAssignmentName({
+//@[000:0202) ├─OutputDeclarationSyntax
+//@[000:0006) | ├─Token(Identifier) |output|
+//@[007:0025) | ├─IdentifierSyntax
+//@[007:0025) | | └─Token(Identifier) |roleAssignmentName|
+//@[026:0032) | ├─TypeVariableAccessSyntax
+//@[026:0032) | | └─IdentifierSyntax
+//@[026:0032) | |   └─Token(Identifier) |string|
+//@[033:0034) | ├─Token(Assignment) |=|
+//@[035:0202) | └─FunctionCallSyntax
+//@[035:0056) |   ├─IdentifierSyntax
+//@[035:0056) |   | └─Token(Identifier) |getRoleAssignmentName|
+//@[056:0057) |   ├─Token(LeftParen) |(|
+//@[057:0201) |   ├─FunctionArgumentSyntax
+//@[057:0201) |   | └─ObjectSyntax
+//@[057:0058) |   |   ├─Token(LeftBrace) |{|
+//@[058:0059) |   |   ├─Token(NewLine) |\n|
+  scope: resourceGroup().id
+//@[002:0027) |   |   ├─ObjectPropertySyntax
+//@[002:0007) |   |   | ├─IdentifierSyntax
+//@[002:0007) |   |   | | └─Token(Identifier) |scope|
+//@[007:0008) |   |   | ├─Token(Colon) |:|
+//@[009:0027) |   |   | └─PropertyAccessSyntax
+//@[009:0024) |   |   |   ├─FunctionCallSyntax
+//@[009:0022) |   |   |   | ├─IdentifierSyntax
+//@[009:0022) |   |   |   | | └─Token(Identifier) |resourceGroup|
+//@[022:0023) |   |   |   | ├─Token(LeftParen) |(|
+//@[023:0024) |   |   |   | └─Token(RightParen) |)|
+//@[024:0025) |   |   |   ├─Token(Dot) |.|
+//@[025:0027) |   |   |   └─IdentifierSyntax
+//@[025:0027) |   |   |     └─Token(Identifier) |id|
+//@[027:0028) |   |   ├─Token(NewLine) |\n|
+  principalId: '00000000-0000-0000-0000-000000000000'
+//@[002:0053) |   |   ├─ObjectPropertySyntax
+//@[002:0013) |   |   | ├─IdentifierSyntax
+//@[002:0013) |   |   | | └─Token(Identifier) |principalId|
+//@[013:0014) |   |   | ├─Token(Colon) |:|
+//@[015:0053) |   |   | └─StringSyntax
+//@[015:0053) |   |   |   └─Token(StringComplete) |'00000000-0000-0000-0000-000000000000'|
+//@[053:0054) |   |   ├─Token(NewLine) |\n|
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+//@[002:0058) |   |   ├─ObjectPropertySyntax
+//@[002:0018) |   |   | ├─IdentifierSyntax
+//@[002:0018) |   |   | | └─Token(Identifier) |roleDefinitionId|
+//@[018:0019) |   |   | ├─Token(Colon) |:|
+//@[020:0058) |   |   | └─StringSyntax
+//@[020:0058) |   |   |   └─Token(StringComplete) |'00000000-0000-0000-0000-000000000001'|
+//@[058:0059) |   |   ├─Token(NewLine) |\n|
+})
+//@[000:0001) |   |   └─Token(RightBrace) |}|
+//@[001:0002) |   └─Token(RightParen) |)|
+//@[002:0003) ├─Token(NewLine) |\n|
 
 //@[000:0000) └─Token(EndOfFile) ||

--- a/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/baselines/Functions_LF/main.tokens.bicep
@@ -516,5 +516,37 @@ output distinctTest3 array = distinct([{a:1}, {a:1}, {b:2}])
 //@[058:059) RightSquare |]|
 //@[059:060) RightParen |)|
 //@[060:061) NewLine |\n|
+output roleAssignmentName string = getRoleAssignmentName({
+//@[000:006) Identifier |output|
+//@[007:025) Identifier |roleAssignmentName|
+//@[026:032) Identifier |string|
+//@[033:034) Assignment |=|
+//@[035:056) Identifier |getRoleAssignmentName|
+//@[056:057) LeftParen |(|
+//@[057:058) LeftBrace |{|
+//@[058:059) NewLine |\n|
+  scope: resourceGroup().id
+//@[002:007) Identifier |scope|
+//@[007:008) Colon |:|
+//@[009:022) Identifier |resourceGroup|
+//@[022:023) LeftParen |(|
+//@[023:024) RightParen |)|
+//@[024:025) Dot |.|
+//@[025:027) Identifier |id|
+//@[027:028) NewLine |\n|
+  principalId: '00000000-0000-0000-0000-000000000000'
+//@[002:013) Identifier |principalId|
+//@[013:014) Colon |:|
+//@[015:053) StringComplete |'00000000-0000-0000-0000-000000000000'|
+//@[053:054) NewLine |\n|
+  roleDefinitionId: '00000000-0000-0000-0000-000000000001'
+//@[002:018) Identifier |roleDefinitionId|
+//@[018:019) Colon |:|
+//@[020:058) StringComplete |'00000000-0000-0000-0000-000000000001'|
+//@[058:059) NewLine |\n|
+})
+//@[000:001) RightBrace |}|
+//@[001:002) RightParen |)|
+//@[002:003) NewLine |\n|
 
 //@[000:000) EndOfFile ||

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/azFunctions.json
@@ -72,6 +72,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "managementGroup",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidExpressions_LF/Completions/symbols.json
@@ -1120,6 +1120,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -1154,6 +1154,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -1154,6 +1154,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/arrayPlusSymbols.json
@@ -658,6 +658,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/boolPlusSymbols.json
@@ -622,6 +622,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/objectPlusSymbols.json
@@ -608,6 +608,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidOutputs_CRLF/Completions/symbols.json
@@ -608,6 +608,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/arrayPlusSymbols.json
@@ -806,6 +806,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/boolPlusSymbols.json
@@ -806,6 +806,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/justSymbols.json
@@ -792,6 +792,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidParameters_LF/Completions/objectPlusSymbols.json
@@ -810,6 +810,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/arrayPlusSymbols.json
@@ -2570,6 +2570,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/boolPropertyValuesPlusSymbols.json
@@ -2517,6 +2517,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cleanupPreferencesPlusSymbols.json
@@ -2562,6 +2562,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols.json
@@ -2776,6 +2776,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for.json
@@ -2776,6 +2776,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_for_if.json
@@ -2776,6 +2776,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/cliPropertyAccessIndexesPlusSymbols_if.json
@@ -2776,6 +2776,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols.json
@@ -2538,6 +2538,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for.json
@@ -2538,6 +2538,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_for_if.json
@@ -2538,6 +2538,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/createModeIndexPlusSymbols_if.json
@@ -2538,6 +2538,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes.json
@@ -3024,6 +3024,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for.json
@@ -3024,6 +3024,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_for_if.json
@@ -3024,6 +3024,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/defaultCreateModeIndexes_if.json
@@ -3024,6 +3024,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols.json
@@ -2531,6 +2531,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for.json
@@ -2531,6 +2531,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_for_if.json
@@ -2531,6 +2531,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/deploymentScriptKindsPlusSymbols_if.json
@@ -2531,6 +2531,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols.json
@@ -2524,6 +2524,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for.json
@@ -2524,6 +2524,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_for_if.json
@@ -2524,6 +2524,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/missingDiscriminatorPropertyIndexPlusSymbols_if.json
@@ -2524,6 +2524,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbols.json
@@ -2520,6 +2520,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/objectPlusSymbolsWithRequiredProperties.json
@@ -2520,6 +2520,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/storageSkuNamePlusSymbols.json
@@ -2646,6 +2646,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbols.json
@@ -2520,6 +2520,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount1.json
@@ -2534,6 +2534,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccount2.json
@@ -2534,6 +2534,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusAccountRuleState.json
@@ -2534,6 +2534,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayAndFor.json
@@ -2570,6 +2570,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusArrayWithoutFor.json
@@ -2534,6 +2534,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidResources_CRLF/Completions/symbolsPlusRule.json
@@ -2534,6 +2534,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/objectVarTopLevelIndexes.json
@@ -776,6 +776,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/symbols.json
@@ -812,6 +812,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
+++ b/src/Bicep.Core.Samples/Files/baselines/InvalidVariables_LF/Completions/twoIndexPlusSymbols.json
@@ -794,6 +794,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "groupBy",
     "kind": "function",
     "documentation": {

--- a/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
+++ b/src/Bicep.Core.Samples/Files/baselines/Variables_LF/Completions/symbolsPlusTypes.json
@@ -1145,6 +1145,27 @@
     }
   },
   {
+    "label": "getRoleAssignmentName",
+    "kind": "function",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\ngetRoleAssignmentName(inputs: inputs): string\n\n```  \nReturns a deterministic name for a role assignment.  \n"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "3_getRoleAssignmentName",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "getRoleAssignmentName($0)"
+    },
+    "command": {
+      "title": "signature help",
+      "command": "editor.action.triggerParameterHints"
+    }
+  },
+  {
     "label": "greater",
     "kind": "variable",
     "detail": "greater",

--- a/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/AzNamespaceType.cs
@@ -189,6 +189,13 @@ namespace Bicep.Core.Semantics.Namespaces
             return new(GetRoleDefinitionReturnType());
         }
 
+        private static ObjectType GetRoleAssignmentNameParameterType()
+            => new("inputs", TypeSymbolValidationFlags.Default, [
+                new NamedTypeProperty("scope", LanguageConstants.String, TypePropertyFlags.Required, Description: "The scope at which the role assignment is created."),
+                new NamedTypeProperty("principalId", LanguageConstants.String, TypePropertyFlags.Required, Description: "The principal ID to assign the role to."),
+                new NamedTypeProperty("roleDefinitionId", LanguageConstants.String, TypePropertyFlags.Required, Description: "The ID of the role definition to assign."),
+            ]);
+
         private static ObjectType GetProvidersSingleResourceReturnType()
         {
             // from https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource?tabs=json#providers
@@ -567,6 +574,14 @@ namespace Bicep.Core.Semantics.Namespaces
                     .WithGenericDescription("Gets a role definition that can be used in role assignments.")
                     .WithDescription("Returns information about the specified role definition including id and roleDefinitionId.")
                     .WithRequiredParameter("roleName", LanguageConstants.String, "The display name of the role definition")
+                    .Build();
+
+                yield return new FunctionOverloadBuilder("getRoleAssignmentName")
+                    .WithReturnResultBuilder(SystemNamespaceType.TryDeriveLiteralReturnType("getRoleAssignmentName", LanguageConstants.String), LanguageConstants.String)
+                    .WithReturnType(LanguageConstants.String)
+                    .WithGenericDescription("Returns a deterministic name for a role assignment.")
+                    .WithRequiredParameter("inputs", GetRoleAssignmentNameParameterType(), "The role assignment inputs")
+                    .WithFlags(FunctionFlags.Pure)
                     .Build();
 
                 const string providersDescription = "Returns information about a resource provider and its supported resource types. If you don't provide a resource type, the function returns all the supported types for the resource provider.";

--- a/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
+++ b/src/Bicep.Core/Semantics/Namespaces/SystemNamespaceType.cs
@@ -1359,10 +1359,10 @@ namespace Bicep.Core.Semantics.Namespaces
              }, null);
         }
 
-        private static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, TypeSymbol nonLiteralReturnType) =>
+        public static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, TypeSymbol nonLiteralReturnType) =>
             TryDeriveLiteralReturnType(armFunctionName, (_, _, _, _) => new(nonLiteralReturnType));
 
-        private static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, FunctionOverload.ResultBuilderDelegate nonLiteralReturnResultBuilder) =>
+        public static FunctionOverload.ResultBuilderDelegate TryDeriveLiteralReturnType(string armFunctionName, FunctionOverload.ResultBuilderDelegate nonLiteralReturnResultBuilder) =>
             (model, diagnostics, functionCall, argumentTypes) =>
             {
                 FunctionResult returnType = ArmFunctionReturnTypeEvaluator.TryEvaluate(armFunctionName, out var diagnosticBuilders, argumentTypes) is { } literalReturnType

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,10 +15,10 @@
     <PackageVersion Include="Azure.Bicep.Types.Az" Version="0.2.911" />
     <PackageVersion Include="Azure.Bicep.Types.K8s" Version="0.1.644" />
     <PackageVersion Include="Azure.Containers.ContainerRegistry" Version="1.3.0" />
-    <PackageVersion Include="Azure.Deployments.Engine" Version="1.683.0" />
+    <PackageVersion Include="Azure.Deployments.Engine" Version="1.765.0" />
     <PackageVersion Include="Azure.Deployments.Extensibility.Core" Version="0.1.67" />
     <PackageVersion Include="Azure.Deployments.Internal.GenerateNotice" Version="0.1.60" />
-    <PackageVersion Include="Azure.Deployments.Templates" Version="1.683.0" />
+    <PackageVersion Include="Azure.Deployments.Templates" Version="1.765.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.ResourceManager.ResourceGraph" Version="1.1.1" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.11.2" />
@@ -58,7 +58,7 @@
     <PackageVersion Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.PowerPlatform.ResourceStack" Version="7.0.0.2080" />
+    <PackageVersion Include="Microsoft.PowerPlatform.ResourceStack" Version="7.0.0.2118" />
     <PackageVersion Include="Microsoft.Test.Apex.VisualStudio" Version="17.11.35222.181" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.12.18" />


### PR DESCRIPTION
Adds the `getRoleAssignmentName` Bicep function:

```bicep
getRoleAssignmentName({
  scope: string
  principalId: string
  roleDefinitionId: string
}): string
```

The function generates a deterministic role assignment resource name from the assignment scope, Microsoft Entra principal ID, and role definition ID.

## Motivation

Role assignment names are immutable GUIDs. Different Azure authoring experiences can generate different names for the same logical assignment, making it difficult to manage Portal- or CLI-created assignments through Bicep without deleting and recreating them.

This function provides a shared deterministic naming convention that we plan to use for Bicep, ARM, Portal, CLI, and PowerShell.

## Naming Algorithm

The inputs are normalized before generating the GUID:

- Scope is lowercased and trailing slashes are removed.
- `principalId` must be a valid GUID and is normalized to lowercase.
- `roleDefinitionId` must be a fully qualified `Microsoft.Authorization/roleDefinitions` resource ID.
- The final role definition ID segment is extracted and normalized.
- This produces equivalent output to
    ```bicep
    var output= guid(
      toLower(scope),
      toLower(principalId),
      toLower(split(roleDefinitionId, '/')[^1]))
    ```

## Example

The following reconciles a role assignment on an existing storage account:

```bicep
resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
  name: accountName
}

resource blobReader 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
  scope: tenant()
  name: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
}

resource assignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
  scope: storage
  name: getRoleAssignmentName({
    scope: storage.id
    principalId: principalId
    roleDefinitionId: blobReaderRoleId
  })
  properties: {
    principalId: principalId
    roleDefinitionId: blobReaderRoleId
  }
}
```