### PR TITLE
Add -NoProfile in the call to PowerShell.exe in the installer

### DIFF
--- a/src/installer-win/bicep.iss
+++ b/src/installer-win/bicep.iss
@@ -37,7 +37,7 @@ Source: "SetPath.ps1"; DestDir: "{app}\setup"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Run]
-Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -Command ""& '{app}\setup\SetPath.ps1' -AppPath '{app}' -Remove $false"" "; WorkingDir: {app}; Flags: runhidden
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Command ""& '{app}\setup\SetPath.ps1' -AppPath '{app}' -Remove $false"" "; WorkingDir: {app}; Flags: runhidden
 
 [UninstallRun]
-Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -Command ""& '{app}\setup\SetPath.ps1' -AppPath '{app}' -Remove $true"" "; WorkingDir: {app}; Flags: runhidden
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -Command ""& '{app}\setup\SetPath.ps1' -AppPath '{app}' -Remove $true"" "; WorkingDir: {app}; Flags: runhidden


### PR DESCRIPTION
## Description

fixes #20295 - accidently calling the PowerShell Profile as part of the install/uninstall process

## Example Usage

Updates the installer to work as should

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20296)