### PR TITLE
Fix bicep test exit code on compilation errors

### DIFF
--- a/src/Bicep.Cli.IntegrationTests/TestFrameworkCommandTests.cs
+++ b/src/Bicep.Cli.IntegrationTests/TestFrameworkCommandTests.cs
@@ -47,6 +47,29 @@ namespace Bicep.Cli.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Test_CompilationErrors_ShouldFail_WithoutReportingOverallSuccess()
+        {
+            var settings = new InvocationSettings(new(TestContext, TestFrameworkEnabled: true, AssertsEnabled: true), BicepTestConstants.ClientFactory, BicepTestConstants.TemplateSpecRepositoryFactory);
+            var outputFileDir = FileHelper.GetResultFilePath(TestContext, "outputdir");
+            Directory.CreateDirectory(outputFileDir);
+
+            // Include a valid test to verify that a compilation error prevents an overall success result.
+            FileHelper.SaveResultFile(TestContext, "test.bicep", "// Valid test target.", outputFileDir);
+            var bicepPath = FileHelper.SaveResultFile(TestContext, "main.bicep", @"test valid 'test.bicep' = {}
+test missing 'missing.bicep' = {}", outputFileDir);
+
+            var (output, error, result) = await Bicep(settings, "test", bicepPath);
+
+            using (new AssertionScope())
+            {
+                result.Should().Be(1);
+                output.Should().Contain("Evaluation valid Passed!");
+                output.Should().NotContain("All 1 evaluations passed!");
+                error.Should().Contain("Error BCP091");
+            }
+        }
+
+        [TestMethod]
         public async Task Test_commandNoParams_ShouldSucceed()
         {
             // Test should succeed when there are no required params

--- a/src/Bicep.Cli/Commands/TestCommand.cs
+++ b/src/Bicep.Cli/Commands/TestCommand.cs
@@ -67,13 +67,13 @@ namespace Bicep.Cli.Commands
             var declarations = semanticModel.Root.TestDeclarations;
             var testResults = TestRunner.Run(declarations);
 
-            LogResults(testResults);
+            LogResults(testResults, summary.HasErrors);
 
-            // return non-zero exit code on errors
-            return testResults.Success ? 0 : 1;
+            // Return a non-zero exit code for compilation and test evaluation errors.
+            return summary.HasErrors || !testResults.Success ? 1 : 0;
         }
 
-        private void LogResults(TestResults testResults)
+        private void LogResults(TestResults testResults, bool hasCompilationErrors)
         {
             foreach (var (testDeclaration, evaluation) in testResults.Results)
             {
@@ -95,11 +95,12 @@ namespace Bicep.Cli.Commands
                     }
                 }
             }
-            if (testResults.Success)
+            // Do not report overall success when compilation diagnostics contain errors.
+            if (testResults.Success && !hasCompilationErrors)
             {
                 io.Output.Writer.WriteLine($"All {testResults.TotalEvaluations} evaluations passed!");
             }
-            else
+            else if (!testResults.Success)
             {
                 io.Error.Writer.WriteLine($"Evaluation Summary: Failure!");
                 io.Error.Writer.WriteLine($"Total: {testResults.TotalEvaluations} - Success: {testResults.SuccessfulEvaluations} - Skipped: {testResults.SkippedEvaluations} - Failed: {testResults.FailedEvaluations}");


### PR DESCRIPTION
## Description

`bicep test` used only test evaluation results to determine its exit code. Compilation errors could therefore be reported while the command still returned `0` and printed an overall success summary.

This change includes compilation errors in the exit status and suppresses the overall success summary when they are present. Per-test results remain available, so existing skipped and failed evaluation output is unchanged.

Fixes #20304.

## Example Usage

For a test declaration that references a missing file, `bicep test` now reports `BCP091` and returns exit code `1` without printing *"All 0 evaluations passed"*.

## Validation

- Added a regression test with one valid test and one missing target
- `Bicep.Cli.IntegrationTests` in Release: 1134 passed

## Checklist

- [x] I have read and adhere to the [contribution guide](https://github.com/Azure/bicep/blob/main/CONTRIBUTING.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/Azure/bicep/pull/20305)