### PR TITLE
Fix external PR reviewer assignment

### DIFF
--- a/.github/workflows/external-pr-review-assignment.yml
+++ b/.github/workflows/external-pr-review-assignment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     # The job below will use the built-in "Request reviewers for a pull request" script to assign reviewers
     steps:
-      - name: Assign reviewer from Bicep External Maintainers team
+      - name: Assign Bicep external maintainers as reviewers
         uses: actions/github-script@v7
         with:
           script: |
@@ -26,5 +26,13 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
-              team_reviewers: ['bicep-external-maintainers']
+              reviewers: [
+                'shenglol',
+                'levimatheri',
+                'majastrz',
+                'harshpatel17',
+                'anthony-c-martin',
+                'stephaniezyen',
+                'tsmallig33'
+              ]
             })

--- a/.github/workflows/external-pr-review-assignment.yml
+++ b/.github/workflows/external-pr-review-assignment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     # The job below will use the built-in "Request reviewers for a pull request" script to assign reviewers
     steps:
-      - name: Assign Bicep external maintainers as reviewers
+      - name: Assign Bicep team members as reviewers
         uses: actions/github-script@v7
         with:
           script: |
@@ -32,7 +32,6 @@ jobs:
                 'majastrz',
                 'harshpatel17',
                 'anthony-c-martin',
-                'stephaniezyen',
                 'tsmallig33'
               ]
             })


### PR DESCRIPTION
## Summary

- replace the Bicep External Maintainers team review request with explicit engineer usernames
- avoid the 422 error caused by requesting review from a team that is not a repository collaborator

The listed engineers were taken from the current Bicep External Maintainers team membership and each has write access to the repository.

Follow-up to #19209.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20303)